### PR TITLE
Fix Windows provisioning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Shell scripts are pushed verbatim to the Portal (Android sh) and MUST keep
+# LF endings regardless of host OS. CRLF makes the on-device shell fail with
+# "syntax error: unexpected 'do'" etc. Keep this even on Windows checkouts.
+*.sh text eol=lf

--- a/provisioning/provision.ps1
+++ b/provisioning/provision.ps1
@@ -237,16 +237,16 @@ $StateFile = "/sdcard/immortal_restore.env"
 function Snapshot-Stock {
   if ("$(A shell "[ -f $StateFile ] && echo yes")".Trim() -eq "yes") { return }
   $pkg = $cfg["PKG"]
-  $home = ((A shell 'cmd package query-activities --components -a android.intent.action.MAIN -c android.intent.category.HOME') -split "`n" |
+  $stockHome = ((A shell 'cmd package query-activities --components -a android.intent.action.MAIN -c android.intent.category.HOME') -split "`n" |
     ForEach-Object { $_.Trim() } |
     Where-Object { $_ -match '^[A-Za-z0-9_.]+/' -and $_ -notmatch "^$pkg/" -and $_ -notmatch '^android/' -and $_ -notmatch '^com\.android\.settings/' } |
     Select-Object -First 1)
-  if (-not $home) { $home = $cfg["STOCK_HOME"] }
+  if (-not $stockHome) { $stockHome = $cfg["STOCK_HOME"] }
   $dream  = (A shell settings get secure screensaver_components).Trim()
   $ddream = (A shell settings get secure screensaver_default_component).Trim()
   if (-not $dream  -or $dream  -eq "null" -or $dream  -like "$pkg/*") { $dream  = $cfg["STOCK_DREAM"] }
   if (-not $ddream -or $ddream -eq "null" -or $ddream -like "$pkg/*") { $ddream = $cfg["STOCK_DEFAULT_DREAM"] }
-  "STOCK_HOME=$home`nSTOCK_DREAM=$dream`nSTOCK_DEFAULT_DREAM=$ddream`n" | A shell "cat > $StateFile" | Out-Null
+  "STOCK_HOME=$stockHome`nSTOCK_DREAM=$dream`nSTOCK_DEFAULT_DREAM=$ddream`n" | A shell "cat > $StateFile" | Out-Null
   Ok "Saved this device's stock launcher/screensaver for restore"
 }
 
@@ -283,7 +283,9 @@ if ($Apps) {
 if ($Status) {
   Wait-Device
   Step "Current state"
-  $home = (A shell 'cmd package resolve-activity -a android.intent.action.MAIN -c android.intent.category.HOME') -match "packageName=" | Out-Null
+  $homePkg = ((A shell 'cmd package resolve-activity -a android.intent.action.MAIN -c android.intent.category.HOME') -split "`n" |
+    Select-String 'packageName=' | Select-Object -First 1) -replace '.*packageName=', ''
+  Write-Host "  home:        $("$homePkg".Trim())"
   Write-Host "  screensaver: $((A shell settings get secure screensaver_components).Trim())"
   $disabled = (A shell pm list packages -d $cfg["VERIFIER_PKG"]).Trim()
   Write-Host "  verifier:    $(if ($disabled) {'disabled'} else {'enabled'})"


### PR DESCRIPTION
Fixes #2 

Addresses two independent bugs on the Windows provisioning path (no shared root cause;
grouped because both are small and block a clean run).

1. installd.sh checked out as CRLF -> install daemon dies (functional).
   With core.autocrlf=true (Git for Windows default), `* text=auto` checks
   shell scripts out with CRLF. provision.ps1 adb-pushes installd.sh verbatim
   to the Portal, where Android's sh fails on the carriage returns
   ("syntax error: unexpected 'do'"). The daemon never writes a heartbeat, so
   the on-device store shows "Installing new apps is paused" on Gen-1 Portals
   (which rely on the daemon). Fix: .gitattributes forces *.sh to eol=lf so
   scripts stay LF on every checkout regardless of core.autocrlf.

2. provision.ps1 PowerShell-semantics bugs (robustness).
   - Snapshot-Stock: rename $home, which collides with PowerShell's read-only
     $HOME automatic variable (VariableNotWritable hard crash).
   - -Status: actually print the home launcher (the result was piped to
     Out-Null, so the line never showed). Incidental one-line fix.
