### PR TITLE
Add optional home-screen weather forecast widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -107,8 +107,8 @@
             android:label="Screensaver"
             android:theme="@style/Theme.SampleApp" />
 
-        <!-- Immortal's own settings (weather unit, tile size), opened from the
-             Immortal tile in the launcher's Settings folder. -->
+        <!-- Immortal's own settings (weather unit, home-screen forecast widget, tile
+             size), opened from the Immortal tile in the launcher's Settings folder. -->
         <activity
             android:name=".ImmortalSettingsActivity"
             android:exported="false"

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -49,6 +49,8 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -288,13 +290,21 @@ private fun LauncherScreen(
   var editMode by remember { mutableStateOf(false) }
   var openFolder by remember { mutableStateOf<String?>(null) }
 
-  // Tile size preference, re-read on resume so a change made in Immortal Settings
-  // applies the moment the user comes back to the home screen.
+  // Immortal Settings the home screen reflects (tile size, and the optional weather
+  // widget's mode/unit), re-read on resume so a change applies the moment the user
+  // comes back to the home screen.
   var tileSize by remember { mutableStateOf(ImmortalSettings.load(context).tileSize) }
+  var weatherWidget by remember { mutableStateOf(ImmortalSettings.load(context).weatherWidget) }
+  var weatherFahrenheit by remember { mutableStateOf(ImmortalSettings.useFahrenheit(context)) }
   val lifecycleOwner = LocalLifecycleOwner.current
   DisposableEffect(lifecycleOwner) {
     val obs = LifecycleEventObserver { _, e ->
-      if (e == Lifecycle.Event.ON_RESUME) tileSize = ImmortalSettings.load(context).tileSize
+      if (e == Lifecycle.Event.ON_RESUME) {
+        val s = ImmortalSettings.load(context)
+        tileSize = s.tileSize
+        weatherWidget = s.weatherWidget
+        weatherFahrenheit = ImmortalSettings.useFahrenheit(context)
+      }
     }
     lifecycleOwner.lifecycle.addObserver(obs)
     onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
@@ -439,7 +449,8 @@ private fun LauncherScreen(
       Spacer(Modifier.size(20.dp))
       Box(
           modifier =
-              Modifier.fillMaxSize()
+              Modifier.fillMaxWidth()
+                  .weight(1f)
                   .onGloballyPositioned { containerOrigin = it.boundsInWindow().topLeft }
                   .pointerInput(editMode) {
                     if (!editMode) return@pointerInput
@@ -527,6 +538,12 @@ private fun LauncherScreen(
             }
           }
         }
+      }
+      // Optional weather forecast, pinned full-width at the bottom of the screen
+      // below the (scrolling) app grid. Off by default.
+      if (weatherWidget != ImmortalSettings.WIDGET_OFF) {
+        Spacer(Modifier.size(16.dp))
+        WeatherWidget(mode = weatherWidget, fahrenheit = weatherFahrenheit)
       }
     }
 
@@ -736,6 +753,155 @@ private fun HeaderBar(onScreensaver: () -> Unit) {
           fontSize = 18.sp,
           modifier = Modifier.padding(top = 4.dp),
       )
+    }
+  }
+}
+
+/** What the forecast widget currently has to show. */
+private sealed interface ForecastState {
+  /** First fetch still in flight — render nothing so the bar doesn't flash. */
+  object Loading : ForecastState
+  /** Tried and failed with nothing cached — show a friendly note instead. */
+  object Unavailable : ForecastState
+  data class Ready(val forecast: Weather.Forecast) : ForecastState
+}
+
+// The two swipeable forecast pages, in left-to-right order.
+private const val PAGE_HOURLY = 0
+private const val PAGE_DAILY = 1
+
+/**
+ * Optional home-screen forecast, shown full-width below the app grid when enabled in
+ * Immortal Settings ▸ Weather. One network call fetches both views; the user swipes
+ * left/right between the hourly and 7-day pages. [mode] picks which page shows first
+ * (and jumps to it if the setting changes). [fahrenheit] only keys a re-fetch when the
+ * unit changes — the unit itself is resolved inside [Weather.fetchForecast].
+ *
+ * Failure handling: the fetch retries every minute until it succeeds. While the very
+ * first attempt is in flight nothing is drawn (no flash). If it can't be reached and
+ * we have no forecast yet, a quiet "unavailable" note replaces the data; once a
+ * forecast has loaded, a later failed refresh keeps the last good one on screen rather
+ * than blanking it.
+ */
+@Composable
+private fun WeatherWidget(mode: String, fahrenheit: Boolean) {
+  val context = androidx.compose.ui.platform.LocalContext.current
+  // Keyed on the unit only: switching pages is a local swipe, not a re-fetch.
+  val state by
+      produceState<ForecastState>(initialValue = ForecastState.Loading, fahrenheit) {
+        while (true) {
+          val f = withContext(Dispatchers.IO) { Weather.fetchForecast(context) }
+          if (f != null) {
+            value = ForecastState.Ready(f)
+            delay(30L * 60 * 1000) // refresh every 30 min
+          } else {
+            // Keep showing the last good forecast if we have one; only surface the
+            // note when there's nothing to display.
+            if (value !is ForecastState.Ready) value = ForecastState.Unavailable
+            delay(60L * 1000) // retry in 1 min
+          }
+        }
+      }
+  if (state is ForecastState.Loading) return
+
+  val startPage = if (mode == ImmortalSettings.WIDGET_DAILY) PAGE_DAILY else PAGE_HOURLY
+  val pagerState = rememberPagerState(initialPage = startPage) { 2 }
+  // Follow the setting: if the user changes the default in Immortal Settings, jump to
+  // that page when they come back (no-op on first composition, where it already matches).
+  LaunchedEffect(mode) {
+    if (pagerState.currentPage != startPage) pagerState.scrollToPage(startPage)
+  }
+
+  val ready = state as? ForecastState.Ready
+  Surface(
+      color = Color(0x14FFFFFF),
+      shape = RoundedCornerShape(20.dp),
+      modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+  ) {
+    Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp)) {
+      // Header: the current page's title, plus a two-dot indicator hinting the swipe.
+      Row(
+          modifier = Modifier.fillMaxWidth().padding(start = 4.dp, end = 4.dp, bottom = 12.dp),
+          verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(
+            when {
+              ready == null -> "Forecast"
+              pagerState.currentPage == PAGE_DAILY -> "7-day forecast"
+              else -> "Hourly forecast"
+            },
+            color = Color(0xFFBFBFBF),
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.weight(1f),
+        )
+        if (ready != null) PageDots(selected = pagerState.currentPage, count = 2)
+      }
+      if (ready != null) {
+        HorizontalPager(state = pagerState, modifier = Modifier.fillMaxWidth()) { page ->
+          // Each page's cells share the width evenly, spanning the whole card.
+          Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.spacedBy(8.dp),
+          ) {
+            if (page == PAGE_HOURLY) {
+              ready.forecast.hours.forEach { HourCell(it, Modifier.weight(1f)) }
+            } else {
+              ready.forecast.days.forEach { DayCell(it, Modifier.weight(1f)) }
+            }
+          }
+        }
+      } else {
+        // Unavailable: no connection / location yet. Retries quietly in the
+        // background, so no action is needed from the user.
+        Text(
+            "Forecast unavailable. It'll appear once your Portal is back online.",
+            color = Color(0xFF9A9A9A),
+            fontSize = 14.sp,
+            modifier = Modifier.padding(start = 4.dp, bottom = 4.dp),
+        )
+      }
+    }
+  }
+}
+
+/** Small page-position dots, hinting the forecast can be swiped between its pages. */
+@Composable
+private fun PageDots(selected: Int, count: Int) {
+  Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+    repeat(count) { i ->
+      Box(
+          modifier =
+              Modifier.size(7.dp)
+                  .clip(androidx.compose.foundation.shape.CircleShape)
+                  .background(if (i == selected) Color.White else Color(0x55FFFFFF)))
+    }
+  }
+}
+
+@Composable
+private fun HourCell(h: Weather.HourForecast, modifier: Modifier = Modifier) {
+  Column(
+      horizontalAlignment = Alignment.CenterHorizontally,
+      modifier = modifier.padding(vertical = 4.dp),
+  ) {
+    Text(h.label, color = Color(0xFFCFCFCF), fontSize = 13.sp, maxLines = 1)
+    Text(Weather.emoji(h.code), fontSize = 26.sp, modifier = Modifier.padding(vertical = 6.dp))
+    Text("${h.temp}°", color = Color.White, fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
+  }
+}
+
+@Composable
+private fun DayCell(d: Weather.DayForecast, modifier: Modifier = Modifier) {
+  Column(
+      horizontalAlignment = Alignment.CenterHorizontally,
+      modifier = modifier.padding(vertical = 4.dp),
+  ) {
+    Text(d.label, color = Color(0xFFCFCFCF), fontSize = 13.sp, maxLines = 1)
+    Text(Weather.emoji(d.code), fontSize = 26.sp, modifier = Modifier.padding(vertical = 6.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+      Text("${d.hi}°", color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+      Text("${d.lo}°", color = Color(0xFF9A9A9A), fontSize = 16.sp)
     }
   }
 }

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
@@ -30,9 +30,15 @@ object ImmortalSettings {
   const val SIZE_LARGE = "large" // 5 columns, 110dp tiles (closer to the stock launcher)
   const val SIZE_XL = "xl" // 4 columns, 140dp tiles (for the big-screen Portal+)
 
+  // Optional home-screen weather forecast widget, shown below the app grid.
+  const val WIDGET_OFF = "off" // no forecast (default)
+  const val WIDGET_HOURLY = "hourly" // hour-by-hour for the next several hours
+  const val WIDGET_DAILY = "daily" // a high/low for each of the next 7 days
+
   data class Settings(
       val weatherUnit: String = UNIT_AUTO,
       val tileSize: String = SIZE_STANDARD,
+      val weatherWidget: String = WIDGET_OFF,
   )
 
   private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
@@ -42,6 +48,7 @@ object ImmortalSettings {
     return Settings(
         weatherUnit = p.getString("weather_unit", UNIT_AUTO) ?: UNIT_AUTO,
         tileSize = p.getString("tile_size", SIZE_STANDARD) ?: SIZE_STANDARD,
+        weatherWidget = p.getString("weather_widget", WIDGET_OFF) ?: WIDGET_OFF,
     )
   }
 
@@ -49,6 +56,9 @@ object ImmortalSettings {
       prefs(c).edit().putString("weather_unit", unit).apply()
 
   fun setTileSize(c: Context, size: String) = prefs(c).edit().putString("tile_size", size).apply()
+
+  fun setWeatherWidget(c: Context, mode: String) =
+      prefs(c).edit().putString("weather_widget", mode).apply()
 
   /** Resolved unit for a fetch: true → Fahrenheit, false → Celsius. */
   fun useFahrenheit(context: Context): Boolean =

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -124,6 +124,34 @@ private fun ImmortalSettingsScreen() {
               },
           )
         }
+        Divider()
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(18.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+          Column(modifier = Modifier.weight(1f)) {
+            Text("Home-screen forecast", color = Color.White, fontSize = 17.sp)
+            Text(
+                "Show a forecast below your apps. Off by default.",
+                color = Color(0xFF9A9A9A),
+                fontSize = 13.sp,
+                modifier = Modifier.padding(top = 2.dp),
+            )
+          }
+          Segmented(
+              options =
+                  listOf(
+                      "Off" to ImmortalSettings.WIDGET_OFF,
+                      "Hourly" to ImmortalSettings.WIDGET_HOURLY,
+                      "7-day" to ImmortalSettings.WIDGET_DAILY,
+                  ),
+              selected = settings.weatherWidget,
+              onSelect = {
+                ImmortalSettings.setWeatherWidget(context, it)
+                settings = settings.copy(weatherWidget = it)
+              },
+          )
+        }
       }
 
       Spacer(Modifier.size(26.dp))
@@ -189,6 +217,11 @@ private fun Card(content: @Composable () -> Unit) {
   ) {
     Column { content() }
   }
+}
+
+@Composable
+private fun Divider() {
+  Spacer(Modifier.fillMaxWidth().height(1.dp).background(Color(0x14FFFFFF)))
 }
 
 @Composable

--- a/app/src/main/java/com/immortal/launcher/Weather.kt
+++ b/app/src/main/java/com/immortal/launcher/Weather.kt
@@ -94,17 +94,29 @@ object Weather {
       runCatching {
             val (lat, lon) = location(context) ?: return null
             // °F or °C per the user's setting (default: follow the device locale).
-            val unit = if (ImmortalSettings.useFahrenheit(context)) "fahrenheit" else "celsius"
-            val root =
-                JSONObject(
-                    httpGet(
-                        "https://api.open-meteo.com/v1/forecast?latitude=$lat&longitude=$lon" +
-                            "&daily=weather_code,temperature_2m_max,temperature_2m_min" +
-                            "&hourly=weather_code,temperature_2m" +
-                            "&forecast_days=7&temperature_unit=$unit&timezone=auto"))
-            Forecast(days = parseDays(root), hours = parseHours(root))
+            val json = httpGet(forecastUrl(lat, lon, ImmortalSettings.useFahrenheit(context)))
+            parseForecast(json, System.currentTimeMillis())
           }
           .getOrNull()
+
+  /** The Open-Meteo request for [fetchForecast]; split out so the unit choice can be
+   * verified in tests. `timezone=auto` makes the response use the location's local
+   * times, which [parseForecast] reads in the device's default zone. */
+  internal fun forecastUrl(lat: Double, lon: Double, fahrenheit: Boolean): String {
+    val unit = if (fahrenheit) "fahrenheit" else "celsius"
+    return "https://api.open-meteo.com/v1/forecast?latitude=$lat&longitude=$lon" +
+        "&daily=weather_code,temperature_2m_max,temperature_2m_min" +
+        "&hourly=weather_code,temperature_2m" +
+        "&forecast_days=7&temperature_unit=$unit&timezone=auto"
+  }
+
+  /** Pure parse of an Open-Meteo forecast response. [nowMillis] is the reference "now"
+   * used to drop already-past hours, passed in (rather than read from the clock) so the
+   * hourly logic is deterministic under test. */
+  internal fun parseForecast(json: String, nowMillis: Long): Forecast {
+    val root = JSONObject(json)
+    return Forecast(days = parseDays(root), hours = parseHours(root, nowMillis))
+  }
 
   private fun parseDays(root: JSONObject): List<DayForecast> {
     val d = root.getJSONObject("daily")
@@ -126,7 +138,7 @@ object Weather {
     }
   }
 
-  private fun parseHours(root: JSONObject): List<HourForecast> {
+  private fun parseHours(root: JSONObject, nowMillis: Long): List<HourForecast> {
     val h = root.getJSONObject("hourly")
     val time = h.getJSONArray("time")
     val code = h.getJSONArray("weather_code")
@@ -134,7 +146,7 @@ object Weather {
     val isoHour = SimpleDateFormat("yyyy-MM-dd'T'HH:mm", Locale.US)
     val hourFmt = SimpleDateFormat("h a", Locale.getDefault())
     // Show the current hour onward; everything before "now" is in the past.
-    val cutoff = System.currentTimeMillis() - 60L * 60 * 1000
+    val cutoff = nowMillis - 60L * 60 * 1000
     val out = ArrayList<HourForecast>(12)
     var first = true
     for (i in 0 until time.length()) {

--- a/app/src/main/java/com/immortal/launcher/Weather.kt
+++ b/app/src/main/java/com/immortal/launcher/Weather.kt
@@ -10,6 +10,8 @@ package com.immortal.launcher
 import android.content.Context
 import java.net.HttpURLConnection
 import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Locale
 import kotlin.math.roundToInt
 import org.json.JSONObject
 
@@ -70,6 +72,83 @@ object Weather {
       }
     }
     return null
+  }
+
+  /** One day of the multi-day forecast. [label] is "Today" then "Mon", "Tue", … */
+  data class DayForecast(val label: String, val code: Int, val hi: Int, val lo: Int)
+
+  /** One hour of the hourly forecast. [label] is "Now" then "1 PM", "2 PM", … */
+  data class HourForecast(val label: String, val code: Int, val temp: Int)
+
+  /** A combined forecast: both views are fetched in one call so the home-screen
+   * widget can switch between hourly and 7-day without re-hitting the network. */
+  data class Forecast(val days: List<DayForecast>, val hours: List<HourForecast>)
+
+  /**
+   * Fetches a 7-day daily forecast and the next ~12 hours of hourly forecast from
+   * Open-Meteo (keyless), for the home-screen weather widget. Returns null if it
+   * can't be fetched (caller can retry). `timezone=auto` makes Open-Meteo return
+   * local times, which we parse in the device's default zone.
+   */
+  fun fetchForecast(context: Context): Forecast? =
+      runCatching {
+            val (lat, lon) = location(context) ?: return null
+            // °F or °C per the user's setting (default: follow the device locale).
+            val unit = if (ImmortalSettings.useFahrenheit(context)) "fahrenheit" else "celsius"
+            val root =
+                JSONObject(
+                    httpGet(
+                        "https://api.open-meteo.com/v1/forecast?latitude=$lat&longitude=$lon" +
+                            "&daily=weather_code,temperature_2m_max,temperature_2m_min" +
+                            "&hourly=weather_code,temperature_2m" +
+                            "&forecast_days=7&temperature_unit=$unit&timezone=auto"))
+            Forecast(days = parseDays(root), hours = parseHours(root))
+          }
+          .getOrNull()
+
+  private fun parseDays(root: JSONObject): List<DayForecast> {
+    val d = root.getJSONObject("daily")
+    val time = d.getJSONArray("time")
+    val code = d.getJSONArray("weather_code")
+    val hi = d.getJSONArray("temperature_2m_max")
+    val lo = d.getJSONArray("temperature_2m_min")
+    val dayFmt = SimpleDateFormat("EEE", Locale.getDefault())
+    val isoDate = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+    return (0 until time.length()).map { i ->
+      val label =
+          if (i == 0) "Today"
+          else runCatching { dayFmt.format(isoDate.parse(time.getString(i))!!) }.getOrDefault("")
+      DayForecast(
+          label = label,
+          code = code.getInt(i),
+          hi = hi.getDouble(i).roundToInt(),
+          lo = lo.getDouble(i).roundToInt())
+    }
+  }
+
+  private fun parseHours(root: JSONObject): List<HourForecast> {
+    val h = root.getJSONObject("hourly")
+    val time = h.getJSONArray("time")
+    val code = h.getJSONArray("weather_code")
+    val temp = h.getJSONArray("temperature_2m")
+    val isoHour = SimpleDateFormat("yyyy-MM-dd'T'HH:mm", Locale.US)
+    val hourFmt = SimpleDateFormat("h a", Locale.getDefault())
+    // Show the current hour onward; everything before "now" is in the past.
+    val cutoff = System.currentTimeMillis() - 60L * 60 * 1000
+    val out = ArrayList<HourForecast>(12)
+    var first = true
+    for (i in 0 until time.length()) {
+      val t = runCatching { isoHour.parse(time.getString(i))!!.time }.getOrNull() ?: continue
+      if (t < cutoff) continue
+      out.add(
+          HourForecast(
+              label = if (first) "Now" else hourFmt.format(time.getString(i).let { isoHour.parse(it)!! }),
+              code = code.getInt(i),
+              temp = temp.getDouble(i).roundToInt()))
+      first = false
+      if (out.size >= 12) break
+    }
+    return out
   }
 
   private fun httpGet(spec: String): String {

--- a/app/src/test/java/com/immortal/launcher/WeatherTest.kt
+++ b/app/src/test/java/com/immortal/launcher/WeatherTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Open-Meteo forecast parsing + URL building (no device/network needed).
+ *
+ * Timezone and locale are pinned so the day/hour labels and the "drop past hours"
+ * cutoff are deterministic: the response carries local times (`timezone=auto`), which
+ * the parser reads in the default zone, and the labels are locale-formatted.
+ */
+class WeatherTest {
+
+  private lateinit var savedTz: TimeZone
+  private lateinit var savedLocale: Locale
+
+  @Before
+  fun pinZoneAndLocale() {
+    savedTz = TimeZone.getDefault()
+    savedLocale = Locale.getDefault()
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+    Locale.setDefault(Locale.US)
+  }
+
+  @After
+  fun restore() {
+    TimeZone.setDefault(savedTz)
+    Locale.setDefault(savedLocale)
+  }
+
+  /** Epoch millis for a UTC wall-clock time like "2026-06-07T13:30". */
+  private fun utc(stamp: String): Long =
+      SimpleDateFormat("yyyy-MM-dd'T'HH:mm", Locale.US)
+          .apply { timeZone = TimeZone.getTimeZone("UTC") }
+          .parse(stamp)!!
+          .time
+
+  // 7 daily entries; 18 hourly entries spanning 10:00 today → 03:00 tomorrow.
+  private val sample =
+      """
+      {
+        "daily": {
+          "time": ["2026-06-07","2026-06-08","2026-06-09","2026-06-10","2026-06-11","2026-06-12","2026-06-13"],
+          "weather_code": [0,1,2,3,45,61,71],
+          "temperature_2m_max": [70.4,71.6,72.0,73.0,74.0,75.0,76.0],
+          "temperature_2m_min": [50.6,51.0,52.0,53.0,54.0,55.0,56.0]
+        },
+        "hourly": {
+          "time": [
+            "2026-06-07T10:00","2026-06-07T11:00","2026-06-07T12:00","2026-06-07T13:00",
+            "2026-06-07T14:00","2026-06-07T15:00","2026-06-07T16:00","2026-06-07T17:00",
+            "2026-06-07T18:00","2026-06-07T19:00","2026-06-07T20:00","2026-06-07T21:00",
+            "2026-06-07T22:00","2026-06-07T23:00","2026-06-08T00:00","2026-06-08T01:00",
+            "2026-06-08T02:00","2026-06-08T03:00"
+          ],
+          "weather_code": [0,0,0,61,0,0,0,0,0,0,0,0,0,0,3,0,0,0],
+          "temperature_2m": [50.0,51.0,52.0,60.4,61.6,63.0,64.0,65.0,66.0,67.0,68.0,69.0,70.0,71.0,72.0,73.0,74.0,75.0]
+        }
+      }
+      """.trimIndent()
+
+  @Test
+  fun `daily labels today then weekday, temps rounded`() {
+    val days = Weather.parseForecast(sample, utc("2026-06-07T13:30")).days
+    assertEquals(7, days.size)
+    assertEquals("Today", days[0].label)
+    assertEquals(0, days[0].code)
+    assertEquals(70, days[0].hi) // 70.4 -> 70
+    assertEquals(51, days[0].lo) // 50.6 -> 51
+
+    // Index > 0 is the weekday of that date (not "Today", never blank).
+    val expectedWeekday =
+        SimpleDateFormat("EEE", Locale.US)
+            .format(SimpleDateFormat("yyyy-MM-dd", Locale.US).parse("2026-06-08")!!)
+    assertEquals(expectedWeekday, days[1].label)
+    assertNotEquals("Today", days[1].label)
+  }
+
+  @Test
+  fun `hourly drops past hours, labels Now then clock, caps at 12`() {
+    // now = 13:30 -> cutoff 12:30, so 10/11/12:00 are dropped; 13:00 is the first kept.
+    val hours = Weather.parseForecast(sample, utc("2026-06-07T13:30")).hours
+    assertEquals(12, hours.size) // 15 candidates from 13:00, capped to 12
+
+    assertEquals("Now", hours[0].label)
+    assertEquals(60, hours[0].temp) // 13:00, 60.4 -> 60
+    assertEquals(61, hours[0].code) // weather_code flows through
+
+    assertEquals("2 PM", hours[1].label) // 14:00
+    assertEquals(62, hours[1].temp) // 61.6 -> 62
+
+    // 12th kept entry is 00:00 the next day.
+    assertEquals("12 AM", hours.last().label)
+    assertEquals(3, hours.last().code)
+  }
+
+  @Test
+  fun `hourly is empty when every hour is in the past`() {
+    val hours = Weather.parseForecast(sample, utc("2030-01-01T00:00")).hours
+    assertTrue(hours.isEmpty())
+  }
+
+  @Test
+  fun `forecast url carries coordinates, span and the chosen unit`() {
+    val f = Weather.forecastUrl(1.5, -2.25, fahrenheit = true)
+    assertTrue(f.contains("latitude=1.5"))
+    assertTrue(f.contains("longitude=-2.25"))
+    assertTrue(f.contains("forecast_days=7"))
+    assertTrue(f.contains("timezone=auto"))
+    assertTrue(f.contains("temperature_unit=fahrenheit"))
+
+    val c = Weather.forecastUrl(1.5, -2.25, fahrenheit = false)
+    assertTrue(c.contains("temperature_unit=celsius"))
+  }
+}


### PR DESCRIPTION
Off by default; enabled from Immortal Settings - Weather as either an hour-by-hour or a next-7-days view. Renders full-width pinned at the bottom of the home screen, below the (scrolling) app grid, so it fills otherwise empty space without crowding app tiles.

- ImmortalSettings: add a weatherWidget mode (off/hourly/daily), default off
- ImmortalSettingsActivity: a "Home-screen forecast" control in the Weather section, beside the temperature unit
- Weather: fetchForecast() pulls a 7-day daily and next-~12h hourly forecast in one keyless Open-Meteo call, honoring the user's temperature unit
- HomeActivity: re-read the setting on resume and render the widget; swipe left/right (HorizontalPager) to slide between the hourly and 7-day views, with the setting choosing the starting page

Failure handling: the fetch retries every minute; nothing is drawn during the first attempt, a quiet "unavailable" note shows if it fails with nothing cached, and a failed refresh keeps the last good forecast on screen.