### PR TITLE
docs: add OpenPortal install badge & browser install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Package: `com.immortal.launcher` · Target: Meta Portal — **Android 9** (API 2
 Portal+ and the Portal TV) and **Android 10** (API 29: the 2019 and 2021 models), arm64, no Google
 services. Touch models and the remote-driven **Portal TV** are both supported.
 
+[![Get it on OpenPortal](https://andronedev.github.io/openportal/openportal-badge.svg)](https://andronedev.github.io/openportal/apps/com.immortal.launcher)
+
 ## What's in it
 
 - **Launcher** (`HomeActivity`) — a fullscreen app grid with a clock/date/weather header and an
@@ -60,6 +62,13 @@ services. Touch models and the remote-driven **Portal TV** are both supported.
 The easiest path is the [provisioning kit](provisioning/): connect the Portal over USB-C with
 ADB enabled, then double-click `Provision-Portal` (macOS/Linux) or `Provision-Portal.bat`
 (Windows). It fetches the latest release automatically.
+
+**No computer setup?** You can also install Immortal straight from your browser with
+[OpenPortal](https://andronedev.github.io/openportal/apps/com.immortal.launcher), a Chromium-based
+web app that drives the Portal over USB with WebUSB + ADB. Nothing to download or run on your
+machine: plug in the Portal, click install, and OpenPortal also runs Immortal's post-install setup
+for you (it sets the launcher as the home screen and applies the overlay tweak). Because it
+installs over the ADB protocol, it sidesteps the broken first-gen installer dialog entirely.
 
 To build from source instead:
 


### PR DESCRIPTION
Hi, and thanks for Immortal, it's a lovely project for keeping these Portals alive.

I maintain [OpenPortal](https://andronedev.github.io/openportal/), a browser-based Meta Portal manager (WebUSB + ADB, no backend), and Immortal is in its catalog. This PR proposes two small README additions:

1. **An install badge** under the intro metadata, linking to Immortal's OpenPortal page:

   [![Get it on OpenPortal](https://andronedev.github.io/openportal/openportal-badge.svg)](https://andronedev.github.io/openportal/apps/com.immortal.launcher)

2. **A short "No computer setup?" note** in the Install section, offering OpenPortal as a browser-based way to get Immortal onto a Portal without downloading the kit or typing `adb`.

Why it might be a good fit for Immortal specifically:

- It installs over the **ADB protocol** (like `adb install`), so on a first-gen Portal+ it sidesteps the broken on-device installer dialog entirely, the same chicken-and-egg the README documents at length.
- OpenPortal's catalog entry runs Immortal's **post-install setup automatically**: `set-home-activity` to make it the home screen, plus the overlay command, so it lands set up, not just installed.
- It's purely a first-install path. Once Immortal is on, your own App Store and self-update take over, so this doesn't overlap with what Immortal already does.

Everything is optional and the placement is yours to adjust. Happy to move the badge, trim the note, or drop either part if you'd prefer something lighter. The plain link is `https://andronedev.github.io/openportal/apps/com.immortal.launcher` if you'd rather not use the badge image.

Thanks for considering it!