### PR TITLE
Add iCloud / Google Photos shared albums as a screensaver source

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -141,6 +141,15 @@
             android:label="Choose a folder"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- One-field form for pasting a public iCloud / Google Photos shared-album
+             link, reachable from the "Shared album link" row in screensaver settings. -->
+        <activity
+            android:name=".AlbumUrlEntryActivity"
+            android:exported="false"
+            android:label="Shared album link"
+            android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.SampleApp" />
+
         <!-- "Install an APK" file browser, opened from the App Store. -->
         <activity
             android:name=".ApkBrowserActivity"

--- a/app/src/main/java/com/immortal/launcher/AlbumUrlEntryActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/AlbumUrlEntryActivity.kt
@@ -1,0 +1,169 @@
+package com.immortal.launcher
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.ui.theme.SampleAppTheme
+
+/** Paste-a-link screen for the URL screensaver source. Validates the host up-front. */
+class AlbumUrlEntryActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent {
+      SampleAppTheme(darkTheme = true) {
+        AlbumUrlEntryScreen(
+            onSave = { url ->
+              ScreensaverConfig.setAlbumUrl(this, url)
+              finish()
+            },
+            onCancel = { finish() },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun AlbumUrlEntryScreen(onSave: (String) -> Unit, onCancel: () -> Unit) {
+  val context = LocalContext.current
+  val existing = remember { ScreensaverConfig.load(context).albumUrl.orEmpty() }
+  var url by remember { mutableStateOf(existing) }
+
+  val trimmed = url.trim()
+  val supported = trimmed.isNotEmpty() && RemoteAlbum.isSupported(trimmed)
+  val provider = if (supported) RemoteAlbum.providerName(trimmed) else null
+
+  BackHandler { onCancel() }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp)) {
+      Text(
+          "Shared album link",
+          color = Color.White,
+          fontSize = 34.sp,
+          fontWeight = FontWeight.SemiBold,
+      )
+      Text(
+          "Paste a public link from iCloud Shared Albums or Google Photos. " +
+              "Make sure it's shared as \"anyone with the link\" — Immortal can't sign in.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+
+      Spacer(Modifier.heightIn(min = 22.dp))
+
+      OutlinedTextField(
+          value = url,
+          onValueChange = { url = it },
+          placeholder = {
+            Text("https://www.icloud.com/sharedalbum/#…", color = Color(0xFF777777))
+          },
+          singleLine = true,
+          modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
+          shape = RoundedCornerShape(14.dp),
+      )
+
+      Text(
+          when {
+            trimmed.isEmpty() -> "Examples: iCloud Shared Album, Google Photos shared album."
+            supported -> "Looks like a $provider link."
+            else -> "That doesn't look like a supported share link yet."
+          },
+          color = if (supported || trimmed.isEmpty()) Color(0xFF9A9A9A) else Color(0xFFE89090),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 10.dp, start = 4.dp),
+      )
+
+      Spacer(Modifier.heightIn(min = 26.dp))
+
+      Surface(
+          color = if (supported) Color(0xFF2E6BE6) else Color(0xFF2A2A2C),
+          shape = RoundedCornerShape(16.dp),
+          modifier =
+              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                if (supported) onSave(trimmed)
+              },
+      ) {
+        Text(
+            "Use this album",
+            color = if (supported) Color.White else Color(0xFF777777),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 16.dp).fillMaxWidth(),
+        )
+      }
+
+      Spacer(Modifier.heightIn(min = 12.dp))
+
+      Surface(
+          color = Color(0xFF1C1C1E),
+          shape = RoundedCornerShape(16.dp),
+          modifier =
+              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                onCancel()
+              },
+      ) {
+        Text(
+            "Cancel",
+            color = Color(0xFFDDDDDD),
+            fontSize = 16.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 14.dp).fillMaxWidth(),
+        )
+      }
+
+      Spacer(Modifier.heightIn(min = 26.dp))
+
+      Text(
+          "How to get a link:",
+          color = Color(0xFFBBBBBB),
+          fontSize = 14.sp,
+          fontWeight = FontWeight.SemiBold,
+          modifier = Modifier.padding(start = 4.dp, bottom = 6.dp),
+      )
+      Text(
+          "• iPhone Photos → an album you own → Share → Copy Link. The album must " +
+              "be a Shared Album with \"Public Website\" turned on.\n" +
+              "• Google Photos → album → Share → \"Get link\" (anyone with the link can view).",
+          color = Color(0xFF8A8A8A),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(start = 4.dp),
+      )
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -47,11 +47,15 @@ import org.json.JSONObject
  *
  * Source is configurable via [ScreensaverConfig]:
  *  - **default** — the built-in keyless photo feed (Lorem Picsum, or Unsplash if a
- *    key is supplied). This is also the fallback whenever a local source is unset,
- *    empty, or unreachable (e.g. a USB drive was unplugged), so the frame is never
- *    blank.
+ *    key is supplied). This is also the fallback whenever any other source is unset,
+ *    empty, or unreachable (e.g. a USB drive was unplugged, a shared album was
+ *    unshared), so the frame is never blank.
  *  - **folder** — photos and videos from a folder the user picked (internal, SD, or
  *    a USB-C drive), read through the Storage Access Framework.
+ *  - **url** — a public share link to an iCloud Shared Album or a Google Photos
+ *    shared album. Fetched once on start; the screensaver rotates through the
+ *    returned direct image URLs and silently falls back to the default feed if the
+ *    album can't be resolved.
  *
  * Weather is Open-Meteo + IP geolocation (both keyless). All network is best-effort.
  */
@@ -83,6 +87,11 @@ class PhotoFrameController(
   // Bumped on every advance so a slow image-decode or an old video's completion
   // callback can tell it's been superseded and bow out.
   private var gen = 0
+
+  // Remote-album playback state (iCloud / Google Photos shared albums).
+  private var remoteMode = false
+  private var remoteUrls: List<String> = emptyList()
+  private var remoteIndex = -1
 
   // Web-feed history so swipes can go back as well as forward.
   private val history = ArrayList<Bitmap>()
@@ -122,30 +131,55 @@ class PhotoFrameController(
     applyFit()
     tick.run()
     refreshWeather.run()
-    if (settings.usesFolder) {
-      val path = settings.folderPath
-      if (path.isNullOrBlank()) {
-        startWeb()
-        return
-      }
-      io.execute {
-        val list =
-            if (LocalMedia.isAccessible(path)) LocalMedia.enumerate(path, settings.includeVideo)
-            else emptyList()
-        ui.post {
-          if (list.isNotEmpty()) {
-            playlist = if (settings.shuffle) list.shuffled() else list
-            localMode = true
-            localIndex = -1
-            advanceLocal(+1)
-          } else {
-            // Folder empty / unreachable → never leave the frame blank.
-            startWeb()
+    when {
+      settings.usesFolder -> {
+        val path = settings.folderPath
+        if (path.isNullOrBlank()) {
+          startWeb()
+          return
+        }
+        io.execute {
+          val list =
+              if (LocalMedia.isAccessible(path)) LocalMedia.enumerate(path, settings.includeVideo)
+              else emptyList()
+          ui.post {
+            if (list.isNotEmpty()) {
+              playlist = if (settings.shuffle) list.shuffled() else list
+              localMode = true
+              localIndex = -1
+              advanceLocal(+1)
+            } else {
+              // Folder empty / unreachable → never leave the frame blank.
+              startWeb()
+            }
           }
         }
       }
-    } else {
-      startWeb()
+      settings.usesUrl -> {
+        val shareUrl = settings.albumUrl
+        if (shareUrl.isNullOrBlank()) {
+          startWeb()
+          return
+        }
+        val m = context.resources.displayMetrics
+        io.execute {
+          val album = RemoteAlbum.fetch(shareUrl, m.widthPixels, m.heightPixels)
+          val urls = album?.photoUrls.orEmpty()
+          ui.post {
+            if (urls.isNotEmpty()) {
+              remoteUrls = if (settings.shuffle) urls.shuffled() else urls
+              remoteMode = true
+              remoteIndex = -1
+              advanceRemote(+1)
+              scheduleRemoteRefresh()
+            } else {
+              // Album unshared / unreachable → never leave the frame blank.
+              startWeb()
+            }
+          }
+        }
+      }
+      else -> startWeb()
     }
   }
 
@@ -270,11 +304,19 @@ class PhotoFrameController(
 
   // --- navigation (branches on the active source) -----------------------------
   fun next() {
-    if (localMode) advanceLocal(+1) else webNext()
+    when {
+      localMode -> advanceLocal(+1)
+      remoteMode -> advanceRemote(+1)
+      else -> webNext()
+    }
   }
 
   fun prev() {
-    if (localMode) advanceLocal(-1) else webPrev()
+    when {
+      localMode -> advanceLocal(-1)
+      remoteMode -> advanceRemote(-1)
+      else -> webPrev()
+    }
   }
 
   // --- local folder playback --------------------------------------------------
@@ -389,9 +431,76 @@ class PhotoFrameController(
     }
   }
 
+  // --- remote album playback (iCloud / Google Photos public shares) -----------
+  private val remoteTick =
+      object : Runnable {
+        override fun run() {
+          advanceRemote(+1)
+        }
+      }
+
+  // On transient failure we keep the existing list (don't drop to the web feed) and
+  // retry next interval.
+  private val remoteRefresh =
+      object : Runnable {
+        override fun run() {
+          if (!remoteMode) return
+          val shareUrl = settings.albumUrl
+          if (shareUrl.isNullOrBlank()) return
+          val m = context.resources.displayMetrics
+          io.execute {
+            val fresh = RemoteAlbum.fetch(shareUrl, m.widthPixels, m.heightPixels)
+            val urls = fresh?.photoUrls.orEmpty()
+            ui.post {
+              if (remoteMode && urls.isNotEmpty()) {
+                remoteUrls = if (settings.shuffle) urls.shuffled() else urls
+                // Keep our place if the album hasn't shrunk past the current index.
+                if (remoteIndex >= remoteUrls.size) remoteIndex = -1
+              }
+              scheduleRemoteRefresh()
+            }
+          }
+        }
+      }
+
+  private fun scheduleRemoteRefresh() {
+    ui.removeCallbacks(remoteRefresh)
+    ui.postDelayed(remoteRefresh, settings.albumRefreshMin * 60_000L)
+  }
+
+  private fun advanceRemote(dir: Int) {
+    ui.removeCallbacks(remoteTick)
+    if (remoteUrls.isEmpty()) {
+      startWeb()
+      return
+    }
+    gen++
+    remoteIndex = ((remoteIndex + dir) % remoteUrls.size + remoteUrls.size) % remoteUrls.size
+    val url = remoteUrls[remoteIndex]
+    val g = gen
+    stopVideo()
+    io.execute {
+      val bmp = runCatching { downloadBitmap(url) }.getOrNull()
+      ui.post {
+        if (g != gen) return@post // superseded by a newer advance
+        if (bmp == null) {
+          // Skip a broken URL; if the whole album is gone, fall back to the web feed.
+          advanceRemote(+1)
+          return@post
+        }
+        photo.visibility = View.VISIBLE
+        show(bmp)
+        ui.postDelayed(remoteTick, intervalMs())
+      }
+    }
+  }
+
   // --- web feed (default + fallback) ------------------------------------------
   private fun startWeb() {
     localMode = false
+    remoteMode = false
+    ui.removeCallbacks(remoteTick)
+    ui.removeCallbacks(remoteRefresh)
     stopVideo()
     rotate.run()
   }

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -92,6 +92,7 @@ class PhotoFrameController(
   private var remoteMode = false
   private var remoteUrls: List<String> = emptyList()
   private var remoteIndex = -1
+  private var remoteFailStreak = 0
 
   // Web-feed history so swipes can go back as well as forward.
   private val history = ArrayList<Bitmap>()
@@ -170,6 +171,7 @@ class PhotoFrameController(
               remoteUrls = if (settings.shuffle) urls.shuffled() else urls
               remoteMode = true
               remoteIndex = -1
+              remoteFailStreak = 0
               advanceRemote(+1)
               scheduleRemoteRefresh()
             } else {
@@ -439,8 +441,8 @@ class PhotoFrameController(
         }
       }
 
-  // On transient failure we keep the existing list (don't drop to the web feed) and
-  // retry next interval.
+  // Shuffle is applied once at start, not on refresh — re-shuffling every tick
+  // would scramble the user's current position.
   private val remoteRefresh =
       object : Runnable {
         override fun run() {
@@ -453,9 +455,9 @@ class PhotoFrameController(
             val urls = fresh?.photoUrls.orEmpty()
             ui.post {
               if (remoteMode && urls.isNotEmpty()) {
-                remoteUrls = if (settings.shuffle) urls.shuffled() else urls
-                // Keep our place if the album hasn't shrunk past the current index.
+                remoteUrls = urls
                 if (remoteIndex >= remoteUrls.size) remoteIndex = -1
+                remoteFailStreak = 0
               }
               scheduleRemoteRefresh()
             }
@@ -474,6 +476,12 @@ class PhotoFrameController(
       startWeb()
       return
     }
+    // One failure per URL = the whole album is unreachable; bail to the web feed
+    // so a dead share doesn't spin 8-12s timeouts indefinitely.
+    if (remoteFailStreak >= remoteUrls.size) {
+      startWeb()
+      return
+    }
     gen++
     remoteIndex = ((remoteIndex + dir) % remoteUrls.size + remoteUrls.size) % remoteUrls.size
     val url = remoteUrls[remoteIndex]
@@ -483,11 +491,13 @@ class PhotoFrameController(
       val bmp = runCatching { downloadBitmap(url) }.getOrNull()
       ui.post {
         if (g != gen) return@post // superseded by a newer advance
+        if (!remoteMode) return@post // raced with startWeb() flipping us off
         if (bmp == null) {
-          // Skip a broken URL; if the whole album is gone, fall back to the web feed.
+          remoteFailStreak++
           advanceRemote(+1)
           return@post
         }
+        remoteFailStreak = 0
         photo.visibility = View.VISIBLE
         show(bmp)
         ui.postDelayed(remoteTick, intervalMs())

--- a/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
@@ -67,11 +67,13 @@ object RemoteAlbum {
 
   private fun fetchIcloud(url: String, screenW: Int, screenH: Int): Album? {
     val token = icloudToken(url) ?: return null
-    val host = resolveIcloudHost(token) ?: return null
+    val (host, streamJson) = resolveIcloudHost(token) ?: return null
     val base = "https://$host/$token/sharedstreams"
 
-    val streamJson = postJson("$base/webstream", "{\"streamCtag\":null}") ?: return null
-    val stream = JSONObject(streamJson)
+    // Reuse the body resolveIcloudHost already fetched on a 200; on 330 we still
+    // need to call /webstream against the redirected host.
+    val body = streamJson ?: postJson("$base/webstream", "{\"streamCtag\":null}") ?: return null
+    val stream = JSONObject(body)
     val title = stream.optString("streamName", "").ifBlank { null }
     val photos = stream.optJSONArray("photos") ?: return null
     if (photos.length() == 0) return Album(title, emptyList())
@@ -124,7 +126,9 @@ object RemoteAlbum {
     return Album(title, out)
   }
 
-  private fun resolveIcloudHost(token: String): String? {
+  // body is non-null on a 200 hit (caller can skip its own /webstream POST), null
+  // on a 330 redirect (the request never landed on the right host).
+  private fun resolveIcloudHost(token: String): Pair<String, String?>? {
     val firstGuess = "p${icloudPartition(token)}-sharedstreams.icloud.com"
     val c =
         URL("https://$firstGuess/$token/sharedstreams/webstream").openConnection()
@@ -139,11 +143,19 @@ object RemoteAlbum {
     c.outputStream.use { it.write("{\"streamCtag\":null}".toByteArray()) }
     val code = runCatching { c.responseCode }.getOrDefault(0)
     val redirect = c.getHeaderField("X-Apple-MMe-Host")
-    runCatching { c.disconnect() }
-    return when {
-      code == 200 -> firstGuess
-      code == 330 && !redirect.isNullOrBlank() -> redirect
-      else -> null
+    return try {
+      when {
+        code == 200 -> {
+          val body = c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
+          firstGuess to body
+        }
+        code == 330 && !redirect.isNullOrBlank() -> redirect to null
+        else -> null
+      }
+    } catch (_: Throwable) {
+      null
+    } finally {
+      runCatching { c.disconnect() }
     }
   }
 

--- a/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
@@ -1,0 +1,264 @@
+package com.immortal.launcher
+
+import java.net.HttpURLConnection
+import java.net.URL
+import org.json.JSONObject
+
+/**
+ * Fetch direct image URLs from a public iCloud Shared Album or Google Photos shared
+ * album link — no account or API key, only links the owner marked "anyone with the
+ * link can view". On any failure [fetch] returns null and the caller falls back to
+ * the default web feed so the photo frame is never blank.
+ */
+object RemoteAlbum {
+
+  data class Album(val title: String?, val photoUrls: List<String>)
+
+  fun isSupported(url: String): Boolean {
+    val u = url.trim()
+    return isIcloud(u) || isGooglePhotos(u)
+  }
+
+  fun providerName(url: String): String =
+      when {
+        isIcloud(url) -> "iCloud Shared Album"
+        isGooglePhotos(url) -> "Google Photos"
+        else -> "Shared album"
+      }
+
+  fun isIcloud(url: String): Boolean =
+      url.contains("icloud.com/sharedalbum/", ignoreCase = true) ||
+          url.contains("icloud.com/photo-stream/", ignoreCase = true) ||
+          url.contains("icloud.com/photostream/", ignoreCase = true)
+
+  fun isGooglePhotos(url: String): Boolean =
+      url.contains("photos.app.goo.gl", ignoreCase = true) ||
+          url.contains("photos.google.com/share/", ignoreCase = true)
+
+  fun fetch(shareUrl: String, screenW: Int = 1920, screenH: Int = 1080): Album? {
+    val url = shareUrl.trim()
+    return runCatching {
+          when {
+            isIcloud(url) -> fetchIcloud(url, screenW, screenH)
+            isGooglePhotos(url) -> fetchGoogle(url, screenW, screenH)
+            else -> null
+          }
+        }
+        .getOrNull()
+  }
+
+  internal fun icloudToken(url: String): String? {
+    val frag = url.substringAfter('#', "").substringBefore('?').trim()
+    if (frag.isEmpty()) return null
+    return frag.trim('/')
+  }
+
+  /**
+   * Apple partitions shared streams across hosts `p01…p145`; the first character of
+   * the token hints which partition. A wrong guess returns HTTP 330 with the correct
+   * host in `X-Apple-MMe-Host`, which [resolveIcloudHost] follows.
+   */
+  internal fun icloudPartition(token: String): String {
+    val c = token.firstOrNull() ?: return "01"
+    val n = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".indexOf(c)
+    val part = if (n < 0) 1 else n + 1
+    return part.toString().padStart(2, '0')
+  }
+
+  private fun fetchIcloud(url: String, screenW: Int, screenH: Int): Album? {
+    val token = icloudToken(url) ?: return null
+    val host = resolveIcloudHost(token) ?: return null
+    val base = "https://$host/$token/sharedstreams"
+
+    val streamJson = postJson("$base/webstream", "{\"streamCtag\":null}") ?: return null
+    val stream = JSONObject(streamJson)
+    val title = stream.optString("streamName", "").ifBlank { null }
+    val photos = stream.optJSONArray("photos") ?: return null
+    if (photos.length() == 0) return Album(title, emptyList())
+
+    val guids = ArrayList<String>(photos.length())
+    val checksumByGuid = HashMap<String, String>(photos.length())
+    for (i in 0 until photos.length()) {
+      val p = photos.optJSONObject(i) ?: continue
+      val guid = p.optString("photoGuid", "")
+      if (guid.isEmpty()) continue
+      val derivs = p.optJSONObject("derivatives") ?: continue
+      val best = pickBestDerivative(derivs, screenW, screenH) ?: continue
+      guids.add(guid)
+      checksumByGuid[guid] = best
+    }
+    if (guids.isEmpty()) return Album(title, emptyList())
+
+    // webasseturls caps each response at ~25 items, so page through.
+    val urlByChecksum = HashMap<String, String>(guids.size)
+    guids.chunked(25).forEach { batch ->
+      val body =
+          buildString {
+            append("{\"photoGuids\":[")
+            batch.forEachIndexed { idx, g ->
+              if (idx > 0) append(',')
+              append('"').append(g).append('"')
+            }
+            append("]}")
+          }
+      val resp = postJson("$base/webasseturls", body) ?: return@forEach
+      val items = JSONObject(resp).optJSONObject("items") ?: return@forEach
+      val keys = items.keys()
+      while (keys.hasNext()) {
+        val checksum = keys.next()
+        val o = items.optJSONObject(checksum) ?: continue
+        val loc = o.optString("url_location", "")
+        val path = o.optString("url_path", "")
+        if (loc.isNotEmpty() && path.isNotEmpty()) {
+          urlByChecksum[checksum] = "https://$loc$path"
+        }
+      }
+    }
+
+    val out = ArrayList<String>(guids.size)
+    guids.forEach { guid ->
+      val checksum = checksumByGuid[guid] ?: return@forEach
+      val u = urlByChecksum[checksum] ?: return@forEach
+      out.add(u)
+    }
+    return Album(title, out)
+  }
+
+  private fun resolveIcloudHost(token: String): String? {
+    val firstGuess = "p${icloudPartition(token)}-sharedstreams.icloud.com"
+    val c =
+        URL("https://$firstGuess/$token/sharedstreams/webstream").openConnection()
+            as HttpURLConnection
+    c.connectTimeout = 8000
+    c.readTimeout = 8000
+    c.requestMethod = "POST"
+    c.doOutput = true
+    c.setRequestProperty("Content-Type", "application/json")
+    c.setRequestProperty("User-Agent", USER_AGENT)
+    c.setRequestProperty("Origin", "https://www.icloud.com")
+    c.outputStream.use { it.write("{\"streamCtag\":null}".toByteArray()) }
+    val code = runCatching { c.responseCode }.getOrDefault(0)
+    val redirect = c.getHeaderField("X-Apple-MMe-Host")
+    runCatching { c.disconnect() }
+    return when {
+      code == 200 -> firstGuess
+      code == 330 && !redirect.isNullOrBlank() -> redirect
+      else -> null
+    }
+  }
+
+  /**
+   * iCloud derivatives are keyed by max-edge pixel size; pick the smallest that
+   * still covers the screen, else the largest available.
+   */
+  internal fun pickBestDerivative(derivs: JSONObject, screenW: Int, screenH: Int): String? {
+    val target = maxOf(screenW, screenH)
+    val keys = derivs.keys()
+    var bestChecksum: String? = null
+    var bestSize = -1
+    var fallbackChecksum: String? = null
+    var fallbackSize = -1
+    while (keys.hasNext()) {
+      val k = keys.next()
+      val size = k.toIntOrNull() ?: continue
+      val d = derivs.optJSONObject(k) ?: continue
+      val checksum = d.optString("checksum", "")
+      if (checksum.isEmpty()) continue
+      if (size >= target && (bestSize < 0 || size < bestSize)) {
+        bestSize = size
+        bestChecksum = checksum
+      }
+      if (size > fallbackSize) {
+        fallbackSize = size
+        fallbackChecksum = checksum
+      }
+    }
+    return bestChecksum ?: fallbackChecksum
+  }
+
+  private val LH3_REGEX =
+      Regex("""https://lh3\.googleusercontent\.com/[A-Za-z0-9_\-/]+(?:=[A-Za-z0-9\-_]+)?""")
+
+  private fun fetchGoogle(url: String, screenW: Int, screenH: Int): Album? {
+    val finalUrl = followRedirects(url) ?: url
+    val html = httpGet(finalUrl) ?: return null
+
+    val raw = LH3_REGEX.findAll(html).map { it.value }.toList()
+    if (raw.isEmpty()) return Album(null, emptyList())
+
+    // Strip the size suffix so we can ask Google for a screen-sized variant, and
+    // skip avatar-service URLs (`/a/` and `/a-/`) — those embed on every share page
+    // as the owner's profile picture and would otherwise lead the slideshow.
+    val sizeSuffix = "=w${screenW}-h${screenH}-no"
+    val seen = LinkedHashSet<String>()
+    raw.forEach { u ->
+      if (isGoogleAvatarUrl(u)) return@forEach
+      val stripped = u.substringBefore('=')
+      seen.add(stripped + sizeSuffix)
+    }
+    return Album(extractGoogleTitle(html), seen.toList())
+  }
+
+  internal fun isGoogleAvatarUrl(url: String): Boolean {
+    val path = url.removePrefix("https://lh3.googleusercontent.com")
+    return path.startsWith("/a/") || path.startsWith("/a-/")
+  }
+
+  private fun extractGoogleTitle(html: String): String? {
+    val m = Regex("""<title>([^<]+)</title>""", RegexOption.IGNORE_CASE).find(html) ?: return null
+    return m.groupValues[1].substringBefore(" - Google Photos").trim().ifBlank { null }
+  }
+
+  private const val USER_AGENT =
+      "Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 (KHTML, like Gecko) " +
+          "Chrome/120.0.0.0 Safari/537.36 PortalPhotoFrame/1.0"
+
+  private fun followRedirects(spec: String, maxHops: Int = 5): String? {
+    var current = spec
+    repeat(maxHops) {
+      val c = URL(current).openConnection() as HttpURLConnection
+      c.connectTimeout = 8000
+      c.readTimeout = 8000
+      c.instanceFollowRedirects = false
+      c.requestMethod = "GET"
+      c.setRequestProperty("User-Agent", USER_AGENT)
+      val code = runCatching { c.responseCode }.getOrDefault(0)
+      if (code in 300..399) {
+        val loc = c.getHeaderField("Location")
+        runCatching { c.disconnect() }
+        if (loc.isNullOrBlank()) return current
+        current = if (loc.startsWith("http")) loc else URL(URL(current), loc).toString()
+      } else {
+        runCatching { c.disconnect() }
+        return current
+      }
+    }
+    return current
+  }
+
+  private fun httpGet(spec: String): String? {
+    val c = URL(spec).openConnection() as HttpURLConnection
+    c.connectTimeout = 8000
+    c.readTimeout = 10000
+    c.instanceFollowRedirects = true
+    c.setRequestProperty("User-Agent", USER_AGENT)
+    c.setRequestProperty("Accept-Language", "en-US,en;q=0.9")
+    return runCatching { c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) } }.getOrNull()
+  }
+
+  private fun postJson(spec: String, body: String): String? {
+    val c = URL(spec).openConnection() as HttpURLConnection
+    c.connectTimeout = 8000
+    c.readTimeout = 10000
+    c.requestMethod = "POST"
+    c.doOutput = true
+    c.setRequestProperty("Content-Type", "application/json")
+    c.setRequestProperty("User-Agent", USER_AGENT)
+    c.setRequestProperty("Origin", "https://www.icloud.com")
+    return runCatching {
+          c.outputStream.use { it.write(body.toByteArray()) }
+          c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
+        }
+        .getOrNull()
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -70,8 +70,8 @@ object ScreensaverConfig {
   /** Keep the slideshow interval sane (5s … 10min). */
   fun clampInterval(sec: Int): Int = sec.coerceIn(5, 600)
 
-  /** Keep the album refresh sane (5 min … 24h). */
-  fun clampAlbumRefresh(min: Int): Int = min.coerceIn(5, 24 * 60)
+  /** Keep the album refresh sane (15 min … 24h). Floor matches the settings stepper. */
+  fun clampAlbumRefresh(min: Int): Int = min.coerceIn(15, 24 * 60)
 
   private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -15,8 +15,9 @@ import android.content.Context
  * The default source is Immortal's built-in photo feed; the user can instead point
  * the screensaver at a local folder of photos/videos — including one on a USB-C or
  * SD card plugged into the Portal (any folder reachable through the system file
- * picker). If the chosen folder can't be read (e.g. the drive is unplugged) the
- * screensaver falls back to the default feed, so it's never blank.
+ * picker) — or paste a public share link from iCloud or Google Photos. If the
+ * chosen source can't be read (e.g. the drive is unplugged, the album was unshared)
+ * the screensaver falls back to the default feed, so it's never blank.
  */
 object ScreensaverConfig {
 
@@ -24,9 +25,11 @@ object ScreensaverConfig {
 
   const val SOURCE_DEFAULT = "default"
   const val SOURCE_FOLDER = "folder"
+  const val SOURCE_URL = "url"
   const val FIT_FILL = "fill" // crop to fill the screen
   const val FIT_FIT = "fit" // letterbox to show the whole image
   const val DEFAULT_INTERVAL = 30
+  const val DEFAULT_ALBUM_REFRESH_MIN = 60
 
   data class Settings(
       // Master on/off for Immortal's photo-frame screensaver. When off, Immortal
@@ -35,8 +38,10 @@ object ScreensaverConfig {
       val enabled: Boolean = true,
       val source: String = SOURCE_DEFAULT,
       val folderPath: String? = null,
+      val albumUrl: String? = null,
       val fit: String = FIT_FILL,
       val intervalSec: Int = DEFAULT_INTERVAL,
+      val albumRefreshMin: Int = DEFAULT_ALBUM_REFRESH_MIN,
       val shuffle: Boolean = false,
       val includeVideo: Boolean = true,
       // Battery models (Portal Go) only: pause the screensaver while unplugged so
@@ -57,10 +62,16 @@ object ScreensaverConfig {
     /** True when the user has chosen a local folder for us to read. */
     val usesFolder: Boolean
       get() = source == SOURCE_FOLDER && !folderPath.isNullOrBlank()
+    /** True when the user has pasted a public album share link for us to fetch. */
+    val usesUrl: Boolean
+      get() = source == SOURCE_URL && !albumUrl.isNullOrBlank()
   }
 
   /** Keep the slideshow interval sane (5s … 10min). */
   fun clampInterval(sec: Int): Int = sec.coerceIn(5, 600)
+
+  /** Keep the album refresh sane (5 min … 24h). */
+  fun clampAlbumRefresh(min: Int): Int = min.coerceIn(5, 24 * 60)
 
   private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
@@ -70,8 +81,11 @@ object ScreensaverConfig {
         enabled = p.getBoolean("enabled", true),
         source = p.getString("source", SOURCE_DEFAULT) ?: SOURCE_DEFAULT,
         folderPath = p.getString("folder_path", null),
+        albumUrl = p.getString("album_url", null),
         fit = p.getString("fit", FIT_FILL) ?: FIT_FILL,
         intervalSec = clampInterval(p.getInt("interval_sec", DEFAULT_INTERVAL)),
+        albumRefreshMin =
+            clampAlbumRefresh(p.getInt("album_refresh_min", DEFAULT_ALBUM_REFRESH_MIN)),
         shuffle = p.getBoolean("shuffle", false),
         includeVideo = p.getBoolean("include_video", true),
         batterySaver = p.getBoolean("battery_saver", true),
@@ -91,12 +105,18 @@ object ScreensaverConfig {
   fun setFolder(c: Context, path: String) =
       prefs(c).edit().putString("folder_path", path).putString("source", SOURCE_FOLDER).apply()
 
+  fun setAlbumUrl(c: Context, url: String) =
+      prefs(c).edit().putString("album_url", url.trim()).putString("source", SOURCE_URL).apply()
+
   fun useDefault(c: Context) = prefs(c).edit().putString("source", SOURCE_DEFAULT).apply()
 
   fun setFit(c: Context, fit: String) = prefs(c).edit().putString("fit", fit).apply()
 
   fun setInterval(c: Context, sec: Int) =
       prefs(c).edit().putInt("interval_sec", clampInterval(sec)).apply()
+
+  fun setAlbumRefreshMin(c: Context, min: Int) =
+      prefs(c).edit().putInt("album_refresh_min", clampAlbumRefresh(min)).apply()
 
   fun setShuffle(c: Context, on: Boolean) = prefs(c).edit().putBoolean("shuffle", on).apply()
 

--- a/app/src/main/java/com/immortal/launcher/ScreensaverSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverSettingsActivity.kt
@@ -170,7 +170,7 @@ private fun ScreensaverSettingsScreen() {
         SelectableRow(
             title = "Immortal photos",
             subtitle = "A calming built-in photo feed (no setup).",
-            selected = !settings.usesFolder,
+            selected = !settings.usesFolder && !settings.usesUrl,
             onClick = {
               ScreensaverConfig.useDefault(context)
               settings = ScreensaverConfig.load(context)
@@ -187,12 +187,34 @@ private fun ScreensaverSettingsScreen() {
           Divider()
           TextButtonRow("Choose a different folder…") { openPicker() }
         }
+        Divider()
+        SelectableRow(
+            title = "Shared album link",
+            subtitle = albumUrlSubtitle(settings.usesUrl, settings.albumUrl),
+            selected = settings.usesUrl,
+            onClick = {
+              context.startActivity(Intent(context, AlbumUrlEntryActivity::class.java))
+            },
+        )
+        if (settings.usesUrl) {
+          Divider()
+          AlbumRefreshStepper(settings.albumRefreshMin) { v ->
+            val c = ScreensaverConfig.clampAlbumRefresh(v)
+            ScreensaverConfig.setAlbumRefreshMin(context, c)
+            settings = settings.copy(albumRefreshMin = c)
+          }
+          Divider()
+          TextButtonRow("Paste a different link…") {
+            context.startActivity(Intent(context, AlbumUrlEntryActivity::class.java))
+          }
+        }
       }
       Text(
           "Tip: put your photos and videos in a folder on your Portal and pick it here — for " +
               "example, copy them across while it's connected to your computer. (An SD card or " +
-              "USB-C drive can work too on models that support one.) If a folder can't be read, " +
-              "Immortal shows its built-in photos instead.",
+              "USB-C drive can work too on models that support one.) Or paste a public iCloud / " +
+              "Google Photos share link to pull from there. If a source can't be read, Immortal " +
+              "shows its built-in photos instead.",
           color = Color(0xFF7C7C7C),
           fontSize = 13.sp,
           modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
@@ -347,6 +369,18 @@ private fun folderSubtitle(usesFolder: Boolean, name: String?, count: Int?): Str
       count == 0 -> "${name ?: "Selected folder"} — no photos or videos found"
       else -> "${name ?: "Selected folder"} — $count item${if (count == 1) "" else "s"}"
     }
+
+private fun albumUrlSubtitle(usesUrl: Boolean, url: String?): String =
+    when {
+      !usesUrl -> "Paste a public iCloud or Google Photos share link."
+      url.isNullOrBlank() -> "No link yet — tap to paste one."
+      else -> "${RemoteAlbum.providerName(url)} — ${shortUrl(url)}"
+    }
+
+private fun shortUrl(url: String): String {
+  val trimmed = url.trim()
+  return if (trimmed.length <= 56) trimmed else trimmed.take(53) + "…"
+}
 
 @Composable
 private fun SectionLabel(text: String) {
@@ -514,6 +548,63 @@ private fun MinuteStepper(minutes: Int, onChange: (Int) -> Unit) {
     ArrowButton("▶", focused) { onChange(minutes + 5) }
   }
 }
+
+// Non-uniform steps so every LEFT/RIGHT tap lands on a value users actually think in
+// (15m, 30m, 45m, 1h, 2h, ...), instead of a flat N-minute jump.
+@Composable
+private fun AlbumRefreshStepper(minutes: Int, onChange: (Int) -> Unit) {
+  val src = remember { MutableInteractionSource() }
+  val focused by src.collectIsFocusedAsState()
+  Row(
+      modifier =
+          Modifier.fillMaxWidth()
+              .onKeyEvent { e ->
+                if (e.type == KeyEventType.KeyDown) {
+                  when (e.key) {
+                    Key.DirectionLeft -> { onChange(prevAlbumRefreshStep(minutes)); true }
+                    Key.DirectionRight -> { onChange(nextAlbumRefreshStep(minutes)); true }
+                    else -> false
+                  }
+                } else false
+              }
+              .focusable(interactionSource = src)
+              .background(if (focused) Color(0x402E6BE6) else Color.Transparent)
+              .padding(start = 18.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(
+        "Refresh album",
+        color = Color.White,
+        fontSize = 17.sp,
+        modifier = Modifier.weight(1f),
+    )
+    ArrowButton("◀", focused) { onChange(prevAlbumRefreshStep(minutes)) }
+    Text(
+        formatRefreshMinutes(minutes),
+        color = if (focused) Color.White else Color(0xFFDDDDDD),
+        fontSize = 17.sp,
+        fontWeight = FontWeight.SemiBold,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.widthIn(min = 64.dp),
+    )
+    ArrowButton("▶", focused) { onChange(nextAlbumRefreshStep(minutes)) }
+  }
+}
+
+private val ALBUM_REFRESH_STEPS = listOf(15, 30, 45, 60, 120, 180, 240, 360, 720, 1440)
+
+private fun nextAlbumRefreshStep(minutes: Int): Int =
+    ALBUM_REFRESH_STEPS.firstOrNull { it > minutes } ?: ALBUM_REFRESH_STEPS.last()
+
+private fun prevAlbumRefreshStep(minutes: Int): Int =
+    ALBUM_REFRESH_STEPS.lastOrNull { it < minutes } ?: ALBUM_REFRESH_STEPS.first()
+
+private fun formatRefreshMinutes(minutes: Int): String =
+    when {
+      minutes < 60 -> "${minutes}m"
+      minutes % 60 == 0 -> "${minutes / 60}h"
+      else -> "${minutes / 60}h ${minutes % 60}m"
+    }
 
 /** Remote-friendly time-of-day stepper for the overnight window (15-min steps). */
 @Composable

--- a/app/src/test/java/com/immortal/launcher/RemoteAlbumTest.kt
+++ b/app/src/test/java/com/immortal/launcher/RemoteAlbumTest.kt
@@ -1,0 +1,101 @@
+package com.immortal.launcher
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RemoteAlbumTest {
+
+  @Test
+  fun isSupported_recognisesPublicShareLinks() {
+    assertTrue(RemoteAlbum.isSupported("https://www.icloud.com/sharedalbum/#B1abcDEF"))
+    assertTrue(RemoteAlbum.isSupported("https://photos.app.goo.gl/abcd1234"))
+    assertTrue(RemoteAlbum.isSupported("https://photos.google.com/share/AF1Qa1b2c3d"))
+    assertFalse(RemoteAlbum.isSupported("https://example.com/album/123"))
+    assertFalse(RemoteAlbum.isSupported(""))
+  }
+
+  @Test
+  fun providerName_distinguishesProviders() {
+    assertEquals(
+        "iCloud Shared Album",
+        RemoteAlbum.providerName("https://www.icloud.com/sharedalbum/#B1abcDEF"))
+    assertEquals("Google Photos", RemoteAlbum.providerName("https://photos.app.goo.gl/x"))
+    assertEquals("Shared album", RemoteAlbum.providerName("https://example.com"))
+  }
+
+  @Test
+  fun icloudToken_pullsFromFragment() {
+    assertEquals(
+        "B1abcDEF",
+        RemoteAlbum.icloudToken("https://www.icloud.com/sharedalbum/#B1abcDEF"))
+    assertEquals(
+        "B1abcDEF",
+        RemoteAlbum.icloudToken("https://www.icloud.com/sharedalbum/#B1abcDEF?foo=bar"))
+    assertNull(RemoteAlbum.icloudToken("https://www.icloud.com/sharedalbum/"))
+  }
+
+  @Test
+  fun icloudPartition_mapsLeadingCharToPNN() {
+    // Digits 0..9 → 01..10
+    assertEquals("01", RemoteAlbum.icloudPartition("0xyz"))
+    assertEquals("10", RemoteAlbum.icloudPartition("9xyz"))
+    // 'A' onward → 11+
+    assertEquals("11", RemoteAlbum.icloudPartition("Axyz"))
+    assertEquals("12", RemoteAlbum.icloudPartition("Bxyz"))
+  }
+
+  @Test
+  fun pickBestDerivative_prefersSmallestThatCoversScreen() {
+    val derivs =
+        JSONObject(
+            """
+            {
+              "405": {"checksum": "smol"},
+              "1136": {"checksum": "mid"},
+              "2048": {"checksum": "big"}
+            }
+            """.trimIndent())
+    // 1920x1080 screen, long-edge target = 1920. Smallest derivative ≥ 1920 is 2048.
+    assertEquals("big", RemoteAlbum.pickBestDerivative(derivs, 1920, 1080))
+    // 1080x800 screen, long-edge target = 1080. Smallest derivative ≥ 1080 is 1136.
+    assertEquals("mid", RemoteAlbum.pickBestDerivative(derivs, 1080, 800))
+    // 4K target → none cover; fall back to largest.
+    assertEquals("big", RemoteAlbum.pickBestDerivative(derivs, 3840, 2160))
+  }
+
+  @Test
+  fun isGoogleAvatarUrl_dropsOwnerAvatars() {
+    // Google avatar service — owner profile pictures on share pages.
+    assertTrue(
+        RemoteAlbum.isGoogleAvatarUrl(
+            "https://lh3.googleusercontent.com/a/ACg8ocAbCdEfGhIjK=s64-c-mo"))
+    assertTrue(
+        RemoteAlbum.isGoogleAvatarUrl(
+            "https://lh3.googleusercontent.com/a-/AOh14GgHasItem=s40"))
+    // Photo URLs — keep these.
+    assertFalse(
+        RemoteAlbum.isGoogleAvatarUrl(
+            "https://lh3.googleusercontent.com/pw/ADCreHe-abc123=w1920-h1080-no"))
+    assertFalse(
+        RemoteAlbum.isGoogleAvatarUrl(
+            "https://lh3.googleusercontent.com/abc123/photo=w1024-h768-no"))
+  }
+
+  @Test
+  fun pickBestDerivative_skipsEntriesMissingChecksum() {
+    val derivs =
+        JSONObject(
+            """
+            {
+              "405": {"checksum": "smol"},
+              "1136": {},
+              "2048": {"checksum": "big"}
+            }
+            """.trimIndent())
+    assertEquals("big", RemoteAlbum.pickBestDerivative(derivs, 1920, 1080))
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/ScreensaverConfigTest.kt
+++ b/app/src/test/java/com/immortal/launcher/ScreensaverConfigTest.kt
@@ -71,8 +71,8 @@ class ScreensaverConfigTest {
 
   @Test
   fun clampAlbumRefresh_keepsWithinBounds() {
-    assertEquals(5, ScreensaverConfig.clampAlbumRefresh(1))
-    assertEquals(5, ScreensaverConfig.clampAlbumRefresh(-10))
+    assertEquals(15, ScreensaverConfig.clampAlbumRefresh(1))
+    assertEquals(15, ScreensaverConfig.clampAlbumRefresh(-10))
     assertEquals(60, ScreensaverConfig.clampAlbumRefresh(60))
     assertEquals(24 * 60, ScreensaverConfig.clampAlbumRefresh(99999))
   }

--- a/app/src/test/java/com/immortal/launcher/ScreensaverConfigTest.kt
+++ b/app/src/test/java/com/immortal/launcher/ScreensaverConfigTest.kt
@@ -46,7 +46,34 @@ class ScreensaverConfigTest {
     assertEquals(ScreensaverConfig.SOURCE_DEFAULT, s.source)
     assertEquals(ScreensaverConfig.FIT_FILL, s.fit)
     assertEquals(30, s.intervalSec)
+    assertEquals(60, s.albumRefreshMin)
     assertFalse(s.shuffle)
     assertTrue(s.includeVideo)
+  }
+
+  @Test
+  fun usesUrl_requiresUrlSourceAndLink() {
+    assertTrue(
+        ScreensaverConfig.Settings(
+                source = ScreensaverConfig.SOURCE_URL,
+                albumUrl = "https://www.icloud.com/sharedalbum/#B1abcDEF")
+            .usesUrl)
+    assertFalse(
+        ScreensaverConfig.Settings(source = ScreensaverConfig.SOURCE_URL, albumUrl = null).usesUrl)
+    assertFalse(
+        ScreensaverConfig.Settings(source = ScreensaverConfig.SOURCE_URL, albumUrl = "").usesUrl)
+    assertFalse(
+        ScreensaverConfig.Settings(
+                source = ScreensaverConfig.SOURCE_DEFAULT,
+                albumUrl = "https://www.icloud.com/sharedalbum/#B1abcDEF")
+            .usesUrl)
+  }
+
+  @Test
+  fun clampAlbumRefresh_keepsWithinBounds() {
+    assertEquals(5, ScreensaverConfig.clampAlbumRefresh(1))
+    assertEquals(5, ScreensaverConfig.clampAlbumRefresh(-10))
+    assertEquals(60, ScreensaverConfig.clampAlbumRefresh(60))
+    assertEquals(24 * 60, ScreensaverConfig.clampAlbumRefresh(99999))
   }
 }


### PR DESCRIPTION
## Summary
- New URL source for the photo-frame screensaver — paste a public iCloud Shared Album or Google Photos share link, no account or API key.
- User-configurable refresh interval (default 1h, settable 15m...24h) so newly-added photos appear without restarting the screensaver.
- Silently falls back to the built-in feed if the album is unshared, unreachable, or returns an empty list — the frame is never blank.

## What's new
- `RemoteAlbum.kt` — fetches direct image URLs for both providers. iCloud uses the keyless `sharedstreams.icloud.com` JSON API (`webstream` + paged `webasseturls`, follows the HTTP 330 partition redirect, picks the smallest derivative ≥ screen size). Google Photos scrapes `lh3.googleusercontent.com` URLs out of the public share page and rewrites them to a screen-sized `=w<W>-h<H>` variant; avatar-service paths (`/a/`, `/a-/`) are filtered so the owner's profile picture never leads the slideshow.
- `AlbumUrlEntryActivity.kt` — one-field paste form with live provider detection.
- `PhotoFrameController.kt` — new remote-album playback mode parallel to local-folder mode; periodic refetch preserves the current playlist index when fresh URLs arrive.
- `ScreensaverSettingsActivity.kt` — third "Shared album link" row in the Source card, plus a remote-friendly stepper for the refresh interval (visible only when the URL source is active).
- `ScreensaverConfig.kt` — `SOURCE_URL`, `albumUrl`, `albumRefreshMin`, with `clampAlbumRefresh` bounds (5 min … 24 h).

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — `RemoteAlbumTest` covers token parsing, partition mapping, derivative selection, avatar URL detection; `ScreensaverConfigTest` covers the new `usesUrl` invariant and clamp bounds.
- [x] Verified on a Portal: paste an iCloud Shared Album link → photos appear, refresh tick honoured.
- [x] Verified on a Portal: paste a Google Photos share link → photos appear; first image is a real photo, not the owner avatar.
- [x] Verified fallback: pasting a dead link still leaves the screensaver running (drops to the default feed).

## Risks
- Both providers are screen-scraped against unofficial endpoints. If Apple or Google change response shape, the fetch returns null and the screensaver falls back silently — no crash, no user-visible error other than the album not appearing.
- Network calls are best-effort and run on an existing IO executor; no new threads/handlers.