### PR TITLE
Home Assistant integration: screensaver hand-off, MQTT publisher, screen controls, device health

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
     applicationId = "com.immortal.launcher"
     minSdk = 24
     targetSdk = 36
-    versionCode = 41
-    versionName = "1.40"
+    versionCode = 42
+    versionName = "1.41"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
     <!-- Fleet Agent: a foreground service so WiFi device management survives a
          reboot on these non-root Portals (where adb-over-WiFi can't). -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- Wake the screen on demand (Home Assistant "wake the panel" via the MQTT screen
+         switch). A normal permission; ScreenControl.wake uses a wake lock. -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!-- Multi-room now-playing: a media-session foreground service (see
          MultiRoomService). Harmless/unused on the Portal's Android 9/10, where the
          per-type FGS rules don't apply. -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -247,6 +247,12 @@
             android:name=".FleetAgentService"
             android:exported="false" />
 
+        <!-- MQTT publisher: exposes this Portal to Home Assistant via MQTT Discovery.
+             Off until the user configures a broker in Immortal settings. -->
+        <service
+            android:name=".MqttService"
+            android:exported="false" />
+
         <!-- Multi-room now-playing relay: reads the Snapcast group's track off the
              snapserver and publishes it as a media session so the now-playing card shows
              on every Portal. Foreground so it survives backgrounding; started by

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,9 +51,9 @@
          different keys, so a signature permission defined by Millennium couldn't be held by us.
          Defining it on the sender means only Immortal-signed apps hold it -> only we can trigger. -->
     <permission
-        android:name="com.immortal.launcher.permission.HEY_TRIGGER"
+        android:name="${applicationId}.permission.HEY_TRIGGER"
         android:protectionLevel="signature" />
-    <uses-permission android:name="com.immortal.launcher.permission.HEY_TRIGGER" />
+    <uses-permission android:name="${applicationId}.permission.HEY_TRIGGER" />
 
     <application
         android:name=".ImmortalApp"
@@ -161,6 +161,14 @@
             android:name=".FolderPickerActivity"
             android:exported="false"
             android:label="Choose a folder"
+            android:theme="@style/Theme.SampleApp" />
+
+        <!-- App picker for "open this app when the screensaver is dismissed",
+             reachable from the "When dismissed" row in screensaver settings. -->
+        <activity
+            android:name=".ScreensaverDismissAppActivity"
+            android:exported="false"
+            android:label="Open when dismissed"
             android:theme="@style/Theme.SampleApp" />
 
         <!-- One-field form for pasting a public iCloud / Google Photos shared-album

--- a/app/src/main/java/com/immortal/launcher/BootReceiver.kt
+++ b/app/src/main/java/com/immortal/launcher/BootReceiver.kt
@@ -24,6 +24,8 @@ class BootReceiver : BroadcastReceiver() {
       // Re-open the WiFi fleet channel after the reboot (the whole point of an
       // in-app agent: it comes back without USB, unlike adb-over-WiFi here).
       FleetAgentService.ensureRunning(context)
+      // Reconnect the Home Assistant MQTT publisher (no-op unless configured).
+      MqttService.sync(context)
       // (Re)launch apps that can't restart themselves (e.g. the MA/Sendspin player,
       // which has no boot receiver). Wait a few seconds first so WiFi is up for their
       // first connect, then hand the screen back to our home so the Portal doesn't sit

--- a/app/src/main/java/com/immortal/launcher/DevicePermissions.kt
+++ b/app/src/main/java/com/immortal/launcher/DevicePermissions.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.os.Build
+import android.provider.Settings
+
+/**
+ * Live status of the special permissions Immortal relies on — all granted by the
+ * provisioning kit (`provision.sh` / `provision.ps1`) over adb, none of them toggleable
+ * from the Portal's own UI on Android 9/10. Surfaced as a "Device health" view so a
+ * struggling user (or we, debugging) can see at a glance which capability is missing and
+ * what it costs them.
+ *
+ * Each [Check] always reports what it enables; the [degraded] cost and [fix] are only
+ * meant to be shown when it's NOT [granted].
+ */
+object DevicePermissions {
+
+  data class Check(
+      val title: String,
+      val enables: String,
+      val granted: Boolean,
+      val degraded: String,
+      val fix: String,
+  )
+
+  fun all(context: Context): List<Check> =
+      listOf(
+          Check(
+              title = "Screen off",
+              enables = "Turning the screen off — idle timeout, overnight sleep, and the Home Assistant control.",
+              granted = ScreenControl.isAdminActive(context),
+              degraded = "The screen can't be turned off automatically or from Home Assistant; it stays on.",
+              fix = "Re-run Immortal setup — it activates the screen-off device admin (dpm set-active-admin).",
+          ),
+          Check(
+              title = "Now playing",
+              enables = "Showing the current track and album art on the screensaver and home header.",
+              granted = SettingsGuard.isMediaListenerEnabled(context),
+              degraded = "What's playing won't appear on the screensaver or the home header.",
+              fix = "Re-run Immortal setup — it grants notification access (cmd notification allow_listener).",
+          ),
+          Check(
+              title = "Install apps",
+              enables = "Installing and updating apps from the Immortal App Store.",
+              granted = canInstallApps(context),
+              degraded = "The App Store can't install or update apps.",
+              fix = "Re-run Immortal setup — it allows installs (appops REQUEST_INSTALL_PACKAGES).",
+          ),
+          Check(
+              title = "Frame relaunch",
+              enables = "Bringing the photo frame straight back when the system force-wakes the screensaver.",
+              granted = Settings.canDrawOverlays(context),
+              degraded = "The photo frame may not reappear promptly after the system force-wakes it.",
+              fix = "Re-run Immortal setup — it grants draw-over-other-apps (appops SYSTEM_ALERT_WINDOW).",
+          ),
+          Check(
+              title = "System settings",
+              enables = "Keeping the screensaver, status bar, and WiFi-debug settings applied (and self-healing them).",
+              granted = SettingsGuard.canWriteSecureSettings(context),
+              degraded = "Immortal can't keep the screensaver/status-bar settings applied or repair them after changes.",
+              fix = "Re-run Immortal setup — it grants write-secure-settings (pm grant WRITE_SECURE_SETTINGS).",
+          ),
+      )
+
+  /** Count of capabilities that aren't granted — 0 means a healthy device. */
+  fun issueCount(context: Context): Int = all(context).count { !it.granted }
+
+  private fun canInstallApps(context: Context): Boolean =
+      runCatching {
+            if (Build.VERSION.SDK_INT >= 26) context.packageManager.canRequestPackageInstalls()
+            else true
+          }
+          .getOrDefault(false)
+}

--- a/app/src/main/java/com/immortal/launcher/ImmortalApp.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalApp.kt
@@ -55,5 +55,9 @@ class ImmortalApp : Application() {
     // speaker (no-op until the user configures a server). Surfaces the group's track on
     // the now-playing card even when the Music Assistant app isn't running here.
     MultiRoomService.sync(this)
+
+    // Publish this Portal to Home Assistant over MQTT if the user configured a broker
+    // (no-op otherwise). Off by default.
+    MqttService.sync(this)
   }
 }

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -85,6 +85,7 @@ private fun ImmortalSettingsScreen() {
   val context = LocalContext.current
   var showBootApps by remember { mutableStateOf(false) }
   var showMultiRoom by remember { mutableStateOf(false) }
+  var showMqtt by remember { mutableStateOf(false) }
   var bootSelected by remember { mutableStateOf(BootLaunch.packages(context).toSet()) }
 
   if (showBootApps) {
@@ -102,16 +103,26 @@ private fun ImmortalSettingsScreen() {
     MultiRoomScreen(onBack = { showMultiRoom = false })
     return
   }
+  if (showMqtt) {
+    MqttScreen(onBack = { showMqtt = false })
+    return
+  }
 
   SettingsMain(
       bootCount = bootSelected.size,
       onOpenBootApps = { showBootApps = true },
       onOpenMultiRoom = { showMultiRoom = true },
+      onOpenMqtt = { showMqtt = true },
   )
 }
 
 @Composable
-private fun SettingsMain(bootCount: Int, onOpenBootApps: () -> Unit, onOpenMultiRoom: () -> Unit) {
+private fun SettingsMain(
+    bootCount: Int,
+    onOpenBootApps: () -> Unit,
+    onOpenMultiRoom: () -> Unit,
+    onOpenMqtt: () -> Unit,
+) {
   val context = LocalContext.current
   var settings by remember { mutableStateOf(ImmortalSettings.load(context)) }
 
@@ -319,6 +330,8 @@ private fun SettingsMain(bootCount: Int, onOpenBootApps: () -> Unit, onOpenMulti
       }
 
       MultiRoomNavRow(onOpen = onOpenMultiRoom)
+
+      MqttNavRow(onOpen = onOpenMqtt)
 
       Spacer(Modifier.size(26.dp))
       BootAppsNavRow(count = bootCount, onOpen = onOpenBootApps)
@@ -668,6 +681,254 @@ private fun MultiRoomScreen(onBack: () -> Unit) {
       Text(
           "Join this Portal to the same Snapcast group as your other rooms, then point it " +
               "at your Music Assistant server. The synced audio is played by the Snapcast app.",
+          color = Color(0xFF7C7C7C),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
+      )
+    }
+  }
+}
+
+/**
+ * Nav row into the Home Assistant (MQTT) subpage. Always shown — no companion app needed;
+ * the subtitle reflects whether publishing is on and the live connection status.
+ */
+@Composable
+private fun MqttNavRow(onOpen: () -> Unit) {
+  val context = LocalContext.current
+  Spacer(Modifier.size(26.dp))
+  SectionLabel("Home Assistant")
+  Card {
+    Row(
+        modifier = Modifier.fillMaxWidth().tvFocusableRow { onOpen() }.padding(18.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Column(modifier = Modifier.weight(1f)) {
+        Text("Home Assistant (MQTT)", color = Color.White, fontSize = 17.sp)
+        Text(
+            if (MqttConfig.isEnabled(context)) MqttStatus.text.ifBlank { "On" } else "Off",
+            color = Color(0xFF9A9A9A),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 2.dp),
+        )
+      }
+      Text("›", color = Color(0xFF7C7C7C), fontSize = 26.sp)
+    }
+  }
+}
+
+/**
+ * The Home Assistant (MQTT) subpage: publish this Portal to Home Assistant as auto-
+ * discovered entities (presence, screen, battery, now-playing, controls) over a local
+ * MQTT broker. Off by default; Back returns to the main settings page.
+ */
+@Composable
+private fun MqttScreen(onBack: () -> Unit) {
+  val context = LocalContext.current
+  var enabled by remember { mutableStateOf(MqttConfig.isEnabled(context)) }
+  var host by remember { mutableStateOf(MqttConfig.host(context)) }
+  var port by remember { mutableStateOf(MqttConfig.port(context).toString()) }
+  var user by remember { mutableStateOf(MqttConfig.username(context)) }
+  var pass by remember { mutableStateOf(MqttConfig.password(context)) }
+  // MqttStatus is a plain holder updated off the main thread, so poll it for live
+  // "Connecting… → Connected" feedback (Compose won't recompose on its writes).
+  var status by remember { mutableStateOf(MqttStatus.text) }
+  LaunchedEffect(Unit) {
+    while (true) {
+      status = MqttStatus.text
+      kotlinx.coroutines.delay(800)
+    }
+  }
+
+  val firstFocus = remember { FocusRequester() }
+  LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
+  val focusManager = LocalFocusManager.current
+  val portFocus = remember { FocusRequester() }
+  val userFocus = remember { FocusRequester() }
+  val passFocus = remember { FocusRequester() }
+
+  fun apply() {
+    MqttConfig.setHost(context, host)
+    MqttConfig.setPort(context, port.toIntOrNull() ?: MqttConfig.DEFAULT_PORT)
+    MqttConfig.setUsername(context, user)
+    MqttConfig.setPassword(context, pass)
+    MqttService.sync(context)
+  }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .onPreviewKeyEvent { e ->
+                if (e.key == Key.Back) {
+                  if (e.type == KeyEventType.KeyUp) onBack()
+                  true
+                } else false
+              }
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp).focusGroup()) {
+      Surface(
+          color = Color(0xFF1C1C1E),
+          shape = RoundedCornerShape(12.dp),
+          modifier =
+              Modifier.focusRequester(firstFocus).tvFocusable(RoundedCornerShape(12.dp)) { onBack() },
+      ) {
+        Text(
+            "‹  Back",
+            color = Color.White,
+            fontSize = 16.sp,
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 10.dp),
+        )
+      }
+      Spacer(Modifier.size(18.dp))
+
+      Text("Home Assistant", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+      Text(
+          "Publish this Portal to Home Assistant as auto-discovered entities — presence, " +
+              "screen, battery, now-playing, and controls — over your MQTT broker.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+      Spacer(Modifier.size(22.dp))
+      Card {
+        Column(modifier = Modifier.padding(18.dp)) {
+          Text("Setting it up", color = Color.White, fontSize = 17.sp)
+          MultiRoomStep(
+              "1",
+              "In Home Assistant, add the Mosquitto broker add-on (Settings → Add-ons) and the " +
+                  "MQTT integration. New to MQTT? See home-assistant.io/integrations/mqtt")
+          MultiRoomStep(
+              "2", "Turn on the toggle below and enter your broker's address (and login, if any).")
+          MultiRoomStep(
+              "3",
+              "This Portal appears automatically under Settings → Devices as a new MQTT device — " +
+                  "no YAML needed.")
+        }
+      }
+      Spacer(Modifier.size(26.dp))
+      Card {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(18.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+          Column(modifier = Modifier.weight(1f)) {
+            Text("Publish to Home Assistant", color = Color.White, fontSize = 17.sp)
+            Text(
+                "Exposes this Portal's state and controls as Home Assistant entities over MQTT.",
+                color = Color(0xFF9A9A9A),
+                fontSize = 13.sp,
+                modifier = Modifier.padding(top = 2.dp),
+            )
+          }
+          Segmented(
+              options = listOf("Off" to "off", "On" to "on"),
+              selected = if (enabled) "on" else "off",
+              onSelect = {
+                val on = it == "on"
+                enabled = on
+                MqttConfig.setEnabled(context, on)
+                if (on) apply() else MqttService.sync(context)
+              },
+          )
+        }
+        if (enabled) {
+          Divider()
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            OutlinedTextField(
+                value = host,
+                onValueChange = {
+                  host = it
+                  MqttConfig.setHost(context, it)
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                keyboardActions = KeyboardActions(onNext = { portFocus.requestFocus() }),
+                label = { Text("MQTT broker IP / host") },
+                modifier = Modifier.weight(1f),
+            )
+            Surface(
+                color = Color(0xFF2E6BE6),
+                shape = RoundedCornerShape(10.dp),
+                modifier =
+                    Modifier.padding(start = 12.dp).tvFocusable(RoundedCornerShape(10.dp)) { apply() },
+            ) {
+              Text(
+                  "Apply",
+                  color = Color.White,
+                  fontSize = 15.sp,
+                  modifier = Modifier.padding(horizontal = 20.dp, vertical = 14.dp),
+              )
+            }
+          }
+          OutlinedTextField(
+              value = port,
+              onValueChange = {
+                port = it.filter { ch -> ch.isDigit() }
+                MqttConfig.setPort(context, port.toIntOrNull() ?: MqttConfig.DEFAULT_PORT)
+              },
+              singleLine = true,
+              keyboardOptions =
+                  KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Next),
+              keyboardActions = KeyboardActions(onNext = { userFocus.requestFocus() }),
+              label = { Text("Port (default 1883)") },
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(start = 18.dp, end = 18.dp, top = 4.dp)
+                      .focusRequester(portFocus),
+          )
+          OutlinedTextField(
+              value = user,
+              onValueChange = {
+                user = it
+                MqttConfig.setUsername(context, it)
+              },
+              singleLine = true,
+              keyboardOptions =
+                  KeyboardOptions(
+                      capitalization = KeyboardCapitalization.None, imeAction = ImeAction.Next),
+              keyboardActions = KeyboardActions(onNext = { passFocus.requestFocus() }),
+              label = { Text("Username (optional)") },
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(start = 18.dp, end = 18.dp, top = 8.dp)
+                      .focusRequester(userFocus),
+          )
+          OutlinedTextField(
+              value = pass,
+              onValueChange = {
+                pass = it
+                MqttConfig.setPassword(context, it)
+              },
+              singleLine = true,
+              visualTransformation = PasswordVisualTransformation(),
+              keyboardOptions =
+                  KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Done),
+              keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus(); apply() }),
+              label = { Text("Password (optional)") },
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .padding(start = 18.dp, end = 18.dp, top = 8.dp)
+                      .focusRequester(passFocus),
+          )
+          // Live connection status — gives Apply visible feedback (Connecting… → Connected).
+          Text(
+              status.ifBlank { "Starting…" },
+              color = Color(0xFF8AB4F8),
+              fontSize = 13.sp,
+              modifier = Modifier.padding(start = 18.dp, end = 18.dp, top = 12.dp, bottom = 16.dp),
+          )
+        }
+      }
+      Text(
+          "Connects to a broker on your LAN (plain MQTT). Your Portal shows up in Home " +
+              "Assistant automatically as a device with presence, screen, battery, now-playing " +
+              "and a few controls — no configuration.yaml editing.",
           color = Color(0xFF7C7C7C),
           fontSize = 13.sp,
           modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -86,6 +86,7 @@ private fun ImmortalSettingsScreen() {
   var showBootApps by remember { mutableStateOf(false) }
   var showMultiRoom by remember { mutableStateOf(false) }
   var showMqtt by remember { mutableStateOf(false) }
+  var showHealth by remember { mutableStateOf(false) }
   var bootSelected by remember { mutableStateOf(BootLaunch.packages(context).toSet()) }
 
   if (showBootApps) {
@@ -107,12 +108,17 @@ private fun ImmortalSettingsScreen() {
     MqttScreen(onBack = { showMqtt = false })
     return
   }
+  if (showHealth) {
+    DeviceHealthScreen(onBack = { showHealth = false })
+    return
+  }
 
   SettingsMain(
       bootCount = bootSelected.size,
       onOpenBootApps = { showBootApps = true },
       onOpenMultiRoom = { showMultiRoom = true },
       onOpenMqtt = { showMqtt = true },
+      onOpenHealth = { showHealth = true },
   )
 }
 
@@ -122,6 +128,7 @@ private fun SettingsMain(
     onOpenBootApps: () -> Unit,
     onOpenMultiRoom: () -> Unit,
     onOpenMqtt: () -> Unit,
+    onOpenHealth: () -> Unit,
 ) {
   val context = LocalContext.current
   var settings by remember { mutableStateOf(ImmortalSettings.load(context)) }
@@ -336,7 +343,7 @@ private fun SettingsMain(
       Spacer(Modifier.size(26.dp))
       BootAppsNavRow(count = bootCount, onOpen = onOpenBootApps)
 
-      DeviceAdminRow()
+      DeviceHealthNavRow(onOpen = onOpenHealth)
 
       Text(
           "Changes apply as soon as you go back to the home screen.",
@@ -959,47 +966,195 @@ private fun loadLaunchableApps(context: Context): List<BootAppOption> {
 }
 
 /**
- * Shown only when Immortal's screen-off device admin is active. Deactivating it turns off
- * the idle / overnight screen-off features AND lets Immortal be uninstalled — the shell
- * can't force-remove a non-test admin, so this in-app action is the clean path.
+ * Row on the main settings page into the "Device health" subpage. Subtitle reflects how
+ * many provisioned permissions are missing, so a problem is visible without drilling in.
  */
 @Composable
-private fun DeviceAdminRow() {
+private fun DeviceHealthNavRow(onOpen: () -> Unit) {
   val context = LocalContext.current
-  var active by remember { mutableStateOf(ScreenControl.isAdminActive(context)) }
-  if (!active) return
-
+  val issues = remember { DevicePermissions.issueCount(context) }
   Spacer(Modifier.size(26.dp))
-  SectionLabel("Device admin")
+  SectionLabel("Device")
   Card {
     Row(
-        modifier = Modifier.fillMaxWidth().padding(18.dp),
+        modifier = Modifier.fillMaxWidth().tvFocusableRow { onOpen() }.padding(18.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
       Column(modifier = Modifier.weight(1f)) {
-        Text("Screen-off control", color = Color.White, fontSize = 17.sp)
+        Text("Device health", color = Color.White, fontSize = 17.sp)
         Text(
-            "Lets Immortal turn the screen off for idle and overnight sleep. Turning it off " +
-                "also allows Immortal to be uninstalled.",
-            color = Color(0xFF9A9A9A),
+            if (issues == 0) "All set up"
+            else "$issues setting${if (issues == 1) " needs" else "s need"} attention",
+            color = if (issues == 0) Color(0xFF9A9A9A) else Color(0xFFE0A030),
             fontSize = 13.sp,
             modifier = Modifier.padding(top = 2.dp),
         )
       }
+      Text("›", color = Color(0xFF7C7C7C), fontSize = 26.sp)
+    }
+  }
+}
+
+/**
+ * The "Device health" subpage: a live status of every special permission provisioning
+ * grants (screen-off device admin, notification access, install, overlay, secure settings),
+ * with — for anything that's missing — what's degraded and how to fix it. A diagnostic to
+ * point a struggling user at. Replaces the old destructive "turn off device admin" button;
+ * the uninstall path it served is kept as a clearly-warned advanced action at the bottom.
+ */
+@Composable
+private fun DeviceHealthScreen(onBack: () -> Unit) {
+  val context = LocalContext.current
+  val checks = remember { DevicePermissions.all(context) }
+  val issues = checks.count { !it.granted }
+  var adminActive by remember { mutableStateOf(ScreenControl.isAdminActive(context)) }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .onPreviewKeyEvent { e ->
+                if (e.key == Key.Back) {
+                  if (e.type == KeyEventType.KeyUp) onBack()
+                  true
+                } else false
+              }
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp).focusGroup()) {
       Surface(
-          color = Color(0xFF3A3A3C),
-          shape = RoundedCornerShape(10.dp),
-          modifier =
-              Modifier.padding(start = 12.dp).tvFocusable(RoundedCornerShape(10.dp)) {
-                ScreenControl.deactivateAdmin(context)
-                active = ScreenControl.isAdminActive(context)
-              },
+          color = Color(0xFF1C1C1E),
+          shape = RoundedCornerShape(12.dp),
+          modifier = Modifier.tvFocusable(RoundedCornerShape(12.dp)) { onBack() },
       ) {
         Text(
-            "Turn off",
+            "‹  Back",
             color = Color.White,
+            fontSize = 16.sp,
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 10.dp),
+        )
+      }
+      Spacer(Modifier.size(18.dp))
+
+      Text("Device health", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+      Text(
+          "The permissions your Portal was set up with, and what each one powers.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+      Spacer(Modifier.size(22.dp))
+
+      // Summary banner — green when healthy, amber when something needs attention.
+      Surface(
+          color = if (issues == 0) Color(0xFF18301C) else Color(0xFF332813),
+          shape = RoundedCornerShape(14.dp),
+          modifier = Modifier.fillMaxWidth(),
+      ) {
+        Text(
+            if (issues == 0) "✓  Everything's set up correctly."
+            else "!  $issues setting${if (issues == 1) " needs" else "s need"} attention — your Portal " +
+                "still works, but some features are limited.",
+            color = if (issues == 0) Color(0xFF7FD18B) else Color(0xFFE0A030),
             fontSize = 15.sp,
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+            modifier = Modifier.padding(16.dp),
+        )
+      }
+      Spacer(Modifier.size(20.dp))
+
+      Card {
+        checks.forEachIndexed { i, c ->
+          if (i > 0) Divider()
+          HealthRow(c)
+        }
+      }
+
+      if (issues > 0) {
+        Spacer(Modifier.size(22.dp))
+        SectionLabel("How to fix")
+        Text(
+            "Reconnect your Portal to a computer and re-run Immortal setup — it re-grants all of " +
+                "these. (Advanced: re-run provision.sh / provision.ps1 from the provisioning kit.)",
+            color = Color(0xFFB8B8B8),
+            fontSize = 14.sp,
+            lineHeight = 20.sp,
+            modifier = Modifier.padding(start = 4.dp, end = 4.dp),
+        )
+      }
+
+      // Advanced: deactivating the screen-off admin is the clean path to uninstall Immortal
+      // (the shell can't force-remove a non-test admin). Tucked away and clearly warned — it
+      // turns off screen-off until re-provisioned.
+      if (adminActive) {
+        Spacer(Modifier.size(28.dp))
+        Text(
+            "Allow uninstall",
+            color = Color(0xFF8A8A8A),
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(start = 4.dp, bottom = 6.dp),
+        )
+        Text(
+            "Disabling the screen-off device admin lets Immortal be uninstalled, but it also stops " +
+                "automatic screen-off (screensaver sleep and the Home Assistant control) until you " +
+                "re-run setup. Only do this if you know what you're doing.",
+            color = Color(0xFF7C7C7C),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(start = 4.dp, end = 4.dp, bottom = 10.dp),
+        )
+        Text(
+            "Disable screen-off admin",
+            color = Color(0xFFE0908A),
+            fontSize = 15.sp,
+            modifier =
+                Modifier.tvFocusable(RoundedCornerShape(8.dp)) {
+                      ScreenControl.deactivateAdmin(context)
+                      adminActive = ScreenControl.isAdminActive(context)
+                    }
+                    .padding(start = 4.dp, top = 2.dp, bottom = 4.dp),
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun HealthRow(c: DevicePermissions.Check) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, top = 14.dp, bottom = 14.dp),
+      verticalAlignment = Alignment.Top,
+  ) {
+    Text(
+        if (c.granted) "✓" else "!",
+        color = if (c.granted) Color(0xFF7FD18B) else Color(0xFFE0A030),
+        fontSize = 18.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(end = 14.dp, top = 1.dp),
+    )
+    Column(modifier = Modifier.weight(1f)) {
+      Text(c.title, color = Color.White, fontSize = 17.sp)
+      Text(
+          c.enables,
+          color = Color(0xFF9A9A9A),
+          fontSize = 13.sp,
+          lineHeight = 18.sp,
+          modifier = Modifier.padding(top = 2.dp),
+      )
+      if (!c.granted) {
+        Text(
+            "Without it: ${c.degraded}",
+            color = Color(0xFFE0A030),
+            fontSize = 13.sp,
+            lineHeight = 18.sp,
+            modifier = Modifier.padding(top = 6.dp),
+        )
+        Text(
+            c.fix,
+            color = Color(0xFF8AB4F8),
+            fontSize = 13.sp,
+            lineHeight = 18.sp,
+            modifier = Modifier.padding(top = 4.dp),
         )
       }
     }

--- a/app/src/main/java/com/immortal/launcher/MqttClient.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttClient.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.EOFException
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetSocketAddress
+import java.net.Socket
+
+/**
+ * A minimal MQTT 3.1.1 client over a raw socket — no Gradle dependency, matching the
+ * hand-rolled net code elsewhere in the app ([FleetHttpServer], [SnapcastControlClient],
+ * [MaWebSocket]). Just what the HA MQTT-Discovery publisher needs: CONNECT (with auth +
+ * last-will), QoS-0 PUBLISH (retained), SUBSCRIBE, and PINGREQ.
+ *
+ * Blocking by design: [connect] and [readPacket] block, so drive them from a worker
+ * thread (see [MqttPublisher]). Writes ([publish]/[subscribe]/[ping]) are synchronized so
+ * the ping thread and the state-publishing threads can't interleave a packet on the wire
+ * while the read loop runs on its own thread.
+ */
+class MqttClient(
+    private val host: String,
+    private val port: Int,
+    private val clientId: String,
+    private val username: String,
+    private val password: String,
+    private val will: Will?,
+) {
+  /** A retained last-will, published by the broker if we drop without a clean DISCONNECT. */
+  data class Will(val topic: String, val payload: String, val retain: Boolean)
+
+  /** A decoded incoming control packet. [type] is the high nibble (e.g. 0x30 = PUBLISH). */
+  data class Packet(val type: Int, val flags: Int, val body: ByteArray)
+
+  private var socket: Socket? = null
+  private var out: OutputStream? = null
+  private var inp: InputStream? = null
+  private val writeLock = Any()
+  private var packetId = 0
+
+  /** Open the socket and complete the MQTT handshake. Returns true on CONNACK accepted. */
+  fun connect(keepAliveSec: Int, connectTimeoutMs: Int = 8000): Boolean {
+    val s = Socket()
+    s.connect(InetSocketAddress(host, port), connectTimeoutMs)
+    s.tcpNoDelay = true
+    socket = s
+    out = BufferedOutputStream(s.getOutputStream())
+    inp = BufferedInputStream(s.getInputStream())
+    sendConnect(keepAliveSec)
+    val ack = readPacket() ?: return false
+    // CONNACK (0x20): byte[1] is the return code; 0 = accepted.
+    return ack.type == 0x20 && ack.body.size >= 2 && ack.body[1].toInt() == 0
+  }
+
+  /** QoS-0 publish. [retain] tells the broker to keep it as the topic's last value. */
+  fun publish(topic: String, payload: String, retain: Boolean) =
+      publish(topic, payload.toByteArray(Charsets.UTF_8), retain)
+
+  fun publish(topic: String, payload: ByteArray, retain: Boolean) {
+    val header = 0x30 or (if (retain) 0x01 else 0x00) // PUBLISH, QoS 0
+    sendPacket(header, encString(topic) + payload)
+  }
+
+  /** Subscribe to [topicFilter] at QoS 0 (SUBACK is consumed by the read loop). */
+  fun subscribe(topicFilter: String) {
+    val id = nextPacketId()
+    sendPacket(0x82, encShort(id) + encString(topicFilter) + byteArrayOf(0x00))
+  }
+
+  fun ping() = sendPacket(0xC0, EMPTY)
+
+  fun disconnect() = runCatching { sendPacket(0xE0, EMPTY) }.let {}
+
+  fun close() {
+    runCatching { socket?.close() }
+    socket = null
+  }
+
+  /** Read one full control packet, blocking. Returns null on a clean EOF. */
+  fun readPacket(): Packet? {
+    val i = inp ?: return null
+    val first = i.read()
+    if (first < 0) return null
+    val len = readRemainingLength(i) ?: return null
+    val body = ByteArray(len)
+    readFully(i, body)
+    return Packet(first and 0xF0, first and 0x0F, body)
+  }
+
+  /** Parse a PUBLISH packet's body into (topic, payload). */
+  fun parsePublish(pkt: Packet): Pair<String, ByteArray> {
+    val qos = (pkt.flags and 0x06) shr 1
+    val b = pkt.body
+    val topicLen = ((b[0].toInt() and 0xff) shl 8) or (b[1].toInt() and 0xff)
+    val topic = String(b, 2, topicLen, Charsets.UTF_8)
+    var idx = 2 + topicLen
+    if (qos > 0) idx += 2 // skip the packet id we don't need at QoS 0
+    return topic to b.copyOfRange(idx, b.size)
+  }
+
+  // --- packet construction ----------------------------------------------------
+
+  private fun sendConnect(keepAliveSec: Int) {
+    var flags = 0x02 // clean session
+    will?.let {
+      flags = flags or 0x04 // will flag (will QoS stays 0)
+      if (it.retain) flags = flags or 0x20
+    }
+    if (username.isNotBlank()) flags = flags or 0x80
+    if (password.isNotBlank()) flags = flags or 0x40
+
+    val varHeader =
+        encString("MQTT") +
+            byteArrayOf(0x04) + // protocol level 4 = MQTT 3.1.1
+            byteArrayOf(flags.toByte()) +
+            encShort(keepAliveSec)
+
+    var payload = encString(clientId)
+    will?.let { payload += encString(it.topic) + encString(it.payload) }
+    if (username.isNotBlank()) payload += encString(username)
+    if (password.isNotBlank()) payload += encString(password)
+
+    sendPacket(0x10, varHeader + payload)
+  }
+
+  private fun sendPacket(header: Int, body: ByteArray) {
+    synchronized(writeLock) {
+      val o = out ?: return
+      o.write(header)
+      o.write(remainingLength(body.size))
+      o.write(body)
+      o.flush()
+    }
+  }
+
+  private fun nextPacketId(): Int {
+    packetId = (packetId % 65535) + 1
+    return packetId
+  }
+
+  // --- wire helpers -----------------------------------------------------------
+
+  /** MQTT string: 2-byte big-endian length prefix + UTF-8 bytes. */
+  private fun encString(s: String): ByteArray {
+    val b = s.toByteArray(Charsets.UTF_8)
+    return encShort(b.size) + b
+  }
+
+  private fun encShort(v: Int): ByteArray =
+      byteArrayOf(((v shr 8) and 0xff).toByte(), (v and 0xff).toByte())
+
+  /** MQTT "remaining length" varint (1–4 bytes). */
+  private fun remainingLength(len: Int): ByteArray {
+    val out = ArrayList<Byte>(4)
+    var x = len
+    do {
+      var enc = x % 128
+      x /= 128
+      if (x > 0) enc = enc or 0x80
+      out.add(enc.toByte())
+    } while (x > 0)
+    return out.toByteArray()
+  }
+
+  private fun readRemainingLength(i: InputStream): Int? {
+    var multiplier = 1
+    var value = 0
+    var digit: Int
+    do {
+      digit = i.read()
+      if (digit < 0) return null
+      value += (digit and 0x7f) * multiplier
+      multiplier *= 128
+      if (multiplier > 128 * 128 * 128) return null // malformed (>4 bytes)
+    } while (digit and 0x80 != 0)
+    return value
+  }
+
+  private fun readFully(i: InputStream, buf: ByteArray) {
+    var off = 0
+    while (off < buf.size) {
+      val n = i.read(buf, off, buf.size - off)
+      if (n < 0) throw EOFException("socket closed mid-packet")
+      off += n
+    }
+  }
+
+  private companion object {
+    val EMPTY = ByteArray(0)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/MqttConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttConfig.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import java.security.SecureRandom
+
+/**
+ * Config for the [MqttService] — the on-device MQTT publisher that exposes this Portal
+ * to Home Assistant via MQTT Discovery. Mirrors the [FleetConfig] / [ImmortalSettings]
+ * prefs idiom.
+ *
+ * Off by default: an un-configured device never opens a connection. The HA device name
+ * is shared with the fleet agent ([FleetConfig.name]) so a Portal shows up under one name
+ * everywhere.
+ */
+object MqttConfig {
+  private const val PREFS = "mqtt_publisher"
+  const val DEFAULT_PORT = 1883
+
+  private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+  fun isEnabled(c: Context): Boolean = prefs(c).getBoolean("enabled", false)
+
+  fun setEnabled(c: Context, on: Boolean) = prefs(c).edit().putBoolean("enabled", on).apply()
+
+  fun host(c: Context): String = prefs(c).getString("host", "")?.trim().orEmpty()
+
+  fun setHost(c: Context, v: String) = prefs(c).edit().putString("host", v.trim()).apply()
+
+  fun port(c: Context): Int = prefs(c).getInt("port", DEFAULT_PORT)
+
+  fun setPort(c: Context, p: Int) =
+      prefs(c).edit().putInt("port", if (p in 1..65535) p else DEFAULT_PORT).apply()
+
+  fun username(c: Context): String = prefs(c).getString("username", "")?.trim().orEmpty()
+
+  fun setUsername(c: Context, v: String) = prefs(c).edit().putString("username", v.trim()).apply()
+
+  fun password(c: Context): String = prefs(c).getString("password", "").orEmpty()
+
+  fun setPassword(c: Context, v: String) = prefs(c).edit().putString("password", v).apply()
+
+  /** True once a broker host is set — the publisher stays idle until then. */
+  fun isConfigured(c: Context): Boolean = host(c).isNotBlank()
+
+  /**
+   * A stable per-device id used in MQTT topics and the HA `unique_id` / device-registry
+   * identifiers. Generated once (SecureRandom, 16 hex chars) and persisted, so the HA
+   * device survives reinstalls of the broker but stays unique across a fleet.
+   */
+  fun deviceId(c: Context): String {
+    prefs(c).getString("device_id", null)?.let { if (it.isNotBlank()) return it }
+    val bytes = ByteArray(8)
+    SecureRandom().nextBytes(bytes)
+    val id = bytes.joinToString("") { "%02x".format(it.toInt() and 0xff) }
+    prefs(c).edit().putString("device_id", id).apply()
+    return id
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.widget.Toast
+import java.net.Inet4Address
+import java.net.NetworkInterface
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** Live status string for the settings screen (mirrors MultiRoomStatus). */
+object MqttStatus {
+  @Volatile var text: String = ""
+}
+
+/**
+ * Publishes this Portal to Home Assistant over MQTT Discovery, reusing the state immortal
+ * already holds: [PresenceHub] (presence + screen), [NowPlayingHub] (media), the battery
+ * broadcast, and [ScreenControl] for the one command we can honour. Owns a worker thread
+ * with a connect → publish → read loop and a fixed-interval reconnect, like
+ * [SnapcastControlClient].
+ *
+ * Topic layout (id = [MqttConfig.deviceId]):
+ *  - discovery  `homeassistant/<component>/immortal_<id>/<obj>/config`  (retained)
+ *  - state      `immortal/<id>/<obj>/state`                            (retained)
+ *  - command    `immortal/<id>/<obj>/set`
+ *  - availability `immortal/<id>/availability`  (LWT: offline / online)
+ */
+class MqttPublisher(private val appContext: Context) {
+  @Volatile private var running = false
+  private var worker: Thread? = null
+  @Volatile private var client: MqttClient? = null
+  @Volatile private var hasBattery = false
+  private val main = Handler(Looper.getMainLooper())
+
+  private val id = MqttConfig.deviceId(appContext)
+  private val base = "immortal/$id"
+
+  private val presenceListener = PresenceHub.Listener { st -> runCatching { publishPresence(st) } }
+  private val nowPlayingListener = NowPlayingHub.Listener { st -> runCatching { publishMedia(st) } }
+  private var batteryReceiver: BroadcastReceiver? = null
+
+  fun start() {
+    if (running) return
+    running = true
+    worker = Thread { loop() }.apply {
+      isDaemon = true
+      name = "mqtt-publisher"
+      start()
+    }
+  }
+
+  fun stop() {
+    running = false
+    detach()
+    runCatching { client?.disconnect() }
+    runCatching { client?.close() }
+    worker?.interrupt()
+    worker = null
+    MqttStatus.text = "Off"
+  }
+
+  // --- connection lifecycle ---------------------------------------------------
+
+  private fun loop() {
+    while (running) {
+      val host = MqttConfig.host(appContext)
+      if (host.isBlank()) {
+        MqttStatus.text = "No broker set"
+        sleep(BACKOFF_MS)
+        continue
+      }
+      val c =
+          MqttClient(
+              host = host,
+              port = MqttConfig.port(appContext),
+              clientId = "immortal-$id",
+              username = MqttConfig.username(appContext),
+              password = MqttConfig.password(appContext),
+              will = MqttClient.Will("$base/availability", "offline", retain = true),
+          )
+      MqttStatus.text = "Connecting to $host…"
+      val ok = runCatching { c.connect(KEEPALIVE_SEC) }.getOrDefault(false)
+      if (!ok) {
+        runCatching { c.close() }
+        MqttStatus.text = "Can't reach broker at $host"
+        sleep(BACKOFF_MS)
+        continue
+      }
+      client = c
+      MqttStatus.text = "Connected to $host"
+      Log.i(TAG, "connected to $host:${MqttConfig.port(appContext)}")
+
+      val pinger =
+          Thread {
+                while (running && client === c) {
+                  sleep(PING_MS)
+                  if (running && client === c) runCatching { c.ping() }.getOrElse { return@Thread }
+                }
+              }
+              .apply {
+                isDaemon = true
+                name = "mqtt-ping"
+                start()
+              }
+
+      runCatching {
+            hasBattery = readBatteryPresent()
+            publishDiscovery(c)
+            c.publish("$base/availability", "online", retain = true)
+            c.subscribe("$base/+/set")
+            attach() // hub listeners + battery receiver replay current state immediately
+            while (running) {
+              val pkt = c.readPacket() ?: break
+              if (pkt.type == 0x30) handleCommand(c.parsePublish(pkt).first)
+            }
+          }
+          .onFailure { if (running) Log.w(TAG, "connection ended: ${it.message}") }
+
+      detach()
+      pinger.interrupt()
+      client = null
+      runCatching { c.close() }
+      if (running) {
+        MqttStatus.text = "Reconnecting…"
+        sleep(BACKOFF_MS)
+      }
+    }
+    MqttStatus.text = "Off"
+  }
+
+  private fun attach() {
+    // Each addListener replays current state immediately, so this also does the initial publish.
+    PresenceHub.addListener(presenceListener)
+    NowPlayingHub.addListener(nowPlayingListener)
+    val r =
+        object : BroadcastReceiver() {
+          override fun onReceive(c: Context, i: Intent) = runCatching { publishBattery(i) }.let {}
+        }
+    batteryReceiver = r
+    // Registering for a sticky broadcast returns the current battery intent — publish it now.
+    val sticky = appContext.registerReceiver(r, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+    sticky?.let { runCatching { publishBattery(it) } }
+    publishIp()
+  }
+
+  private fun detach() {
+    runCatching { PresenceHub.removeListener(presenceListener) }
+    runCatching { NowPlayingHub.removeListener(nowPlayingListener) }
+    batteryReceiver?.let { r -> runCatching { appContext.unregisterReceiver(r) } }
+    batteryReceiver = null
+  }
+
+  // --- commands (broker → device) ---------------------------------------------
+
+  private fun handleCommand(topic: String) {
+    // topic = immortal/<id>/<obj>/set
+    val obj = topic.removePrefix("$base/").removeSuffix("/set")
+    Log.i(TAG, "command: $obj")
+    main.post {
+      runCatching {
+        when (obj) {
+          "screen_off" -> ScreenControl.sleep(appContext)
+          "identify" ->
+              Toast.makeText(appContext, "Immortal · ${FleetConfig.name(appContext)}", Toast.LENGTH_LONG)
+                  .show()
+          "media_play_pause" -> NowPlayingHub.playPause()
+          "media_next" -> NowPlayingHub.next()
+          "media_previous" -> NowPlayingHub.previous()
+          else -> Log.w(TAG, "unknown command $obj")
+        }
+      }
+    }
+  }
+
+  // --- state (device → broker) ------------------------------------------------
+
+  private fun publishPresence(st: PresenceState) {
+    val c = client ?: return
+    // Use immortal's presence proxy when it has a reading; when it doesn't yet (UNKNOWN —
+    // e.g. just after boot, before the first screensaver cycle) fall back to whether the
+    // screen is on, a coarse "panel in use" signal, so the entity is never just
+    // "unavailable". The `confident` attribute tells HA how far to trust it.
+    val on =
+        when (st.presence) {
+          Presence.PRESENT -> true
+          Presence.ABSENT -> false
+          Presence.UNKNOWN -> isScreenOn()
+        }
+    c.publish("$base/presence/state", if (on) "ON" else "OFF", retain = true)
+    c.publish(
+        "$base/presence/attributes",
+        JSONObject()
+            .put("confident", st.confident)
+            .put("source", if (st.presence == Presence.UNKNOWN) "screen" else "proxy")
+            .put("raw", st.presence.name.lowercase())
+            .toString(),
+        retain = true,
+    )
+    c.publish("$base/screen/state", st.screen.name.lowercase(), retain = true)
+  }
+
+  private fun isScreenOn(): Boolean =
+      runCatching {
+            (appContext.getSystemService(Context.POWER_SERVICE) as android.os.PowerManager).isInteractive
+          }
+          .getOrDefault(false)
+
+  private fun publishMedia(st: NowPlayingState?) {
+    val c = client ?: return
+    val state =
+        when (st?.state) {
+          PlaybackState.PLAYING -> "playing"
+          PlaybackState.PAUSED -> "paused"
+          else -> "idle"
+        }
+    c.publish("$base/media_state/state", state, retain = true)
+    c.publish("$base/media_title/state", st?.title.orEmpty(), retain = true)
+    c.publish("$base/media_artist/state", st?.artist.orEmpty(), retain = true)
+  }
+
+  private fun publishBattery(i: Intent) {
+    if (!hasBattery) return
+    val c = client ?: return
+    val level = i.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+    val scale = i.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+    if (level >= 0 && scale > 0) {
+      c.publish("$base/battery/state", (level * 100 / scale).toString(), retain = true)
+    }
+    val charging = i.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0) != 0
+    c.publish("$base/charging/state", if (charging) "ON" else "OFF", retain = true)
+  }
+
+  private fun publishIp() {
+    client?.publish("$base/ip/state", currentIp().ifBlank { "unknown" }, retain = true)
+  }
+
+  private fun readBatteryPresent(): Boolean {
+    val i =
+        appContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED)) ?: return false
+    return i.getBooleanExtra(BatteryManager.EXTRA_PRESENT, false)
+  }
+
+  // --- discovery --------------------------------------------------------------
+
+  private fun publishDiscovery(c: MqttClient) {
+    sensor(c, "screen", "Screen", icon = "mdi:monitor")
+    button(c, "screen_off", "Screen off", icon = "mdi:monitor-off")
+    binarySensor(c, "presence", "Presence", deviceClass = "occupancy", jsonAttributes = true)
+
+    if (hasBattery) {
+      sensor(c, "battery", "Battery", deviceClass = "battery", unit = "%", stateClass = "measurement")
+      binarySensor(c, "charging", "Charging", deviceClass = "battery_charging")
+    }
+
+    sensor(c, "media_state", "Media", icon = "mdi:music")
+    sensor(c, "media_title", "Media title", icon = "mdi:music-note")
+    sensor(c, "media_artist", "Media artist", icon = "mdi:account-music")
+    button(c, "media_play_pause", "Play / pause", icon = "mdi:play-pause")
+    button(c, "media_next", "Next track", icon = "mdi:skip-next")
+    button(c, "media_previous", "Previous track", icon = "mdi:skip-previous")
+
+    button(c, "identify", "Identify", icon = "mdi:bullhorn")
+    sensor(c, "ip", "IP address", icon = "mdi:ip-network", diagnostic = true)
+  }
+
+  private fun device(): JSONObject =
+      JSONObject()
+          .put("identifiers", JSONArray().put("immortal_$id"))
+          .put("name", FleetConfig.name(appContext))
+          .put("model", Build.MODEL ?: "Portal")
+          .put("manufacturer", "Meta")
+          .put("sw_version", appVersion())
+
+  private fun base(obj: String, name: String): JSONObject =
+      JSONObject()
+          .put("name", name)
+          .put("unique_id", "immortal_${id}_$obj")
+          .put("device", device())
+
+  private fun sensor(
+      c: MqttClient,
+      obj: String,
+      name: String,
+      icon: String? = null,
+      deviceClass: String? = null,
+      unit: String? = null,
+      stateClass: String? = null,
+      diagnostic: Boolean = false,
+  ) {
+    val cfg =
+        base(obj, name)
+            .put("state_topic", "$base/$obj/state")
+            .put("availability_topic", "$base/availability")
+    icon?.let { cfg.put("icon", it) }
+    deviceClass?.let { cfg.put("device_class", it) }
+    unit?.let { cfg.put("unit_of_measurement", it) }
+    stateClass?.let { cfg.put("state_class", it) }
+    if (diagnostic) cfg.put("entity_category", "diagnostic")
+    publishConfig(c, "sensor", obj, cfg)
+  }
+
+  private fun binarySensor(
+      c: MqttClient,
+      obj: String,
+      name: String,
+      deviceClass: String,
+      jsonAttributes: Boolean = false,
+  ) {
+    val cfg =
+        base(obj, name)
+            .put("state_topic", "$base/$obj/state")
+            .put("availability_topic", "$base/availability")
+            .put("device_class", deviceClass)
+            .put("payload_on", "ON")
+            .put("payload_off", "OFF")
+    if (jsonAttributes) cfg.put("json_attributes_topic", "$base/$obj/attributes")
+    publishConfig(c, "binary_sensor", obj, cfg)
+  }
+
+  private fun button(c: MqttClient, obj: String, name: String, icon: String) {
+    val cfg =
+        base(obj, name)
+            .put("command_topic", "$base/$obj/set")
+            .put("payload_press", "PRESS")
+            .put("availability_topic", "$base/availability")
+            .put("icon", icon)
+    publishConfig(c, "button", obj, cfg)
+  }
+
+  private fun publishConfig(c: MqttClient, component: String, obj: String, cfg: JSONObject) {
+    c.publish("homeassistant/$component/immortal_$id/$obj/config", cfg.toString(), retain = true)
+  }
+
+  // --- misc -------------------------------------------------------------------
+
+  private fun appVersion(): String =
+      runCatching {
+            appContext.packageManager.getPackageInfo(appContext.packageName, 0).versionName ?: "?"
+          }
+          .getOrDefault("?")
+
+  private fun currentIp(): String =
+      runCatching {
+            NetworkInterface.getNetworkInterfaces()
+                .toList()
+                .filter { it.isUp && !it.isLoopback }
+                .flatMap { it.inetAddresses.toList() }
+                .firstOrNull { it is Inet4Address && it.isSiteLocalAddress }
+                ?.hostAddress
+                .orEmpty()
+          }
+          .getOrDefault("")
+
+  private fun sleep(ms: Long) = runCatching { Thread.sleep(ms) }.let {}
+
+  private companion object {
+    const val TAG = "ImmortalMqtt"
+    const val KEEPALIVE_SEC = 45
+    const val PING_MS = 20_000L
+    const val BACKOFF_MS = 4_000L
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -11,6 +11,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.net.Uri
 import android.os.BatteryManager
 import android.os.Build
 import android.os.Handler
@@ -53,6 +54,7 @@ class MqttPublisher(private val appContext: Context) {
   private val presenceListener = PresenceHub.Listener { st -> runCatching { publishPresence(st) } }
   private val nowPlayingListener = NowPlayingHub.Listener { st -> runCatching { publishMedia(st) } }
   private var batteryReceiver: BroadcastReceiver? = null
+  private var screenReceiver: BroadcastReceiver? = null
 
   fun start() {
     if (running) return
@@ -64,11 +66,28 @@ class MqttPublisher(private val appContext: Context) {
     }
   }
 
-  fun stop() {
+  /**
+   * Stop publishing. When [clearDiscovery] is true (a deliberate disable, not a transient
+   * service kill), first remove this device's entities from HA by publishing empty retained
+   * configs — otherwise HA would keep showing the Portal forever as "unavailable".
+   */
+  fun stop(clearDiscovery: Boolean) {
     running = false
+    val c = client // still connected here; the read loop hasn't torn it down yet
+    if (clearDiscovery && c != null) {
+      runCatching {
+        clearDiscovery(c)
+        // Let the empty (retained) configs flush and be processed before we drop the
+        // socket — otherwise HA only sees the disconnect and leaves the entities behind
+        // as "unavailable" instead of removing them. (No "offline" publish: a clean
+        // DISCONNECT suppresses the LWT, so removal isn't preceded by an unavailable flash.)
+        Thread.sleep(400)
+      }
+    }
     detach()
-    runCatching { client?.disconnect() }
-    runCatching { client?.close() }
+    runCatching { c?.disconnect() }
+    runCatching { c?.close() }
+    client = null
     worker?.interrupt()
     worker = null
     MqttStatus.text = "Off"
@@ -109,7 +128,14 @@ class MqttPublisher(private val appContext: Context) {
           Thread {
                 while (running && client === c) {
                   sleep(PING_MS)
-                  if (running && client === c) runCatching { c.ping() }.getOrElse { return@Thread }
+                  if (running && client === c) {
+                    runCatching { c.ping() }.getOrElse { return@Thread }
+                    // Heartbeat: refresh live-derived state so HA stays current even if the
+                    // Portal's screen on/off broadcasts are unreliable (they are, for admin
+                    // sleep) — keeps the screen sensor and presence from going stale.
+                    runCatching { publishScreen() }
+                    runCatching { publishPresence(PresenceHub.current) }
+                  }
                 }
               }
               .apply {
@@ -126,7 +152,10 @@ class MqttPublisher(private val appContext: Context) {
             attach() // hub listeners + battery receiver replay current state immediately
             while (running) {
               val pkt = c.readPacket() ?: break
-              if (pkt.type == 0x30) handleCommand(c.parsePublish(pkt).first)
+              if (pkt.type == 0x30) {
+                val (t, p) = c.parsePublish(pkt)
+                handleCommand(t, String(p, Charsets.UTF_8))
+              }
             }
           }
           .onFailure { if (running) Log.w(TAG, "connection ended: ${it.message}") }
@@ -155,6 +184,20 @@ class MqttPublisher(private val appContext: Context) {
     // Registering for a sticky broadcast returns the current battery intent — publish it now.
     val sticky = appContext.registerReceiver(r, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
     sticky?.let { runCatching { publishBattery(it) } }
+    // Keep the screen switch state accurate as the display turns on/off (PresenceHub's
+    // screen field can lag; the system broadcast is immediate).
+    val sr =
+        object : BroadcastReceiver() {
+          override fun onReceive(c: Context, i: Intent) = runCatching { publishScreen() }.let {}
+        }
+    screenReceiver = sr
+    appContext.registerReceiver(
+        sr,
+        IntentFilter().apply {
+          addAction(Intent.ACTION_SCREEN_ON)
+          addAction(Intent.ACTION_SCREEN_OFF)
+        })
+    publishScreen()
     publishIp()
   }
 
@@ -163,18 +206,31 @@ class MqttPublisher(private val appContext: Context) {
     runCatching { NowPlayingHub.removeListener(nowPlayingListener) }
     batteryReceiver?.let { r -> runCatching { appContext.unregisterReceiver(r) } }
     batteryReceiver = null
+    screenReceiver?.let { r -> runCatching { appContext.unregisterReceiver(r) } }
+    screenReceiver = null
   }
 
   // --- commands (broker → device) ---------------------------------------------
 
-  private fun handleCommand(topic: String) {
+  private fun handleCommand(topic: String, payload: String) {
     // topic = immortal/<id>/<obj>/set
     val obj = topic.removePrefix("$base/").removeSuffix("/set")
-    Log.i(TAG, "command: $obj")
+    Log.i(TAG, "command: $obj = $payload")
     main.post {
       runCatching {
         when (obj) {
-          "screen_off" -> ScreenControl.sleep(appContext)
+          // Optimistic switch (no state_topic), so HA reflects the command itself — we don't
+          // echo state. The Portal reports the screen as "interactive" for ~10s after
+          // lockNow, so reading it back here would wrongly flip the switch on then off.
+          "screen_power" ->
+              if (payload.trim().equals("ON", ignoreCase = true)) ScreenControl.wake(appContext)
+              else ScreenControl.sleep(appContext)
+          "go_home" ->
+              appContext.startActivity(
+                  Intent(Intent.ACTION_MAIN)
+                      .addCategory(Intent.CATEGORY_HOME)
+                      .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+          "open" -> openTarget(payload)
           "identify" ->
               Toast.makeText(appContext, "Immortal · ${FleetConfig.name(appContext)}", Toast.LENGTH_LONG)
                   .show()
@@ -185,6 +241,34 @@ class MqttPublisher(private val appContext: Context) {
         }
       }
     }
+  }
+
+  /**
+   * Open whatever Home Assistant asked for via the "Open" entity. Accepts a full URL
+   * (http/https → browser, homeassistant:// → HA), an installed package name (launch it),
+   * or a bare HA dashboard path like "today-home/security" (deep-linked into the HA app).
+   * Reuses [ScreensaverDismiss]'s HA helpers so the behaviour matches the screensaver picker.
+   */
+  private fun openTarget(payload: String) {
+    val t = payload.trim()
+    if (t.isBlank()) return
+    val pm = appContext.packageManager
+    when {
+      t.startsWith("http://") || t.startsWith("https://") || t.startsWith("homeassistant://") ->
+          appContext.startActivity(
+              Intent(Intent.ACTION_VIEW, Uri.parse(t)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+      pm.getLaunchIntentForPackage(t) != null ->
+          appContext.startActivity(pm.getLaunchIntentForPackage(t)!!.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+      else -> {
+        val pkg = ScreensaverDismiss.installedHaPackage(appContext) ?: return
+        appContext.startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(ScreensaverDismiss.haDeepLink(t)))
+                .setPackage(pkg)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+      }
+    }
+    // Echo the last target so the text entity shows what it was set to.
+    client?.publish("$base/open/state", t, retain = true)
   }
 
   // --- state (device → broker) ------------------------------------------------
@@ -211,7 +295,24 @@ class MqttPublisher(private val appContext: Context) {
             .toString(),
         retain = true,
     )
-    c.publish("$base/screen/state", st.screen.name.lowercase(), retain = true)
+    publishScreen()
+  }
+
+  /**
+   * Publish the screen-state sensor from the LIVE display state. immortal's PresenceHub
+   * screen field only changes on dream/sleep/interaction events, so it can read "off" while
+   * the panel is actually on — reconcile against PowerManager, using the proxy only to tell
+   * interactive from the screensaver. (The switch is optimistic, so it has no state topic.)
+   */
+  private fun publishScreen() {
+    val c = client ?: return
+    val enum =
+        when {
+          !isScreenOn() -> "off"
+          PresenceHub.current.screen == ScreenState.DREAMING -> "dreaming"
+          else -> "interactive"
+        }
+    c.publish("$base/screen/state", enum, retain = true)
   }
 
   private fun isScreenOn(): Boolean =
@@ -258,8 +359,12 @@ class MqttPublisher(private val appContext: Context) {
   // --- discovery --------------------------------------------------------------
 
   private fun publishDiscovery(c: MqttClient) {
-    sensor(c, "screen", "Screen", icon = "mdi:monitor")
-    button(c, "screen_off", "Screen off", icon = "mdi:monitor-off")
+    // Two-way screen control (wake / off) now that ScreenControl.wake exists, plus a
+    // read-only detail sensor.
+    switchEntity(c, "screen_power", "Screen", icon = "mdi:monitor", optimistic = true)
+    sensor(c, "screen", "Screen state", icon = "mdi:monitor")
+    // Pre-1.41 shipped a one-way "Screen off" button; remove it so it doesn't orphan.
+    publishConfig(c, "button", "screen_off", null)
     binarySensor(c, "presence", "Presence", deviceClass = "occupancy", jsonAttributes = true)
 
     if (hasBattery) {
@@ -274,8 +379,36 @@ class MqttPublisher(private val appContext: Context) {
     button(c, "media_next", "Next track", icon = "mdi:skip-next")
     button(c, "media_previous", "Previous track", icon = "mdi:skip-previous")
 
+    button(c, "go_home", "Home", icon = "mdi:home")
+    textEntity(c, "open", "Open", icon = "mdi:open-in-app")
     button(c, "identify", "Identify", icon = "mdi:bullhorn")
     sensor(c, "ip", "IP address", icon = "mdi:ip-network", diagnostic = true)
+  }
+
+  /** The (component, object) of every entity we publish — used to tear them down on disable. */
+  private val allEntities: List<Pair<String, String>> =
+      listOf(
+          "switch" to "screen_power",
+          "sensor" to "screen",
+          "binary_sensor" to "presence",
+          "sensor" to "battery",
+          "binary_sensor" to "charging",
+          "sensor" to "media_state",
+          "sensor" to "media_title",
+          "sensor" to "media_artist",
+          "button" to "media_play_pause",
+          "button" to "media_next",
+          "button" to "media_previous",
+          "button" to "go_home",
+          "text" to "open",
+          "button" to "identify",
+          "sensor" to "ip",
+          "button" to "screen_off", // legacy (pre-1.41)
+      )
+
+  /** Remove this device's entities from HA by clearing their retained discovery configs. */
+  private fun clearDiscovery(c: MqttClient) {
+    allEntities.forEach { (component, obj) -> publishConfig(c, component, obj, null) }
   }
 
   private fun device(): JSONObject =
@@ -342,8 +475,42 @@ class MqttPublisher(private val appContext: Context) {
     publishConfig(c, "button", obj, cfg)
   }
 
-  private fun publishConfig(c: MqttClient, component: String, obj: String, cfg: JSONObject) {
-    c.publish("homeassistant/$component/immortal_$id/$obj/config", cfg.toString(), retain = true)
+  private fun switchEntity(
+      c: MqttClient,
+      obj: String,
+      name: String,
+      icon: String,
+      optimistic: Boolean = false,
+  ) {
+    val cfg =
+        base(obj, name)
+            .put("command_topic", "$base/$obj/set")
+            .put("availability_topic", "$base/availability")
+            .put("payload_on", "ON")
+            .put("payload_off", "OFF")
+            .put("icon", icon)
+    // Optimistic: no state_topic, so HA tracks the commanded state itself (avoids the
+    // post-lockNow flap where the Portal still reports the screen on for ~10s).
+    if (!optimistic) cfg.put("state_topic", "$base/$obj/state")
+    publishConfig(c, "switch", obj, cfg)
+  }
+
+  private fun textEntity(c: MqttClient, obj: String, name: String, icon: String) {
+    val cfg =
+        base(obj, name)
+            .put("command_topic", "$base/$obj/set")
+            .put("state_topic", "$base/$obj/state")
+            .put("availability_topic", "$base/availability")
+            // It's really an automation target ("tell the panel to show X"), not a control
+            // to mix in with the dashboard — config category keeps it off auto-dashboards.
+            .put("entity_category", "config")
+            .put("icon", icon)
+    publishConfig(c, "text", obj, cfg)
+  }
+
+  /** Publish (or, when [cfg] is null, clear) a retained discovery config. */
+  private fun publishConfig(c: MqttClient, component: String, obj: String, cfg: JSONObject?) {
+    c.publish("homeassistant/$component/immortal_$id/$obj/config", cfg?.toString() ?: "", retain = true)
   }
 
   // --- misc -------------------------------------------------------------------

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -71,21 +71,32 @@ class MqttPublisher(private val appContext: Context) {
    * service kill), first remove this device's entities from HA by publishing empty retained
    * configs — otherwise HA would keep showing the Portal forever as "unavailable".
    */
-  fun stop(clearDiscovery: Boolean) {
+  fun stop(removeFromHa: Boolean) {
     running = false
     val c = client // still connected here; the read loop hasn't torn it down yet
-    if (clearDiscovery && c != null) {
-      runCatching {
-        clearDiscovery(c)
-        // Let the empty (retained) configs flush and be processed before we drop the
-        // socket — otherwise HA only sees the disconnect and leaves the entities behind
-        // as "unavailable" instead of removing them. (No "offline" publish: a clean
-        // DISCONNECT suppresses the LWT, so removal isn't preceded by an unavailable flash.)
-        Thread.sleep(400)
-      }
-    }
+    Log.i(TAG, "stop(removeFromHa=$removeFromHa) connected=${c != null}")
     detach()
-    runCatching { c?.disconnect() }
+    if (removeFromHa && c != null) {
+      // stop() runs on the main thread (Service.onDestroy), so the socket writes can't go
+      // here (NetworkOnMainThreadException). Do the removal — empty retained configs so HA
+      // drops the entities rather than leaving them "unavailable" — then a clean DISCONNECT
+      // (suppresses the LWT) on a worker, and block briefly so it actually reaches the broker.
+      val t =
+          Thread {
+                runCatching {
+                      clearDiscovery(c)
+                      Thread.sleep(300) // let the retained clears flush before we disconnect
+                      c.disconnect()
+                      Log.i(TAG, "teardown: cleared ${allEntities.size} entity configs")
+                    }
+                    .onFailure { Log.w(TAG, "teardown clear failed", it) }
+              }
+              .apply {
+                isDaemon = true
+                start()
+              }
+      runCatching { t.join(2500) } // onDestroy can wait a moment; ANR budget is generous
+    }
     runCatching { c?.close() }
     client = null
     worker?.interrupt()

--- a/app/src/main/java/com/immortal/launcher/MqttService.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttService.kt
@@ -43,7 +43,7 @@ class MqttService : Service() {
     // A deliberate disable (the user turned it off) → clear the HA entities. A transient
     // system kill while still enabled → keep them; START_STICKY will reconnect.
     val deliberate = !MqttConfig.isEnabled(this)
-    runCatching { publisher?.stop(clearDiscovery = deliberate) }
+    runCatching { publisher?.stop(removeFromHa = deliberate) }
     publisher = null
     super.onDestroy()
   }

--- a/app/src/main/java/com/immortal/launcher/MqttService.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttService.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+
+/**
+ * Foreground service that runs the [MqttPublisher], exposing this Portal to Home Assistant
+ * over MQTT Discovery. Mirrors [FleetAgentService]: a long-running, reboot-proof on-device
+ * service, off until the user configures a broker.
+ *
+ * [sync] starts it when enabled+configured and stops it otherwise, so toggling the setting
+ * (and boot) just calls one method — like [MultiRoomService.sync].
+ */
+class MqttService : Service() {
+
+  private var publisher: MqttPublisher? = null
+
+  override fun onCreate() {
+    super.onCreate()
+    createChannel()
+    startForeground(NOTIF_ID, notification())
+    publisher = MqttPublisher(applicationContext).also { it.start() }
+  }
+
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_STICKY
+
+  override fun onBind(intent: Intent?): IBinder? = null
+
+  override fun onDestroy() {
+    runCatching { publisher?.stop() }
+    publisher = null
+    super.onDestroy()
+  }
+
+  private fun createChannel() {
+    if (Build.VERSION.SDK_INT >= 26) {
+      val ch =
+          NotificationChannel(CHANNEL, "Home Assistant", NotificationManager.IMPORTANCE_MIN).apply {
+            description = "Publishes this Portal to Home Assistant over MQTT"
+          }
+      getSystemService(NotificationManager::class.java)?.createNotificationChannel(ch)
+    }
+  }
+
+  private fun notification(): Notification {
+    val b =
+        if (Build.VERSION.SDK_INT >= 26) Notification.Builder(this, CHANNEL)
+        else @Suppress("DEPRECATION") Notification.Builder(this)
+    return b.setSmallIcon(R.mipmap.ic_launcher)
+        .setContentTitle("Immortal · Home Assistant")
+        .setContentText("Publishing this Portal to Home Assistant")
+        .setOngoing(true)
+        .build()
+  }
+
+  companion object {
+    private const val CHANNEL = "mqtt_publisher"
+    private const val NOTIF_ID = 4712
+
+    /** Start the publisher when enabled+configured, stop it otherwise. Safe to call repeatedly. */
+    fun sync(context: Context) {
+      val intent = Intent(context, MqttService::class.java)
+      if (MqttConfig.isEnabled(context) && MqttConfig.isConfigured(context)) {
+        if (Build.VERSION.SDK_INT >= 26) context.startForegroundService(intent)
+        else context.startService(intent)
+      } else {
+        context.stopService(intent)
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/MqttService.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttService.kt
@@ -40,7 +40,10 @@ class MqttService : Service() {
   override fun onBind(intent: Intent?): IBinder? = null
 
   override fun onDestroy() {
-    runCatching { publisher?.stop() }
+    // A deliberate disable (the user turned it off) → clear the HA entities. A transient
+    // system kill while still enabled → keep them; START_STICKY will reconnect.
+    val deliberate = !MqttConfig.isEnabled(this)
+    runCatching { publisher?.stop(clearDiscovery = deliberate) }
     publisher = null
     super.onDestroy()
   }

--- a/app/src/main/java/com/immortal/launcher/PhotoDreamService.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoDreamService.kt
@@ -36,6 +36,10 @@ class PhotoDreamService : DreamService() {
       Log.i(TAG, "onExit (tap) -> finish()")
       // Mark this as a USER exit so DreamPolicy doesn't relaunch the frame.
       DreamPolicy.userExitAt = System.currentTimeMillis()
+      // If the user chose an app to open on dismiss (e.g. their Home Assistant
+      // dashboard), launch it; otherwise this is a no-op and we fall back to the
+      // launcher — same as before, and also the path when that app is uninstalled.
+      ScreensaverDismiss.launchChosenApp(this)
       finish()
     }
     val root = frame.view

--- a/app/src/main/java/com/immortal/launcher/ScreenControl.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreenControl.kt
@@ -10,6 +10,7 @@ package com.immortal.launcher
 import android.app.admin.DevicePolicyManager
 import android.content.ComponentName
 import android.content.Context
+import android.os.PowerManager
 import android.util.Log
 
 /**
@@ -43,6 +44,29 @@ object ScreenControl {
     runCatching { dpm(context).removeActiveAdmin(admin(context)) }
         .onSuccess { Log.i(TAG, "device admin deactivated") }
         .onFailure { Log.w(TAG, "couldn't deactivate admin", it) }
+  }
+
+  /**
+   * Turn the screen on. A normal app can't call PowerManager.wakeUp (signature
+   * permission), but a wake lock acquired with ACQUIRE_CAUSES_WAKEUP powers the display
+   * on — this is what lets Home Assistant wake the panel (e.g. on a doorbell). Held
+   * briefly then auto-released; the screensaver / idle policy keeps it on afterwards.
+   * Needs only the normal WAKE_LOCK permission (no provisioning), unlike screen-off.
+   */
+  fun wake(context: Context) {
+    runCatching {
+          val pm = context.getSystemService(PowerManager::class.java)
+          @Suppress("DEPRECATION") // FULL_WAKE_LOCK is the working wake path on API 28/29 Portals
+          val wl =
+              pm.newWakeLock(
+                  PowerManager.FULL_WAKE_LOCK or
+                      PowerManager.ACQUIRE_CAUSES_WAKEUP or
+                      PowerManager.ON_AFTER_RELEASE,
+                  "immortal:wake")
+          wl.acquire(3_000L) // turns the display on; auto-releases after 3s
+        }
+        .onSuccess { Log.i(TAG, "wake(): screen on") }
+        .onFailure { Log.w(TAG, "wake() failed", it) }
   }
 
   /** Blank the screen now, if we hold the device-admin force-lock policy. */

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -77,6 +77,16 @@ object ScreensaverConfig {
       val overnightEnabled: Boolean = false,
       val overnightStartMin: Int = 22 * 60,
       val overnightEndMin: Int = 7 * 60,
+      // What to open when the user taps the frame to dismiss it. null = the Immortal
+      // launcher (the original behaviour). Otherwise a flattened ComponentName of an
+      // installed app — Home Assistant users typically point this at their HA app so a
+      // tap drops them straight back into their dashboard. See [ScreensaverDismiss].
+      val dismissAppComponent: String? = null,
+      // Home Assistant dashboard mode. When non-null, a tap opens the HA companion app
+      // (taking precedence over [dismissAppComponent]); a non-blank value is the
+      // dashboard path to deep-link to (e.g. "today-home/security"), and "" opens the
+      // user's default dashboard. Only offered when an HA app is installed.
+      val dismissHaDashboard: String? = null,
   ) {
     /** True when the idle screen-off timeout is active. */
     val idleSleepOn: Boolean
@@ -119,6 +129,8 @@ object ScreensaverConfig {
         overnightEnabled = p.getBoolean("overnight_enabled", false),
         overnightStartMin = p.getInt("overnight_start_min", 22 * 60),
         overnightEndMin = p.getInt("overnight_end_min", 7 * 60),
+        dismissAppComponent = p.getString("dismiss_app_component", null),
+        dismissHaDashboard = p.getString("dismiss_ha_dashboard", null),
     )
   }
 
@@ -171,4 +183,30 @@ object ScreensaverConfig {
 
   fun setOvernightEndMin(c: Context, min: Int) =
       prefs(c).edit().putInt("overnight_end_min", wrapMinuteOfDay(min)).apply()
+
+  // --- Dismiss target (launcher / app / Home Assistant dashboard) ---------------
+  // The three are mutually exclusive, so each setter clears the others.
+
+  /** Return to the Immortal launcher on dismiss (the default). */
+  fun setDismissLauncher(c: Context) =
+      prefs(c).edit().remove("dismiss_app_component").remove("dismiss_ha_dashboard").apply()
+
+  /** Open [component] (a flattened ComponentName) when the frame is tapped to dismiss. */
+  fun setDismissApp(c: Context, component: String) =
+      prefs(c)
+          .edit()
+          .putString("dismiss_app_component", component)
+          .remove("dismiss_ha_dashboard")
+          .apply()
+
+  /**
+   * Open Home Assistant on dismiss. [path] is the dashboard to deep-link to (e.g.
+   * "today-home/security"); blank opens the user's default dashboard.
+   */
+  fun setDismissHaDashboard(c: Context, path: String) =
+      prefs(c)
+          .edit()
+          .putString("dismiss_ha_dashboard", path.trim())
+          .remove("dismiss_app_component")
+          .apply()
 }

--- a/app/src/main/java/com/immortal/launcher/ScreensaverDismissAppActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverDismissAppActivity.kt
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.graphics.drawable.toBitmap
+import com.immortal.launcher.ui.theme.SampleAppTheme
+import java.util.Locale
+import kotlin.concurrent.thread
+
+/**
+ * Resolves and launches whatever the user picked to open when they tap the photo-frame
+ * screensaver to dismiss it (see [ScreensaverDismissAppActivity]). Kept separate from
+ * [ScreensaverConfig] (pure preference storage) because this touches the PackageManager
+ * and launches activities.
+ *
+ * Three mutually-exclusive targets, in precedence order:
+ *  1. **Home Assistant** ([ScreensaverConfig.Settings.dismissHaDashboard] non-null) —
+ *     deep-link to a dashboard via `homeassistant://navigate/<path>`, or open HA's
+ *     default dashboard when the path is blank.
+ *  2. **An app** ([ScreensaverConfig.Settings.dismissAppComponent]) — a plain launch.
+ *  3. **The Immortal launcher** (both null) — the default; [launchChosenApp] is a no-op
+ *     and the dream just finishes home.
+ *
+ * Everything degrades to the launcher: an uninstalled app or a removed HA companion
+ * makes [launchChosenApp] return false, so a stale choice can never strand the dream.
+ */
+object ScreensaverDismiss {
+  private const val TAG = "ImmortalDismiss"
+
+  // Both flavours of the official HA Android app; the minimal (F-Droid) build is what
+  // no-GMS devices like the Portal run, the other is the Play build.
+  private val HA_PACKAGES =
+      listOf("io.homeassistant.companion.android", "io.homeassistant.companion.android.minimal")
+
+  /** The installed HA companion package (either flavour), or null if neither is present. */
+  fun installedHaPackage(context: Context): String? {
+    val pm = context.packageManager
+    return HA_PACKAGES.firstOrNull { pkg ->
+      runCatching { pm.getPackageInfo(pkg, 0) }.isSuccess
+    }
+  }
+
+  /** The chosen app launch target, or null if none is set or it's no longer installed. */
+  fun chosenComponent(context: Context): ComponentName? {
+    val flat = ScreensaverConfig.load(context).dismissAppComponent ?: return null
+    val cn = ComponentName.unflattenFromString(flat) ?: return null
+    return runCatching { context.packageManager.getActivityInfo(cn, 0); cn }.getOrNull()
+  }
+
+  /** Friendly label of the current dismiss target, or null when it resolves to the launcher. */
+  fun chosenLabel(context: Context): String? {
+    val cfg = ScreensaverConfig.load(context)
+    cfg.dismissHaDashboard?.let { path ->
+      if (installedHaPackage(context) == null) return null // HA gone → effectively launcher
+      val p = path.trim()
+      return if (p.isBlank()) "Home Assistant" else "Home Assistant · $p"
+    }
+    val cn = chosenComponent(context) ?: return null
+    val pm = context.packageManager
+    val raw = runCatching { pm.getActivityInfo(cn, 0).loadLabel(pm).toString() }.getOrNull()
+    return raw?.let { Curation.displayLabel(cn.packageName, it) }
+  }
+
+  /**
+   * Launch the chosen target, if any. Called from the dream's tap-to-dismiss handler.
+   * Returns true if something was launched. Best-effort: any failure is swallowed so the
+   * dream still finishes to the launcher.
+   */
+  fun launchChosenApp(context: Context): Boolean {
+    val cfg = ScreensaverConfig.load(context)
+
+    // 1. Home Assistant dashboard / app.
+    cfg.dismissHaDashboard?.let { path ->
+      val pkg = installedHaPackage(context) ?: return false
+      return runCatching {
+            val intent =
+                if (path.isBlank()) {
+                  context.packageManager.getLaunchIntentForPackage(pkg)?.addFlags(
+                      Intent.FLAG_ACTIVITY_NEW_TASK) ?: return false
+                } else {
+                  Intent(Intent.ACTION_VIEW, Uri.parse(haDeepLink(path)))
+                      .setPackage(pkg)
+                      .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+            context.startActivity(intent)
+            true
+          }
+          .onFailure { Log.w(TAG, "couldn't open HA dashboard '$path': $it") }
+          .getOrDefault(false)
+    }
+
+    // 2. A plain app.
+    val cn = chosenComponent(context) ?: return false
+    return runCatching {
+          context.startActivity(
+              Intent(Intent.ACTION_MAIN)
+                  .addCategory(Intent.CATEGORY_LAUNCHER)
+                  .setComponent(cn)
+                  .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+          true
+        }
+        .onFailure { Log.w(TAG, "couldn't open dismiss target $cn: $it") }
+        .getOrDefault(false)
+  }
+
+  /** An app's launcher icon as an [ImageBitmap], or null if it can't be loaded. */
+  fun appIcon(context: Context, pkg: String): ImageBitmap? =
+      runCatching { context.packageManager.getApplicationIcon(pkg).toBitmap(144, 144).asImageBitmap() }
+          .getOrNull()
+
+  /**
+   * Turn user-entered dashboard text into a `homeassistant://navigate/<path>` deep link.
+   * Accepts a bare path ("today-home/security"), a leading slash ("/lovelace/0"), a full
+   * `homeassistant://` URI (used verbatim), or a pasted `http(s)://host/<path>` URL (the
+   * host is stripped). Only called with non-blank input.
+   */
+  fun haDeepLink(input: String): String {
+    val p = input.trim()
+    if (p.startsWith("homeassistant://")) return p
+    val rel =
+        when {
+          p.startsWith("http://") || p.startsWith("https://") ->
+              p.substringAfter("://").substringAfter('/', "")
+          else -> p
+        }
+            .trim()
+            .trimStart('/')
+    return "homeassistant://navigate/$rel"
+  }
+}
+
+/** One installed, launchable app shown in the picker. */
+private data class PickEntry(
+    val label: String,
+    val component: ComponentName,
+    val icon: ImageBitmap,
+)
+
+/**
+ * Picker for the "open this when the screensaver is dismissed" setting. Offers a Home
+ * Assistant section (only when an HA app is installed) with an optional dashboard deep
+ * link, then the Immortal launcher (default) and the installed apps. Reached from the
+ * screensaver settings.
+ */
+class ScreensaverDismissAppActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { DismissAppScreen { finish() } } }
+  }
+}
+
+@Composable
+private fun DismissAppScreen(onDone: () -> Unit) {
+  val context = LocalContext.current
+  val haPkg = remember { ScreensaverDismiss.installedHaPackage(context) }
+  val initial = remember { ScreensaverConfig.load(context) }
+
+  // Three-way selection: HA mode, a specific app component, or neither (launcher).
+  var haMode by remember { mutableStateOf(initial.dismissHaDashboard != null) }
+  var haPath by remember { mutableStateOf(initial.dismissHaDashboard ?: "") }
+  var selectedComponent by remember { mutableStateOf(initial.dismissAppComponent) }
+
+  // null = still loading; emptyList would mean "no apps" (shouldn't happen on a Portal).
+  var apps by remember { mutableStateOf<List<PickEntry>?>(null) }
+  var haIcon by remember { mutableStateOf<ImageBitmap?>(null) }
+  // Enumerating + decoding icons is slow; do it off the main thread.
+  LaunchedEffect(Unit) {
+    thread {
+      haPkg?.let { haIcon = ScreensaverDismiss.appIcon(context, it) }
+      apps = loadLaunchableApps(context)
+    }
+  }
+
+  BackHandler { onDone() }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 24.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp)) {
+      // Header with a back affordance, matching the glyph idiom of our other sub-pages.
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier =
+                Modifier.size(44.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .tvFocusable(RoundedCornerShape(12.dp), focusScale = 1f) { onDone() },
+            contentAlignment = Alignment.Center,
+        ) {
+          Text("←", color = Color.White, fontSize = 26.sp)
+        }
+        Spacer(Modifier.size(14.dp))
+        Text(
+            "Open when dismissed",
+            color = Color.White,
+            fontSize = 30.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+      }
+      Text(
+          "Choose what opens when you tap the screensaver to wake the Portal.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp, start = 58.dp),
+      )
+      Spacer(Modifier.size(26.dp))
+
+      // --- Home Assistant (only when the companion app is installed) -----------------
+      if (haPkg != null) {
+        SectionLabel("Home Assistant")
+        Card {
+          DismissRow(
+              icon = haIcon,
+              title = "Home Assistant",
+              subtitle = "Open your Home Assistant dashboard on tap.",
+              selected = haMode,
+          ) {
+            haMode = true
+            selectedComponent = null
+            ScreensaverConfig.setDismissHaDashboard(context, haPath)
+          }
+          if (haMode) {
+            Divider()
+            Column(modifier = Modifier.padding(start = 18.dp, end = 18.dp, top = 14.dp, bottom = 16.dp)) {
+              Text("Dashboard", color = Color.White, fontSize = 15.sp)
+              OutlinedTextField(
+                  value = haPath,
+                  onValueChange = {
+                    // Single-line: strip any newline the IME might inject.
+                    val v = it.replace("\n", "")
+                    haPath = v
+                    ScreensaverConfig.setDismissHaDashboard(context, v)
+                  },
+                  placeholder = { Text("today-home/security", color = Color(0xFF6E6E6E)) },
+                  singleLine = true,
+                  shape = RoundedCornerShape(12.dp),
+                  modifier = Modifier.fillMaxWidth().heightIn(min = 54.dp).padding(top = 8.dp),
+              )
+              Text(
+                  "The path after your Home Assistant address (e.g. lovelace/0). " +
+                      "Leave blank to open your default dashboard.",
+                  color = Color(0xFF8A8A8A),
+                  fontSize = 13.sp,
+                  modifier = Modifier.padding(top = 8.dp),
+              )
+            }
+          }
+        }
+        Spacer(Modifier.size(26.dp))
+      }
+
+      // --- Launcher + installed apps -------------------------------------------------
+      SectionLabel(if (haPkg != null) "Or an app" else "Open")
+      Card {
+        DismissRow(
+            icon = null,
+            title = "Immortal launcher",
+            subtitle = "Return to your home screen (default).",
+            selected = !haMode && selectedComponent == null,
+        ) {
+          ScreensaverConfig.setDismissLauncher(context)
+          onDone()
+        }
+
+        val list = apps
+        if (list == null) {
+          Divider()
+          Text(
+              "Finding your apps…",
+              color = Color(0xFF9A9A9A),
+              fontSize = 15.sp,
+              modifier = Modifier.padding(18.dp),
+          )
+        } else {
+          list.forEach { app ->
+            Divider()
+            val flat = app.component.flattenToString()
+            DismissRow(
+                icon = app.icon,
+                title = app.label,
+                subtitle = null,
+                selected = !haMode && selectedComponent == flat,
+            ) {
+              ScreensaverConfig.setDismissApp(context, flat)
+              onDone()
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun DismissRow(
+    icon: ImageBitmap?,
+    title: String,
+    subtitle: String?,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+  Row(
+      modifier =
+          Modifier.fillMaxWidth().tvFocusableRow { onClick() }
+              .padding(start = 18.dp, end = 12.dp, top = 14.dp, bottom = 14.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(14.dp),
+  ) {
+    if (icon != null) {
+      Image(
+          bitmap = icon,
+          contentDescription = null,
+          modifier = Modifier.size(40.dp).clip(RoundedCornerShape(10.dp)),
+      )
+    } else {
+      Spacer(Modifier.size(40.dp))
+    }
+    Column(modifier = Modifier.weight(1f)) {
+      Text(title, color = Color.White, fontSize = 17.sp)
+      if (subtitle != null) {
+        Text(
+            subtitle,
+            color = Color(0xFF9A9A9A),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 2.dp),
+        )
+      }
+    }
+    // Visual only — the whole row is the focus/click target.
+    RadioButton(selected = selected, onClick = null)
+  }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+  Text(
+      text.uppercase(),
+      color = Color(0xFF7C7C7C),
+      fontSize = 13.sp,
+      fontWeight = FontWeight.SemiBold,
+      modifier = Modifier.padding(start = 4.dp, bottom = 8.dp),
+  )
+}
+
+@Composable
+private fun Card(content: @Composable () -> Unit) {
+  Surface(
+      color = Color(0xFF1C1C1E),
+      shape = RoundedCornerShape(18.dp),
+      modifier = Modifier.fillMaxWidth(),
+  ) {
+    Column { content() }
+  }
+}
+
+@Composable
+private fun Divider() {
+  Spacer(Modifier.fillMaxWidth().height(1.dp).background(Color(0x14FFFFFF)))
+}
+
+/**
+ * Installed launchable apps, mirroring the launcher's own curation (hidden packages,
+ * label overrides, one tile per package) so the picker shows the same friendly set the
+ * user sees on the home screen — minus Immortal itself.
+ */
+private fun loadLaunchableApps(context: Context): List<PickEntry> {
+  val pm = context.packageManager
+  val intent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
+  return pm.queryIntentActivities(intent, 0)
+      .filter {
+        val pkg = it.activityInfo.packageName
+        pkg != context.packageName && !Curation.isHidden(pkg, "")
+      }
+      .mapNotNull { ri ->
+        runCatching {
+              val ai = ri.activityInfo
+              val rawLabel = ri.loadLabel(pm).toString()
+              val bmp: Bitmap = ri.loadIcon(pm).toBitmap(144, 144)
+              PickEntry(
+                  label = Curation.displayLabel(ai.packageName, rawLabel),
+                  component = ComponentName(ai.packageName, ai.name),
+                  icon = bmp.asImageBitmap(),
+              ) to rawLabel
+            }
+            .getOrNull()
+      }
+      .filterNot { (_, raw) -> raw in Curation.hiddenLabels }
+      .map { it.first }
+      .distinctBy { it.component.packageName }
+      .sortedBy { it.label.lowercase(Locale.getDefault()) }
+}

--- a/app/src/main/java/com/immortal/launcher/ScreensaverSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverSettingsActivity.kt
@@ -263,6 +263,32 @@ private fun ScreensaverSettingsScreen() {
         }
       }
 
+      // When dismissed — where a tap on the frame takes you. Default is the launcher;
+      // Home Assistant users typically point this at their dashboard app instead.
+      Spacer(Modifier.size(26.dp))
+      SectionLabel("When dismissed")
+      val dismissLabel =
+          remember(settings.dismissAppComponent, settings.dismissHaDashboard) {
+            ScreensaverDismiss.chosenLabel(context)
+          }
+      Card {
+        NavRow(
+            title = "Open when you tap to exit",
+            value =
+                if (dismissLabel != null) "Opens $dismissLabel"
+                else "Immortal launcher",
+        ) {
+          context.startActivity(Intent(context, ScreensaverDismissAppActivity::class.java))
+        }
+      }
+      Text(
+          "Tap the screensaver to wake your Portal. By default that brings you home to " +
+              "Immortal — or pick an app (like Home Assistant) to drop straight into it.",
+          color = Color(0xFF7C7C7C),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
+      )
+
       // Music — sourced from the device's own media session, so it works with any
       // app (Spotify, podcasts, the Music Assistant player…); shown for everyone.
       Spacer(Modifier.size(26.dp))
@@ -470,6 +496,21 @@ private fun SelectableRow(title: String, subtitle: String, selected: Boolean, on
     }
     // Visual only — the whole row is the focus/click target.
     RadioButton(selected = selected, onClick = null)
+  }
+}
+
+/** A row that opens a sub-page; shows the current [value] and a chevron. */
+@Composable
+private fun NavRow(title: String, value: String, onClick: () -> Unit) {
+  Row(
+      modifier =
+          Modifier.fillMaxWidth().tvFocusableRow { onClick() }
+              .padding(start = 18.dp, end = 18.dp, top = 16.dp, bottom = 16.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(title, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+    Text(value, color = Color(0xFF9A9A9A), fontSize = 15.sp)
+    Text("  ›", color = Color(0xFF7C7C7C), fontSize = 20.sp)
   }
 }
 

--- a/provisioning/provision.ps1
+++ b/provisioning/provision.ps1
@@ -242,9 +242,14 @@ function Grant-Perms {
   # apps" toggle is non-functional, so grant the source op directly here; with the Gen-1
   # installer-overlay fix the confirm dialog is then visible and usable.
   A shell appops set $cfg["PKG"] REQUEST_INSTALL_PACKAGES allow | Out-Null
-  # Device admin (force-lock only): lets Immortal turn the screen off for its idle
-  # and overnight sleep features via lockNow(). Harmless if it can't be set.
-  A shell dpm set-active-admin "$($cfg["PKG"])/.AdminReceiver" | Out-Null
+  # Device admin (force-lock only): lets Immortal turn the screen off for its idle and
+  # overnight sleep features (and the Home Assistant screen control) via lockNow(). Warn
+  # rather than swallow a failure — without it, screen-off silently won't work.
+  if ((A shell dpm set-active-admin "$($cfg["PKG"])/.AdminReceiver") -match "Success") {
+    Ok "Screen-off (device admin) enabled"
+  } else {
+    Warn "Couldn't enable screen-off device admin — screensaver sleep and the Home Assistant screen control won't work on this device. Re-run setup; if it keeps failing, check Device health in Immortal settings."
+  }
   # Lets Immortal read the device's active media sessions (native now-playing) for
   # the screensaver card + header mini-player. Also self-enabled on app launch.
   A shell cmd notification allow_listener "$($cfg["PKG"])/com.immortal.launcher.MediaNotificationListenerService" | Out-Null

--- a/provisioning/provision.sh
+++ b/provisioning/provision.sh
@@ -303,10 +303,15 @@ grant_perms() {
   # apps" toggle is non-functional, so grant the source op directly here; combined with the
   # Gen-1 installer-overlay fix, the confirm dialog is then visible and usable.
   a shell appops set "$PKG" REQUEST_INSTALL_PACKAGES allow >/dev/null 2>&1
-  # Device admin (force-lock only): lets Immortal turn the screen off for its idle
-  # and overnight sleep features via lockNow(). Harmless if it can't be set.
-  a shell dpm set-active-admin "$PKG/.AdminReceiver" >/dev/null 2>&1 \
-    && ok "Screen-off (device admin) enabled" || true
+  # Device admin (force-lock only): lets Immortal turn the screen off for its idle and
+  # overnight sleep features (and the Home Assistant screen control) via lockNow(). Warn
+  # rather than swallow a failure — without it, screen-off silently won't work, which is a
+  # confusing thing to debug after the fact.
+  if a shell dpm set-active-admin "$PKG/.AdminReceiver" 2>&1 | grep -q "Success"; then
+    ok "Screen-off (device admin) enabled"
+  else
+    warn "Couldn't enable screen-off device admin — screensaver sleep and the Home Assistant screen control won't work on this device. Re-run setup; if it keeps failing, check Device health in Immortal settings."
+  fi
   # Lets Immortal read the device's active media sessions (native now-playing) for
   # the screensaver card + header mini-player. `cmd notification allow_listener`
   # writes the secure setting AND rebinds the listener reliably on A9/A10. The app


### PR DESCRIPTION
## Home Assistant integration

Embraces the HA community already running Immortal on repurposed Portals, across three layers: interoperate, hand off, and expose the device natively.

### What's included
- **Screensaver dismiss → app / HA dashboard** — tapping the photo-frame screensaver can open a chosen app, or deep-link to a specific Home Assistant dashboard (`homeassistant://navigate/...`), instead of always returning to the launcher. New "When dismissed" picker + sub-page, gated on an HA app being installed.
- **Native MQTT Discovery publisher** — exposes this Portal to HA as auto-discovered entities (presence, screen, battery, now-playing, IP, plus screen / identify / media-transport controls), reusing state Immortal already holds. Raw, zero-dependency MQTT 3.1.1 client (matches the FleetHttpServer / Snapcast house style). Off by default; configured in settings. Disabling cleanly removes the device from HA.
- **Screen wake + controls** — HA can wake the panel (wake lock, no provisioning) and toggle the screen; the screen is a two-way switch.
- **Device health page** — a diagnostic listing each provisioned permission (screen-off admin, notification access, install, overlay, secure settings) with what's degraded + how to fix when missing. Replaces the old destructive device-admin toggle.
- **Provisioning hardening** — `dpm set-active-admin` now warns instead of silently swallowing a failure (provision.sh / provision.ps1).

### Testing
Verified end-to-end on a Portal Go (Android 10) against a live Home Assistant: dashboard deep-links land correctly (warm + cold start, #5505 did not reproduce), MQTT device + 13 entities auto-discovered, state flows (presence/battery/screen/now-playing), commands work (media/screen/identify), and disabling removes the device.

### Notes / limits
- True screen-off needs the device-admin grant (provisioning sets it; surfaced on the Device health page).
- v1 entity scope = what Immortal already collects; brightness / volume / foreground-app deferred (need new permissions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)