### PR TITLE
Top-bar app switcher (quick-button overlay)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,9 @@
     <!-- Wake the screen on demand (Home Assistant "wake the panel" via the MQTT screen
          switch). A normal permission; ScreenControl.wake uses a wake lock. -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <!-- App switcher "close" action: a soft stop of an app's background processes. Normal
+         permission (auto-granted). Not a true force-stop, which needs system privilege. -->
+    <uses-permission android:name="android.permission.KILL_BACKGROUND_PROCESSES" />
     <!-- Multi-room now-playing: a media-session foreground service (see
          MultiRoomService). Harmless/unused on the Portal's Android 9/10, where the
          per-type FGS rules don't apply. -->
@@ -255,6 +258,28 @@
         <service
             android:name=".MqttService"
             android:exported="false" />
+
+        <!-- App switcher, opened from the quick-button overlay (internal). -->
+        <activity
+            android:name=".AppSwitcherActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:theme="@style/Theme.SampleApp" />
+
+        <!-- Watches window changes to show the quick-button cluster in sync with the system top
+             bar, AND hosts the cluster overlay (as a TYPE_ACCESSIBILITY_OVERLAY, so it renders on
+             the bar). immortal self-enables this only while the Quick buttons feature is on. -->
+        <service
+            android:name=".BarWatchService"
+            android:exported="false"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+          <intent-filter>
+            <action android:name="android.accessibilityservice.AccessibilityService" />
+          </intent-filter>
+          <meta-data
+              android:name="android.accessibilityservice"
+              android:resource="@xml/bar_watch_service" />
+        </service>
 
         <!-- Multi-room now-playing relay: reads the Snapcast group's track off the
              snapserver and publishes it as a media session so the now-playing card shows

--- a/app/src/main/java/com/immortal/launcher/AppSwitcherActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/AppSwitcherActivity.kt
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.ActivityManager
+import android.app.usage.UsageStatsManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Bundle
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.graphics.drawable.toBitmap
+import com.immortal.launcher.ui.theme.SampleAppTheme
+import java.util.Locale
+import kotlin.concurrent.thread
+
+/**
+ * App switcher: recently-used apps (most-recent first) with per-app notification badges, usage
+ * info, and actions; plus a search box that turns it into an all-apps drawer. Opened from the
+ * quick-button cluster ([QuickBar]).
+ *
+ * Recents/usage come from [UsageStatsManager] (foreground history — not running processes, which
+ * a non-system app can't enumerate; and no live thumbnails on this API level). Badges come from
+ * [MediaNotificationListenerService]'s active notifications.
+ */
+class AppSwitcherActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { AppSwitcherScreen { finish() } } }
+  }
+}
+
+private data class AppItem(
+    val label: String,
+    val component: ComponentName,
+    val icon: ImageBitmap,
+    val lastUsedMs: Long = 0L,
+    val fgMs: Long = 0L,
+)
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun AppSwitcherScreen(onDone: () -> Unit) {
+  val context = LocalContext.current
+  var recents by remember { mutableStateOf<List<AppItem>?>(null) }
+  var allApps by remember { mutableStateOf<List<AppItem>>(emptyList()) }
+  var badges by remember { mutableStateOf<Map<String, Int>>(emptyMap()) }
+  var query by remember { mutableStateOf("") }
+  var menuFor by remember { mutableStateOf<AppItem?>(null) }
+
+  LaunchedEffect(Unit) {
+    badges = MediaNotificationListenerService.activeCountsByPackage()
+    thread {
+      recents = loadRecents(context)
+      allApps = loadAllApps(context)
+    }
+  }
+
+  BackHandler { if (menuFor != null) menuFor = null else onDone() }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Color(0xFF101012))
+              .padding(horizontal = 28.dp, vertical = 24.dp),
+  ) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = { query = it },
+        singleLine = true,
+        placeholder = { Text("Search apps", color = Color(0xFF777777)) },
+        shape = RoundedCornerShape(14.dp),
+        modifier = Modifier.fillMaxWidth(),
+    )
+
+    val searching = query.isNotBlank()
+    val list =
+        if (searching)
+            allApps.filter { it.label.contains(query.trim(), ignoreCase = true) }
+        else recents
+
+    Text(
+        if (searching) "All apps" else "Recent apps",
+        color = Color(0xFF9A9A9A),
+        fontSize = 13.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(top = 16.dp, bottom = 8.dp, start = 4.dp),
+    )
+
+    when {
+      list == null -> Hint("Loading…")
+      list.isEmpty() && searching -> Hint("No apps match “${query.trim()}”.")
+      list.isEmpty() -> Hint("No recent apps yet. Open a few and they'll show up here.")
+      else ->
+          LazyVerticalGrid(
+              columns = GridCells.Adaptive(minSize = 132.dp),
+              modifier = Modifier.fillMaxSize(),
+              horizontalArrangement = Arrangement.spacedBy(8.dp),
+              verticalArrangement = Arrangement.spacedBy(8.dp),
+          ) {
+            items(list) { app ->
+              AppTile(
+                  app = app,
+                  badge = badges[app.component.packageName] ?: 0,
+                  subtitle = if (searching) null else recencyLine(app),
+                  onClick = {
+                    switchTo(context, app.component)
+                    onDone()
+                  },
+                  onLongClick = { menuFor = app },
+              )
+            }
+          }
+    }
+  }
+
+  menuFor?.let { app ->
+    AppActionMenu(
+        app = app,
+        onOpen = {
+          switchTo(context, app.component)
+          onDone()
+        },
+        onAppInfo = {
+          open(context, Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, pkgUri(app)))
+          onDone()
+        },
+        onUninstall = {
+          open(context, Intent(Intent.ACTION_DELETE, pkgUri(app)))
+          menuFor = null
+        },
+        onClose = {
+          runCatching {
+            (context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager)
+                .killBackgroundProcesses(app.component.packageName)
+          }
+          menuFor = null
+        },
+        onDismiss = { menuFor = null },
+    )
+  }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun AppTile(
+    app: AppItem,
+    badge: Int,
+    subtitle: String?,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+) {
+  Column(
+      modifier =
+          Modifier.clip(RoundedCornerShape(16.dp))
+              .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+              .padding(vertical = 14.dp, horizontal = 4.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    BadgedBox(
+        badge = { if (badge > 0) Badge { Text(if (badge > 9) "9+" else "$badge") } },
+        modifier = Modifier.size(56.dp),
+    ) {
+      Image(bitmap = app.icon, contentDescription = null, modifier = Modifier.size(56.dp))
+    }
+    Text(
+        app.label,
+        color = Color.White,
+        fontSize = 13.sp,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(top = 8.dp).fillMaxWidth(),
+    )
+    if (subtitle != null) {
+      Text(
+          subtitle,
+          color = Color(0xFF7C7C7C),
+          fontSize = 11.sp,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+          textAlign = TextAlign.Center,
+          modifier = Modifier.fillMaxWidth(),
+      )
+    }
+  }
+}
+
+@Composable
+private fun AppActionMenu(
+    app: AppItem,
+    onOpen: () -> Unit,
+    onAppInfo: () -> Unit,
+    onUninstall: () -> Unit,
+    onClose: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+  androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
+    Surface(color = Color(0xFF1C1C1E), shape = RoundedCornerShape(18.dp)) {
+      Column(modifier = Modifier.padding(vertical = 10.dp)) {
+        Text(
+            app.label,
+            color = Color.White,
+            fontSize = 17.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(horizontal = 22.dp, vertical = 12.dp),
+        )
+        ActionRow("Open") { onOpen() }
+        ActionRow("App info") { onAppInfo() }
+        ActionRow("Close (free up memory)") { onClose() }
+        ActionRow("Uninstall", danger = true) { onUninstall() }
+      }
+    }
+  }
+}
+
+@Composable
+private fun ActionRow(label: String, danger: Boolean = false, onClick: () -> Unit) {
+  Text(
+      label,
+      color = if (danger) Color(0xFFE0908A) else Color.White,
+      fontSize = 16.sp,
+      modifier = Modifier.fillMaxWidth().tvFocusableRow { onClick() }.padding(horizontal = 22.dp, vertical = 14.dp),
+  )
+}
+
+@Composable
+private fun Hint(text: String) {
+  Text(text, color = Color(0xFF9A9A9A), fontSize = 15.sp, modifier = Modifier.padding(top = 24.dp, start = 4.dp))
+}
+
+// --- helpers ------------------------------------------------------------------
+
+private fun switchTo(context: Context, component: ComponentName) {
+  runCatching {
+    context.startActivity(
+        Intent(Intent.ACTION_MAIN)
+            .addCategory(Intent.CATEGORY_LAUNCHER)
+            .setComponent(component)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+  }
+}
+
+private fun open(context: Context, intent: Intent) {
+  runCatching { context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)) }
+}
+
+private fun pkgUri(app: AppItem): Uri = Uri.parse("package:${app.component.packageName}")
+
+private fun recencyLine(app: AppItem): String {
+  val ago = ago(System.currentTimeMillis() - app.lastUsedMs)
+  val today = duration(app.fgMs)
+  return if (today.isNotEmpty()) "$ago · $today today" else ago
+}
+
+private fun ago(ms: Long): String {
+  val s = ms / 1000
+  return when {
+    s < 45 -> "just now"
+    s < 3600 -> "${s / 60}m ago"
+    s < 86400 -> "${s / 3600}h ago"
+    else -> "${s / 86400}d ago"
+  }
+}
+
+private fun duration(ms: Long): String {
+  val m = ms / 60000
+  return when {
+    m <= 0 -> ""
+    m < 60 -> "${m}m"
+    else -> "${m / 60}h ${m % 60}m"
+  }
+}
+
+/** Recently-used apps, most-recent first, with usage time; launchable + curated, minus Immortal. */
+private fun loadRecents(context: Context): List<AppItem> {
+  val usm =
+      context.getSystemService(Context.USAGE_STATS_SERVICE) as? UsageStatsManager
+          ?: return emptyList()
+  val now = System.currentTimeMillis()
+  val stats = usm.queryUsageStats(UsageStatsManager.INTERVAL_BEST, now - 24L * 3600_000, now)
+  if (stats.isNullOrEmpty()) return emptyList()
+
+  val lastUsed = HashMap<String, Long>()
+  val fg = HashMap<String, Long>()
+  for (s in stats) {
+    if (s.lastTimeUsed > (lastUsed[s.packageName] ?: 0)) lastUsed[s.packageName] = s.lastTimeUsed
+    fg[s.packageName] = (fg[s.packageName] ?: 0) + s.totalTimeInForeground
+  }
+
+  val pm = context.packageManager
+  return lastUsed.entries
+      .sortedByDescending { it.value }
+      .mapNotNull { (pkg, last) ->
+        if (pkg == context.packageName || Curation.isHidden(pkg, "")) return@mapNotNull null
+        // Drop epoch/stale entries UsageStats sometimes reports (e.g. a never-foregrounded
+        // system service with lastTimeUsed≈0 showing as "20000d ago").
+        if (last <= 0L || now - last > 7L * 86400_000) return@mapNotNull null
+        val component = pm.getLaunchIntentForPackage(pkg)?.component ?: return@mapNotNull null
+        runCatching {
+              val ai = pm.getApplicationInfo(pkg, 0)
+              val raw = pm.getApplicationLabel(ai).toString()
+              val bmp: Bitmap = pm.getApplicationIcon(ai).toBitmap(144, 144)
+              AppItem(Curation.displayLabel(pkg, raw), component, bmp.asImageBitmap(), last, fg[pkg] ?: 0)
+            }
+            .getOrNull()
+      }
+      .filterNot { it.label in Curation.hiddenLabels }
+      .take(16)
+}
+
+/** All installed launchable apps (for search / drawer), alphabetised, curated, minus Immortal. */
+private fun loadAllApps(context: Context): List<AppItem> {
+  val pm = context.packageManager
+  val intent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
+  return pm.queryIntentActivities(intent, 0)
+      .filter { it.activityInfo.packageName != context.packageName && !Curation.isHidden(it.activityInfo.packageName, "") }
+      .mapNotNull { ri ->
+        runCatching {
+              val ai = ri.activityInfo
+              val raw = ri.loadLabel(pm).toString()
+              val bmp: Bitmap = ri.loadIcon(pm).toBitmap(144, 144)
+              AppItem(
+                  Curation.displayLabel(ai.packageName, raw),
+                  ComponentName(ai.packageName, ai.name),
+                  bmp.asImageBitmap()) to raw
+            }
+            .getOrNull()
+      }
+      .filterNot { (_, raw) -> raw in Curation.hiddenLabels }
+      .map { it.first }
+      .distinctBy { it.component.packageName }
+      .sortedBy { it.label.lowercase(Locale.getDefault()) }
+}

--- a/app/src/main/java/com/immortal/launcher/BarWatchService.kt
+++ b/app/src/main/java/com/immortal/launcher/BarWatchService.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.accessibilityservice.AccessibilityService
+import android.graphics.Rect
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityWindowInfo
+
+/**
+ * Watches for the system top bar being revealed (immortal hides it by default; the OS shows it
+ * transiently on a swipe-down) and tells [QuickBar] to show/hide the quick-button cluster in
+ * sync. This is the only way to detect the reveal on the Portal — an overlay can't observe it
+ * (insets don't change for sticky-immersive transient bars; verified by spike), but an
+ * accessibility service sees a top-of-screen TYPE_SYSTEM window appear/disappear.
+ *
+ * Enabled by provisioning (added to `enabled_accessibility_services`); a no-op until then.
+ */
+class BarWatchService : AccessibilityService() {
+
+  override fun onServiceConnected() {
+    QuickBar.attach(this) // host the cluster as a TYPE_ACCESSIBILITY_OVERLAY (renders on the bar)
+    updateBar()
+  }
+
+  override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+    if (event?.eventType == AccessibilityEvent.TYPE_WINDOWS_CHANGED) updateBar()
+  }
+
+  override fun onUnbind(intent: android.content.Intent?): Boolean {
+    QuickBar.detach()
+    return super.onUnbind(intent)
+  }
+
+  override fun onInterrupt() {}
+
+  private fun updateBar() {
+    val ws = runCatching { windows }.getOrNull() ?: return
+    val dm = resources.displayMetrics
+    val r = Rect()
+    // The status/top bar is a TYPE_SYSTEM window pinned to the top edge, spanning most of the
+    // width and only a sliver tall — distinct from full-height system windows.
+    val barShown =
+        ws.any { w ->
+          if (w.type != AccessibilityWindowInfo.TYPE_SYSTEM) return@any false
+          w.getBoundsInScreen(r)
+          r.top <= 0 && r.width() >= dm.widthPixels / 2 && r.height() in 1..(dm.heightPixels / 4)
+        }
+    QuickBar.setBarVisible(barShown)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -340,6 +340,8 @@ private fun SettingsMain(
 
       MqttNavRow(onOpen = onOpenMqtt)
 
+      QuickButtonsSection()
+
       Spacer(Modifier.size(26.dp))
       BootAppsNavRow(count = bootCount, onOpen = onOpenBootApps)
 
@@ -694,6 +696,83 @@ private fun MultiRoomScreen(onBack: () -> Unit) {
       )
     }
   }
+}
+
+/**
+ * "Quick buttons" section: a centered overlay button cluster at the top of the screen (v1: an
+ * app switcher). Enable it, and choose whether it shows only while the top bar is revealed
+ * (default) or always.
+ */
+@Composable
+private fun QuickButtonsSection() {
+  val context = LocalContext.current
+  var enabled by remember { mutableStateOf(QuickBarConfig.isEnabled(context)) }
+  var always by remember { mutableStateOf(QuickBarConfig.alwaysShow(context)) }
+
+  Spacer(Modifier.size(26.dp))
+  SectionLabel("Quick buttons")
+  Card {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(18.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Column(modifier = Modifier.weight(1f)) {
+        Text("Top-bar app switcher", color = Color.White, fontSize = 17.sp)
+        Text(
+            "A centered button at the top that opens your recent apps to switch between them.",
+            color = Color(0xFF9A9A9A),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 2.dp),
+        )
+      }
+      Segmented(
+          options = listOf("Off" to "off", "On" to "on"),
+          selected = if (enabled) "on" else "off",
+          onSelect = {
+            val on = it == "on"
+            enabled = on
+            QuickBarConfig.setEnabled(context, on)
+            // Enabling the bar watcher both detects the bar and hosts the cluster overlay; it
+            // runs only while the feature is on, so this is the whole on/off switch.
+            SettingsGuard.setBarWatchEnabled(context, on)
+          },
+      )
+    }
+    if (enabled) {
+      Divider()
+      Row(
+          modifier = Modifier.fillMaxWidth().padding(18.dp),
+          verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Column(modifier = Modifier.weight(1f)) {
+          Text("When to show", color = Color.White, fontSize = 17.sp)
+          Text(
+              "Swipe down from the top to reveal the bar (and the buttons), or keep them always on.",
+              color = Color(0xFF9A9A9A),
+              fontSize = 13.sp,
+              modifier = Modifier.padding(top = 2.dp),
+          )
+        }
+        Segmented(
+            options = listOf("With bar" to "bar", "Always" to "always"),
+            selected = if (always) "always" else "bar",
+            onSelect = {
+              val a = it == "always"
+              always = a
+              QuickBarConfig.setAlwaysShow(context, a)
+              QuickBar.applyConfig()
+            },
+        )
+      }
+    }
+  }
+  Text(
+      "Needs the accessibility-based top-bar watch enabled during setup. The switcher shows your " +
+          "recently used apps; tap one to switch.",
+      color = Color(0xFF7C7C7C),
+      fontSize = 13.sp,
+      modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
+  )
 }
 
 /**

--- a/app/src/main/java/com/immortal/launcher/MediaNotificationListenerService.kt
+++ b/app/src/main/java/com/immortal/launcher/MediaNotificationListenerService.kt
@@ -22,10 +22,32 @@ import android.service.notification.NotificationListenerService
  */
 class MediaNotificationListenerService : NotificationListenerService() {
   override fun onListenerConnected() {
+    instance = this
     MediaSessionReader.onListenerConnected(this)
   }
 
   override fun onListenerDisconnected() {
+    if (instance === this) instance = null
     MediaSessionReader.onListenerDisconnected()
+  }
+
+  companion object {
+    @Volatile private var instance: MediaNotificationListenerService? = null
+
+    /**
+     * Active-notification count per package (for app-switcher badges). Empty when the listener
+     * isn't bound (e.g. un-provisioned device). Ongoing/group-summary notifications are excluded
+     * so a count reflects what the user would actually see.
+     */
+    fun activeCountsByPackage(): Map<String, Int> =
+        instance?.let { svc ->
+          runCatching {
+                svc.activeNotifications
+                    .filter { it.isClearable && (it.notification.flags and android.app.Notification.FLAG_GROUP_SUMMARY) == 0 }
+                    .groupingBy { it.packageName }
+                    .eachCount()
+              }
+              .getOrNull()
+        } ?: emptyMap()
   }
 }

--- a/app/src/main/java/com/immortal/launcher/QuickBar.kt
+++ b/app/src/main/java/com/immortal/launcher/QuickBar.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.accessibilityservice.AccessibilityService
+import android.content.Context
+import android.content.Intent
+import android.graphics.PixelFormat
+import android.graphics.drawable.GradientDrawable
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import android.widget.ImageView
+import android.widget.LinearLayout
+
+/**
+ * The quick-button cluster: a centered row of buttons pinned to the top of the screen, over any
+ * app. Centered (not left/right) so it never collides with the system bar's back/home (left) or
+ * status icons (right), and works on any Portal size without per-model layout.
+ *
+ * Hosted by [BarWatchService] as a **TYPE_ACCESSIBILITY_OVERLAY** — that renders ABOVE the system
+ * bar (a plain app overlay sits below it, so it would draw under the bar and its taps would be
+ * eaten). The same service detects the bar reveal and drives [setBarVisible]. Visibility =
+ * always-show OR the top bar is showing. The accessibility service only runs while the feature is
+ * enabled (immortal self-enables it), so no separate foreground service is needed.
+ *
+ * v1 holds one button (app switcher). The row is the extension point — add child views later.
+ */
+object QuickBar {
+  private const val TAG = "ImmortalQuickBar"
+  private val main = Handler(Looper.getMainLooper())
+
+  private var host: AccessibilityService? = null
+  private var wm: WindowManager? = null
+  private var view: View? = null
+  @Volatile private var barVisible = false
+
+  /** Add the (initially evaluated) cluster overlay, hosted by the accessibility service. */
+  fun attach(service: AccessibilityService) {
+    main.post {
+      if (view != null) {
+        refresh()
+        return@post
+      }
+      host = service
+      val wmgr = service.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+      wm = wmgr
+      val cluster = buildCluster(service)
+      val lp =
+          WindowManager.LayoutParams(
+                  WindowManager.LayoutParams.WRAP_CONTENT,
+                  // Span the full bar height so the button can sit vertically centered within it,
+                  // matching the back/home buttons (rather than flush to the top edge).
+                  statusBarHeight(service),
+                  WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+                  WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+                  PixelFormat.TRANSLUCENT,
+              )
+              .apply { gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL }
+      runCatching { wmgr.addView(cluster, lp); view = cluster }
+          .onFailure { Log.w(TAG, "addView failed", it) }
+      refresh()
+    }
+  }
+
+  fun detach() {
+    main.post {
+      view?.let { v -> runCatching { wm?.removeView(v) } }
+      view = null
+      host = null
+      wm = null
+    }
+  }
+
+  /** Called by [BarWatchService] when the system top bar is revealed / hidden. */
+  fun setBarVisible(visible: Boolean) {
+    barVisible = visible
+    main.post { refresh() }
+  }
+
+  /** Re-evaluate visibility after a config change (e.g. the always-show toggle). */
+  fun applyConfig() = main.post { refresh() }
+
+  private fun refresh() {
+    val v = view ?: return
+    val ctx = host ?: return
+    v.visibility = if (QuickBarConfig.alwaysShow(ctx) || barVisible) View.VISIBLE else View.GONE
+  }
+
+  private fun statusBarHeight(ctx: Context): Int {
+    val id = ctx.resources.getIdentifier("status_bar_height", "dimen", "android")
+    return if (id > 0) ctx.resources.getDimensionPixelSize(id)
+    else (28 * ctx.resources.displayMetrics.density).toInt()
+  }
+
+  // --- UI ---------------------------------------------------------------------
+
+  private fun buildCluster(ctx: Context): View =
+      // Fills the bar-height window; CENTER keeps the button vertically centered in the bar.
+      LinearLayout(ctx).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER
+        addView(appSwitcherButton(ctx))
+      }
+
+  /** A pill sized/shaped to match the system bar's back/home buttons, with the standard recents glyph. */
+  private fun appSwitcherButton(ctx: Context): View {
+    val d = ctx.resources.displayMetrics.density
+    fun dp(v: Int) = (v * d).toInt()
+    return ImageView(ctx).apply {
+      setImageResource(R.drawable.ic_app_switcher)
+      scaleType = ImageView.ScaleType.CENTER_INSIDE
+      // Match the back/home pill footprint: wider than tall, fully rounded, light fill.
+      minimumWidth = dp(76)
+      minimumHeight = dp(44)
+      setPadding(dp(20), dp(10), dp(20), dp(10))
+      background =
+          GradientDrawable().apply {
+            shape = GradientDrawable.RECTANGLE
+            cornerRadius = dp(22).toFloat()
+            setColor(0x33FFFFFF)
+          }
+      setOnClickListener {
+        runCatching {
+          ctx.startActivity(
+              Intent(ctx, AppSwitcherActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/QuickBarConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/QuickBarConfig.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+
+/**
+ * Config for the quick-button cluster ([QuickBar]) — a centered overlay button row at the top of
+ * the screen (v1: an app-switcher button). Off by default. Mirrors the other prefs objects.
+ */
+object QuickBarConfig {
+  private const val PREFS = "quick_bar"
+
+  private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+  fun isEnabled(c: Context): Boolean = prefs(c).getBoolean("enabled", false)
+
+  fun setEnabled(c: Context, on: Boolean) = prefs(c).edit().putBoolean("enabled", on).apply()
+
+  /** True = always visible; false (default) = only while the system top bar is revealed. */
+  fun alwaysShow(c: Context): Boolean = prefs(c).getBoolean("always_show", false)
+
+  fun setAlwaysShow(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("always_show", on).apply()
+}

--- a/app/src/main/java/com/immortal/launcher/SettingsGuard.kt
+++ b/app/src/main/java/com/immortal/launcher/SettingsGuard.kt
@@ -170,4 +170,24 @@ object SettingsGuard {
   fun canWriteSecureSettings(context: Context): Boolean =
       context.checkSelfPermission(android.Manifest.permission.WRITE_SECURE_SETTINGS) ==
           android.content.pm.PackageManager.PERMISSION_GRANTED
+
+  /**
+   * Enable or disable our [BarWatchService] accessibility service by editing the secure setting
+   * ourselves. Unlike notification listeners (OS-protected on A10), `enabled_accessibility_services`
+   * IS writable with WRITE_SECURE_SETTINGS — so the quick-button feature can turn its watcher on
+   * only when the user enables it, instead of provisioning leaving an always-on a11y service.
+   */
+  fun setBarWatchEnabled(context: Context, on: Boolean) {
+    runCatching {
+      val comp = ComponentName(context, BarWatchService::class.java).flattenToString()
+      val cr = context.contentResolver
+      val cur = Settings.Secure.getString(cr, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES) ?: ""
+      val parts = cur.split(':').filter { it.isNotBlank() && !it.equals(comp, ignoreCase = true) }
+      val next = (if (on) parts + comp else parts).joinToString(":")
+      Settings.Secure.putString(cr, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES, next)
+      if (on) Settings.Secure.putInt(cr, Settings.Secure.ACCESSIBILITY_ENABLED, 1)
+      android.util.Log.i("ImmortalQuickBar", "BarWatch a11y ${if (on) "enabled" else "disabled"}")
+    }
+        .onFailure { android.util.Log.w("ImmortalQuickBar", "couldn't toggle BarWatch a11y", it) }
+  }
 }

--- a/app/src/main/res/drawable/ic_app_switcher.xml
+++ b/app/src/main/res/drawable/ic_app_switcher.xml
@@ -1,0 +1,15 @@
+<!-- Copyright (c) Meta Platforms, Inc. and affiliates.
+     This source code is licensed under the MIT license found in the
+     LICENSE file in the root directory of this source tree. -->
+<!-- App-switcher / recents glyph: three rounded vertical bars (One-UI style). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeColor="#FFFFFFFF"
+      android:strokeWidth="3"
+      android:strokeLineCap="round"
+      android:pathData="M5,6 L5,18 M12,6 L12,18 M19,6 L19,18" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
 <resources>
     <string name="app_name">Immortal</string>
     <string name="install_confirm_desc">Lets Immortal confirm the app-install dialog automatically, so apps deployed over WiFi from the fleet manager install without a tap on this Portal.</string>
+    <string name="bar_watch_desc">Lets Immortal show its quick buttons (like the app switcher) in step with the Portal\'s top bar — it watches for the bar being revealed. It doesn\'t read screen content.</string>
 </resources>

--- a/app/src/main/res/xml/bar_watch_service.xml
+++ b/app/src/main/res/xml/bar_watch_service.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Meta Platforms, Inc. and affiliates.
+     This source code is licensed under the MIT license found in the
+     LICENSE file in the root directory of this source tree. -->
+<!-- Watches window changes only, to detect the system top bar being revealed (so the
+     quick-button cluster can show in sync). flagRetrieveInteractiveWindows + window content
+     are needed for getWindows(); it inspects window bounds/type, not content. -->
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowsChanged"
+    android:accessibilityFlags="flagRetrieveInteractiveWindows"
+    android:canRetrieveWindowContent="true"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:notificationTimeout="0"
+    android:description="@string/bar_watch_desc" />

--- a/provisioning/provision.ps1
+++ b/provisioning/provision.ps1
@@ -242,6 +242,9 @@ function Grant-Perms {
   # apps" toggle is non-functional, so grant the source op directly here; with the Gen-1
   # installer-overlay fix the confirm dialog is then visible and usable.
   A shell appops set $cfg["PKG"] REQUEST_INSTALL_PACKAGES allow | Out-Null
+  # Lets the app switcher (Quick buttons) list recently-used apps via UsageStatsManager —
+  # getRecentTasks can't see other apps since Android 5. Harmless when the feature is off.
+  A shell appops set $cfg["PKG"] GET_USAGE_STATS allow | Out-Null
   # Device admin (force-lock only): lets Immortal turn the screen off for its idle and
   # overnight sleep features (and the Home Assistant screen control) via lockNow(). Warn
   # rather than swallow a failure — without it, screen-off silently won't work.

--- a/provisioning/provision.sh
+++ b/provisioning/provision.sh
@@ -303,6 +303,9 @@ grant_perms() {
   # apps" toggle is non-functional, so grant the source op directly here; combined with the
   # Gen-1 installer-overlay fix, the confirm dialog is then visible and usable.
   a shell appops set "$PKG" REQUEST_INSTALL_PACKAGES allow >/dev/null 2>&1
+  # Lets the app switcher (Quick buttons) list recently-used apps via UsageStatsManager —
+  # getRecentTasks can't see other apps since Android 5. Harmless when the feature is off.
+  a shell appops set "$PKG" GET_USAGE_STATS allow >/dev/null 2>&1
   # Device admin (force-lock only): lets Immortal turn the screen off for its idle and
   # overnight sleep features (and the Home Assistant screen control) via lockNow(). Warn
   # rather than swallow a failure — without it, screen-off silently won't work, which is a


### PR DESCRIPTION
## Top-bar app switcher (quick-button overlay)

The Portal has no app switcher; this adds one. (Reopened as a fresh PR after the HA work merged — supersedes #18, which auto-closed when its base branch was deleted.)

### What it does
- A centered button on the system top bar — hosted by an accessibility service as a `TYPE_ACCESSIBILITY_OVERLAY` so it renders *on* the bar (a plain app overlay sits below it and its taps get eaten). Styled to match the back/home pills; three-bar recents glyph; shown in sync with the bar's reveal.
- Opens an **app switcher**: recently-used apps (UsageStats) with per-app **notification badges**, **usage + recency** labels ("5m ago · 8m today"), a long-press **action menu** (Open / App info / Close / Uninstall), and a **search box** that doubles as an all-apps drawer. Tap to switch.
- Off by default ("Quick buttons" setting). Immortal self-enables the accessibility watcher (via WRITE_SECURE_SETTINGS) only while the feature is on, so there's no always-on a11y service. Provisioning grants GET_USAGE_STATS.

### Testing
Verified end-to-end on a Portal Go: on-bar render + tap, bar-synced show/hide, recents ordering, notification badges, usage labels, the long-press action menu, and search / all-apps.

### Limits (OS-level for a non-system app)
- No live thumbnails (API 29) — it's an icon grid, not the stock card carousel.
- No "currently running" list (can't enumerate other apps) — shows recently-*used*.
- In always-visible-bar mode the pill sits just below the bar (can't draw above a *permanent* status bar); in the default hide-bar mode it's on the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)