### PR TITLE
Fix provision.ps1 crash on Windows PowerShell 5.1 (em dash → parse error)

### DIFF
--- a/.github/workflows/provisioning.yml
+++ b/.github/workflows/provisioning.yml
@@ -3,16 +3,27 @@ name: Provisioning scripts
 # Catch syntax errors in the provisioning kit before they reach users — bash and
 # (especially) PowerShell, which has historically broken on release without anyone
 # noticing until Windows users hit it.
+#
+# The PowerShell parse runs TWICE on purpose:
+#   - pwsh (PowerShell 7) on Ubuntu catches structural syntax errors quickly.
+#   - Windows PowerShell 5.1 on a Windows runner is what real users actually run
+#     (the .bat invokes the built-in powershell.exe). 5.1 reads a BOM-less file as
+#     the ANSI codepage, so a stray non-ASCII char (e.g. an em dash) mis-decodes
+#     into a phantom quote and breaks parsing — pwsh 7 reads UTF-8 and never sees it.
+#     That false-green is exactly how a broken provision.ps1 shipped before.
+# The ASCII guard makes the most common cause fail fast with a clear message.
 on:
   pull_request:
     paths:
       - "provisioning/provision.sh"
       - "provisioning/provision.ps1"
+      - "provisioning/*.bat"
   push:
     branches: [main]
     paths:
       - "provisioning/provision.sh"
       - "provisioning/provision.ps1"
+      - "provisioning/*.bat"
 
 jobs:
   lint:
@@ -23,7 +34,24 @@ jobs:
       - name: provision.sh — bash syntax
         run: bash -n provisioning/provision.sh
 
-      - name: provision.ps1 — PowerShell parse (pwsh ships on the runner)
+      - name: Windows scripts must be pure ASCII (5.1 mis-decodes non-ASCII)
+        run: |
+          # Windows PowerShell 5.1 reads BOM-less files as ANSI, so any byte > 0x7F
+          # can turn into a phantom quote/brace and break parsing. Keep the
+          # Windows-executed scripts 7-bit clean. provision.sh is exempt — it only
+          # runs on macOS/Linux, where UTF-8 is read natively.
+          fail=0
+          for f in provisioning/provision.ps1 provisioning/*.bat; do
+            [ -e "$f" ] || continue
+            if LC_ALL=C grep -nP "[^\x00-\x7F]" "$f"; then
+              echo "::error file=$f::Non-ASCII byte(s) above — Windows PowerShell 5.1 will mis-decode these. Use ASCII (e.g. '-' instead of '—')."
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] && echo "Windows scripts are pure ASCII"
+          exit $fail
+
+      - name: provision.ps1 — PowerShell 7 parse (quick structural check)
         shell: pwsh
         run: |
           $errs = $null
@@ -33,4 +61,23 @@ jobs:
             $errs | ForEach-Object { Write-Error "line $($_.Extent.StartLineNumber): $($_.Message)" }
             exit 1
           }
-          Write-Host "provision.ps1 parses clean"
+          Write-Host "provision.ps1 parses clean under pwsh 7"
+
+  windows-parse:
+    # The real thing: parse under Windows PowerShell 5.1, exactly what the .bat runs
+    # on a user's machine. `shell: powershell` is 5.1 on the runner; `pwsh` is 7.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: provision.ps1 — Windows PowerShell 5.1 parse
+        shell: powershell
+        run: |
+          $errs = $null
+          [void][System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path provisioning/provision.ps1).Path, [ref]$null, [ref]$errs)
+          if ($errs) {
+            $errs | ForEach-Object { Write-Error "line $($_.Extent.StartLineNumber): $($_.Message)" }
+            exit 1
+          }
+          Write-Host "provision.ps1 parses clean under Windows PowerShell 5.1"

--- a/provisioning/provision.ps1
+++ b/provisioning/provision.ps1
@@ -242,16 +242,16 @@ function Grant-Perms {
   # apps" toggle is non-functional, so grant the source op directly here; with the Gen-1
   # installer-overlay fix the confirm dialog is then visible and usable.
   A shell appops set $cfg["PKG"] REQUEST_INSTALL_PACKAGES allow | Out-Null
-  # Lets the app switcher (Quick buttons) list recently-used apps via UsageStatsManager —
+  # Lets the app switcher (Quick buttons) list recently-used apps via UsageStatsManager -
   # getRecentTasks can't see other apps since Android 5. Harmless when the feature is off.
   A shell appops set $cfg["PKG"] GET_USAGE_STATS allow | Out-Null
   # Device admin (force-lock only): lets Immortal turn the screen off for its idle and
   # overnight sleep features (and the Home Assistant screen control) via lockNow(). Warn
-  # rather than swallow a failure — without it, screen-off silently won't work.
+  # rather than swallow a failure - without it, screen-off silently won't work.
   if ((A shell dpm set-active-admin "$($cfg["PKG"])/.AdminReceiver") -match "Success") {
     Ok "Screen-off (device admin) enabled"
   } else {
-    Warn "Couldn't enable screen-off device admin — screensaver sleep and the Home Assistant screen control won't work on this device. Re-run setup; if it keeps failing, check Device health in Immortal settings."
+    Warn "Couldn't enable screen-off device admin - screensaver sleep and the Home Assistant screen control won't work on this device. Re-run setup; if it keeps failing, check Device health in Immortal settings."
   }
   # Lets Immortal read the device's active media sessions (native now-playing) for
   # the screensaver card + header mini-player. Also self-enabled on app launch.


### PR DESCRIPTION
## What happened
A Windows user (running `Provision-Portal.bat`) hit a hard parse error and provisioning never started:

```
At ...\provision.ps1:225 char:22
+ function Grant-Perms {
Missing closing '}' in statement block or type definition.
+ FullyQualifiedErrorId : MissingEndCurlyBrace
```

## Root cause
The 1.42 provisioning hardening added three em dashes (`—`) to the device-admin / usage-stats block — one of them **inside a string** (the `Warn` message).

`Provision-Portal.bat` runs the built-in `powershell.exe`, i.e. **Windows PowerShell 5.1**. With no BOM, 5.1 reads the file as the ANSI codepage; the em dash's `0x94` byte decodes to a curly close-quote (U+201D) that 5.1 treats as a **string terminator** — so the `Warn` string ends early and the parser never finds the function's closing brace, reporting the misleading missing-brace error back at `function Grant-Perms`.

**pwsh 7 reads UTF-8 correctly and never sees the phantom quote** — which is exactly why the local check *and the existing CI parse step* (which ran under pwsh 7 on Ubuntu) both stayed green.

## Fix
- Replace the three em dashes with ASCII hyphens → `provision.ps1` is pure 7-bit ASCII and parses identically under 5.1 and 7.

## Stop it recurring
- **New `windows-parse` job** parses `provision.ps1` under **real Windows PowerShell 5.1** (`shell: powershell` on `windows-latest`) — the interpreter users actually run. This would have caught it.
- **ASCII-only guard** fails fast with a clear message if any Windows-executed script (`provision.ps1` / `*.bat`) contains a non-ASCII byte. `provision.sh` is exempt (macOS/Linux only, UTF-8 read natively).

## Verification
- Local pwsh parse: clean. ASCII guard: passes. Confirmed `provision.ps1` is no longer in the non-ASCII set.
- The new Windows 5.1 CI job on this PR is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)