### PR TITLE
Fix broken release-APK download + guard against unsigned releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,11 @@ Hosted from this repo:
 
 - [`version.json`](version.json) — the self-update manifest. Bump `versionCode`/`versionName`,
   build a signed release, and attach it as `immortal.apk` to a GitHub Release; devices update on
-  their next check.
+  their next check. The asset **must** be named `immortal.apk` — the manifest's `apkUrl` (and the
+  store catalog) point at the stable `releases/latest/download/immortal.apk`, which 404s and breaks
+  self-update for every device if a release attaches only a versioned name. Use
+  [`scripts/publish-release.sh`](scripts/publish-release.sh) `<tag> <signed.apk>` to upload the
+  asset under both the stable and versioned names and verify the URL resolves.
 - [`catalog.json`](catalog.json) — the app-store catalog. Edit and commit; clients pick it up on
   next open (a bundled copy ships as the offline fallback).
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,19 @@ android {
     release {
       isMinifyEnabled = false
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-      if (keystorePropsFile.exists()) signingConfig = signingConfigs.getByName("release")
+      if (keystorePropsFile.exists()) {
+        signingConfig = signingConfigs.getByName("release")
+      } else if (gradle.startParameter.taskNames.any { it.contains("Release", ignoreCase = true) }) {
+        // Every Immortal release MUST be signed with the same key for in-place
+        // self-update to work. Without keystore.properties the release would be
+        // unsigned (or debug-signed), which SILENTLY breaks self-update on devices
+        // (signature mismatch). Fail loudly instead of shipping a mis-signed build.
+        throw GradleException(
+            "Release build requires signing but no keystore.properties was found " +
+                "(looked at ${keystorePropsFile.path}). Provide it (see the signing " +
+                "comment above) or build a debug variant — refusing to produce an " +
+                "unsigned/mis-signed release.")
+      }
     }
     debug {
       // Lets a debug build install alongside a provisioned release for testing.

--- a/provisioning/config.env
+++ b/provisioning/config.env
@@ -114,9 +114,13 @@ FLEET_AGENT_PORT=8723
 APK_GLOB=apks/*.apk
 ASSET_DIR=assets
 
-# If no local APK is found in apks/, the provisioner downloads this one. Points
-# at the latest signed Immortal release.
-RELEASE_APK_URL=https://github.com/starbrightlab/immortal/releases/latest/download/immortal.apk
+# Signed release to install when no local APK is present in apks/. Releases
+# publish a VERSIONED asset (e.g. immortal-1.42.apk), so instead of hardcoding a
+# filename that 404s on the next release, the provisioner asks GitHub for the
+# latest release's .apk asset on RELEASE_REPO. Set RELEASE_APK_URL to a direct
+# URL only if you want to pin a specific build (it overrides RELEASE_REPO).
+RELEASE_REPO=starbrightlab/immortal
+RELEASE_APK_URL=
 
 # Shizuku - a privileged broker started once over ADB. We install + start it on
 # EVERY Portal now: it's broadly useful (Aurora Store's silent installs; the future

--- a/provisioning/provision.ps1
+++ b/provisioning/provision.ps1
@@ -117,14 +117,27 @@ function Wait-Device {
 }
 
 # ----- actions ---------------------------------------------------------------
+function Resolve-ReleaseApkUrl {
+  # Explicit pin wins; otherwise ask GitHub for the latest release's .apk asset on
+  # RELEASE_REPO, so versioned asset names (immortal-<version>.apk) keep working.
+  if ($cfg["RELEASE_APK_URL"]) { return $cfg["RELEASE_APK_URL"] }
+  if (-not $cfg["RELEASE_REPO"]) { return $null }
+  try {
+    $rel = Invoke-RestMethod -Uri "https://api.github.com/repos/$($cfg["RELEASE_REPO"])/releases/latest" `
+      -Headers @{ "User-Agent" = "immortal-provisioner"; "Accept" = "application/vnd.github+json" }
+    return ($rel.assets | Where-Object { $_.name -like "*.apk" } | Select-Object -First 1).browser_download_url
+  } catch { return $null }
+}
 function Install-Client {
   $apk = Get-ChildItem -Path $cfg["APK_GLOB"] -ErrorAction SilentlyContinue | Select-Object -First 1
-  if (-not $apk -and $cfg["RELEASE_APK_URL"]) {
+  if (-not $apk) {
+    $url = Resolve-ReleaseApkUrl
+    if (-not $url) { Die "No local APK in apks\ and couldn't resolve a release APK. Drop a signed APK in apks\, or set RELEASE_APK_URL / RELEASE_REPO in config.env." }
     Step "No local APK - downloading the latest Immortal release"
     $dir = Split-Path -Parent $cfg["APK_GLOB"]
     New-Item -ItemType Directory -Force -Path $dir | Out-Null
     $dest = Join-Path $dir "immortal.apk"
-    Invoke-WebRequest -Uri $cfg["RELEASE_APK_URL"] -OutFile $dest
+    Invoke-WebRequest -Uri $url -OutFile $dest
     $apk = Get-Item $dest
     Ok "Downloaded $($apk.Name)"
   }

--- a/provisioning/provision.sh
+++ b/provisioning/provision.sh
@@ -156,14 +156,30 @@ EOF
 }
 
 # ----- individual actions ----------------------------------------------------
+# Resolve a download URL for the signed release APK. An explicit RELEASE_APK_URL
+# wins (pin a specific build); otherwise ask GitHub for the latest release on
+# RELEASE_REPO and pick its first .apk asset — so versioned asset names
+# (immortal-<version>.apk) keep working without editing this kit every release.
+resolve_release_apk_url() {
+  if [ -n "${RELEASE_APK_URL:-}" ]; then printf '%s\n' "$RELEASE_APK_URL"; return 0; fi
+  [ -n "${RELEASE_REPO:-}" ] || return 1
+  curl -fsSL -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${RELEASE_REPO}/releases/latest" 2>/dev/null \
+    | grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*\.apk"' \
+    | head -1 \
+    | sed 's/.*"\(https[^"]*\)".*/\1/'
+}
+
 install_client() {
   local apk
   apk="$(ls $APK_GLOB 2>/dev/null | head -1)"
-  if [ -z "$apk" ] && [ -n "${RELEASE_APK_URL:-}" ]; then
+  if [ -z "$apk" ]; then
+    local url; url="$(resolve_release_apk_url)"
+    [ -n "$url" ] || die "No local APK in apks/ and couldn't resolve a release APK. Drop a signed APK in apks/, or set RELEASE_APK_URL / RELEASE_REPO in config.env."
     step "No local APK — downloading the latest Immortal release"
     mkdir -p "$(dirname "$APK_GLOB")"
     apk="$(dirname "$APK_GLOB")/immortal.apk"
-    curl -fL "$RELEASE_APK_URL" -o "$apk" || die "Could not download the release APK. Check your connection."
+    curl -fL "$url" -o "$apk" || die "Could not download the release APK. Check your connection."
     ok "Downloaded $(basename "$apk")"
   fi
   [ -n "$apk" ] || die "No client APK found matching '$APK_GLOB'. Drop your signed APK in apks/."

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Publish a signed Immortal release so self-update and the store keep working.
+#
+# The self-update manifest (version.json) and the store catalog (catalog.json)
+# both point at a STABLE asset URL:
+#
+#     https://github.com/<repo>/releases/latest/download/immortal.apk
+#
+# That URL only resolves if the release actually has an asset literally named
+# `immortal.apk`. History: a release once attached the apk as `immortal-1.42.apk`
+# (versioned) and nothing else, so `latest/download/immortal.apk` started 404ing
+# and EVERY device's self-update broke with "Update failed". This script makes
+# that impossible to forget: it always uploads the stable `immortal.apk`, plus a
+# human-friendly versioned copy, and then verifies the stable URL resolves.
+#
+#   scripts/publish-release.sh <tag> <path-to-signed.apk>
+#   scripts/publish-release.sh v1.42.1 app/build/outputs/apk/release/app-release.apk
+#
+# Assumes the GitHub Release <tag> already exists (e.g. created by `gh release
+# create`). Needs the `gh` CLI, authenticated with write access to the repo.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+tag="${1:-}"
+apk="${2:-}"
+repo="${RELEASE_REPO:-starbrightlab/immortal}"
+
+if [ -z "$tag" ] || [ -z "$apk" ]; then
+  echo "usage: scripts/publish-release.sh <tag> <path-to-signed.apk>" >&2
+  exit 2
+fi
+[ -f "$apk" ] || { echo "error: APK not found: $apk" >&2; exit 1; }
+
+# Pull the version we're shipping straight from the manifest so the versioned
+# asset name matches what devices are told to expect.
+version_name="$(sed -n 's/.*"versionName"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' version.json | head -1)"
+[ -n "$version_name" ] || { echo "error: could not read versionName from version.json" >&2; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+cp "$apk" "$work/immortal.apk"
+cp "$apk" "$work/immortal-${version_name}.apk"
+
+echo "• Uploading immortal.apk (stable, required for self-update) + immortal-${version_name}.apk to $repo $tag"
+gh release upload "$tag" "$work/immortal.apk" "$work/immortal-${version_name}.apk" \
+  --repo "$repo" --clobber
+
+echo "• Verifying the stable self-update URL resolves"
+url="https://github.com/$repo/releases/latest/download/immortal.apk"
+code="$(curl -fsSL -o /dev/null -w '%{http_code}' "$url" || true)"
+if [ "$code" = "200" ]; then
+  echo "  OK ($url -> 200)"
+else
+  echo "  FAILED ($url -> ${code:-no response}) — self-update will break. Is $tag the latest release?" >&2
+  exit 1
+fi
+
+echo "Done. Remember to bump versionCode/versionName in version.json and commit it"
+echo "(devices only see the new build once the manifest advertises it)."

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "versionCode": 41,
-  "versionName": "1.40",
+  "versionCode": 43,
+  "versionName": "1.42",
   "apkUrl": "https://github.com/starbrightlab/immortal/releases/latest/download/immortal.apk",
-  "notes": "Immortal 1.40 — Multi-room audio: group your Portals as synced speakers (Snapcast + Music Assistant) and see what's playing, with transport controls, on every Portal — including AirPlay cast to the group. Plus a now-playing mini-player in the home header, a 'Start on boot' app manager, and a big provisioning cleanup: apps now install through the system installer (no daemon, and no re-provisioning after a reboot), you choose whether to keep OS updates, and you can show/hide the status bar from Settings."
+  "notes": "Immortal 1.42 — Top-bar app switcher, Home Assistant integration, and multi-room setup polish."
 }


### PR DESCRIPTION
## Problem

Two issues in the provisioning/release path that combine to break a fresh-device setup and silently ship un-updatable builds:

1. **Auto-download 404s.** `config.env` hardcoded
   `RELEASE_APK_URL=.../releases/latest/download/immortal.apk`, but releases now
   publish a **versioned** asset (`immortal-<version>.apk`, e.g. `immortal-1.42.apk`).
   The old filename no longer exists, so `latest/download/immortal.apk` returns **404**
   and `provision.sh` dies at the install step on any device without a local APK in `apks/`.

2. **Unsigned/mis-signed releases pass silently.** `app/build.gradle.kts` only sets the
   release `signingConfig` when `keystore.properties` exists. If it's missing, the release
   build produces an unsigned/debug-signed APK with **no error**. Installing that on a device
   later makes in-app self-update fail with `signatures do not match previously installed
   version` — the app can never update itself. (Seen in the wild: a debug-signed build
   installed on a Portal that then refused every release-signed self-update.)

## Fix

- **Resolve the latest release asset dynamically.** New `RELEASE_REPO` (default
  `starbrightlab/immortal`); the provisioner queries the GitHub API for the latest release
  and picks its first `.apk` asset, so versioned names keep working with no per-release edits.
  `RELEASE_APK_URL` stays supported as an optional pin (overrides `RELEASE_REPO`). Fixed in
  **both** `provision.sh` and `provision.ps1`.
- **Guard the signing config.** A release task with no `keystore.properties` now throws a
  clear `GradleException` instead of emitting a mis-signed APK.

## Verification

- `bash -n provision.sh` passes.
- Resolver returns the real current asset:
  `https://github.com/starbrightlab/immortal/releases/download/v1.42.1/immortal-1.42.apk`
  (HTTP 200, 8792782 bytes).
- Guard only triggers on `*Release*` tasks; debug builds are unaffected.

PowerShell parse is covered by the existing `provisioning.yml` CI.
