### PR TITLE
Support the new iCloud (CloudKit) shared-album links in the screensaver

### DIFF
--- a/app/src/main/java/com/immortal/launcher/AlbumUrlEntryActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/AlbumUrlEntryActivity.kt
@@ -90,7 +90,7 @@ private fun AlbumUrlEntryScreen(onSave: (String) -> Unit, onCancel: () -> Unit) 
           value = url,
           onValueChange = { url = it },
           placeholder = {
-            Text("https://www.icloud.com/sharedalbum/#…", color = Color(0xFF777777))
+            Text("https://photos.icloud.com/shared/album/…", color = Color(0xFF777777))
           },
           singleLine = true,
           modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
@@ -157,8 +157,9 @@ private fun AlbumUrlEntryScreen(onSave: (String) -> Unit, onCancel: () -> Unit) 
           modifier = Modifier.padding(start = 4.dp, bottom = 6.dp),
       )
       Text(
-          "• iPhone Photos → an album you own → Share → Copy Link. The album must " +
-              "be a Shared Album with \"Public Website\" turned on.\n" +
+          "• iPhone Photos → a Shared Album you own → people/share button → " +
+              "Share Link → Copy Link (works with the current " +
+              "photos.icloud.com/shared/album/… links).\n" +
               "• Google Photos → album → Share → \"Get link\" (anyone with the link can view).",
           color = Color(0xFF8A8A8A),
           fontSize = 13.sp,

--- a/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
@@ -2,6 +2,8 @@ package com.immortal.launcher
 
 import java.net.HttpURLConnection
 import java.net.URL
+import java.net.URLEncoder
+import org.json.JSONArray
 import org.json.JSONObject
 
 /**
@@ -9,6 +11,14 @@ import org.json.JSONObject
  * album link — no account or API key, only links the owner marked "anyone with the
  * link can view". On any failure [fetch] returns null and the caller falls back to
  * the default web feed so the photo frame is never blank.
+ *
+ * iCloud comes in two flavours, both supported here:
+ *  - **Legacy "Shared Streams"** — `www.icloud.com/sharedalbum/#TOKEN` (token in the
+ *    URL fragment). Retired with iOS/macOS 26; handled by [fetchIcloud].
+ *  - **CloudKit shared albums** — `photos.icloud.com/shared/album/TOKEN` (token in the
+ *    path). The current format; handled by [fetchIcloudCloudKit], which resolves the
+ *    share's CloudKit zone and pages its photo records straight from CloudKit Web
+ *    Services (no account — the resolve step mints a short-lived anonymous token).
  */
 object RemoteAlbum {
 
@@ -26,10 +36,17 @@ object RemoteAlbum {
         else -> "Shared album"
       }
 
-  fun isIcloud(url: String): Boolean =
+  fun isIcloud(url: String): Boolean = isIcloudLegacy(url) || isIcloudCloudKit(url)
+
+  /** Legacy "Shared Streams" links (pre iOS/macOS 26); token lives in the `#` fragment. */
+  internal fun isIcloudLegacy(url: String): Boolean =
       url.contains("icloud.com/sharedalbum/", ignoreCase = true) ||
           url.contains("icloud.com/photo-stream/", ignoreCase = true) ||
           url.contains("icloud.com/photostream/", ignoreCase = true)
+
+  /** Current CloudKit shared albums: `photos.icloud.com/shared/album/<shortGUID>`. */
+  internal fun isIcloudCloudKit(url: String): Boolean =
+      url.contains("icloud.com/shared/album/", ignoreCase = true)
 
   fun isGooglePhotos(url: String): Boolean =
       url.contains("photos.app.goo.gl", ignoreCase = true) ||
@@ -39,7 +56,8 @@ object RemoteAlbum {
     val url = shareUrl.trim()
     return runCatching {
           when {
-            isIcloud(url) -> fetchIcloud(url, screenW, screenH)
+            isIcloudCloudKit(url) -> fetchIcloudCloudKit(url, screenW, screenH)
+            isIcloudLegacy(url) -> fetchIcloud(url, screenW, screenH)
             isGooglePhotos(url) -> fetchGoogle(url, screenW, screenH)
             else -> null
           }
@@ -51,6 +69,19 @@ object RemoteAlbum {
     val frag = url.substringAfter('#', "").substringBefore('?').trim()
     if (frag.isEmpty()) return null
     return frag.trim('/')
+  }
+
+  /**
+   * The CloudKit shortGUID from a `…/shared/album/<token>` link. Unlike the legacy
+   * token it lives in the PATH (not the `#` fragment), so strip any trailing query,
+   * fragment, or path segment.
+   */
+  internal fun cloudKitToken(url: String): String? {
+    val marker = "shared/album/"
+    val idx = url.indexOf(marker, ignoreCase = true)
+    if (idx < 0) return null
+    val rest = url.substring(idx + marker.length)
+    return rest.substringBefore('?').substringBefore('#').substringBefore('/').trim().ifEmpty { null }
   }
 
   /**
@@ -186,6 +217,125 @@ object RemoteAlbum {
       }
     }
     return bestChecksum ?: fallbackChecksum
+  }
+
+  // --- CloudKit shared albums (iOS/macOS 26+) --------------------------------
+
+  private const val CK_HOST = "https://ckdatabasews.icloud.com"
+  private const val CK_CONTAINER = "com.apple.photos.cloud"
+  // CloudKit Web Services treats these as telemetry, not auth — the server accepts
+  // any value (verified with a dummy build), so a constant is safe and stable.
+  private const val CK_BUILD = "2620BuildBeta48"
+  private const val CK_PARAMS = "clientBuildNumber=$CK_BUILD&clientMasteringNumber=$CK_BUILD"
+  // The asset-and-master index the iCloud web app pages, newest first.
+  private const val CK_RECORD_TYPE = "CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted"
+  private const val CK_PAGE_SIZE = 200
+  private const val CK_MAX_PAGES = 50 // hard cap so a huge album can't loop forever
+
+  /**
+   * Resolve a `…/shared/album/<shortGUID>` link to its CloudKit zone, then page the
+   * shared zone's photo records straight from CloudKit Web Services. No account: the
+   * public `records/resolve` call returns a short-lived anonymous access token that
+   * authorises the (per-partition) `records/query` calls.
+   */
+  private fun fetchIcloudCloudKit(url: String, screenW: Int, screenH: Int): Album? {
+    val token = cloudKitToken(url) ?: return null
+
+    // 1. Resolve the share: zone + anonymous token + the partition host to query.
+    val resolveUrl = "$CK_HOST/database/1/$CK_CONTAINER/production/public/records/resolve?$CK_PARAMS"
+    val resolveBody = postJson(resolveUrl, "{\"shortGUIDs\":[{\"value\":\"$token\"}]}") ?: return null
+    val resolved = JSONObject(resolveBody).optJSONArray("results")?.optJSONObject(0) ?: return null
+    val zone = resolved.optJSONObject("zoneID") ?: return null
+    val zoneName = zone.optString("zoneName", "").ifBlank { return null }
+    val ownerRecordName = zone.optString("ownerRecordName", "")
+    val zoneType = zone.optString("zoneType", "REGULAR_CUSTOM_ZONE")
+    val access = resolved.optJSONObject("anonymousPublicAccess") ?: return null
+    val authToken = access.optString("token", "").ifBlank { return null }
+    // Records live on the share's partition host (e.g. p117-…); fall back to the
+    // generic host if the resolve didn't pin one. Strip the explicit `:443`.
+    val partition =
+        access.optString("databasePartition", "").ifBlank { CK_HOST }.removeSuffix(":443")
+    val title =
+        resolved
+            .optJSONObject("share")
+            ?.optJSONObject("fields")
+            ?.optJSONObject("cloudkit.title")
+            ?.optString("value", "")
+            ?.ifBlank { null }
+
+    // 2. Page the shared zone's assets. downloadURLs come inline — unlike the legacy
+    //    API there's no separate webasseturls round-trip.
+    val zoneJson =
+        "{\"zoneName\":\"$zoneName\",\"ownerRecordName\":\"$ownerRecordName\",\"zoneType\":\"$zoneType\"}"
+    val queryUrl =
+        "$partition/database/1/$CK_CONTAINER/production/shared/records/query?$CK_PARAMS" +
+            "&publicAccessAuthToken=${URLEncoder.encode(authToken, "UTF-8")}"
+
+    val out = ArrayList<String>()
+    var marker: String? = null
+    var pages = 0
+    do {
+      val markerJson = marker?.let { ",\"continuationMarker\":\"$it\"" } ?: ""
+      val body =
+          "{\"query\":{\"recordType\":\"$CK_RECORD_TYPE\",\"filterBy\":[{\"fieldName\":\"direction\"," +
+              "\"comparator\":\"EQUALS\",\"fieldValue\":{\"value\":\"DESCENDING\",\"type\":\"STRING\"}}]}," +
+              "\"zoneID\":$zoneJson,\"resultsLimit\":$CK_PAGE_SIZE$markerJson}"
+      val resp = postJson(queryUrl, body) ?: break
+      val obj = JSONObject(resp)
+      val records: JSONArray = obj.optJSONArray("records") ?: break
+      for (i in 0 until records.length()) {
+        val rec = records.optJSONObject(i) ?: continue
+        if (rec.optString("recordType") != "CPLMaster") continue
+        val fields = rec.optJSONObject("fields") ?: continue
+        if (!isCloudKitImage(fields)) continue
+        pickBestCloudKitAsset(fields, screenW, screenH)?.let { out.add(it) }
+      }
+      marker = obj.optString("continuationMarker", "").ifBlank { null }
+      pages++
+    } while (marker != null && pages < CK_MAX_PAGES)
+
+    return Album(title, out)
+  }
+
+  /** True for still-image masters; skips videos (we only feed photos to the frame). */
+  internal fun isCloudKitImage(fields: JSONObject): Boolean {
+    val itemType = fields.optJSONObject("itemType")?.optString("value", "") ?: ""
+    if (itemType.isEmpty()) return true // unknown → keep, picker still needs a JPEG derivative
+    val t = itemType.lowercase()
+    return !t.contains("movie") && !t.contains("video")
+  }
+
+  /**
+   * Choose the best downloadable derivative on a CPLMaster: the smallest whose long
+   * edge still covers the screen, else the largest available. Mirrors the legacy
+   * [pickBestDerivative] policy. Each `res*Res` field carries the asset blob (with a
+   * `downloadURL`); its pixel width is in the sibling `res*Width` field.
+   */
+  internal fun pickBestCloudKitAsset(fields: JSONObject, screenW: Int, screenH: Int): String? {
+    val target = maxOf(screenW, screenH)
+    var bestUrl: String? = null
+    var bestW = -1
+    var fallbackUrl: String? = null
+    var fallbackW = -1
+    val keys = fields.keys()
+    while (keys.hasNext()) {
+      val k = keys.next()
+      // res*Res hold the image blobs; res*Vid*Res are video tracks — never photos.
+      if (!k.startsWith("res") || !k.endsWith("Res") || k.contains("Vid")) continue
+      val value = fields.optJSONObject(k)?.optJSONObject("value") ?: continue
+      val dl = value.optString("downloadURL", "")
+      if (dl.isEmpty() || dl == "null") continue
+      val width = fields.optJSONObject(k.removeSuffix("Res") + "Width")?.optInt("value", 0) ?: 0
+      if (width in target..Int.MAX_VALUE && (bestW < 0 || width < bestW)) {
+        bestW = width
+        bestUrl = dl
+      }
+      if (width > fallbackW) {
+        fallbackW = width
+        fallbackUrl = dl
+      }
+    }
+    return bestUrl ?: fallbackUrl
   }
 
   private val LH3_REGEX =

--- a/app/src/test/java/com/immortal/launcher/RemoteAlbumTest.kt
+++ b/app/src/test/java/com/immortal/launcher/RemoteAlbumTest.kt
@@ -12,6 +12,7 @@ class RemoteAlbumTest {
   @Test
   fun isSupported_recognisesPublicShareLinks() {
     assertTrue(RemoteAlbum.isSupported("https://www.icloud.com/sharedalbum/#B1abcDEF"))
+    assertTrue(RemoteAlbum.isSupported("https://photos.icloud.com/shared/album/037SP6pgkQQ_LNS48MIYBgiTQ"))
     assertTrue(RemoteAlbum.isSupported("https://photos.app.goo.gl/abcd1234"))
     assertTrue(RemoteAlbum.isSupported("https://photos.google.com/share/AF1Qa1b2c3d"))
     assertFalse(RemoteAlbum.isSupported("https://example.com/album/123"))
@@ -23,8 +24,89 @@ class RemoteAlbumTest {
     assertEquals(
         "iCloud Shared Album",
         RemoteAlbum.providerName("https://www.icloud.com/sharedalbum/#B1abcDEF"))
+    assertEquals(
+        "iCloud Shared Album",
+        RemoteAlbum.providerName("https://photos.icloud.com/shared/album/037SP6pgkQQ_LNS48MIYBgiTQ"))
     assertEquals("Google Photos", RemoteAlbum.providerName("https://photos.app.goo.gl/x"))
     assertEquals("Shared album", RemoteAlbum.providerName("https://example.com"))
+  }
+
+  @Test
+  fun icloudFormats_legacyAndCloudKitAreDistinct() {
+    val legacy = "https://www.icloud.com/sharedalbum/#B1abcDEF"
+    val cloudKit = "https://photos.icloud.com/shared/album/037SP6pgkQQ_LNS48MIYBgiTQ"
+    assertTrue(RemoteAlbum.isIcloudLegacy(legacy))
+    assertFalse(RemoteAlbum.isIcloudCloudKit(legacy))
+    assertTrue(RemoteAlbum.isIcloudCloudKit(cloudKit))
+    assertFalse(RemoteAlbum.isIcloudLegacy(cloudKit))
+  }
+
+  @Test
+  fun cloudKitToken_pullsFromPath() {
+    assertEquals(
+        "037SP6pgkQQ_LNS48MIYBgiTQ",
+        RemoteAlbum.cloudKitToken("https://photos.icloud.com/shared/album/037SP6pgkQQ_LNS48MIYBgiTQ"))
+    // Trailing query / fragment / extra path segments are stripped.
+    assertEquals(
+        "TOK123",
+        RemoteAlbum.cloudKitToken("https://photos.icloud.com/shared/album/TOK123?l=en"))
+    assertEquals(
+        "TOK123",
+        RemoteAlbum.cloudKitToken("https://photos.icloud.com/shared/album/TOK123#photos"))
+    assertEquals(
+        "TOK123",
+        RemoteAlbum.cloudKitToken("https://photos.icloud.com/shared/album/TOK123/"))
+    assertNull(RemoteAlbum.cloudKitToken("https://photos.icloud.com/shared/album/"))
+    assertNull(RemoteAlbum.cloudKitToken("https://example.com/x"))
+  }
+
+  @Test
+  fun pickBestCloudKitAsset_choosesSmallestCoveringDerivative() {
+    // CPLMaster-shaped fields: each res*Res blob has a sibling res*Width.
+    fun field(url: String) = JSONObject().put("value", JSONObject().put("downloadURL", url))
+    fun width(w: Int) = JSONObject().put("value", w)
+    val fields =
+        JSONObject()
+            .put("resJPEGThumbRes", field("https://cvws/thumb"))
+            .put("resJPEGThumbWidth", width(360))
+            .put("resJPEGMedRes", field("https://cvws/med"))
+            .put("resJPEGMedWidth", width(1280))
+            .put("resOriginalRes", field("https://cvws/orig"))
+            .put("resOriginalWidth", width(4032))
+    // 1920 long-edge → smallest derivative ≥ 1920 is the 4032 original.
+    assertEquals("https://cvws/orig", RemoteAlbum.pickBestCloudKitAsset(fields, 1920, 1080))
+    // 1080 long-edge → smallest ≥ 1080 is the 1280 medium.
+    assertEquals("https://cvws/med", RemoteAlbum.pickBestCloudKitAsset(fields, 1080, 720))
+    // Tiny screen still covered by the 360 thumb.
+    assertEquals("https://cvws/thumb", RemoteAlbum.pickBestCloudKitAsset(fields, 320, 240))
+  }
+
+  @Test
+  fun pickBestCloudKitAsset_fallsBackToLargestAndSkipsVideoTracks() {
+    fun field(url: String) = JSONObject().put("value", JSONObject().put("downloadURL", url))
+    fun width(w: Int) = JSONObject().put("value", w)
+    val fields =
+        JSONObject()
+            .put("resJPEGThumbRes", field("https://cvws/thumb"))
+            .put("resJPEGThumbWidth", width(360))
+            .put("resOriginalRes", field("https://cvws/orig"))
+            .put("resOriginalWidth", width(1536))
+            // A video track must never be picked as a photo, even though it's largest.
+            .put("resVidFullRes", field("https://cvws/video"))
+            .put("resVidFullWidth", width(3840))
+    // 4K target → nothing covers it among photos; fall back to the largest photo (1536).
+    assertEquals("https://cvws/orig", RemoteAlbum.pickBestCloudKitAsset(fields, 3840, 2160))
+  }
+
+  @Test
+  fun isCloudKitImage_keepsPhotosDropsVideos() {
+    fun item(t: String) = JSONObject().put("itemType", JSONObject().put("value", t))
+    assertTrue(RemoteAlbum.isCloudKitImage(item("public.jpeg")))
+    assertTrue(RemoteAlbum.isCloudKitImage(item("public.heic")))
+    assertFalse(RemoteAlbum.isCloudKitImage(item("com.apple.quicktime-movie")))
+    assertFalse(RemoteAlbum.isCloudKitImage(item("public.mpeg-4-video")))
+    // Missing itemType → keep (the derivative picker still requires a real blob).
+    assertTrue(RemoteAlbum.isCloudKitImage(JSONObject()))
   }
 
   @Test


### PR DESCRIPTION
## Why

Apple retired the legacy **Shared Streams** share links (`https://www.icloud.com/sharedalbum/#TOKEN`) in iOS/macOS 26. Newly created iCloud shared albums now produce **`https://photos.icloud.com/shared/album/TOKEN`** links, which are served by **CloudKit Web Services**, not the old `sharedstreams` API.

`RemoteAlbum` only spoke the legacy `sharedstreams` protocol and only recognised `icloud.com/sharedalbum/` URLs (reading the token from the `#` fragment). As a result the new links aren't recognised, `RemoteAlbum.isSupported()` returns `false`, and the screensaver's **"Use this album"** button stays disabled — so the photo frame can't use any album shared from a current iPhone/Mac.

## What

Add a CloudKit fetch path **alongside** the existing legacy one (legacy links keep working unchanged):

- **Detect** `…/shared/album/<shortGUID>` via `isIcloudCloudKit()`. `isIcloud()` is now the umbrella over `isIcloudLegacy()` + `isIcloudCloudKit()`, so `providerName()` still reports "iCloud Shared Album". The token lives in the **path**, so `cloudKitToken()` parses it there (stripping any trailing `?`, `#`, or path segment) rather than from the `#` fragment.
- **Resolve the share anonymously** — `POST /database/1/com.apple.photos.cloud/production/public/records/resolve` with `{"shortGUIDs":[{"value":TOKEN}]}`. No account or API key: the response carries the CloudKit `zoneID`, the share title, and an `anonymousPublicAccess` block with a short-lived `token` and the share's `databasePartition` host.
- **Page the photos** — `POST <partition>/database/1/com.apple.photos.cloud/production/shared/records/query` for the `CPLAssetAndMasterByAssetDateWithoutHiddenOrDeleted` index, passing the resolved token as the `publicAccessAuthToken` query param. Download URLs are returned **inline** on each `CPLMaster` (no separate `webasseturls` round-trip like the legacy path). Paginated via `continuationMarker` (capped at 50 pages × 200).
- **Pick the right derivative** — `pickBestCloudKitAsset()` chooses the smallest `res*Res` blob whose sibling `res*Width` covers the screen, else the largest; mirrors the existing `pickBestDerivative` policy. `isCloudKitImage()` skips video items so only photos reach the frame.
- On any failure the function returns `null`, so the frame falls back to the default feed exactly as before.

Also updates the paste-link screen (`AlbumUrlEntryActivity`) placeholder and help text to the current `photos.icloud.com/shared/album/…` form.

## How the endpoint shape was determined

Reverse-engineered from the iCloud Photos web client (`photos.icloud.com`) and verified live against a real public album: the `resolve` → `query` → `downloadURL` chain works with no authentication, and `clientBuildNumber`/`clientMasteringNumber` are telemetry only (the server accepts any value, so a constant is safe).

## Testing

- `./gradlew :app:testDebugUnitTest` — **12 tests, 0 failures**. New cases cover: new-format `isSupported`/`providerName`, legacy-vs-CloudKit detection, `cloudKitToken` path parsing (query/fragment/trailing-slash variants), `pickBestCloudKitAsset` selection + largest-fallback + video-track skipping, and `isCloudKitImage` photo/video filtering. Legacy `sharedstreams` tests are unchanged and still pass.
- `./gradlew :app:assembleDebug` — succeeds.
- End-to-end check against a live `photos.icloud.com/shared/album/…` album returned 139 photos across 2 pages; first and last fetched as valid JPEGs.

## Compatibility / notes

- Backwards compatible: legacy `sharedalbum/#…` links still resolve through the original path.
- No new permissions, no new dependencies (reuses the existing `postJson` helper and `org.json`).
- Anonymous public access only — works for albums shared as "anyone with the link".
