### PR TITLE
Add TLS support to Home Assistant MQTT publisher

### DIFF
--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -816,6 +816,8 @@ private fun MqttScreen(onBack: () -> Unit) {
   var port by remember { mutableStateOf(MqttConfig.port(context).toString()) }
   var user by remember { mutableStateOf(MqttConfig.username(context)) }
   var pass by remember { mutableStateOf(MqttConfig.password(context)) }
+  var useTls by remember { mutableStateOf(MqttConfig.useTls(context)) }
+  var validateCert by remember { mutableStateOf(MqttConfig.validateCert(context)) }
   // MqttStatus is a plain holder updated off the main thread, so poll it for live
   // "Connecting… → Connected" feedback (Compose won't recompose on its writes).
   var status by remember { mutableStateOf(MqttStatus.text) }
@@ -838,6 +840,8 @@ private fun MqttScreen(onBack: () -> Unit) {
     MqttConfig.setPort(context, port.toIntOrNull() ?: MqttConfig.DEFAULT_PORT)
     MqttConfig.setUsername(context, user)
     MqttConfig.setPassword(context, pass)
+    MqttConfig.setUseTls(context, useTls)
+    MqttConfig.setValidateCert(context, validateCert)
     MqttService.sync(context)
   }
 
@@ -962,7 +966,7 @@ private fun MqttScreen(onBack: () -> Unit) {
               keyboardOptions =
                   KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Next),
               keyboardActions = KeyboardActions(onNext = { userFocus.requestFocus() }),
-              label = { Text("Port (default 1883)") },
+              label = { Text("Port (default 1883, or 8883 for TLS)") },
               modifier =
                   Modifier.fillMaxWidth()
                       .padding(start = 18.dp, end = 18.dp, top = 4.dp)
@@ -1002,6 +1006,59 @@ private fun MqttScreen(onBack: () -> Unit) {
                       .padding(start = 18.dp, end = 18.dp, top = 8.dp)
                       .focusRequester(passFocus),
           )
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, top = 16.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Column(modifier = Modifier.weight(1f)) {
+              Text("Use TLS / SSL", color = Color.White, fontSize = 15.sp)
+              Text(
+                  "Encrypt the connection (e.g. a broker behind a reverse proxy on port 8883).",
+                  color = Color(0xFF9A9A9A),
+                  fontSize = 13.sp,
+                  modifier = Modifier.padding(top = 2.dp),
+              )
+            }
+            Segmented(
+                options = listOf("Off" to "off", "On" to "on"),
+                selected = if (useTls) "on" else "off",
+                onSelect = {
+                  val on = it == "on"
+                  useTls = on
+                  // Hop to the matching default port if the field is still on the other default.
+                  if (on && port == MqttConfig.DEFAULT_PORT.toString())
+                      port = MqttConfig.DEFAULT_TLS_PORT.toString()
+                  else if (!on && port == MqttConfig.DEFAULT_TLS_PORT.toString())
+                      port = MqttConfig.DEFAULT_PORT.toString()
+                  apply()
+                },
+            )
+          }
+          if (useTls) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, top = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+              Column(modifier = Modifier.weight(1f)) {
+                Text("Validate certificate", color = Color.White, fontSize = 15.sp)
+                Text(
+                    "Verify the broker's certificate and hostname. Turn off only for a " +
+                        "self-signed broker on a trusted network.",
+                    color = Color(0xFF9A9A9A),
+                    fontSize = 13.sp,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+              }
+              Segmented(
+                  options = listOf("Off" to "off", "On" to "on"),
+                  selected = if (validateCert) "on" else "off",
+                  onSelect = {
+                    validateCert = it == "on"
+                    apply()
+                  },
+              )
+            }
+          }
           // Live connection status — gives Apply visible feedback (Connecting… → Connected).
           Text(
               status.ifBlank { "Starting…" },
@@ -1012,9 +1069,9 @@ private fun MqttScreen(onBack: () -> Unit) {
         }
       }
       Text(
-          "Connects to a broker on your LAN (plain MQTT). Your Portal shows up in Home " +
-              "Assistant automatically as a device with presence, screen, battery, now-playing " +
-              "and a few controls — no configuration.yaml editing.",
+          "Connects to a broker on your LAN over plain MQTT or TLS. Your Portal shows up in " +
+              "Home Assistant automatically as a device with presence, screen, battery, " +
+              "now-playing and a few controls — no configuration.yaml editing.",
           color = Color(0xFF7C7C7C),
           fontSize = 13.sp,
           modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),

--- a/app/src/main/java/com/immortal/launcher/MqttClient.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttClient.kt
@@ -14,6 +14,11 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.net.InetSocketAddress
 import java.net.Socket
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
 
 /**
  * A minimal MQTT 3.1.1 client over a raw socket — no Gradle dependency, matching the
@@ -33,7 +38,14 @@ class MqttClient(
     private val username: String,
     private val password: String,
     private val will: Will?,
+    private val tls: Tls? = null,
 ) {
+  /**
+   * TLS options. [validateCert] off uses a trust-all manager and skips hostname checks — only
+   * for self-signed brokers on a trusted LAN, never the public internet.
+   */
+  data class Tls(val validateCert: Boolean)
+
   /** A retained last-will, published by the broker if we drop without a clean DISCONNECT. */
   data class Will(val topic: String, val payload: String, val retain: Boolean)
 
@@ -48,9 +60,11 @@ class MqttClient(
 
   /** Open the socket and complete the MQTT handshake. Returns true on CONNACK accepted. */
   fun connect(keepAliveSec: Int, connectTimeoutMs: Int = 8000): Boolean {
-    val s = Socket()
-    s.connect(InetSocketAddress(host, port), connectTimeoutMs)
-    s.tcpNoDelay = true
+    // Plain TCP first; the TLS handshake can only run once the socket is connected.
+    val raw = Socket()
+    raw.connect(InetSocketAddress(host, port), connectTimeoutMs)
+    raw.tcpNoDelay = true
+    val s = if (tls != null) wrapTls(raw) else raw
     socket = s
     out = BufferedOutputStream(s.getOutputStream())
     inp = BufferedInputStream(s.getInputStream())
@@ -58,6 +72,37 @@ class MqttClient(
     val ack = readPacket() ?: return false
     // CONNACK (0x20): byte[1] is the return code; 0 = accepted.
     return ack.type == 0x20 && ack.body.size >= 2 && ack.body[1].toInt() == 0
+  }
+
+  /**
+   * Wrap a connected socket in TLS over [host]. With [Tls.validateCert] on we set the HTTPS
+   * endpoint-identification algorithm so the JSSE checks the hostname too (an SSLSocket alone
+   * verifies the chain but not the name); off, we trust everything for self-signed LAN setups.
+   */
+  private fun wrapTls(raw: Socket): SSLSocket {
+    val opts = tls!!
+    val ctx = SSLContext.getInstance("TLS")
+    if (opts.validateCert) {
+      ctx.init(null, null, null) // platform default trust managers
+    } else {
+      ctx.init(null, arrayOf<TrustManager>(TrustAll), java.security.SecureRandom())
+    }
+    val ssl = ctx.socketFactory.createSocket(raw, host, port, true) as SSLSocket
+    ssl.useClientMode = true
+    if (opts.validateCert) {
+      ssl.sslParameters = ssl.sslParameters.apply { endpointIdentificationAlgorithm = "HTTPS" }
+    }
+    ssl.startHandshake()
+    return ssl
+  }
+
+  /** Accepts any certificate. Used only when the user opts out of validation for a self-signed broker. */
+  private object TrustAll : X509TrustManager {
+    override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {}
+
+    override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {}
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
   }
 
   /** QoS-0 publish. [retain] tells the broker to keep it as the topic's last value. */

--- a/app/src/main/java/com/immortal/launcher/MqttConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttConfig.kt
@@ -22,6 +22,7 @@ import java.security.SecureRandom
 object MqttConfig {
   private const val PREFS = "mqtt_publisher"
   const val DEFAULT_PORT = 1883
+  const val DEFAULT_TLS_PORT = 8883
 
   private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
@@ -45,6 +46,21 @@ object MqttConfig {
   fun password(c: Context): String = prefs(c).getString("password", "").orEmpty()
 
   fun setPassword(c: Context, v: String) = prefs(c).edit().putString("password", v).apply()
+
+  /** Wrap the broker connection in TLS (e.g. Mosquitto behind a reverse proxy on 8883). */
+  fun useTls(c: Context): Boolean = prefs(c).getBoolean("use_tls", false)
+
+  fun setUseTls(c: Context, on: Boolean) = prefs(c).edit().putBoolean("use_tls", on).apply()
+
+  /**
+   * Verify the broker's certificate (chain + hostname) when [useTls] is on. Default true —
+   * turn off only for self-signed certs you can't add to the device trust store. Ignored
+   * when TLS is off.
+   */
+  fun validateCert(c: Context): Boolean = prefs(c).getBoolean("validate_cert", true)
+
+  fun setValidateCert(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("validate_cert", on).apply()
 
   /** True once a broker host is set — the publisher stays idle until then. */
   fun isConfigured(c: Context): Boolean = host(c).isNotBlank()

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -122,6 +122,10 @@ class MqttPublisher(private val appContext: Context) {
               username = MqttConfig.username(appContext),
               password = MqttConfig.password(appContext),
               will = MqttClient.Will("$base/availability", "offline", retain = true),
+              tls =
+                  if (MqttConfig.useTls(appContext))
+                      MqttClient.Tls(validateCert = MqttConfig.validateCert(appContext))
+                  else null,
           )
       MqttStatus.text = "Connecting to $host…"
       val ok = runCatching { c.connect(KEEPALIVE_SEC) }.getOrDefault(false)

--- a/app/src/test/java/com/immortal/launcher/MqttClientTest.kt
+++ b/app/src/test/java/com/immortal/launcher/MqttClientTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import java.io.DataInputStream
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Drives [MqttClient] against a tiny loopback "broker" that just reads the CONNECT and replies
+ * with a CONNACK. Guards the plain-TCP path through [MqttClient.connect] (the same path the TLS
+ * change re-routes through [MqttClient.wrapTls]) — a real broker isn't needed to prove the
+ * handshake plumbing.
+ */
+class MqttClientTest {
+
+  /** Accept one connection, drain the CONNECT, and send back a CONNACK with [returnCode]. */
+  private fun fakeBroker(returnCode: Int): ServerSocket {
+    val server = ServerSocket()
+    server.bind(InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0))
+    Thread {
+          runCatching {
+            server.accept().use { sock ->
+              val inp = DataInputStream(sock.getInputStream())
+              // CONNECT fixed header: type byte, then a remaining-length varint we decode so we
+              // consume exactly the packet before replying.
+              inp.readByte()
+              var len = 0
+              var shift = 0
+              while (true) {
+                val b = inp.readByte().toInt() and 0xff
+                len = len or ((b and 0x7f) shl shift)
+                if (b and 0x80 == 0) break
+                shift += 7
+              }
+              repeat(len) { inp.readByte() }
+              // CONNACK: 0x20, remaining length 2, session-present 0, return code.
+              sock.getOutputStream().apply {
+                write(byteArrayOf(0x20, 0x02, 0x00, returnCode.toByte()))
+                flush()
+              }
+            }
+          }
+        }
+        .apply { isDaemon = true }
+        .start()
+    return server
+  }
+
+  private fun clientTo(server: ServerSocket) =
+      MqttClient(
+          host = "127.0.0.1",
+          port = server.localPort,
+          clientId = "test",
+          username = "",
+          password = "",
+          will = null,
+      )
+
+  @Test
+  fun connect_returnsTrue_whenBrokerAccepts() {
+    fakeBroker(returnCode = 0).use { server ->
+      val c = clientTo(server)
+      try {
+        assertTrue(c.connect(keepAliveSec = 30, connectTimeoutMs = 2000))
+      } finally {
+        c.close()
+      }
+    }
+  }
+
+  @Test
+  fun connect_returnsFalse_whenBrokerRefuses() {
+    fakeBroker(returnCode = 5).use { server -> // 5 = not authorized
+      val c = clientTo(server)
+      try {
+        assertFalse(c.connect(keepAliveSec = 30, connectTimeoutMs = 2000))
+      } finally {
+        c.close()
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #28. The hand-rolled MQTT client opened a **plain TCP socket only**, so any broker that requires TLS (e.g. a self-hosted Mosquitto behind a reverse proxy on port 8883) could never connect — the publisher sat on *"Connecting…"* and timed out, exactly as the reporter described.

This adds an optional TLS layer plus the two toggles most MQTT clients expose:

- **Use TLS / SSL** — wraps the connected socket in an `SSLSocket`.
- **Validate certificate** (default on) — uses the platform trust store **and** enables HTTPS endpoint identification so the broker hostname is verified, not just the chain. Turning it off trusts any cert, for self-signed brokers on a trusted LAN.

## Changes

- **`MqttClient.kt`** — new optional `Tls` parameter; `connect()` now connects the raw socket first, then routes through `wrapTls()` when TLS is enabled. Trust-all path gated behind the validate-cert toggle.
- **`MqttConfig.kt`** — new `use_tls` / `validate_cert` prefs and a `DEFAULT_TLS_PORT = 8883`.
- **`MqttPublisher.kt`** — passes the configured TLS options into the client.
- **`ImmortalSettingsActivity.kt`** — "Use TLS / SSL" and (conditional) "Validate certificate" toggles; toggling TLS hops the port field between the 1883/8883 defaults; updated help text.
- **`MqttClientTest.kt`** — new unit tests driving the `connect()` handshake (accept + refuse) against a loopback broker, guarding the socket-wrapping refactor.

## Scope

Covers plain ↔ TLS with optional hostname/cert validation, which should handle the reporter's Traefik + Let's Encrypt setup. **Mutual TLS / CA-cert & client-cert upload is intentionally out of scope** for this change.

## Testing

`./gradlew :app:testDebugUnitTest` passes (full suite). The TLS path itself can't be exercised against a real broker in CI, so this needs a manual test against a live TLS broker before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEBNGRHi8AoTm3CskBAxMK)_