### PR TITLE
Calendar widget for the photo-frame screensaver

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -228,6 +228,16 @@
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- One-field form for pasting a public iCalendar (.ics) feed link from Google
+             Calendar or Apple iCloud, reachable from the "Calendar" section in
+             screensaver settings. -->
+        <activity
+            android:name=".CalendarUrlEntryActivity"
+            android:exported="false"
+            android:label="Calendar link"
+            android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.SampleApp" />
+
         <!-- "Install an APK" file browser, opened from the App Store. -->
         <activity
             android:name=".ApkBrowserActivity"

--- a/app/src/main/java/com/immortal/launcher/CalendarFeed.kt
+++ b/app/src/main/java/com/immortal/launcher/CalendarFeed.kt
@@ -1,0 +1,483 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import java.net.HttpURLConnection
+import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Read upcoming events from a public iCalendar (.ics) feed URL — no account or API
+ * key, the calendar equivalent of [RemoteAlbum]'s public share links. Both Google
+ * Calendar and Apple iCloud expose a calendar this way:
+ *
+ *  - **Google Calendar** → Settings → *Integrate calendar* → "Secret address in
+ *    iCal format" (a private `…/basic.ics` URL — keep it private; anyone with it can
+ *    read the calendar).
+ *  - **Apple iCloud** → Calendar app → share a calendar → *Public Calendar* → a
+ *    `webcal://…/.ics` link.
+ *
+ * This is a deliberately small RFC 5545 reader: it handles line-unfolding, the
+ * common `DTSTART`/`DTEND` forms (UTC `Z`, `TZID=`, floating, and all-day `VALUE=DATE`),
+ * `SUMMARY`/`LOCATION` with text escapes, and the recurrence rules people actually
+ * use (`RRULE` with `FREQ`/`INTERVAL`/`COUNT`/`UNTIL`, weekly `BYDAY`, plus `EXDATE`
+ * exclusions). Anything it can't make sense of is skipped rather than crashing, and a
+ * malformed recurrence falls back to showing the event once — the frame degrades
+ * gracefully, like the rest of the screensaver.
+ *
+ * On any network/parse failure [fetch] returns an empty list and the widget simply
+ * shows nothing.
+ */
+object CalendarFeed {
+
+  /** A single calendar occurrence, already resolved to absolute wall-clock millis. */
+  data class Event(
+      val startMillis: Long,
+      val endMillis: Long,
+      val title: String,
+      val allDay: Boolean,
+      val location: String? = null,
+  )
+
+  // Display windows for the screensaver widget. Stored verbatim in ScreensaverConfig.
+  const val RANGE_DAY = "day" // today only
+  const val RANGE_3DAY = "3day" // today + next 2 days
+  const val RANGE_WEEK = "week" // today + next 6 days
+  const val RANGE_AGENDA = "agenda" // the next N events, however far out ("only events")
+
+  /** Clamp a stored range to a known value (defaults to a single day). */
+  fun clampRange(v: String?): String =
+      when (v) {
+        RANGE_DAY, RANGE_3DAY, RANGE_WEEK, RANGE_AGENDA -> v
+        else -> RANGE_DAY
+      }
+
+  /** Greatest number of rows we ever render, to keep the widget clean. */
+  const val MAX_EVENTS = 8
+
+  // --- URL handling -----------------------------------------------------------
+
+  /** True for a link we can actually fetch as an ICS feed. */
+  fun isSupported(url: String): Boolean {
+    val u = url.trim()
+    if (u.isEmpty()) return false
+    val lower = u.lowercase(Locale.US)
+    val schemeOk =
+        lower.startsWith("http://") ||
+            lower.startsWith("https://") ||
+            lower.startsWith("webcal://")
+    if (!schemeOk) return false
+    // Accept anything that looks like an ICS endpoint or a known calendar host —
+    // Google/Apple feeds don't always end in ".ics" (Google uses ".../basic.ics" but
+    // iCloud uses an opaque path), so we also recognise the provider hosts.
+    return lower.contains(".ics") ||
+        lower.startsWith("webcal://") ||
+        isGoogle(lower) ||
+        isApple(lower)
+  }
+
+  private fun isGoogle(lower: String): Boolean =
+      lower.contains("calendar.google.com") || lower.contains("google.com/calendar")
+
+  private fun isApple(lower: String): Boolean =
+      lower.contains("icloud.com") || lower.contains("apple.com")
+
+  /** Human label for the settings screen. */
+  fun providerName(url: String): String {
+    val lower = url.trim().lowercase(Locale.US)
+    return when {
+      isGoogle(lower) -> "Google Calendar"
+      isApple(lower) -> "Apple iCloud"
+      else -> "Calendar feed"
+    }
+  }
+
+  /** `webcal://` is just `https://` for a calendar; normalise so we can fetch it. */
+  fun normalizeUrl(url: String): String {
+    val u = url.trim()
+    return when {
+      u.startsWith("webcal://", ignoreCase = true) -> "https://" + u.substring("webcal://".length)
+      else -> u
+    }
+  }
+
+  // --- fetch ------------------------------------------------------------------
+
+  /**
+   * Fetch and parse the feed, returning every occurrence between [nowMillis] and
+   * [nowMillis] + [horizonDays] (already filtered, sorted, and de-duplicated).
+   * Returns an empty list on any failure.
+   */
+  fun fetch(
+      url: String,
+      nowMillis: Long = System.currentTimeMillis(),
+      horizonDays: Int = 45,
+  ): List<Event> =
+      runCatching {
+            val ics = httpGet(normalizeUrl(url)) ?: return emptyList()
+            parse(ics, nowMillis, horizonDays)
+          }
+          .getOrDefault(emptyList())
+
+  // --- parsing (pure; unit-tested) --------------------------------------------
+
+  /**
+   * Pure parse of an iCalendar document. [nowMillis] is the reference "now" (passed
+   * in rather than read from the clock so tests are deterministic); occurrences that
+   * have already ended, or that start beyond the horizon, are dropped.
+   */
+  internal fun parse(ics: String, nowMillis: Long, horizonDays: Int = 45): List<Event> {
+    val horizonEnd = nowMillis + horizonDays * 24L * 60 * 60 * 1000
+    val lines = unfold(ics)
+    val out = ArrayList<Event>()
+    var i = 0
+    while (i < lines.size) {
+      if (lines[i].trim().equals("BEGIN:VEVENT", ignoreCase = true)) {
+        val end = run {
+          var j = i + 1
+          while (j < lines.size && !lines[j].trim().equals("END:VEVENT", ignoreCase = true)) j++
+          j
+        }
+        parseEvent(lines.subList(i + 1, minOf(end, lines.size)), nowMillis, horizonEnd, out)
+        i = end + 1
+      } else {
+        i++
+      }
+    }
+    // Sort by start, then cap defensively so a runaway recurrence can't flood the UI.
+    return out.sortedBy { it.startMillis }.take(500)
+  }
+
+  private fun parseEvent(
+      body: List<String>,
+      nowMillis: Long,
+      horizonEnd: Long,
+      out: MutableList<Event>,
+  ) {
+    var start: Long? = null
+    var startAllDay = false
+    var end: Long? = null
+    var title = ""
+    var location: String? = null
+    var rrule: String? = null
+    val exdates = ArrayList<Long>()
+
+    for (raw in body) {
+      val p = parseLine(raw) ?: continue
+      when (p.name.uppercase(Locale.US)) {
+        "DTSTART" -> parseDt(p)?.let { (m, allDay) -> start = m; startAllDay = allDay }
+        "DTEND" -> parseDt(p)?.let { (m, _) -> end = m }
+        "SUMMARY" -> title = unescapeText(p.value)
+        "LOCATION" -> location = unescapeText(p.value).ifBlank { null }
+        "RRULE" -> rrule = p.value
+        "EXDATE" -> parseDt(p)?.let { (m, _) -> exdates.add(m) }
+      }
+    }
+
+    val s = start ?: return
+    if (title.isBlank()) title = "(busy)"
+    // No DTEND → all-day events span the day; timed events are treated as instantaneous.
+    val duration = (end ?: if (startAllDay) s + 24L * 60 * 60 * 1000 else s) - s
+    // Drop occurrences that already finished (with an all-day grace so "today"'s
+    // all-day events stay visible all day).
+    val floor = nowMillis
+
+    val starts =
+        if (rrule.isNullOrBlank()) listOf(s)
+        else expandRecurrence(s, rrule, exdates, horizonEnd)
+    for (st in starts) {
+      val en = st + duration
+      if (en < floor) continue
+      if (st > horizonEnd) continue
+      out.add(Event(st, en, title, startAllDay, location))
+    }
+  }
+
+  /**
+   * Unfold RFC 5545 continuation lines: a CRLF (or LF) followed by a space or tab is
+   * a fold of the previous logical line.
+   */
+  internal fun unfold(ics: String): List<String> {
+    val rawLines = ics.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    val out = ArrayList<String>(rawLines.size)
+    for (line in rawLines) {
+      if (line.isNotEmpty() && (line[0] == ' ' || line[0] == '\t') && out.isNotEmpty()) {
+        out[out.size - 1] = out[out.size - 1] + line.substring(1)
+      } else {
+        out.add(line)
+      }
+    }
+    return out
+  }
+
+  private data class Prop(val name: String, val params: Map<String, String>, val value: String)
+
+  /** Split a content line into name, parameters, and value (best-effort). */
+  private fun parseLine(line: String): Prop? {
+    if (line.isBlank()) return null
+    val colon = line.indexOf(':')
+    if (colon < 0) return null
+    val left = line.substring(0, colon)
+    val value = line.substring(colon + 1)
+    val parts = left.split(';')
+    val name = parts[0]
+    val params = HashMap<String, String>()
+    for (k in 1 until parts.size) {
+      val eq = parts[k].indexOf('=')
+      if (eq > 0) {
+        params[parts[k].substring(0, eq).uppercase(Locale.US)] =
+            parts[k].substring(eq + 1).trim('"')
+      }
+    }
+    return Prop(name, params, value)
+  }
+
+  /**
+   * Parse a date/date-time property to absolute millis. Returns the instant and
+   * whether it's an all-day (date-only) value. Handles:
+   *  - `VALUE=DATE` or bare `yyyyMMdd` → local midnight, all-day
+   *  - `yyyyMMdd'T'HHmmss'Z'` → UTC
+   *  - `;TZID=Zone:yyyyMMdd'T'HHmmss` → that zone
+   *  - `yyyyMMdd'T'HHmmss` → device-local (floating)
+   *
+   * EXDATE values can carry a comma-separated list; only the first is parsed here
+   * (multiple exclusions on one line are rare and degrade safely to "not excluded").
+   */
+  private fun parseDt(p: Prop): Pair<Long, Boolean>? {
+    val v = p.value.substringBefore(',').trim()
+    if (v.isEmpty()) return null
+    val dateOnly = p.params["VALUE"].equals("DATE", true) || (v.length == 8 && !v.contains('T'))
+    return runCatching {
+          if (dateOnly) {
+            val cal = Calendar.getInstance()
+            cal.clear()
+            cal.set(
+                v.substring(0, 4).toInt(),
+                v.substring(4, 6).toInt() - 1,
+                v.substring(6, 8).toInt(),
+                0,
+                0,
+                0)
+            cal.timeInMillis to true
+          } else {
+            val utc = v.endsWith("Z")
+            val basic = v.removeSuffix("Z")
+            val zone =
+                when {
+                  utc -> TimeZone.getTimeZone("UTC")
+                  p.params["TZID"] != null -> TimeZone.getTimeZone(p.params["TZID"])
+                  else -> TimeZone.getDefault()
+                }
+            val fmt = SimpleDateFormat("yyyyMMdd'T'HHmmss", Locale.US)
+            fmt.timeZone = zone
+            (fmt.parse(basic)?.time ?: return null) to false
+          }
+        }
+        .getOrNull()
+  }
+
+  /** Resolve `\n`, `\,`, `\;`, `\\` text escapes used in SUMMARY/LOCATION. */
+  internal fun unescapeText(s: String): String {
+    val sb = StringBuilder(s.length)
+    var i = 0
+    while (i < s.length) {
+      val c = s[i]
+      if (c == '\\' && i + 1 < s.length) {
+        when (s[i + 1]) {
+          'n', 'N' -> sb.append(' ')
+          ',', ';', '\\' -> sb.append(s[i + 1])
+          else -> sb.append(s[i + 1])
+        }
+        i += 2
+      } else {
+        sb.append(c)
+        i++
+      }
+    }
+    return sb.toString().trim()
+  }
+
+  /**
+   * Expand an RRULE into occurrence start-times up to [horizonEnd]. Supports the
+   * common shapes (FREQ DAILY/WEEKLY/MONTHLY/YEARLY, INTERVAL, COUNT, UNTIL, and
+   * weekly BYDAY); on anything unexpected it falls back to a single occurrence so the
+   * event still shows once.
+   */
+  internal fun expandRecurrence(
+      start: Long,
+      rrule: String,
+      exdates: List<Long>,
+      horizonEnd: Long,
+  ): List<Long> =
+      runCatching {
+            val rules =
+                rrule
+                    .split(';')
+                    .mapNotNull {
+                      val eq = it.indexOf('=')
+                      if (eq > 0) it.substring(0, eq).uppercase(Locale.US) to it.substring(eq + 1)
+                      else null
+                    }
+                    .toMap()
+            val freq = rules["FREQ"]?.uppercase(Locale.US) ?: return@runCatching listOf(start)
+            val interval = rules["INTERVAL"]?.toIntOrNull()?.coerceAtLeast(1) ?: 1
+            val count = rules["COUNT"]?.toIntOrNull()
+            val until = rules["UNTIL"]?.let { parseUntil(it) }
+            val byDay =
+                rules["BYDAY"]?.split(',')?.mapNotNull { weekdayOf(it.trim()) }?.takeIf {
+                  it.isNotEmpty()
+                }
+
+            val cap = 366
+            val out = ArrayList<Long>()
+            val exSet = exdates.toHashSet()
+            val cal = Calendar.getInstance()
+            cal.timeInMillis = start
+            // RFC 5545: COUNT counts generated occurrences; EXDATE then removes some
+            // from that set. So we track generation separately from what we keep.
+            var generated = 0
+
+            // Emit one occurrence (subject to EXDATE). Returns false once we've run
+            // past UNTIL / the horizon, so the caller can stop generating.
+            fun emit(t: Long): Boolean {
+              if (until != null && t > until) return false
+              if (t > horizonEnd) return false
+              if (t !in exSet) out.add(t)
+              return true
+            }
+
+            if (freq == "WEEKLY" && byDay != null) {
+              // Walk week by week (INTERVAL weeks apart); within each week emit every
+              // listed weekday, preserving the original time-of-day.
+              val hour = cal.get(Calendar.HOUR_OF_DAY)
+              val min = cal.get(Calendar.MINUTE)
+              val sec = cal.get(Calendar.SECOND)
+              // Move to the Sunday that starts this event's week.
+              val weekStart = Calendar.getInstance()
+              weekStart.timeInMillis = start
+              weekStart.set(Calendar.HOUR_OF_DAY, hour)
+              weekStart.set(Calendar.MINUTE, min)
+              weekStart.set(Calendar.SECOND, sec)
+              weekStart.set(Calendar.MILLISECOND, 0)
+              weekStart.add(Calendar.DAY_OF_MONTH, -(weekStart.get(Calendar.DAY_OF_WEEK) - 1))
+              var weeks = 0
+              while (weeks < cap) {
+                var anyInHorizon = false
+                for (dow in byDay.sorted()) {
+                  val occ = weekStart.clone() as Calendar
+                  occ.add(Calendar.DAY_OF_MONTH, dow - 1) // dow: 1=Sun..7=Sat
+                  val t = occ.timeInMillis
+                  if (t < start) continue // skip days before the series actually begins
+                  anyInHorizon = anyInHorizon || t <= horizonEnd
+                  if (count != null && generated >= count) return@runCatching out
+                  generated++
+                  if (!emit(t) && until != null) return@runCatching out
+                }
+                if (!anyInHorizon && weekStart.timeInMillis > horizonEnd) break
+                weekStart.add(Calendar.DAY_OF_MONTH, 7 * interval)
+                weeks++
+              }
+              return@runCatching out
+            }
+
+            var iterations = 0
+            while (iterations < cap) {
+              if (count != null && generated >= count) break
+              val t = cal.timeInMillis
+              generated++
+              if (!emit(t)) {
+                if (t > horizonEnd && (until == null || t > until)) break
+              }
+              when (freq) {
+                "DAILY" -> cal.add(Calendar.DAY_OF_MONTH, interval)
+                "WEEKLY" -> cal.add(Calendar.DAY_OF_MONTH, 7 * interval)
+                "MONTHLY" -> cal.add(Calendar.MONTH, interval)
+                "YEARLY" -> cal.add(Calendar.YEAR, interval)
+                else -> return@runCatching listOf(start)
+              }
+              iterations++
+            }
+            out
+          }
+          .getOrDefault(listOf(start))
+
+  /** RRULE UNTIL is a date or UTC date-time; resolve to millis. */
+  private fun parseUntil(v: String): Long? =
+      runCatching {
+            val s = v.trim()
+            if (s.length == 8 && !s.contains('T')) {
+              val cal = Calendar.getInstance()
+              cal.clear()
+              cal.set(s.substring(0, 4).toInt(), s.substring(4, 6).toInt() - 1, s.substring(6, 8).toInt(), 23, 59, 59)
+              cal.timeInMillis
+            } else {
+              val fmt = SimpleDateFormat("yyyyMMdd'T'HHmmss", Locale.US)
+              fmt.timeZone = TimeZone.getTimeZone(if (s.endsWith("Z")) "UTC" else TimeZone.getDefault().id)
+              fmt.parse(s.removeSuffix("Z"))?.time
+            }
+          }
+          .getOrNull()
+
+  /** "MO","TU",… (optionally prefixed like "2MO") → Calendar.DAY_OF_WEEK. */
+  private fun weekdayOf(token: String): Int? {
+    val day = token.takeLast(2).uppercase(Locale.US)
+    return when (day) {
+      "SU" -> Calendar.SUNDAY
+      "MO" -> Calendar.MONDAY
+      "TU" -> Calendar.TUESDAY
+      "WE" -> Calendar.WEDNESDAY
+      "TH" -> Calendar.THURSDAY
+      "FR" -> Calendar.FRIDAY
+      "SA" -> Calendar.SATURDAY
+      else -> null
+    }
+  }
+
+  // --- windowing (pure; unit-tested) ------------------------------------------
+
+  /**
+   * Pick the events to show for a display [range], relative to [nowMillis]. For the
+   * day/3-day/week ranges this is everything that overlaps the window [now → end of
+   * the Nth day]; for the agenda range it's simply the next [MAX_EVENTS] events,
+   * however far out. Already-finished events are dropped either way.
+   */
+  fun window(events: List<Event>, range: String, nowMillis: Long): List<Event> {
+    val live = events.filter { it.endMillis > nowMillis }.sortedBy { it.startMillis }
+    if (range == RANGE_AGENDA) return live.take(MAX_EVENTS)
+    val days =
+        when (range) {
+          RANGE_WEEK -> 7
+          RANGE_3DAY -> 3
+          else -> 1
+        }
+    val cal = Calendar.getInstance()
+    cal.timeInMillis = nowMillis
+    cal.set(Calendar.HOUR_OF_DAY, 0)
+    cal.set(Calendar.MINUTE, 0)
+    cal.set(Calendar.SECOND, 0)
+    cal.set(Calendar.MILLISECOND, 0)
+    cal.add(Calendar.DAY_OF_MONTH, days)
+    val windowEnd = cal.timeInMillis // exclusive: start of the day after the window
+    return live.filter { it.startMillis < windowEnd }.take(MAX_EVENTS)
+  }
+
+  // --- net --------------------------------------------------------------------
+
+  private fun httpGet(spec: String): String? {
+    val c = URL(spec).openConnection() as HttpURLConnection
+    c.connectTimeout = 8000
+    c.readTimeout = 12000
+    c.instanceFollowRedirects = true
+    c.setRequestProperty("User-Agent", "Immortal/1.0")
+    c.setRequestProperty("Accept", "text/calendar, text/plain, */*")
+    return runCatching { c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) } }.getOrNull()
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/CalendarUrlEntryActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/CalendarUrlEntryActivity.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.ui.theme.SampleAppTheme
+
+/** Paste-a-link screen for the calendar widget's ICS feed. Validates the link up-front. */
+class CalendarUrlEntryActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent {
+      SampleAppTheme(darkTheme = true) {
+        CalendarUrlEntryScreen(
+            onSave = { url ->
+              ScreensaverConfig.setCalendarUrl(this, url)
+              finish()
+            },
+            onRemove = {
+              ScreensaverConfig.clearCalendarUrl(this)
+              finish()
+            },
+            onCancel = { finish() },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun CalendarUrlEntryScreen(
+    onSave: (String) -> Unit,
+    onRemove: () -> Unit,
+    onCancel: () -> Unit,
+) {
+  val context = LocalContext.current
+  val existing = remember { ScreensaverConfig.load(context).calendarUrl.orEmpty() }
+  var url by remember { mutableStateOf(existing) }
+
+  val trimmed = url.trim()
+  val supported = trimmed.isNotEmpty() && CalendarFeed.isSupported(trimmed)
+  val provider = if (supported) CalendarFeed.providerName(trimmed) else null
+
+  BackHandler { onCancel() }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp)) {
+      Text(
+          "Calendar link",
+          color = Color.White,
+          fontSize = 34.sp,
+          fontWeight = FontWeight.SemiBold,
+      )
+      Text(
+          "Paste a private iCalendar (.ics) link from Google Calendar or Apple iCloud. " +
+              "Immortal reads it directly — it can't sign in to your account.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+
+      Spacer(Modifier.heightIn(min = 22.dp))
+
+      OutlinedTextField(
+          value = url,
+          onValueChange = { url = it },
+          placeholder = {
+            Text("https://calendar.google.com/calendar/ical/…/basic.ics", color = Color(0xFF777777))
+          },
+          singleLine = true,
+          modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
+          shape = RoundedCornerShape(14.dp),
+      )
+
+      Text(
+          when {
+            trimmed.isEmpty() -> "Examples: Google \"secret address in iCal format\", Apple iCloud public calendar."
+            supported -> "Looks like a $provider link."
+            else -> "That doesn't look like a calendar (.ics) link yet."
+          },
+          color = if (supported || trimmed.isEmpty()) Color(0xFF9A9A9A) else Color(0xFFE89090),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 10.dp, start = 4.dp),
+      )
+
+      Spacer(Modifier.heightIn(min = 26.dp))
+
+      Surface(
+          color = if (supported) Color(0xFF2E6BE6) else Color(0xFF2A2A2C),
+          shape = RoundedCornerShape(16.dp),
+          modifier =
+              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                if (supported) onSave(trimmed)
+              },
+      ) {
+        Text(
+            "Use this calendar",
+            color = if (supported) Color.White else Color(0xFF777777),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 16.dp).fillMaxWidth(),
+        )
+      }
+
+      Spacer(Modifier.heightIn(min = 12.dp))
+
+      if (existing.isNotBlank()) {
+        Surface(
+            color = Color(0xFF1C1C1E),
+            shape = RoundedCornerShape(16.dp),
+            modifier =
+                Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                  onRemove()
+                },
+        ) {
+          Text(
+              "Remove calendar",
+              color = Color(0xFFE89090),
+              fontSize = 16.sp,
+              textAlign = TextAlign.Center,
+              modifier = Modifier.padding(vertical = 14.dp).fillMaxWidth(),
+          )
+        }
+        Spacer(Modifier.heightIn(min = 12.dp))
+      }
+
+      Surface(
+          color = Color(0xFF1C1C1E),
+          shape = RoundedCornerShape(16.dp),
+          modifier =
+              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                onCancel()
+              },
+      ) {
+        Text(
+            "Cancel",
+            color = Color(0xFFDDDDDD),
+            fontSize = 16.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 14.dp).fillMaxWidth(),
+        )
+      }
+
+      Spacer(Modifier.heightIn(min = 26.dp))
+
+      Text(
+          "How to get a link:",
+          color = Color(0xFFBBBBBB),
+          fontSize = 14.sp,
+          fontWeight = FontWeight.SemiBold,
+          modifier = Modifier.padding(start = 4.dp, bottom = 6.dp),
+      )
+      Text(
+          "• Google Calendar (on a computer) → Settings → your calendar → " +
+              "\"Integrate calendar\" → copy the \"Secret address in iCal format\". " +
+              "Keep it private — anyone with it can read the calendar.\n" +
+              "• Apple iCloud → Calendar app → tap a calendar → turn on \"Public Calendar\" " +
+              "→ Copy Link (a webcal:// link works too).",
+          color = Color(0xFF8A8A8A),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(start = 4.dp),
+      )
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -12,17 +12,25 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.graphics.Matrix
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
 import android.os.Handler
 import android.os.Looper
+import android.text.TextUtils
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
 import android.widget.VideoView
 import androidx.exifinterface.media.ExifInterface
 import java.net.HttpURLConnection
 import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import java.util.concurrent.Executors
 import kotlin.math.abs
 import org.json.JSONObject
@@ -53,6 +61,7 @@ class PhotoFrameController(
     private val unsplashKey: String = "",
     private val unsplashQuery: String = "nature,landscape,scenic",
     private val weatherRefreshMs: Long = 30 * 60_000L,
+    private val calendarRefreshMs: Long = 30 * 60_000L,
 ) {
   private val io = Executors.newSingleThreadExecutor()
   private val ui = Handler(Looper.getMainLooper())
@@ -63,6 +72,19 @@ class PhotoFrameController(
   // The overlay (clock / date / weather / battery / now-playing) is built and driven by the
   // FaceRenderer from a Face descriptor; this controller owns only the photo/video layer.
   private val faceRenderer = FaceRenderer(context, weatherRefreshMs)
+
+  // Calendar widget (top-right): a clean upcoming-events panel fed by a public ICS
+  // feed (Google secret-iCal / Apple iCloud public-calendar). Hidden when no link.
+  private lateinit var calendarPanel: LinearLayout
+  private lateinit var calendarHeader: TextView
+  private lateinit var calendarRows: LinearLayout
+  private var calendarEvents: List<CalendarFeed.Event> = emptyList()
+  // Text/padding scale for the current calendar size (0/1/2 → small/medium/large),
+  // applied as the panel is (re)rendered so a size change takes effect live.
+  private var calScale: Float = 1f
+  // The minute we last re-windowed the calendar, so the 1s tick only rebuilds it
+  // when the clock minute changes (drops past events, refreshes Today/Tomorrow).
+  private var lastCalMinute: Long = -1L
 
   private var settings = ScreensaverConfig.Settings()
 
@@ -134,6 +156,8 @@ class PhotoFrameController(
       return
     }
     applyFit()
+    refreshCalendar.run()
+    calendarTick.run()
     // Build + drive the overlay from the user's selected face ([FaceCatalog]); faceOverride lets
     // the debug preview harness (and the overnight night clock) render a specific face instead.
     faceRenderer.start(faceOverride ?: FaceCatalog.active(context))
@@ -316,7 +340,154 @@ class PhotoFrameController(
     root.addView(videoView, FrameLayout.LayoutParams(MATCH, MATCH, Gravity.CENTER))
 
     root.addView(faceRenderer.view)
+    buildCalendar(root)
     return root
+  }
+
+  /** A clean upcoming-events panel top-right, over the photo. Its own translucent
+   *  rounded backing keeps it legible without a full-screen scrim. Hidden until a
+   *  calendar link is set and there's something to show. */
+  private fun buildCalendar(root: FrameLayout) {
+    calendarPanel = LinearLayout(context)
+    calendarPanel.orientation = LinearLayout.VERTICAL
+    calendarPanel.visibility = View.GONE
+    val bg = GradientDrawable()
+    bg.setColor(0x66000000)
+    bg.cornerRadius = dp(18).toFloat()
+    calendarPanel.background = bg
+    calendarPanel.setPadding(dp(22), dp(18), dp(22), dp(18))
+    val lp = FrameLayout.LayoutParams(WRAP, WRAP, Gravity.TOP or Gravity.END)
+    lp.setMargins(0, dp(40), dp(40), 0)
+    root.addView(calendarPanel, lp)
+
+    calendarHeader = text(15f, 0xCCFFFFFF.toInt(), false)
+    calendarHeader.typeface = Typeface.DEFAULT_BOLD
+    calendarHeader.letterSpacing = 0.08f
+    calendarPanel.addView(calendarHeader)
+
+    calendarRows = LinearLayout(context)
+    calendarRows.orientation = LinearLayout.VERTICAL
+    val rowsLp = LinearLayout.LayoutParams(WRAP, WRAP)
+    rowsLp.topMargin = dp(10)
+    calendarPanel.addView(calendarRows, rowsLp)
+  }
+
+  /** Rebuild the calendar panel from the cached events for the chosen range. Cheap
+   *  (no network) — called when a fetch lands and once per minute from [tick]. */
+  private fun renderCalendar() {
+    if (!this::calendarPanel.isInitialized) return
+    if (!settings.usesCalendar) {
+      calendarPanel.visibility = View.GONE
+      return
+    }
+    val now = System.currentTimeMillis()
+    val shown = CalendarFeed.window(calendarEvents, settings.calendarRange, now)
+    // Size + position can change at runtime (settings screen or a fleet push), so
+    // (re)apply the chrome each render. Scale drives text/padding; side drives the edge.
+    calScale =
+        when (settings.calendarSize) {
+          0 -> 0.82f
+          2 -> 1.22f
+          else -> 1f
+        }
+    applyCalendarChrome()
+    calendarHeader.textSize = 15f * calScale
+    calendarHeader.text = rangeLabel(settings.calendarRange).uppercase(Locale.getDefault())
+    calendarRows.removeAllViews()
+    calendarPanel.visibility = View.VISIBLE
+
+    if (shown.isEmpty()) {
+      val empty = text(17f * calScale, 0xCCFFFFFF.toInt(), false)
+      empty.text = "Nothing scheduled"
+      calendarRows.addView(empty)
+      return
+    }
+
+    val agenda = settings.calendarRange == CalendarFeed.RANGE_AGENDA
+    var lastDayKey = ""
+    for (ev in shown) {
+      // Day header whenever the day changes (and always in agenda mode, which spans
+      // arbitrary dates). A single-day range needs no per-day header.
+      val key = dayKey(ev.startMillis)
+      if (key != lastDayKey && (agenda || settings.calendarRange != CalendarFeed.RANGE_DAY)) {
+        val header = text(13f * calScale, 0x99FFFFFF.toInt(), false)
+        header.typeface = Typeface.DEFAULT_BOLD
+        header.text = dayHeader(ev.startMillis).uppercase(Locale.getDefault())
+        val hlp = LinearLayout.LayoutParams(WRAP, WRAP)
+        hlp.topMargin = if (calendarRows.childCount == 0) 0 else dp(12)
+        calendarRows.addView(header, hlp)
+      }
+      lastDayKey = key
+      calendarRows.addView(buildEventRow(ev))
+    }
+  }
+
+  /** Position the panel against the chosen edge and scale its padding to the size. */
+  private fun applyCalendarChrome() {
+    val pad = (22 * calScale).toInt()
+    val padV = (18 * calScale).toInt()
+    calendarPanel.setPadding(dp(pad), dp(padV), dp(pad), dp(padV))
+    val gravity =
+        Gravity.TOP or
+            (if (settings.calendarSide == ScreensaverConfig.CAL_SIDE_LEFT) Gravity.START
+            else Gravity.END)
+    val lp = FrameLayout.LayoutParams(WRAP, WRAP, gravity)
+    val side = dp(40)
+    if (settings.calendarSide == ScreensaverConfig.CAL_SIDE_LEFT) lp.setMargins(side, dp(40), 0, 0)
+    else lp.setMargins(0, dp(40), side, 0)
+    calendarPanel.layoutParams = lp
+  }
+
+  private fun buildEventRow(ev: CalendarFeed.Event): View {
+    val row = LinearLayout(context)
+    row.orientation = LinearLayout.HORIZONTAL
+    row.gravity = Gravity.CENTER_VERTICAL
+    val rowLp = LinearLayout.LayoutParams(WRAP, WRAP)
+    rowLp.topMargin = dp(6)
+
+    val time = text(17f * calScale, Color.WHITE, false)
+    time.text = if (ev.allDay) "All day" else timeLabel(ev.startMillis)
+    time.width = dp((96 * calScale).toInt())
+
+    val title = text(17f * calScale, Color.WHITE, false)
+    title.typeface = Typeface.DEFAULT_BOLD
+    title.text = ev.title
+    title.maxLines = 1
+    title.ellipsize = TextUtils.TruncateAt.END
+    title.maxWidth = dp((360 * calScale).toInt())
+
+    row.addView(time)
+    row.addView(title)
+    row.layoutParams = rowLp
+    return row
+  }
+
+  private fun rangeLabel(range: String): String =
+      when (range) {
+        CalendarFeed.RANGE_3DAY -> "Next 3 days"
+        CalendarFeed.RANGE_WEEK -> "This week"
+        CalendarFeed.RANGE_AGENDA -> "Upcoming"
+        else -> "Today"
+      }
+
+  private fun timeLabel(millis: Long): String {
+    val pattern = if (ImmortalSettings.use24HourClock(context)) "H:mm" else "h:mm a"
+    return SimpleDateFormat(pattern, Locale.getDefault()).format(Date(millis))
+  }
+
+  /** A stable per-day key (yyyyDDD) so the renderer can tell when the day changes. */
+  private fun dayKey(millis: Long): String =
+      SimpleDateFormat("yyyyDDD", Locale.US).format(Date(millis))
+
+  /** "Today" / "Tomorrow" / "Sat, Jun 21" relative to now. */
+  private fun dayHeader(millis: Long): String {
+    val today = dayKey(System.currentTimeMillis())
+    val tomorrow = dayKey(System.currentTimeMillis() + 24L * 60 * 60 * 1000)
+    return when (dayKey(millis)) {
+      today -> "Today"
+      tomorrow -> "Tomorrow"
+      else -> SimpleDateFormat("EEE, MMM d", Locale.getDefault()).format(Date(millis))
+    }
   }
 
   private fun applyFit() {
@@ -326,9 +497,33 @@ class PhotoFrameController(
         else ImageView.ScaleType.CENTER_CROP
   }
 
+  private fun text(sizeSp: Float, color: Int, light: Boolean): TextView {
+    val t = TextView(context)
+    t.textSize = sizeSp
+    t.setTextColor(color)
+    if (light) t.typeface = Typeface.create("sans-serif-light", Typeface.NORMAL)
+    t.setShadowLayer(8f, 0f, 2f, 0x99000000.toInt())
+    return t
+  }
+
   private fun intervalMs(): Long = settings.intervalSec * 1000L
 
   // --- periodic loops ---------------------------------------------------------
+  private val calendarTick =
+      object : Runnable {
+        override fun run() {
+          // Re-window the calendar once per minute (cheap, no network): drops events
+          // as they pass and rolls the Today/Tomorrow labels over at midnight.
+          val now = Date()
+          val minute = now.time / 60_000L
+          if (minute != lastCalMinute) {
+            lastCalMinute = minute
+            renderCalendar()
+          }
+          ui.postDelayed(this, 1_000L)
+        }
+      }
+
   private val rotate =
       object : Runnable {
         override fun run() {
@@ -337,6 +532,34 @@ class PhotoFrameController(
         }
       }
 
+  private val refreshCalendar =
+      object : Runnable {
+        override fun run() {
+          // Pick up calendar changes pushed over the fleet API (or via in-app
+          // settings) without restarting the dream: reload just the calendar fields,
+          // leaving the live slideshow state untouched.
+          val fresh = ScreensaverConfig.load(context)
+          if (fresh.calendarUrl != settings.calendarUrl ||
+              fresh.calendarRange != settings.calendarRange) {
+            settings = settings.copy(calendarUrl = fresh.calendarUrl, calendarRange = fresh.calendarRange)
+            renderCalendar()
+          }
+          val url = settings.calendarUrl
+          if (settings.usesCalendar && !url.isNullOrBlank()) {
+            io.execute {
+              val events = CalendarFeed.fetch(url)
+              ui.post {
+                calendarEvents = events
+                renderCalendar()
+              }
+            }
+          } else {
+            calendarEvents = emptyList()
+            renderCalendar()
+          }
+          ui.postDelayed(this, calendarRefreshMs)
+        }
+      }
   // --- navigation (branches on the active source) -----------------------------
   fun next() {
     when {

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -51,6 +51,10 @@ object ScreensaverConfig {
   const val DEFAULT_INTERVAL = 30
   const val DEFAULT_ALBUM_REFRESH_MIN = 60
 
+  // Which edge the calendar widget hugs. Top of that edge either way.
+  const val CAL_SIDE_LEFT = "left"
+  const val CAL_SIDE_RIGHT = "right"
+
   data class Settings(
       // Master on/off for Immortal's photo-frame screensaver. When off, Immortal
       // stops asserting itself as the system Dream and lets the Portal sleep / lets
@@ -83,6 +87,18 @@ object ScreensaverConfig {
       val albumRefreshMin: Int = DEFAULT_ALBUM_REFRESH_MIN,
       val shuffle: Boolean = false,
       val includeVideo: Boolean = true,
+      // Calendar widget: a public iCalendar (.ics) feed link (Google "secret iCal"
+      // address or an Apple iCloud public-calendar / webcal link) and how much of it
+      // to show on the frame. Empty link = the widget is off.
+      val calendarUrl: String? = null,
+      val calendarRange: String = CalendarFeed.RANGE_DAY,
+      // Show/hide the calendar widget without forgetting the link, so the user can
+      // toggle it off and back on. Defaults on, so a freshly-added link shows.
+      val calendarEnabled: Boolean = true,
+      // Calendar widget size (0 = Small, 1 = Medium, 2 = Large) and which screen edge
+      // it hugs (left/right). Defaults: medium, right — the original placement.
+      val calendarSize: Int = 1,
+      val calendarSide: String = CAL_SIDE_RIGHT,
       // Battery models (Portal Go) only: pause the screensaver while unplugged so
       // the device can actually sleep, instead of showing photos until empty.
       val batterySaver: Boolean = true,
@@ -132,6 +148,12 @@ object ScreensaverConfig {
     /** True when the user has pasted a public album share link for us to fetch. */
     val usesUrl: Boolean
       get() = source == SOURCE_URL && !albumUrl.isNullOrBlank()
+    /** True when a calendar link is set, regardless of the on/off toggle. */
+    val hasCalendarLink: Boolean
+      get() = !calendarUrl.isNullOrBlank()
+    /** True when the widget should show: a link is set AND the toggle is on. */
+    val usesCalendar: Boolean
+      get() = calendarEnabled && hasCalendarLink
     /** True when the user has connected an Immich server for us to pull from. */
     val usesImmich: Boolean
       get() = source == SOURCE_IMMICH && !immichUrl.isNullOrBlank() && !immichKey.isNullOrBlank()
@@ -180,6 +202,13 @@ object ScreensaverConfig {
             clampAlbumRefresh(p.getInt("album_refresh_min", DEFAULT_ALBUM_REFRESH_MIN)),
         shuffle = p.getBoolean("shuffle", false),
         includeVideo = p.getBoolean("include_video", true),
+        calendarUrl = p.getString("calendar_url", null),
+        calendarRange = CalendarFeed.clampRange(p.getString("calendar_range", CalendarFeed.RANGE_DAY)),
+        calendarEnabled = p.getBoolean("calendar_enabled", true),
+        calendarSize = p.getInt("calendar_size", 1).coerceIn(0, 2),
+        calendarSide =
+            if (p.getString("calendar_side", CAL_SIDE_RIGHT) == CAL_SIDE_LEFT) CAL_SIDE_LEFT
+            else CAL_SIDE_RIGHT,
         batterySaver = p.getBoolean("battery_saver", true),
         showNowPlaying = p.getBoolean("show_now_playing", true),
         facesEnabled = p.getBoolean("faces_enabled", true),
@@ -271,6 +300,33 @@ object ScreensaverConfig {
       prefs(c).edit().putInt("album_refresh_min", clampAlbumRefresh(min)).apply()
 
   fun setShuffle(c: Context, on: Boolean) = prefs(c).edit().putBoolean("shuffle", on).apply()
+
+  /** Save (or clear, when blank) the calendar feed link. */
+  fun setCalendarUrl(c: Context, url: String) {
+    val trimmed = url.trim()
+    if (trimmed.isEmpty()) prefs(c).edit().remove("calendar_url").apply()
+    else prefs(c).edit().putString("calendar_url", trimmed).apply()
+  }
+
+  fun clearCalendarUrl(c: Context) = prefs(c).edit().remove("calendar_url").apply()
+
+  /** Show/hide the calendar widget without clearing the saved link. */
+  fun setCalendarEnabled(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("calendar_enabled", on).apply()
+
+  /** Calendar widget size: 0 = Small, 1 = Medium, 2 = Large. */
+  fun setCalendarSize(c: Context, i: Int) =
+      prefs(c).edit().putInt("calendar_size", i.coerceIn(0, 2)).apply()
+
+  /** Which edge the calendar widget hugs ([CAL_SIDE_LEFT] / [CAL_SIDE_RIGHT]). */
+  fun setCalendarSide(c: Context, side: String) =
+      prefs(c)
+          .edit()
+          .putString("calendar_side", if (side == CAL_SIDE_LEFT) CAL_SIDE_LEFT else CAL_SIDE_RIGHT)
+          .apply()
+
+  fun setCalendarRange(c: Context, range: String) =
+      prefs(c).edit().putString("calendar_range", CalendarFeed.clampRange(range)).apply()
 
   fun setIncludeVideo(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("include_video", on).apply()

--- a/app/src/main/java/com/immortal/launcher/ScreensaverSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverSettingsActivity.kt
@@ -257,6 +257,93 @@ private fun ScreensaverSettingsScreen() {
           modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
       )
 
+      // Calendar — a clean upcoming-events panel, fed by a public iCalendar (.ics)
+      // link from Google Calendar or Apple iCloud (no account sign-in).
+      Spacer(Modifier.size(26.dp))
+      SectionLabel("Calendar")
+      Card {
+        NavRow(
+            title = "Calendar link",
+            value = calendarValue(settings),
+        ) {
+          context.startActivity(Intent(context, CalendarUrlEntryActivity::class.java))
+        }
+        if (settings.hasCalendarLink) {
+          Divider()
+          // Show/hide the widget without forgetting the link, so it's a quick toggle.
+          ToggleRow("Show calendar widget", settings.calendarEnabled) {
+            ScreensaverConfig.setCalendarEnabled(context, it)
+            settings = settings.copy(calendarEnabled = it)
+          }
+        }
+        if (settings.usesCalendar) {
+          Divider()
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text("Show", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+            Segmented(
+                options =
+                    listOf(
+                        "1 day" to CalendarFeed.RANGE_DAY,
+                        "3 days" to CalendarFeed.RANGE_3DAY,
+                        "Week" to CalendarFeed.RANGE_WEEK,
+                        "Events" to CalendarFeed.RANGE_AGENDA,
+                    ),
+                selected = settings.calendarRange,
+                onSelect = {
+                  ScreensaverConfig.setCalendarRange(context, it)
+                  settings = settings.copy(calendarRange = it)
+                },
+            )
+          }
+          Divider()
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text("Size", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+            Segmented(
+                options = listOf("Small" to "0", "Medium" to "1", "Large" to "2"),
+                selected = settings.calendarSize.toString(),
+                onSelect = {
+                  val i = it.toIntOrNull() ?: 1
+                  ScreensaverConfig.setCalendarSize(context, i)
+                  settings = settings.copy(calendarSize = i)
+                },
+            )
+          }
+          Divider()
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text("Position", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+            Segmented(
+                options =
+                    listOf(
+                        "Left" to ScreensaverConfig.CAL_SIDE_LEFT,
+                        "Right" to ScreensaverConfig.CAL_SIDE_RIGHT,
+                    ),
+                selected = settings.calendarSide,
+                onSelect = {
+                  ScreensaverConfig.setCalendarSide(context, it)
+                  settings = settings.copy(calendarSide = it)
+                },
+            )
+          }
+        }
+      }
+      Text(
+          "Shows your upcoming events on the frame. \"Events\" lists the next " +
+              "few whenever they are; the others show a day, three days, or the week ahead. " +
+              "Use a Google \"secret iCal\" address or an Apple iCloud public-calendar link.",
+          color = Color(0xFF7C7C7C),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
+      )
+
       Spacer(Modifier.size(26.dp))
 
       val hasBattery = remember { DreamPolicy.hasBattery(context) }
@@ -400,6 +487,22 @@ private fun currentSourceLabel(s: ScreensaverConfig.Settings): String =
       s.usesDav -> "WebDAV folder"
       s.usesWebUrl -> "Web page"
       else -> "Immortal photos"
+    }
+
+private fun calendarValue(s: ScreensaverConfig.Settings): String =
+    when {
+      s.calendarUrl.isNullOrBlank() -> "Off"
+      !s.calendarEnabled -> "${CalendarFeed.providerName(s.calendarUrl)} - hidden"
+      else -> "${CalendarFeed.providerName(s.calendarUrl)} - ${calendarRangeLabel(s.calendarRange)}"
+    }
+
+private fun calendarRangeLabel(range: String): String =
+    when (CalendarFeed.clampRange(range)) {
+      CalendarFeed.RANGE_DAY -> "1 day"
+      CalendarFeed.RANGE_3DAY -> "3 days"
+      CalendarFeed.RANGE_WEEK -> "Week"
+      CalendarFeed.RANGE_AGENDA -> "Events"
+      else -> "1 day"
     }
 
 @Composable

--- a/app/src/test/java/com/immortal/launcher/CalendarFeedTest.kt
+++ b/app/src/test/java/com/immortal/launcher/CalendarFeedTest.kt
@@ -1,0 +1,206 @@
+package com.immortal.launcher
+
+import java.util.Calendar
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CalendarFeedTest {
+
+  @Test
+  fun isSupported_recognisesIcsAndKnownHosts() {
+    assertTrue(
+        CalendarFeed.isSupported(
+            "https://calendar.google.com/calendar/ical/abc%40group.calendar.google.com/private-x/basic.ics"))
+    assertTrue(CalendarFeed.isSupported("webcal://p01-caldav.icloud.com/published/2/MT234"))
+    assertTrue(CalendarFeed.isSupported("https://example.com/feed.ics"))
+    assertFalse(CalendarFeed.isSupported("https://example.com/album/123"))
+    assertFalse(CalendarFeed.isSupported(""))
+    assertFalse(CalendarFeed.isSupported("not a url"))
+  }
+
+  @Test
+  fun providerName_distinguishesProviders() {
+    assertEquals(
+        "Google Calendar",
+        CalendarFeed.providerName("https://calendar.google.com/calendar/ical/x/basic.ics"))
+    assertEquals(
+        "Apple iCloud", CalendarFeed.providerName("webcal://p01-caldav.icloud.com/published/2/x"))
+    assertEquals("Calendar feed", CalendarFeed.providerName("https://example.com/feed.ics"))
+  }
+
+  @Test
+  fun normalizeUrl_rewritesWebcalToHttps() {
+    assertEquals(
+        "https://p01-caldav.icloud.com/x",
+        CalendarFeed.normalizeUrl("webcal://p01-caldav.icloud.com/x"))
+    assertEquals(
+        "https://example.com/feed.ics",
+        CalendarFeed.normalizeUrl("  https://example.com/feed.ics "))
+  }
+
+  @Test
+  fun clampRange_fallsBackToDay() {
+    assertEquals(CalendarFeed.RANGE_WEEK, CalendarFeed.clampRange("week"))
+    assertEquals(CalendarFeed.RANGE_AGENDA, CalendarFeed.clampRange("agenda"))
+    assertEquals(CalendarFeed.RANGE_DAY, CalendarFeed.clampRange("bogus"))
+    assertEquals(CalendarFeed.RANGE_DAY, CalendarFeed.clampRange(null))
+  }
+
+  @Test
+  fun unescapeText_resolvesEscapes() {
+    assertEquals("a,b c", CalendarFeed.unescapeText("""a\,b\nc"""))
+    assertEquals("semi;colon", CalendarFeed.unescapeText("""semi\;colon"""))
+  }
+
+  @Test
+  fun unfold_joinsContinuationLines() {
+    val ics = "SUMMARY:Long\r\n  title here\r\nDTSTART:20231115T140000Z"
+    val lines = CalendarFeed.unfold(ics)
+    assertEquals("SUMMARY:Long title here", lines[0])
+    assertEquals("DTSTART:20231115T140000Z", lines[1])
+  }
+
+  @Test
+  fun parse_readsTimedAndAllDayEvents() {
+    val now = 1_700_000_000_000L // 2023-11-14T22:13:20Z
+    val ics =
+        """
+        BEGIN:VCALENDAR
+        BEGIN:VEVENT
+        SUMMARY:Team standup
+        DTSTART:20231115T140000Z
+        DTEND:20231115T143000Z
+        END:VEVENT
+        BEGIN:VEVENT
+        SUMMARY:Holiday\, all day
+        DTSTART;VALUE=DATE:20231116
+        END:VEVENT
+        END:VCALENDAR
+        """
+            .trimIndent()
+    val events = CalendarFeed.parse(ics, now)
+    assertEquals(2, events.size)
+    assertEquals("Team standup", events[0].title)
+    assertFalse(events[0].allDay)
+    assertEquals("Holiday, all day", events[1].title)
+    assertTrue(events[1].allDay)
+  }
+
+  @Test
+  fun parse_dropsEventsThatAlreadyEnded() {
+    val now = 1_700_000_000_000L
+    val ics =
+        """
+        BEGIN:VCALENDAR
+        BEGIN:VEVENT
+        SUMMARY:Yesterday
+        DTSTART:20231113T140000Z
+        DTEND:20231113T150000Z
+        END:VEVENT
+        BEGIN:VEVENT
+        SUMMARY:Soon
+        DTSTART:20231115T140000Z
+        DTEND:20231115T150000Z
+        END:VEVENT
+        END:VCALENDAR
+        """
+            .trimIndent()
+    val events = CalendarFeed.parse(ics, now)
+    assertEquals(1, events.size)
+    assertEquals("Soon", events[0].title)
+  }
+
+  @Test
+  fun expandRecurrence_weeklyCountYieldsThree() {
+    val start = 1_700_000_000_000L
+    val horizon = start + 60L * 24 * 60 * 60 * 1000
+    val occ = CalendarFeed.expandRecurrence(start, "FREQ=WEEKLY;COUNT=3", emptyList(), horizon)
+    assertEquals(3, occ.size)
+    assertEquals(start, occ[0])
+  }
+
+  @Test
+  fun expandRecurrence_honoursExdate() {
+    val start = 1_700_000_000_000L
+    val horizon = start + 60L * 24 * 60 * 60 * 1000
+    val full = CalendarFeed.expandRecurrence(start, "FREQ=DAILY;COUNT=3", emptyList(), horizon)
+    assertEquals(3, full.size)
+    val excluded =
+        CalendarFeed.expandRecurrence(start, "FREQ=DAILY;COUNT=3", listOf(full[1]), horizon)
+    assertEquals(2, excluded.size)
+    assertFalse(excluded.contains(full[1]))
+  }
+
+  @Test
+  fun expandRecurrence_stopsAtHorizon() {
+    val start = 1_700_000_000_000L
+    val horizon = start + 10L * 24 * 60 * 60 * 1000 // 10 days
+    val occ = CalendarFeed.expandRecurrence(start, "FREQ=DAILY", emptyList(), horizon)
+    // No COUNT/UNTIL: bounded only by the 10-day horizon → 11 daily occurrences (days 0..10).
+    assertEquals(11, occ.size)
+  }
+
+  @Test
+  fun expandRecurrence_unknownRuleFallsBackToSingle() {
+    val start = 1_700_000_000_000L
+    val occ = CalendarFeed.expandRecurrence(start, "GARBAGE", emptyList(), start + 1000)
+    assertEquals(listOf(start), occ)
+  }
+
+  // --- windowing (anchored to local noon so day boundaries are deterministic) ---
+
+  private fun localNoon(): Long {
+    val c = Calendar.getInstance()
+    c.set(Calendar.HOUR_OF_DAY, 12)
+    c.set(Calendar.MINUTE, 0)
+    c.set(Calendar.SECOND, 0)
+    c.set(Calendar.MILLISECOND, 0)
+    return c.timeInMillis
+  }
+
+  private fun ev(start: Long, title: String) =
+      CalendarFeed.Event(start, start + 60L * 60 * 1000, title, false)
+
+  @Test
+  fun window_dayRangeKeepsOnlyToday() {
+    val now = localNoon()
+    val hour = 60L * 60 * 1000
+    val day = 24 * hour
+    val events =
+        listOf(
+            ev(now - 2 * hour, "ended"), // already over
+            ev(now + hour, "today"), // 1pm today
+            ev(now + 30 * hour, "tomorrow"), // ~next day
+            ev(now + 8 * day, "next week"),
+        )
+    val shown = CalendarFeed.window(events, CalendarFeed.RANGE_DAY, now)
+    assertEquals(listOf("today"), shown.map { it.title })
+  }
+
+  @Test
+  fun window_weekRangeKeepsThroughSevenDays() {
+    val now = localNoon()
+    val day = 24L * 60 * 60 * 1000
+    val events =
+        listOf(
+            ev(now + 2 * 60 * 60 * 1000, "today"),
+            ev(now + 2 * day, "in 2 days"),
+            ev(now + 5 * day, "in 5 days"),
+            ev(now + 10 * day, "in 10 days"),
+        )
+    val shown = CalendarFeed.window(events, CalendarFeed.RANGE_WEEK, now)
+    assertEquals(listOf("today", "in 2 days", "in 5 days"), shown.map { it.title })
+  }
+
+  @Test
+  fun window_agendaIgnoresDateAndCaps() {
+    val now = localNoon()
+    val day = 24L * 60 * 60 * 1000
+    val events = (1..12).map { ev(now + it * day, "event $it") }
+    val shown = CalendarFeed.window(events, CalendarFeed.RANGE_AGENDA, now)
+    assertEquals(CalendarFeed.MAX_EVENTS, shown.size)
+    assertEquals("event 1", shown.first().title)
+  }
+}


### PR DESCRIPTION
## Calendar widget for the photo-frame screensaver

A clean upcoming-events panel on the screensaver, fed by a **public iCalendar (`.ics`) link** — a Google "secret iCal" address or an Apple iCloud public-calendar / `webcal://` link — with **no account sign-in** and no extra dependencies.

### What's included
- **`CalendarFeed`** — a tiny, std-only ICS fetch + parse, range windowing (day / 3-day / week / agenda), provider detection (Google / Apple / generic), and link-validation helpers. Pure logic, unit-tested (`CalendarFeedTest`).
- **`CalendarUrlEntryActivity`** — paste / clear the feed link from the screensaver settings.
- **`PhotoFrameController`** — renders a translucent rounded panel over the photo, refreshed on the frame's existing loop; hidden when there's no link or the widget is toggled off.
- **Screensaver settings** — link entry, range selector, an **enable/disable toggle** (hides the widget without forgetting the link), a **Small / Medium / Large** size option, and a **Left / Right** edge position.
- **`ScreensaverConfig`** — `calendarUrl` / `calendarRange` / `calendarEnabled` / `calendarSize` / `calendarSide` with clamping setters.

### Notes
- Keyless and account-free — same spirit as the existing keyless weather/photo feeds.
- No new third-party dependencies.

### Tested
`./gradlew :app:testDebugUnitTest :app:assembleDebug` green (incl. `CalendarFeedTest`). Built against current `main` (v1.43).
