### PR TITLE
fleetctl CLI + dev-mode / screensaver / calendar agent endpoints (dev & debug tooling)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -228,6 +228,16 @@
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- One-field form for pasting a public iCalendar (.ics) feed link from Google
+             Calendar or Apple iCloud, reachable from the "Calendar" section in
+             screensaver settings. -->
+        <activity
+            android:name=".CalendarUrlEntryActivity"
+            android:exported="false"
+            android:label="Calendar link"
+            android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.SampleApp" />
+
         <!-- "Install an APK" file browser, opened from the App Store. -->
         <activity
             android:name=".ApkBrowserActivity"

--- a/app/src/main/java/com/immortal/launcher/CalendarFeed.kt
+++ b/app/src/main/java/com/immortal/launcher/CalendarFeed.kt
@@ -1,0 +1,483 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import java.net.HttpURLConnection
+import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Read upcoming events from a public iCalendar (.ics) feed URL — no account or API
+ * key, the calendar equivalent of [RemoteAlbum]'s public share links. Both Google
+ * Calendar and Apple iCloud expose a calendar this way:
+ *
+ *  - **Google Calendar** → Settings → *Integrate calendar* → "Secret address in
+ *    iCal format" (a private `…/basic.ics` URL — keep it private; anyone with it can
+ *    read the calendar).
+ *  - **Apple iCloud** → Calendar app → share a calendar → *Public Calendar* → a
+ *    `webcal://…/.ics` link.
+ *
+ * This is a deliberately small RFC 5545 reader: it handles line-unfolding, the
+ * common `DTSTART`/`DTEND` forms (UTC `Z`, `TZID=`, floating, and all-day `VALUE=DATE`),
+ * `SUMMARY`/`LOCATION` with text escapes, and the recurrence rules people actually
+ * use (`RRULE` with `FREQ`/`INTERVAL`/`COUNT`/`UNTIL`, weekly `BYDAY`, plus `EXDATE`
+ * exclusions). Anything it can't make sense of is skipped rather than crashing, and a
+ * malformed recurrence falls back to showing the event once — the frame degrades
+ * gracefully, like the rest of the screensaver.
+ *
+ * On any network/parse failure [fetch] returns an empty list and the widget simply
+ * shows nothing.
+ */
+object CalendarFeed {
+
+  /** A single calendar occurrence, already resolved to absolute wall-clock millis. */
+  data class Event(
+      val startMillis: Long,
+      val endMillis: Long,
+      val title: String,
+      val allDay: Boolean,
+      val location: String? = null,
+  )
+
+  // Display windows for the screensaver widget. Stored verbatim in ScreensaverConfig.
+  const val RANGE_DAY = "day" // today only
+  const val RANGE_3DAY = "3day" // today + next 2 days
+  const val RANGE_WEEK = "week" // today + next 6 days
+  const val RANGE_AGENDA = "agenda" // the next N events, however far out ("only events")
+
+  /** Clamp a stored range to a known value (defaults to a single day). */
+  fun clampRange(v: String?): String =
+      when (v) {
+        RANGE_DAY, RANGE_3DAY, RANGE_WEEK, RANGE_AGENDA -> v
+        else -> RANGE_DAY
+      }
+
+  /** Greatest number of rows we ever render, to keep the widget clean. */
+  const val MAX_EVENTS = 8
+
+  // --- URL handling -----------------------------------------------------------
+
+  /** True for a link we can actually fetch as an ICS feed. */
+  fun isSupported(url: String): Boolean {
+    val u = url.trim()
+    if (u.isEmpty()) return false
+    val lower = u.lowercase(Locale.US)
+    val schemeOk =
+        lower.startsWith("http://") ||
+            lower.startsWith("https://") ||
+            lower.startsWith("webcal://")
+    if (!schemeOk) return false
+    // Accept anything that looks like an ICS endpoint or a known calendar host —
+    // Google/Apple feeds don't always end in ".ics" (Google uses ".../basic.ics" but
+    // iCloud uses an opaque path), so we also recognise the provider hosts.
+    return lower.contains(".ics") ||
+        lower.startsWith("webcal://") ||
+        isGoogle(lower) ||
+        isApple(lower)
+  }
+
+  private fun isGoogle(lower: String): Boolean =
+      lower.contains("calendar.google.com") || lower.contains("google.com/calendar")
+
+  private fun isApple(lower: String): Boolean =
+      lower.contains("icloud.com") || lower.contains("apple.com")
+
+  /** Human label for the settings screen. */
+  fun providerName(url: String): String {
+    val lower = url.trim().lowercase(Locale.US)
+    return when {
+      isGoogle(lower) -> "Google Calendar"
+      isApple(lower) -> "Apple iCloud"
+      else -> "Calendar feed"
+    }
+  }
+
+  /** `webcal://` is just `https://` for a calendar; normalise so we can fetch it. */
+  fun normalizeUrl(url: String): String {
+    val u = url.trim()
+    return when {
+      u.startsWith("webcal://", ignoreCase = true) -> "https://" + u.substring("webcal://".length)
+      else -> u
+    }
+  }
+
+  // --- fetch ------------------------------------------------------------------
+
+  /**
+   * Fetch and parse the feed, returning every occurrence between [nowMillis] and
+   * [nowMillis] + [horizonDays] (already filtered, sorted, and de-duplicated).
+   * Returns an empty list on any failure.
+   */
+  fun fetch(
+      url: String,
+      nowMillis: Long = System.currentTimeMillis(),
+      horizonDays: Int = 45,
+  ): List<Event> =
+      runCatching {
+            val ics = httpGet(normalizeUrl(url)) ?: return emptyList()
+            parse(ics, nowMillis, horizonDays)
+          }
+          .getOrDefault(emptyList())
+
+  // --- parsing (pure; unit-tested) --------------------------------------------
+
+  /**
+   * Pure parse of an iCalendar document. [nowMillis] is the reference "now" (passed
+   * in rather than read from the clock so tests are deterministic); occurrences that
+   * have already ended, or that start beyond the horizon, are dropped.
+   */
+  internal fun parse(ics: String, nowMillis: Long, horizonDays: Int = 45): List<Event> {
+    val horizonEnd = nowMillis + horizonDays * 24L * 60 * 60 * 1000
+    val lines = unfold(ics)
+    val out = ArrayList<Event>()
+    var i = 0
+    while (i < lines.size) {
+      if (lines[i].trim().equals("BEGIN:VEVENT", ignoreCase = true)) {
+        val end = run {
+          var j = i + 1
+          while (j < lines.size && !lines[j].trim().equals("END:VEVENT", ignoreCase = true)) j++
+          j
+        }
+        parseEvent(lines.subList(i + 1, minOf(end, lines.size)), nowMillis, horizonEnd, out)
+        i = end + 1
+      } else {
+        i++
+      }
+    }
+    // Sort by start, then cap defensively so a runaway recurrence can't flood the UI.
+    return out.sortedBy { it.startMillis }.take(500)
+  }
+
+  private fun parseEvent(
+      body: List<String>,
+      nowMillis: Long,
+      horizonEnd: Long,
+      out: MutableList<Event>,
+  ) {
+    var start: Long? = null
+    var startAllDay = false
+    var end: Long? = null
+    var title = ""
+    var location: String? = null
+    var rrule: String? = null
+    val exdates = ArrayList<Long>()
+
+    for (raw in body) {
+      val p = parseLine(raw) ?: continue
+      when (p.name.uppercase(Locale.US)) {
+        "DTSTART" -> parseDt(p)?.let { (m, allDay) -> start = m; startAllDay = allDay }
+        "DTEND" -> parseDt(p)?.let { (m, _) -> end = m }
+        "SUMMARY" -> title = unescapeText(p.value)
+        "LOCATION" -> location = unescapeText(p.value).ifBlank { null }
+        "RRULE" -> rrule = p.value
+        "EXDATE" -> parseDt(p)?.let { (m, _) -> exdates.add(m) }
+      }
+    }
+
+    val s = start ?: return
+    if (title.isBlank()) title = "(busy)"
+    // No DTEND → all-day events span the day; timed events are treated as instantaneous.
+    val duration = (end ?: if (startAllDay) s + 24L * 60 * 60 * 1000 else s) - s
+    // Drop occurrences that already finished (with an all-day grace so "today"'s
+    // all-day events stay visible all day).
+    val floor = nowMillis
+
+    val starts =
+        if (rrule.isNullOrBlank()) listOf(s)
+        else expandRecurrence(s, rrule, exdates, horizonEnd)
+    for (st in starts) {
+      val en = st + duration
+      if (en < floor) continue
+      if (st > horizonEnd) continue
+      out.add(Event(st, en, title, startAllDay, location))
+    }
+  }
+
+  /**
+   * Unfold RFC 5545 continuation lines: a CRLF (or LF) followed by a space or tab is
+   * a fold of the previous logical line.
+   */
+  internal fun unfold(ics: String): List<String> {
+    val rawLines = ics.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    val out = ArrayList<String>(rawLines.size)
+    for (line in rawLines) {
+      if (line.isNotEmpty() && (line[0] == ' ' || line[0] == '\t') && out.isNotEmpty()) {
+        out[out.size - 1] = out[out.size - 1] + line.substring(1)
+      } else {
+        out.add(line)
+      }
+    }
+    return out
+  }
+
+  private data class Prop(val name: String, val params: Map<String, String>, val value: String)
+
+  /** Split a content line into name, parameters, and value (best-effort). */
+  private fun parseLine(line: String): Prop? {
+    if (line.isBlank()) return null
+    val colon = line.indexOf(':')
+    if (colon < 0) return null
+    val left = line.substring(0, colon)
+    val value = line.substring(colon + 1)
+    val parts = left.split(';')
+    val name = parts[0]
+    val params = HashMap<String, String>()
+    for (k in 1 until parts.size) {
+      val eq = parts[k].indexOf('=')
+      if (eq > 0) {
+        params[parts[k].substring(0, eq).uppercase(Locale.US)] =
+            parts[k].substring(eq + 1).trim('"')
+      }
+    }
+    return Prop(name, params, value)
+  }
+
+  /**
+   * Parse a date/date-time property to absolute millis. Returns the instant and
+   * whether it's an all-day (date-only) value. Handles:
+   *  - `VALUE=DATE` or bare `yyyyMMdd` → local midnight, all-day
+   *  - `yyyyMMdd'T'HHmmss'Z'` → UTC
+   *  - `;TZID=Zone:yyyyMMdd'T'HHmmss` → that zone
+   *  - `yyyyMMdd'T'HHmmss` → device-local (floating)
+   *
+   * EXDATE values can carry a comma-separated list; only the first is parsed here
+   * (multiple exclusions on one line are rare and degrade safely to "not excluded").
+   */
+  private fun parseDt(p: Prop): Pair<Long, Boolean>? {
+    val v = p.value.substringBefore(',').trim()
+    if (v.isEmpty()) return null
+    val dateOnly = p.params["VALUE"].equals("DATE", true) || (v.length == 8 && !v.contains('T'))
+    return runCatching {
+          if (dateOnly) {
+            val cal = Calendar.getInstance()
+            cal.clear()
+            cal.set(
+                v.substring(0, 4).toInt(),
+                v.substring(4, 6).toInt() - 1,
+                v.substring(6, 8).toInt(),
+                0,
+                0,
+                0)
+            cal.timeInMillis to true
+          } else {
+            val utc = v.endsWith("Z")
+            val basic = v.removeSuffix("Z")
+            val zone =
+                when {
+                  utc -> TimeZone.getTimeZone("UTC")
+                  p.params["TZID"] != null -> TimeZone.getTimeZone(p.params["TZID"])
+                  else -> TimeZone.getDefault()
+                }
+            val fmt = SimpleDateFormat("yyyyMMdd'T'HHmmss", Locale.US)
+            fmt.timeZone = zone
+            (fmt.parse(basic)?.time ?: return null) to false
+          }
+        }
+        .getOrNull()
+  }
+
+  /** Resolve `\n`, `\,`, `\;`, `\\` text escapes used in SUMMARY/LOCATION. */
+  internal fun unescapeText(s: String): String {
+    val sb = StringBuilder(s.length)
+    var i = 0
+    while (i < s.length) {
+      val c = s[i]
+      if (c == '\\' && i + 1 < s.length) {
+        when (s[i + 1]) {
+          'n', 'N' -> sb.append(' ')
+          ',', ';', '\\' -> sb.append(s[i + 1])
+          else -> sb.append(s[i + 1])
+        }
+        i += 2
+      } else {
+        sb.append(c)
+        i++
+      }
+    }
+    return sb.toString().trim()
+  }
+
+  /**
+   * Expand an RRULE into occurrence start-times up to [horizonEnd]. Supports the
+   * common shapes (FREQ DAILY/WEEKLY/MONTHLY/YEARLY, INTERVAL, COUNT, UNTIL, and
+   * weekly BYDAY); on anything unexpected it falls back to a single occurrence so the
+   * event still shows once.
+   */
+  internal fun expandRecurrence(
+      start: Long,
+      rrule: String,
+      exdates: List<Long>,
+      horizonEnd: Long,
+  ): List<Long> =
+      runCatching {
+            val rules =
+                rrule
+                    .split(';')
+                    .mapNotNull {
+                      val eq = it.indexOf('=')
+                      if (eq > 0) it.substring(0, eq).uppercase(Locale.US) to it.substring(eq + 1)
+                      else null
+                    }
+                    .toMap()
+            val freq = rules["FREQ"]?.uppercase(Locale.US) ?: return@runCatching listOf(start)
+            val interval = rules["INTERVAL"]?.toIntOrNull()?.coerceAtLeast(1) ?: 1
+            val count = rules["COUNT"]?.toIntOrNull()
+            val until = rules["UNTIL"]?.let { parseUntil(it) }
+            val byDay =
+                rules["BYDAY"]?.split(',')?.mapNotNull { weekdayOf(it.trim()) }?.takeIf {
+                  it.isNotEmpty()
+                }
+
+            val cap = 366
+            val out = ArrayList<Long>()
+            val exSet = exdates.toHashSet()
+            val cal = Calendar.getInstance()
+            cal.timeInMillis = start
+            // RFC 5545: COUNT counts generated occurrences; EXDATE then removes some
+            // from that set. So we track generation separately from what we keep.
+            var generated = 0
+
+            // Emit one occurrence (subject to EXDATE). Returns false once we've run
+            // past UNTIL / the horizon, so the caller can stop generating.
+            fun emit(t: Long): Boolean {
+              if (until != null && t > until) return false
+              if (t > horizonEnd) return false
+              if (t !in exSet) out.add(t)
+              return true
+            }
+
+            if (freq == "WEEKLY" && byDay != null) {
+              // Walk week by week (INTERVAL weeks apart); within each week emit every
+              // listed weekday, preserving the original time-of-day.
+              val hour = cal.get(Calendar.HOUR_OF_DAY)
+              val min = cal.get(Calendar.MINUTE)
+              val sec = cal.get(Calendar.SECOND)
+              // Move to the Sunday that starts this event's week.
+              val weekStart = Calendar.getInstance()
+              weekStart.timeInMillis = start
+              weekStart.set(Calendar.HOUR_OF_DAY, hour)
+              weekStart.set(Calendar.MINUTE, min)
+              weekStart.set(Calendar.SECOND, sec)
+              weekStart.set(Calendar.MILLISECOND, 0)
+              weekStart.add(Calendar.DAY_OF_MONTH, -(weekStart.get(Calendar.DAY_OF_WEEK) - 1))
+              var weeks = 0
+              while (weeks < cap) {
+                var anyInHorizon = false
+                for (dow in byDay.sorted()) {
+                  val occ = weekStart.clone() as Calendar
+                  occ.add(Calendar.DAY_OF_MONTH, dow - 1) // dow: 1=Sun..7=Sat
+                  val t = occ.timeInMillis
+                  if (t < start) continue // skip days before the series actually begins
+                  anyInHorizon = anyInHorizon || t <= horizonEnd
+                  if (count != null && generated >= count) return@runCatching out
+                  generated++
+                  if (!emit(t) && until != null) return@runCatching out
+                }
+                if (!anyInHorizon && weekStart.timeInMillis > horizonEnd) break
+                weekStart.add(Calendar.DAY_OF_MONTH, 7 * interval)
+                weeks++
+              }
+              return@runCatching out
+            }
+
+            var iterations = 0
+            while (iterations < cap) {
+              if (count != null && generated >= count) break
+              val t = cal.timeInMillis
+              generated++
+              if (!emit(t)) {
+                if (t > horizonEnd && (until == null || t > until)) break
+              }
+              when (freq) {
+                "DAILY" -> cal.add(Calendar.DAY_OF_MONTH, interval)
+                "WEEKLY" -> cal.add(Calendar.DAY_OF_MONTH, 7 * interval)
+                "MONTHLY" -> cal.add(Calendar.MONTH, interval)
+                "YEARLY" -> cal.add(Calendar.YEAR, interval)
+                else -> return@runCatching listOf(start)
+              }
+              iterations++
+            }
+            out
+          }
+          .getOrDefault(listOf(start))
+
+  /** RRULE UNTIL is a date or UTC date-time; resolve to millis. */
+  private fun parseUntil(v: String): Long? =
+      runCatching {
+            val s = v.trim()
+            if (s.length == 8 && !s.contains('T')) {
+              val cal = Calendar.getInstance()
+              cal.clear()
+              cal.set(s.substring(0, 4).toInt(), s.substring(4, 6).toInt() - 1, s.substring(6, 8).toInt(), 23, 59, 59)
+              cal.timeInMillis
+            } else {
+              val fmt = SimpleDateFormat("yyyyMMdd'T'HHmmss", Locale.US)
+              fmt.timeZone = TimeZone.getTimeZone(if (s.endsWith("Z")) "UTC" else TimeZone.getDefault().id)
+              fmt.parse(s.removeSuffix("Z"))?.time
+            }
+          }
+          .getOrNull()
+
+  /** "MO","TU",… (optionally prefixed like "2MO") → Calendar.DAY_OF_WEEK. */
+  private fun weekdayOf(token: String): Int? {
+    val day = token.takeLast(2).uppercase(Locale.US)
+    return when (day) {
+      "SU" -> Calendar.SUNDAY
+      "MO" -> Calendar.MONDAY
+      "TU" -> Calendar.TUESDAY
+      "WE" -> Calendar.WEDNESDAY
+      "TH" -> Calendar.THURSDAY
+      "FR" -> Calendar.FRIDAY
+      "SA" -> Calendar.SATURDAY
+      else -> null
+    }
+  }
+
+  // --- windowing (pure; unit-tested) ------------------------------------------
+
+  /**
+   * Pick the events to show for a display [range], relative to [nowMillis]. For the
+   * day/3-day/week ranges this is everything that overlaps the window [now → end of
+   * the Nth day]; for the agenda range it's simply the next [MAX_EVENTS] events,
+   * however far out. Already-finished events are dropped either way.
+   */
+  fun window(events: List<Event>, range: String, nowMillis: Long): List<Event> {
+    val live = events.filter { it.endMillis > nowMillis }.sortedBy { it.startMillis }
+    if (range == RANGE_AGENDA) return live.take(MAX_EVENTS)
+    val days =
+        when (range) {
+          RANGE_WEEK -> 7
+          RANGE_3DAY -> 3
+          else -> 1
+        }
+    val cal = Calendar.getInstance()
+    cal.timeInMillis = nowMillis
+    cal.set(Calendar.HOUR_OF_DAY, 0)
+    cal.set(Calendar.MINUTE, 0)
+    cal.set(Calendar.SECOND, 0)
+    cal.set(Calendar.MILLISECOND, 0)
+    cal.add(Calendar.DAY_OF_MONTH, days)
+    val windowEnd = cal.timeInMillis // exclusive: start of the day after the window
+    return live.filter { it.startMillis < windowEnd }.take(MAX_EVENTS)
+  }
+
+  // --- net --------------------------------------------------------------------
+
+  private fun httpGet(spec: String): String? {
+    val c = URL(spec).openConnection() as HttpURLConnection
+    c.connectTimeout = 8000
+    c.readTimeout = 12000
+    c.instanceFollowRedirects = true
+    c.setRequestProperty("User-Agent", "Immortal/1.0")
+    c.setRequestProperty("Accept", "text/calendar, text/plain, */*")
+    return runCatching { c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) } }.getOrNull()
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/CalendarUrlEntryActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/CalendarUrlEntryActivity.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.ui.theme.SampleAppTheme
+
+/** Paste-a-link screen for the calendar widget's ICS feed. Validates the link up-front. */
+class CalendarUrlEntryActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent {
+      SampleAppTheme(darkTheme = true) {
+        CalendarUrlEntryScreen(
+            onSave = { url ->
+              ScreensaverConfig.setCalendarUrl(this, url)
+              finish()
+            },
+            onRemove = {
+              ScreensaverConfig.clearCalendarUrl(this)
+              finish()
+            },
+            onCancel = { finish() },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun CalendarUrlEntryScreen(
+    onSave: (String) -> Unit,
+    onRemove: () -> Unit,
+    onCancel: () -> Unit,
+) {
+  val context = LocalContext.current
+  val existing = remember { ScreensaverConfig.load(context).calendarUrl.orEmpty() }
+  var url by remember { mutableStateOf(existing) }
+
+  val trimmed = url.trim()
+  val supported = trimmed.isNotEmpty() && CalendarFeed.isSupported(trimmed)
+  val provider = if (supported) CalendarFeed.providerName(trimmed) else null
+
+  BackHandler { onCancel() }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp)) {
+      Text(
+          "Calendar link",
+          color = Color.White,
+          fontSize = 34.sp,
+          fontWeight = FontWeight.SemiBold,
+      )
+      Text(
+          "Paste a private iCalendar (.ics) link from Google Calendar or Apple iCloud. " +
+              "Immortal reads it directly — it can't sign in to your account.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+
+      Spacer(Modifier.heightIn(min = 22.dp))
+
+      OutlinedTextField(
+          value = url,
+          onValueChange = { url = it },
+          placeholder = {
+            Text("https://calendar.google.com/calendar/ical/…/basic.ics", color = Color(0xFF777777))
+          },
+          singleLine = true,
+          modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
+          shape = RoundedCornerShape(14.dp),
+      )
+
+      Text(
+          when {
+            trimmed.isEmpty() -> "Examples: Google \"secret address in iCal format\", Apple iCloud public calendar."
+            supported -> "Looks like a $provider link."
+            else -> "That doesn't look like a calendar (.ics) link yet."
+          },
+          color = if (supported || trimmed.isEmpty()) Color(0xFF9A9A9A) else Color(0xFFE89090),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 10.dp, start = 4.dp),
+      )
+
+      Spacer(Modifier.heightIn(min = 26.dp))
+
+      Surface(
+          color = if (supported) Color(0xFF2E6BE6) else Color(0xFF2A2A2C),
+          shape = RoundedCornerShape(16.dp),
+          modifier =
+              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                if (supported) onSave(trimmed)
+              },
+      ) {
+        Text(
+            "Use this calendar",
+            color = if (supported) Color.White else Color(0xFF777777),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 16.dp).fillMaxWidth(),
+        )
+      }
+
+      Spacer(Modifier.heightIn(min = 12.dp))
+
+      if (existing.isNotBlank()) {
+        Surface(
+            color = Color(0xFF1C1C1E),
+            shape = RoundedCornerShape(16.dp),
+            modifier =
+                Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                  onRemove()
+                },
+        ) {
+          Text(
+              "Remove calendar",
+              color = Color(0xFFE89090),
+              fontSize = 16.sp,
+              textAlign = TextAlign.Center,
+              modifier = Modifier.padding(vertical = 14.dp).fillMaxWidth(),
+          )
+        }
+        Spacer(Modifier.heightIn(min = 12.dp))
+      }
+
+      Surface(
+          color = Color(0xFF1C1C1E),
+          shape = RoundedCornerShape(16.dp),
+          modifier =
+              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                onCancel()
+              },
+      ) {
+        Text(
+            "Cancel",
+            color = Color(0xFFDDDDDD),
+            fontSize = 16.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 14.dp).fillMaxWidth(),
+        )
+      }
+
+      Spacer(Modifier.heightIn(min = 26.dp))
+
+      Text(
+          "How to get a link:",
+          color = Color(0xFFBBBBBB),
+          fontSize = 14.sp,
+          fontWeight = FontWeight.SemiBold,
+          modifier = Modifier.padding(start = 4.dp, bottom = 6.dp),
+      )
+      Text(
+          "• Google Calendar (on a computer) → Settings → your calendar → " +
+              "\"Integrate calendar\" → copy the \"Secret address in iCal format\". " +
+              "Keep it private — anyone with it can read the calendar.\n" +
+              "• Apple iCloud → Calendar app → tap a calendar → turn on \"Public Calendar\" " +
+              "→ Copy Link (a webcal:// link works too).",
+          color = Color(0xFF8A8A8A),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(start = 4.dp),
+      )
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/DevMode.kt
+++ b/app/src/main/java/com/immortal/launcher/DevMode.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import org.json.JSONObject
+
+/**
+ * Developer mode for iterating on Immortal over the fleet channel.
+ *
+ * When ON, Immortal's over-the-air self-updater ([UpdateManager.checkForUpdate]) is
+ * paused, so a locally-built APK pushed via the fleet agent isn't silently
+ * overwritten the next time the device polls the official `version.json`. It changes
+ * nothing else — the launcher, store, and screensaver run exactly as before.
+ *
+ * Toggled (and read) over the fleet API via `/dev`, and surfaced in `/info`. The
+ * companion CLI command is `fleetctl dev on|off|status|update <apk>`.
+ */
+object DevMode {
+
+  private const val PREFS = "immortal_dev"
+
+  private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+  fun isEnabled(c: Context): Boolean = prefs(c).getBoolean("enabled", false)
+
+  fun setEnabled(c: Context, on: Boolean) = prefs(c).edit().putBoolean("enabled", on).apply()
+
+  /** Pure status payload for the `/dev` and `/info` responses (no Context needed). */
+  internal fun statusJson(enabled: Boolean, versionCode: Long, versionName: String): JSONObject =
+      JSONObject()
+          .put("enabled", enabled)
+          .put("versionCode", versionCode)
+          .put("versionName", versionName)
+}

--- a/app/src/main/java/com/immortal/launcher/FleetCalendar.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetCalendar.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Calendar-widget slice of the Fleet Agent API (see [FleetRoutes] `/calendar`). Lets
+ * the laptop fleet tool read and push the screensaver calendar's feed link and
+ * display range over WiFi — no wireless ADB, no per-device tap-through.
+ *
+ * Kept tiny and split from the socket/routing layer so the JSON shaping is
+ * JVM-unit-testable: [toJson] is a pure `Settings → JSON` mapping, and [apply] is the
+ * only Context-touching part (it just funnels recognised keys to the existing
+ * [ScreensaverConfig] setters, which already clamp/validate).
+ *
+ * Wire format (both directions use the same field names):
+ * ```
+ * { "url": "https://…/basic.ics",   // "" clears the calendar (widget off)
+ *   "range": "day|3day|week|agenda" } // unknown values clamp to "day"
+ * ```
+ */
+object FleetCalendar {
+
+  /** The display ranges a client can choose from, advertised in [toJson]. */
+  val RANGES =
+      listOf(
+          CalendarFeed.RANGE_DAY,
+          CalendarFeed.RANGE_3DAY,
+          CalendarFeed.RANGE_WEEK,
+          CalendarFeed.RANGE_AGENDA,
+      )
+
+  /** Pure render of the calendar settings the agent reports back. */
+  fun toJson(s: ScreensaverConfig.Settings): JSONObject {
+    val url = s.calendarUrl.orEmpty()
+    return JSONObject()
+        // "enabled" = effective: a link is set AND the on/off toggle is on (the widget
+        // actually shows). "widgetOn" is the toggle alone, "hasLink" whether a link is
+        // saved — so a client can tell "linked but hidden" from "no link".
+        .put("enabled", s.usesCalendar)
+        .put("widgetOn", s.calendarEnabled)
+        .put("hasLink", s.hasCalendarLink)
+        .put("url", url)
+        .put("range", s.calendarRange)
+        .put("size", s.calendarSize)
+        .put("side", s.calendarSide)
+        .put("provider", if (url.isBlank()) "" else CalendarFeed.providerName(url))
+        // True when the link looks like a fetchable ICS feed; a client can warn the
+        // operator before saving an obviously-wrong link (the device stores it either way).
+        .put("supported", url.isNotBlank() && CalendarFeed.isSupported(url))
+        .put("ranges", JSONArray(RANGES))
+  }
+
+  /**
+   * Apply a pushed calendar config. Only the keys actually present are touched, so a
+   * partial push (e.g. just `{"range":"week"}`) leaves the link untouched. Returns the
+   * list of applied keys for the response.
+   */
+  fun apply(context: Context, body: JSONObject): List<String> {
+    val applied = ArrayList<String>(3)
+    if (body.has("url")) {
+      // setCalendarUrl trims and clears the widget when blank.
+      ScreensaverConfig.setCalendarUrl(context, body.optString("url"))
+      applied.add("url")
+    }
+    if (body.has("enabled")) {
+      // The on/off toggle — hides/shows the widget without forgetting the link.
+      ScreensaverConfig.setCalendarEnabled(context, body.optBoolean("enabled"))
+      applied.add("enabled")
+    }
+    if (body.has("range")) {
+      // setCalendarRange clamps unknown values back to a single day.
+      ScreensaverConfig.setCalendarRange(context, body.optString("range"))
+      applied.add("range")
+    }
+    if (body.has("size")) {
+      // setCalendarSize clamps to 0..2 (Small/Medium/Large).
+      ScreensaverConfig.setCalendarSize(context, body.optInt("size"))
+      applied.add("size")
+    }
+    if (body.has("side")) {
+      // setCalendarSide normalises anything but "left" to "right".
+      ScreensaverConfig.setCalendarSide(context, body.optString("side"))
+      applied.add("side")
+    }
+    return applied
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/FleetCalendar.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetCalendar.kt
@@ -71,10 +71,14 @@ object FleetCalendar {
       ScreensaverConfig.setCalendarUrl(context, body.optString("url"))
       applied.add("url")
     }
-    if (body.has("enabled")) {
-      // The on/off toggle — hides/shows the widget without forgetting the link.
-      ScreensaverConfig.setCalendarEnabled(context, body.optBoolean("enabled"))
-      applied.add("enabled")
+    // The on/off toggle. Preferred write key is "widgetOn", which round-trips
+    // symmetrically with the GET payload's "widgetOn"; "enabled" is accepted as an
+    // alias for it (note: GET "enabled" is the *effective* value — link set AND toggle
+    // on — so writing "enabled" sets only the toggle, by design).
+    if (body.has("widgetOn") || body.has("enabled")) {
+      val on = if (body.has("widgetOn")) body.optBoolean("widgetOn") else body.optBoolean("enabled")
+      ScreensaverConfig.setCalendarEnabled(context, on)
+      applied.add("widgetOn")
     }
     if (body.has("range")) {
       // setCalendarRange clamps unknown values back to a single day.

--- a/app/src/main/java/com/immortal/launcher/FleetRoutes.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetRoutes.kt
@@ -51,7 +51,10 @@ class FleetRoutes(private val context: Context) {
       "/apps" -> requireMethod("GET", req) { apps() }
       "/install" -> requireMethod("POST", req) { install(req) }
       "/update" -> requireMethod("POST", req) { update(req) }
+      "/dev" -> dev(req)
       "/config" -> requireMethod("POST", req) { config(req) }
+      "/calendar" -> calendar(req)
+      "/screensaver" -> screensaver(req)
       "/action" -> requireMethod("POST", req) { action(req) }
       "/fs/list" -> requireMethod("GET", req) { resp(200, FleetFs.list(req.queryParam("path") ?: "/sdcard")) }
       "/fs/read" -> requireMethod("GET", req) { fsRead(req) }
@@ -94,9 +97,10 @@ class FleetRoutes(private val context: Context) {
                     // dialog-mode is still unattended when auto-confirm is on
                     .put("autoConfirm", SettingsGuard.isInstallConfirmEnabled(context)))
             .put("canWriteSecureSettings", SettingsGuard.canWriteSecureSettings(context))
+            .put("devMode", DevMode.isEnabled(context))
             .put(
                 "capabilities",
-                JSONObject().put("files", true).put("diag", true).put("logcat", canReadLogs()))
+                JSONObject().put("files", true).put("diag", true).put("calendar", true).put("screensaver", true).put("dev", true).put("logcat", canReadLogs()))
     // Installed catalog apps + a CHEAP (no-network) update hint from the catalog pin.
     // The authoritative F-Droid check is POST /update {"dryRun":true}, kept off the
     // hot dashboard-poll path so /info stays fast across a whole wall of devices.
@@ -133,6 +137,21 @@ class FleetRoutes(private val context: Context) {
 
   private fun install(req: FleetHttpServer.Request): FleetHttpServer.Response {
     val body = parseJson(req.bodyText()) ?: return resp(400, err("bad_json"))
+    // Local-build install: a device-side APK path (pushed via /fs/write), installed
+    // directly — no catalog lookup, no versionCode gate. This is the dev-iteration
+    // path (e.g. `fleetctl dev update`). The package is derived from the APK if not
+    // given. NOTE: an in-place update is OS signature-checked, so a local build must
+    // be signed with the same key as the installed one (see the dev-mode docs).
+    //
+    // Gated behind dev mode: installing an arbitrary device-side APK sidesteps the
+    // catalog/versionCode gate, so it's only allowed when the operator has explicitly
+    // opted in via /dev. Outside dev mode the token only installs known catalog apps.
+    val localPath = body.optString("path").ifBlank { null }
+    if (localPath != null) {
+      if (!DevMode.isEnabled(context)) return resp(403, err("dev_mode_required"))
+      return installFile(localPath, body.optString("packageName").ifBlank { null })
+    }
+
     val pkg = body.optString("packageName").ifBlank { null } ?: return resp(400, err("packageName_required"))
     val apkUrl = body.optString("apkUrl").ifBlank { null }
     val app =
@@ -175,6 +194,30 @@ class FleetRoutes(private val context: Context) {
     return resp(200, ok().put("count", targets.size).put("updated", results))
   }
 
+  /**
+   * Read (GET) or toggle (POST `{"enabled":bool}`) developer mode. When on, the
+   * device's official self-updater is paused so a locally-pushed build isn't
+   * overwritten (see [DevMode] / `fleetctl dev`).
+   */
+  private fun dev(req: FleetHttpServer.Request): FleetHttpServer.Response =
+      when (req.method) {
+        "GET" -> resp(200, ok().put("dev", devStatus()))
+        "POST" -> {
+          val body = parseJson(req.bodyText())
+          if (body == null) resp(400, err("bad_json"))
+          else {
+            if (body.has("enabled")) DevMode.setEnabled(context, body.optBoolean("enabled"))
+            resp(200, ok().put("dev", devStatus()))
+          }
+        }
+        else -> resp(405, err("method_not_allowed"))
+      }
+
+  private fun devStatus(): JSONObject {
+    val (code, name) = appVersion()
+    return DevMode.statusJson(DevMode.isEnabled(context), code, name)
+  }
+
   private fun config(req: FleetHttpServer.Request): FleetHttpServer.Response {
     val body = parseJson(req.bodyText()) ?: return resp(400, err("bad_json"))
     if (body.has("name")) FleetConfig.setName(context, body.getString("name"))
@@ -185,6 +228,60 @@ class FleetRoutes(private val context: Context) {
     FleetConfig.allValues(context).forEach { (k, v) -> cfg.put(k, v) }
     return resp(200, ok().put("name", FleetConfig.name(context)).put("config", cfg))
   }
+
+  /**
+   * Read (GET) or push (POST) the screensaver calendar's feed link + display range,
+   * so a fleet can be configured over WiFi without wireless ADB. Pushes apply live —
+   * the running photo frame reloads the calendar on its refresh loop — so no reboot
+   * or re-dream is needed.
+   */
+  private fun calendar(req: FleetHttpServer.Request): FleetHttpServer.Response =
+      when (req.method) {
+        "GET" -> resp(200, ok().put("calendar", FleetCalendar.toJson(ScreensaverConfig.load(context))))
+        "POST" -> {
+          val body = parseJson(req.bodyText())
+          if (body == null) resp(400, err("bad_json"))
+          else {
+            val applied = FleetCalendar.apply(context, body)
+            resp(
+                200,
+                ok()
+                    .put("applied", JSONArray(applied))
+                    .put("calendar", FleetCalendar.toJson(ScreensaverConfig.load(context))))
+          }
+        }
+        else -> resp(405, err("method_not_allowed"))
+      }
+
+  /**
+   * Read (GET) or push (POST) the photo-frame screensaver config — source, fit,
+   * interval, shuffle, videos, now-playing, presence/power, and idle/overnight
+   * screen-off. Lets a fleet be configured over WiFi without wireless ADB. Display
+   * changes take effect on the next screensaver cycle (as in the in-app settings);
+   * `enabled` and overnight changes apply immediately — we reaffirm screensaver
+   * ownership and reschedule the overnight window after a push.
+   */
+  private fun screensaver(req: FleetHttpServer.Request): FleetHttpServer.Response =
+      when (req.method) {
+        "GET" ->
+            resp(200, ok().put("screensaver", FleetScreensaver.toJson(ScreensaverConfig.load(context))))
+        "POST" -> {
+          val body = parseJson(req.bodyText())
+          if (body == null) resp(400, err("bad_json"))
+          else {
+            val applied = FleetScreensaver.apply(context, body)
+            SettingsGuard.reaffirmScreensaver(context)
+            // Overnight alarms are armed eagerly so a window change takes effect now.
+            if (applied.any { it.startsWith("overnight") }) SleepScheduler.applyOvernightNow(context)
+            resp(
+                200,
+                ok()
+                    .put("applied", JSONArray(applied))
+                    .put("screensaver", FleetScreensaver.toJson(ScreensaverConfig.load(context))))
+          }
+        }
+        else -> resp(405, err("method_not_allowed"))
+      }
 
   private fun action(req: FleetHttpServer.Request): FleetHttpServer.Response {
     val body = parseJson(req.bodyText()) ?: return resp(400, err("bad_json"))
@@ -220,6 +317,44 @@ class FleetRoutes(private val context: Context) {
       if (m.mode == "silent") silentInstall(app) else dialogInstall(app)
     } finally {
       inFlight.remove(app.packageName)
+    }
+  }
+
+  /**
+   * Install a local device-path APK directly (the dev-iteration path). Mirrors
+   * [doInstall] but skips any download — the file is already on the device (pushed
+   * via /fs/write). [pkg] labels the daemon queue entry / install session.
+   */
+  private fun installFile(path: String, pkgArg: String?): FleetHttpServer.Response {
+    val apk = File(path)
+    if (!apk.isFile || !apk.canRead()) return resp(404, err("file_not_found"))
+    val pkg =
+        pkgArg
+            ?: runCatching { context.packageManager.getPackageArchiveInfo(path, 0)?.packageName }
+                .getOrNull()
+            ?: return resp(400, err("packageName_required"))
+    val result = doInstallFile(apk, pkg)
+    val status = if (result == BUSY) 409 else 200
+    return resp(
+        status,
+        JSONObject()
+            .put("ok", result == "installed")
+            .put("packageName", pkg)
+            .put("result", result)
+            .put("mode", installMode().mode))
+  }
+
+  private fun doInstallFile(apk: File, pkg: String): String {
+    val m = installMode()
+    if (m.paused) return "paused"
+    if (!inFlight.add(pkg)) return BUSY
+    return try {
+      val ok =
+          if (m.mode == "silent") InstallDaemon.install(context, apk, pkg)
+          else HeadlessInstaller.install(context, apk, pkg)
+      if (ok) "installed" else "failed"
+    } finally {
+      inFlight.remove(pkg)
     }
   }
 

--- a/app/src/main/java/com/immortal/launcher/FleetScreensaver.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetScreensaver.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import org.json.JSONObject
+
+/**
+ * Screensaver slice of the Fleet Agent API (see [FleetRoutes] `/screensaver`). Lets
+ * the laptop fleet tool read and push the whole photo-frame configuration over WiFi
+ * — source, fit, interval, shuffle, videos, now-playing, presence/power, and the
+ * idle/overnight screen-off windows — so a wall of Portals can be set up without
+ * wireless ADB or a per-device tap-through. (The calendar widget has its own
+ * [FleetCalendar] / `/calendar` endpoint and is intentionally left out here.)
+ *
+ * Like [FleetCalendar], the JSON shaping is split out so it's JVM-unit-testable:
+ * [toJson] is a pure `Settings → JSON` mapping; [apply] is the only Context-touching
+ * part and just funnels recognised keys to the existing [ScreensaverConfig] setters,
+ * which already clamp/validate. Only keys actually present in the body are touched,
+ * so a partial push leaves everything else alone.
+ *
+ * Note: display changes (source/fit/interval/…) take effect on the next screensaver
+ * cycle, exactly as they do from the in-app settings screen — the agent doesn't
+ * force-restart a running dream. The `enabled` and overnight changes apply right
+ * away ([FleetRoutes] reaffirms ownership and reschedules the overnight window).
+ */
+object FleetScreensaver {
+
+  /** Pure render of the screensaver settings the agent reports back. */
+  fun toJson(s: ScreensaverConfig.Settings): JSONObject =
+      JSONObject()
+          .put("enabled", s.enabled)
+          .put("source", s.source)
+          .put("folderPath", s.folderPath ?: "")
+          .put("albumUrl", s.albumUrl ?: "")
+          .put("albumRefreshMin", s.albumRefreshMin)
+          .put("fit", s.fit)
+          .put("intervalSec", s.intervalSec)
+          .put("shuffle", s.shuffle)
+          .put("includeVideo", s.includeVideo)
+          .put("batterySaver", s.batterySaver)
+          .put("showNowPlaying", s.showNowPlaying)
+          .put("presenceMode", s.presenceMode.name)
+          .put("idleSleepMin", s.idleSleepMin)
+          .put("overnightEnabled", s.overnightEnabled)
+          .put("overnightStartMin", s.overnightStartMin)
+          .put("overnightEndMin", s.overnightEndMin)
+
+  /** Coerce a fit string to a known value, or null if unrecognised. Pure. */
+  internal fun coerceFit(v: String?): String? =
+      when (v) {
+        ScreensaverConfig.FIT_FILL, ScreensaverConfig.FIT_FIT -> v
+        else -> null
+      }
+
+  /** Parse a presence-mode name; defaults to ALWAYS_ON on anything unexpected. Pure. */
+  internal fun coercePresenceMode(v: String?): FrameMode =
+      runCatching { FrameMode.valueOf((v ?: "").uppercase()) }.getOrDefault(FrameMode.ALWAYS_ON)
+
+  /** Source keys understood by [apply] beyond the value-driven folder/url paths. */
+  internal val RECOGNIZED_KEYS =
+      setOf(
+          "enabled",
+          "source",
+          "folderPath",
+          "albumUrl",
+          "albumRefreshMin",
+          "fit",
+          "intervalSec",
+          "shuffle",
+          "includeVideo",
+          "batterySaver",
+          "showNowPlaying",
+          "presenceMode",
+          "idleSleepMin",
+          "overnightEnabled",
+          "overnightStartMin",
+          "overnightEndMin",
+      )
+
+  /**
+   * Apply a pushed screensaver config. Returns the list of applied keys, plus a flag
+   * (via [applied] containing any "overnight*" key) the caller uses to reschedule the
+   * overnight window.
+   */
+  fun apply(context: Context, body: JSONObject): List<String> {
+    val applied = ArrayList<String>()
+
+    if (body.has("enabled")) {
+      ScreensaverConfig.setEnabled(context, body.optBoolean("enabled"))
+      applied.add("enabled")
+    }
+    // Source: "default" resets to the built-in feed; folder/url are driven by their
+    // value keys below (which also flip the source), so an explicit folder/url here
+    // is a no-op unless its path/url is supplied.
+    if (body.has("source") && body.optString("source") == ScreensaverConfig.SOURCE_DEFAULT) {
+      ScreensaverConfig.useDefault(context)
+      applied.add("source")
+    }
+    if (body.has("folderPath")) {
+      val p = body.optString("folderPath")
+      if (p.isNotBlank()) {
+        ScreensaverConfig.setFolder(context, p)
+        applied.add("folderPath")
+      }
+    }
+    if (body.has("albumUrl")) {
+      val u = body.optString("albumUrl")
+      if (u.isNotBlank()) {
+        ScreensaverConfig.setAlbumUrl(context, u)
+        applied.add("albumUrl")
+      }
+    }
+    if (body.has("albumRefreshMin")) {
+      ScreensaverConfig.setAlbumRefreshMin(context, body.optInt("albumRefreshMin"))
+      applied.add("albumRefreshMin")
+    }
+    coerceFit(if (body.has("fit")) body.optString("fit") else null)?.let {
+      ScreensaverConfig.setFit(context, it)
+      applied.add("fit")
+    }
+    if (body.has("intervalSec")) {
+      ScreensaverConfig.setInterval(context, body.optInt("intervalSec"))
+      applied.add("intervalSec")
+    }
+    if (body.has("shuffle")) {
+      ScreensaverConfig.setShuffle(context, body.optBoolean("shuffle"))
+      applied.add("shuffle")
+    }
+    if (body.has("includeVideo")) {
+      ScreensaverConfig.setIncludeVideo(context, body.optBoolean("includeVideo"))
+      applied.add("includeVideo")
+    }
+    if (body.has("batterySaver")) {
+      ScreensaverConfig.setBatterySaver(context, body.optBoolean("batterySaver"))
+      applied.add("batterySaver")
+    }
+    if (body.has("showNowPlaying")) {
+      ScreensaverConfig.setShowNowPlaying(context, body.optBoolean("showNowPlaying"))
+      applied.add("showNowPlaying")
+    }
+    if (body.has("presenceMode")) {
+      ScreensaverConfig.setPresenceMode(context, coercePresenceMode(body.optString("presenceMode")))
+      applied.add("presenceMode")
+    }
+    if (body.has("idleSleepMin")) {
+      ScreensaverConfig.setIdleSleepMin(context, body.optInt("idleSleepMin"))
+      applied.add("idleSleepMin")
+    }
+    if (body.has("overnightEnabled")) {
+      ScreensaverConfig.setOvernightEnabled(context, body.optBoolean("overnightEnabled"))
+      applied.add("overnightEnabled")
+    }
+    if (body.has("overnightStartMin")) {
+      ScreensaverConfig.setOvernightStartMin(context, body.optInt("overnightStartMin"))
+      applied.add("overnightStartMin")
+    }
+    if (body.has("overnightEndMin")) {
+      ScreensaverConfig.setOvernightEndMin(context, body.optInt("overnightEndMin"))
+      applied.add("overnightEndMin")
+    }
+    return applied
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/FleetScreensaver.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetScreensaver.kt
@@ -58,30 +58,13 @@ object FleetScreensaver {
         else -> null
       }
 
-  /** Parse a presence-mode name; defaults to ALWAYS_ON on anything unexpected. Pure. */
-  internal fun coercePresenceMode(v: String?): FrameMode =
-      runCatching { FrameMode.valueOf((v ?: "").uppercase()) }.getOrDefault(FrameMode.ALWAYS_ON)
-
-  /** Source keys understood by [apply] beyond the value-driven folder/url paths. */
-  internal val RECOGNIZED_KEYS =
-      setOf(
-          "enabled",
-          "source",
-          "folderPath",
-          "albumUrl",
-          "albumRefreshMin",
-          "fit",
-          "intervalSec",
-          "shuffle",
-          "includeVideo",
-          "batterySaver",
-          "showNowPlaying",
-          "presenceMode",
-          "idleSleepMin",
-          "overnightEnabled",
-          "overnightStartMin",
-          "overnightEndMin",
-      )
+  /**
+   * Parse a presence-mode name, or null if unrecognised. Pure. Returning null (rather
+   * than defaulting) lets [apply] skip an unknown value instead of silently flipping
+   * the mode on a typo — the same fail-safe shape as [coerceFit].
+   */
+  internal fun coercePresenceMode(v: String?): FrameMode? =
+      runCatching { FrameMode.valueOf((v ?: "").uppercase()) }.getOrNull()
 
   /**
    * Apply a pushed screensaver config. Returns the list of applied keys, plus a flag
@@ -145,8 +128,12 @@ object FleetScreensaver {
       applied.add("showNowPlaying")
     }
     if (body.has("presenceMode")) {
-      ScreensaverConfig.setPresenceMode(context, coercePresenceMode(body.optString("presenceMode")))
-      applied.add("presenceMode")
+      // Ignore an unrecognised mode rather than defaulting (which would silently flip
+      // the setting on a typo); a valid value is applied.
+      coercePresenceMode(body.optString("presenceMode"))?.let {
+        ScreensaverConfig.setPresenceMode(context, it)
+        applied.add("presenceMode")
+      }
     }
     if (body.has("idleSleepMin")) {
       ScreensaverConfig.setIdleSleepMin(context, body.optInt("idleSleepMin"))

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -12,17 +12,25 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.graphics.Matrix
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
 import android.os.Handler
 import android.os.Looper
+import android.text.TextUtils
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
 import android.widget.VideoView
 import androidx.exifinterface.media.ExifInterface
 import java.net.HttpURLConnection
 import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import java.util.concurrent.Executors
 import kotlin.math.abs
 import org.json.JSONObject
@@ -53,6 +61,7 @@ class PhotoFrameController(
     private val unsplashKey: String = "",
     private val unsplashQuery: String = "nature,landscape,scenic",
     private val weatherRefreshMs: Long = 30 * 60_000L,
+    private val calendarRefreshMs: Long = 30 * 60_000L,
 ) {
   private val io = Executors.newSingleThreadExecutor()
   private val ui = Handler(Looper.getMainLooper())
@@ -63,6 +72,19 @@ class PhotoFrameController(
   // The overlay (clock / date / weather / battery / now-playing) is built and driven by the
   // FaceRenderer from a Face descriptor; this controller owns only the photo/video layer.
   private val faceRenderer = FaceRenderer(context, weatherRefreshMs)
+
+  // Calendar widget (top-right): a clean upcoming-events panel fed by a public ICS
+  // feed (Google secret-iCal / Apple iCloud public-calendar). Hidden when no link.
+  private lateinit var calendarPanel: LinearLayout
+  private lateinit var calendarHeader: TextView
+  private lateinit var calendarRows: LinearLayout
+  private var calendarEvents: List<CalendarFeed.Event> = emptyList()
+  // Text/padding scale for the current calendar size (0/1/2 → small/medium/large),
+  // applied as the panel is (re)rendered so a size change takes effect live.
+  private var calScale: Float = 1f
+  // The minute we last re-windowed the calendar, so the 1s tick only rebuilds it
+  // when the clock minute changes (drops past events, refreshes Today/Tomorrow).
+  private var lastCalMinute: Long = -1L
 
   private var settings = ScreensaverConfig.Settings()
 
@@ -134,6 +156,8 @@ class PhotoFrameController(
       return
     }
     applyFit()
+    refreshCalendar.run()
+    calendarTick.run()
     // Build + drive the overlay from the user's selected face ([FaceCatalog]); faceOverride lets
     // the debug preview harness (and the overnight night clock) render a specific face instead.
     faceRenderer.start(faceOverride ?: FaceCatalog.active(context))
@@ -316,7 +340,154 @@ class PhotoFrameController(
     root.addView(videoView, FrameLayout.LayoutParams(MATCH, MATCH, Gravity.CENTER))
 
     root.addView(faceRenderer.view)
+    buildCalendar(root)
     return root
+  }
+
+  /** A clean upcoming-events panel top-right, over the photo. Its own translucent
+   *  rounded backing keeps it legible without a full-screen scrim. Hidden until a
+   *  calendar link is set and there's something to show. */
+  private fun buildCalendar(root: FrameLayout) {
+    calendarPanel = LinearLayout(context)
+    calendarPanel.orientation = LinearLayout.VERTICAL
+    calendarPanel.visibility = View.GONE
+    val bg = GradientDrawable()
+    bg.setColor(0x66000000)
+    bg.cornerRadius = dp(18).toFloat()
+    calendarPanel.background = bg
+    calendarPanel.setPadding(dp(22), dp(18), dp(22), dp(18))
+    val lp = FrameLayout.LayoutParams(WRAP, WRAP, Gravity.TOP or Gravity.END)
+    lp.setMargins(0, dp(40), dp(40), 0)
+    root.addView(calendarPanel, lp)
+
+    calendarHeader = text(15f, 0xCCFFFFFF.toInt(), false)
+    calendarHeader.typeface = Typeface.DEFAULT_BOLD
+    calendarHeader.letterSpacing = 0.08f
+    calendarPanel.addView(calendarHeader)
+
+    calendarRows = LinearLayout(context)
+    calendarRows.orientation = LinearLayout.VERTICAL
+    val rowsLp = LinearLayout.LayoutParams(WRAP, WRAP)
+    rowsLp.topMargin = dp(10)
+    calendarPanel.addView(calendarRows, rowsLp)
+  }
+
+  /** Rebuild the calendar panel from the cached events for the chosen range. Cheap
+   *  (no network) — called when a fetch lands and once per minute from [tick]. */
+  private fun renderCalendar() {
+    if (!this::calendarPanel.isInitialized) return
+    if (!settings.usesCalendar) {
+      calendarPanel.visibility = View.GONE
+      return
+    }
+    val now = System.currentTimeMillis()
+    val shown = CalendarFeed.window(calendarEvents, settings.calendarRange, now)
+    // Size + position can change at runtime (settings screen or a fleet push), so
+    // (re)apply the chrome each render. Scale drives text/padding; side drives the edge.
+    calScale =
+        when (settings.calendarSize) {
+          0 -> 0.82f
+          2 -> 1.22f
+          else -> 1f
+        }
+    applyCalendarChrome()
+    calendarHeader.textSize = 15f * calScale
+    calendarHeader.text = rangeLabel(settings.calendarRange).uppercase(Locale.getDefault())
+    calendarRows.removeAllViews()
+    calendarPanel.visibility = View.VISIBLE
+
+    if (shown.isEmpty()) {
+      val empty = text(17f * calScale, 0xCCFFFFFF.toInt(), false)
+      empty.text = "Nothing scheduled"
+      calendarRows.addView(empty)
+      return
+    }
+
+    val agenda = settings.calendarRange == CalendarFeed.RANGE_AGENDA
+    var lastDayKey = ""
+    for (ev in shown) {
+      // Day header whenever the day changes (and always in agenda mode, which spans
+      // arbitrary dates). A single-day range needs no per-day header.
+      val key = dayKey(ev.startMillis)
+      if (key != lastDayKey && (agenda || settings.calendarRange != CalendarFeed.RANGE_DAY)) {
+        val header = text(13f * calScale, 0x99FFFFFF.toInt(), false)
+        header.typeface = Typeface.DEFAULT_BOLD
+        header.text = dayHeader(ev.startMillis).uppercase(Locale.getDefault())
+        val hlp = LinearLayout.LayoutParams(WRAP, WRAP)
+        hlp.topMargin = if (calendarRows.childCount == 0) 0 else dp(12)
+        calendarRows.addView(header, hlp)
+      }
+      lastDayKey = key
+      calendarRows.addView(buildEventRow(ev))
+    }
+  }
+
+  /** Position the panel against the chosen edge and scale its padding to the size. */
+  private fun applyCalendarChrome() {
+    val pad = (22 * calScale).toInt()
+    val padV = (18 * calScale).toInt()
+    calendarPanel.setPadding(dp(pad), dp(padV), dp(pad), dp(padV))
+    val gravity =
+        Gravity.TOP or
+            (if (settings.calendarSide == ScreensaverConfig.CAL_SIDE_LEFT) Gravity.START
+            else Gravity.END)
+    val lp = FrameLayout.LayoutParams(WRAP, WRAP, gravity)
+    val side = dp(40)
+    if (settings.calendarSide == ScreensaverConfig.CAL_SIDE_LEFT) lp.setMargins(side, dp(40), 0, 0)
+    else lp.setMargins(0, dp(40), side, 0)
+    calendarPanel.layoutParams = lp
+  }
+
+  private fun buildEventRow(ev: CalendarFeed.Event): View {
+    val row = LinearLayout(context)
+    row.orientation = LinearLayout.HORIZONTAL
+    row.gravity = Gravity.CENTER_VERTICAL
+    val rowLp = LinearLayout.LayoutParams(WRAP, WRAP)
+    rowLp.topMargin = dp(6)
+
+    val time = text(17f * calScale, Color.WHITE, false)
+    time.text = if (ev.allDay) "All day" else timeLabel(ev.startMillis)
+    time.width = dp((96 * calScale).toInt())
+
+    val title = text(17f * calScale, Color.WHITE, false)
+    title.typeface = Typeface.DEFAULT_BOLD
+    title.text = ev.title
+    title.maxLines = 1
+    title.ellipsize = TextUtils.TruncateAt.END
+    title.maxWidth = dp((360 * calScale).toInt())
+
+    row.addView(time)
+    row.addView(title)
+    row.layoutParams = rowLp
+    return row
+  }
+
+  private fun rangeLabel(range: String): String =
+      when (range) {
+        CalendarFeed.RANGE_3DAY -> "Next 3 days"
+        CalendarFeed.RANGE_WEEK -> "This week"
+        CalendarFeed.RANGE_AGENDA -> "Upcoming"
+        else -> "Today"
+      }
+
+  private fun timeLabel(millis: Long): String {
+    val pattern = if (ImmortalSettings.use24HourClock(context)) "H:mm" else "h:mm a"
+    return SimpleDateFormat(pattern, Locale.getDefault()).format(Date(millis))
+  }
+
+  /** A stable per-day key (yyyyDDD) so the renderer can tell when the day changes. */
+  private fun dayKey(millis: Long): String =
+      SimpleDateFormat("yyyyDDD", Locale.US).format(Date(millis))
+
+  /** "Today" / "Tomorrow" / "Sat, Jun 21" relative to now. */
+  private fun dayHeader(millis: Long): String {
+    val today = dayKey(System.currentTimeMillis())
+    val tomorrow = dayKey(System.currentTimeMillis() + 24L * 60 * 60 * 1000)
+    return when (dayKey(millis)) {
+      today -> "Today"
+      tomorrow -> "Tomorrow"
+      else -> SimpleDateFormat("EEE, MMM d", Locale.getDefault()).format(Date(millis))
+    }
   }
 
   private fun applyFit() {
@@ -326,9 +497,33 @@ class PhotoFrameController(
         else ImageView.ScaleType.CENTER_CROP
   }
 
+  private fun text(sizeSp: Float, color: Int, light: Boolean): TextView {
+    val t = TextView(context)
+    t.textSize = sizeSp
+    t.setTextColor(color)
+    if (light) t.typeface = Typeface.create("sans-serif-light", Typeface.NORMAL)
+    t.setShadowLayer(8f, 0f, 2f, 0x99000000.toInt())
+    return t
+  }
+
   private fun intervalMs(): Long = settings.intervalSec * 1000L
 
   // --- periodic loops ---------------------------------------------------------
+  private val calendarTick =
+      object : Runnable {
+        override fun run() {
+          // Re-window the calendar once per minute (cheap, no network): drops events
+          // as they pass and rolls the Today/Tomorrow labels over at midnight.
+          val now = Date()
+          val minute = now.time / 60_000L
+          if (minute != lastCalMinute) {
+            lastCalMinute = minute
+            renderCalendar()
+          }
+          ui.postDelayed(this, 1_000L)
+        }
+      }
+
   private val rotate =
       object : Runnable {
         override fun run() {
@@ -337,6 +532,34 @@ class PhotoFrameController(
         }
       }
 
+  private val refreshCalendar =
+      object : Runnable {
+        override fun run() {
+          // Pick up calendar changes pushed over the fleet API (or via in-app
+          // settings) without restarting the dream: reload just the calendar fields,
+          // leaving the live slideshow state untouched.
+          val fresh = ScreensaverConfig.load(context)
+          if (fresh.calendarUrl != settings.calendarUrl ||
+              fresh.calendarRange != settings.calendarRange) {
+            settings = settings.copy(calendarUrl = fresh.calendarUrl, calendarRange = fresh.calendarRange)
+            renderCalendar()
+          }
+          val url = settings.calendarUrl
+          if (settings.usesCalendar && !url.isNullOrBlank()) {
+            io.execute {
+              val events = CalendarFeed.fetch(url)
+              ui.post {
+                calendarEvents = events
+                renderCalendar()
+              }
+            }
+          } else {
+            calendarEvents = emptyList()
+            renderCalendar()
+          }
+          ui.postDelayed(this, calendarRefreshMs)
+        }
+      }
   // --- navigation (branches on the active source) -----------------------------
   fun next() {
     when {

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -51,6 +51,10 @@ object ScreensaverConfig {
   const val DEFAULT_INTERVAL = 30
   const val DEFAULT_ALBUM_REFRESH_MIN = 60
 
+  // Which edge the calendar widget hugs. Top of that edge either way.
+  const val CAL_SIDE_LEFT = "left"
+  const val CAL_SIDE_RIGHT = "right"
+
   data class Settings(
       // Master on/off for Immortal's photo-frame screensaver. When off, Immortal
       // stops asserting itself as the system Dream and lets the Portal sleep / lets
@@ -83,6 +87,18 @@ object ScreensaverConfig {
       val albumRefreshMin: Int = DEFAULT_ALBUM_REFRESH_MIN,
       val shuffle: Boolean = false,
       val includeVideo: Boolean = true,
+      // Calendar widget: a public iCalendar (.ics) feed link (Google "secret iCal"
+      // address or an Apple iCloud public-calendar / webcal link) and how much of it
+      // to show on the frame. Empty link = the widget is off.
+      val calendarUrl: String? = null,
+      val calendarRange: String = CalendarFeed.RANGE_DAY,
+      // Show/hide the calendar widget without forgetting the link, so the user can
+      // toggle it off and back on. Defaults on, so a freshly-added link shows.
+      val calendarEnabled: Boolean = true,
+      // Calendar widget size (0 = Small, 1 = Medium, 2 = Large) and which screen edge
+      // it hugs (left/right). Defaults: medium, right — the original placement.
+      val calendarSize: Int = 1,
+      val calendarSide: String = CAL_SIDE_RIGHT,
       // Battery models (Portal Go) only: pause the screensaver while unplugged so
       // the device can actually sleep, instead of showing photos until empty.
       val batterySaver: Boolean = true,
@@ -132,6 +148,12 @@ object ScreensaverConfig {
     /** True when the user has pasted a public album share link for us to fetch. */
     val usesUrl: Boolean
       get() = source == SOURCE_URL && !albumUrl.isNullOrBlank()
+    /** True when a calendar link is set, regardless of the on/off toggle. */
+    val hasCalendarLink: Boolean
+      get() = !calendarUrl.isNullOrBlank()
+    /** True when the widget should show: a link is set AND the toggle is on. */
+    val usesCalendar: Boolean
+      get() = calendarEnabled && hasCalendarLink
     /** True when the user has connected an Immich server for us to pull from. */
     val usesImmich: Boolean
       get() = source == SOURCE_IMMICH && !immichUrl.isNullOrBlank() && !immichKey.isNullOrBlank()
@@ -180,6 +202,13 @@ object ScreensaverConfig {
             clampAlbumRefresh(p.getInt("album_refresh_min", DEFAULT_ALBUM_REFRESH_MIN)),
         shuffle = p.getBoolean("shuffle", false),
         includeVideo = p.getBoolean("include_video", true),
+        calendarUrl = p.getString("calendar_url", null),
+        calendarRange = CalendarFeed.clampRange(p.getString("calendar_range", CalendarFeed.RANGE_DAY)),
+        calendarEnabled = p.getBoolean("calendar_enabled", true),
+        calendarSize = p.getInt("calendar_size", 1).coerceIn(0, 2),
+        calendarSide =
+            if (p.getString("calendar_side", CAL_SIDE_RIGHT) == CAL_SIDE_LEFT) CAL_SIDE_LEFT
+            else CAL_SIDE_RIGHT,
         batterySaver = p.getBoolean("battery_saver", true),
         showNowPlaying = p.getBoolean("show_now_playing", true),
         facesEnabled = p.getBoolean("faces_enabled", true),
@@ -271,6 +300,33 @@ object ScreensaverConfig {
       prefs(c).edit().putInt("album_refresh_min", clampAlbumRefresh(min)).apply()
 
   fun setShuffle(c: Context, on: Boolean) = prefs(c).edit().putBoolean("shuffle", on).apply()
+
+  /** Save (or clear, when blank) the calendar feed link. */
+  fun setCalendarUrl(c: Context, url: String) {
+    val trimmed = url.trim()
+    if (trimmed.isEmpty()) prefs(c).edit().remove("calendar_url").apply()
+    else prefs(c).edit().putString("calendar_url", trimmed).apply()
+  }
+
+  fun clearCalendarUrl(c: Context) = prefs(c).edit().remove("calendar_url").apply()
+
+  /** Show/hide the calendar widget without clearing the saved link. */
+  fun setCalendarEnabled(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("calendar_enabled", on).apply()
+
+  /** Calendar widget size: 0 = Small, 1 = Medium, 2 = Large. */
+  fun setCalendarSize(c: Context, i: Int) =
+      prefs(c).edit().putInt("calendar_size", i.coerceIn(0, 2)).apply()
+
+  /** Which edge the calendar widget hugs ([CAL_SIDE_LEFT] / [CAL_SIDE_RIGHT]). */
+  fun setCalendarSide(c: Context, side: String) =
+      prefs(c)
+          .edit()
+          .putString("calendar_side", if (side == CAL_SIDE_LEFT) CAL_SIDE_LEFT else CAL_SIDE_RIGHT)
+          .apply()
+
+  fun setCalendarRange(c: Context, range: String) =
+      prefs(c).edit().putString("calendar_range", CalendarFeed.clampRange(range)).apply()
 
   fun setIncludeVideo(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("include_video", on).apply()

--- a/app/src/main/java/com/immortal/launcher/ScreensaverSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverSettingsActivity.kt
@@ -257,6 +257,93 @@ private fun ScreensaverSettingsScreen() {
           modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
       )
 
+      // Calendar — a clean upcoming-events panel, fed by a public iCalendar (.ics)
+      // link from Google Calendar or Apple iCloud (no account sign-in).
+      Spacer(Modifier.size(26.dp))
+      SectionLabel("Calendar")
+      Card {
+        NavRow(
+            title = "Calendar link",
+            value = calendarValue(settings),
+        ) {
+          context.startActivity(Intent(context, CalendarUrlEntryActivity::class.java))
+        }
+        if (settings.hasCalendarLink) {
+          Divider()
+          // Show/hide the widget without forgetting the link, so it's a quick toggle.
+          ToggleRow("Show calendar widget", settings.calendarEnabled) {
+            ScreensaverConfig.setCalendarEnabled(context, it)
+            settings = settings.copy(calendarEnabled = it)
+          }
+        }
+        if (settings.usesCalendar) {
+          Divider()
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text("Show", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+            Segmented(
+                options =
+                    listOf(
+                        "1 day" to CalendarFeed.RANGE_DAY,
+                        "3 days" to CalendarFeed.RANGE_3DAY,
+                        "Week" to CalendarFeed.RANGE_WEEK,
+                        "Events" to CalendarFeed.RANGE_AGENDA,
+                    ),
+                selected = settings.calendarRange,
+                onSelect = {
+                  ScreensaverConfig.setCalendarRange(context, it)
+                  settings = settings.copy(calendarRange = it)
+                },
+            )
+          }
+          Divider()
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text("Size", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+            Segmented(
+                options = listOf("Small" to "0", "Medium" to "1", "Large" to "2"),
+                selected = settings.calendarSize.toString(),
+                onSelect = {
+                  val i = it.toIntOrNull() ?: 1
+                  ScreensaverConfig.setCalendarSize(context, i)
+                  settings = settings.copy(calendarSize = i)
+                },
+            )
+          }
+          Divider()
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text("Position", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+            Segmented(
+                options =
+                    listOf(
+                        "Left" to ScreensaverConfig.CAL_SIDE_LEFT,
+                        "Right" to ScreensaverConfig.CAL_SIDE_RIGHT,
+                    ),
+                selected = settings.calendarSide,
+                onSelect = {
+                  ScreensaverConfig.setCalendarSide(context, it)
+                  settings = settings.copy(calendarSide = it)
+                },
+            )
+          }
+        }
+      }
+      Text(
+          "Shows your upcoming events on the frame. \"Events\" lists the next " +
+              "few whenever they are; the others show a day, three days, or the week ahead. " +
+              "Use a Google \"secret iCal\" address or an Apple iCloud public-calendar link.",
+          color = Color(0xFF7C7C7C),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
+      )
+
       Spacer(Modifier.size(26.dp))
 
       val hasBattery = remember { DreamPolicy.hasBattery(context) }
@@ -400,6 +487,22 @@ private fun currentSourceLabel(s: ScreensaverConfig.Settings): String =
       s.usesDav -> "WebDAV folder"
       s.usesWebUrl -> "Web page"
       else -> "Immortal photos"
+    }
+
+private fun calendarValue(s: ScreensaverConfig.Settings): String =
+    when {
+      s.calendarUrl.isNullOrBlank() -> "Off"
+      !s.calendarEnabled -> "${CalendarFeed.providerName(s.calendarUrl)} - hidden"
+      else -> "${CalendarFeed.providerName(s.calendarUrl)} - ${calendarRangeLabel(s.calendarRange)}"
+    }
+
+private fun calendarRangeLabel(range: String): String =
+    when (CalendarFeed.clampRange(range)) {
+      CalendarFeed.RANGE_DAY -> "1 day"
+      CalendarFeed.RANGE_3DAY -> "3 days"
+      CalendarFeed.RANGE_WEEK -> "Week"
+      CalendarFeed.RANGE_AGENDA -> "Events"
+      else -> "1 day"
     }
 
 @Composable

--- a/app/src/main/java/com/immortal/launcher/UpdateManager.kt
+++ b/app/src/main/java/com/immortal/launcher/UpdateManager.kt
@@ -52,6 +52,12 @@ object UpdateManager {
 
   /** Returns an [UpdateInfo] on the main thread only if a newer build exists. */
   fun checkForUpdate(context: Context, onResult: (UpdateInfo?) -> Unit) {
+    // Dev mode pauses the official self-updater so a locally-pushed build sticks.
+    if (DevMode.isEnabled(context)) {
+      android.util.Log.i("ImmortalUpdate", "dev mode on; skipping official update check")
+      onResult(null)
+      return
+    }
     io.execute {
       val available =
           runCatching {

--- a/app/src/test/java/com/immortal/launcher/CalendarFeedTest.kt
+++ b/app/src/test/java/com/immortal/launcher/CalendarFeedTest.kt
@@ -1,0 +1,206 @@
+package com.immortal.launcher
+
+import java.util.Calendar
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CalendarFeedTest {
+
+  @Test
+  fun isSupported_recognisesIcsAndKnownHosts() {
+    assertTrue(
+        CalendarFeed.isSupported(
+            "https://calendar.google.com/calendar/ical/abc%40group.calendar.google.com/private-x/basic.ics"))
+    assertTrue(CalendarFeed.isSupported("webcal://p01-caldav.icloud.com/published/2/MT234"))
+    assertTrue(CalendarFeed.isSupported("https://example.com/feed.ics"))
+    assertFalse(CalendarFeed.isSupported("https://example.com/album/123"))
+    assertFalse(CalendarFeed.isSupported(""))
+    assertFalse(CalendarFeed.isSupported("not a url"))
+  }
+
+  @Test
+  fun providerName_distinguishesProviders() {
+    assertEquals(
+        "Google Calendar",
+        CalendarFeed.providerName("https://calendar.google.com/calendar/ical/x/basic.ics"))
+    assertEquals(
+        "Apple iCloud", CalendarFeed.providerName("webcal://p01-caldav.icloud.com/published/2/x"))
+    assertEquals("Calendar feed", CalendarFeed.providerName("https://example.com/feed.ics"))
+  }
+
+  @Test
+  fun normalizeUrl_rewritesWebcalToHttps() {
+    assertEquals(
+        "https://p01-caldav.icloud.com/x",
+        CalendarFeed.normalizeUrl("webcal://p01-caldav.icloud.com/x"))
+    assertEquals(
+        "https://example.com/feed.ics",
+        CalendarFeed.normalizeUrl("  https://example.com/feed.ics "))
+  }
+
+  @Test
+  fun clampRange_fallsBackToDay() {
+    assertEquals(CalendarFeed.RANGE_WEEK, CalendarFeed.clampRange("week"))
+    assertEquals(CalendarFeed.RANGE_AGENDA, CalendarFeed.clampRange("agenda"))
+    assertEquals(CalendarFeed.RANGE_DAY, CalendarFeed.clampRange("bogus"))
+    assertEquals(CalendarFeed.RANGE_DAY, CalendarFeed.clampRange(null))
+  }
+
+  @Test
+  fun unescapeText_resolvesEscapes() {
+    assertEquals("a,b c", CalendarFeed.unescapeText("""a\,b\nc"""))
+    assertEquals("semi;colon", CalendarFeed.unescapeText("""semi\;colon"""))
+  }
+
+  @Test
+  fun unfold_joinsContinuationLines() {
+    val ics = "SUMMARY:Long\r\n  title here\r\nDTSTART:20231115T140000Z"
+    val lines = CalendarFeed.unfold(ics)
+    assertEquals("SUMMARY:Long title here", lines[0])
+    assertEquals("DTSTART:20231115T140000Z", lines[1])
+  }
+
+  @Test
+  fun parse_readsTimedAndAllDayEvents() {
+    val now = 1_700_000_000_000L // 2023-11-14T22:13:20Z
+    val ics =
+        """
+        BEGIN:VCALENDAR
+        BEGIN:VEVENT
+        SUMMARY:Team standup
+        DTSTART:20231115T140000Z
+        DTEND:20231115T143000Z
+        END:VEVENT
+        BEGIN:VEVENT
+        SUMMARY:Holiday\, all day
+        DTSTART;VALUE=DATE:20231116
+        END:VEVENT
+        END:VCALENDAR
+        """
+            .trimIndent()
+    val events = CalendarFeed.parse(ics, now)
+    assertEquals(2, events.size)
+    assertEquals("Team standup", events[0].title)
+    assertFalse(events[0].allDay)
+    assertEquals("Holiday, all day", events[1].title)
+    assertTrue(events[1].allDay)
+  }
+
+  @Test
+  fun parse_dropsEventsThatAlreadyEnded() {
+    val now = 1_700_000_000_000L
+    val ics =
+        """
+        BEGIN:VCALENDAR
+        BEGIN:VEVENT
+        SUMMARY:Yesterday
+        DTSTART:20231113T140000Z
+        DTEND:20231113T150000Z
+        END:VEVENT
+        BEGIN:VEVENT
+        SUMMARY:Soon
+        DTSTART:20231115T140000Z
+        DTEND:20231115T150000Z
+        END:VEVENT
+        END:VCALENDAR
+        """
+            .trimIndent()
+    val events = CalendarFeed.parse(ics, now)
+    assertEquals(1, events.size)
+    assertEquals("Soon", events[0].title)
+  }
+
+  @Test
+  fun expandRecurrence_weeklyCountYieldsThree() {
+    val start = 1_700_000_000_000L
+    val horizon = start + 60L * 24 * 60 * 60 * 1000
+    val occ = CalendarFeed.expandRecurrence(start, "FREQ=WEEKLY;COUNT=3", emptyList(), horizon)
+    assertEquals(3, occ.size)
+    assertEquals(start, occ[0])
+  }
+
+  @Test
+  fun expandRecurrence_honoursExdate() {
+    val start = 1_700_000_000_000L
+    val horizon = start + 60L * 24 * 60 * 60 * 1000
+    val full = CalendarFeed.expandRecurrence(start, "FREQ=DAILY;COUNT=3", emptyList(), horizon)
+    assertEquals(3, full.size)
+    val excluded =
+        CalendarFeed.expandRecurrence(start, "FREQ=DAILY;COUNT=3", listOf(full[1]), horizon)
+    assertEquals(2, excluded.size)
+    assertFalse(excluded.contains(full[1]))
+  }
+
+  @Test
+  fun expandRecurrence_stopsAtHorizon() {
+    val start = 1_700_000_000_000L
+    val horizon = start + 10L * 24 * 60 * 60 * 1000 // 10 days
+    val occ = CalendarFeed.expandRecurrence(start, "FREQ=DAILY", emptyList(), horizon)
+    // No COUNT/UNTIL: bounded only by the 10-day horizon → 11 daily occurrences (days 0..10).
+    assertEquals(11, occ.size)
+  }
+
+  @Test
+  fun expandRecurrence_unknownRuleFallsBackToSingle() {
+    val start = 1_700_000_000_000L
+    val occ = CalendarFeed.expandRecurrence(start, "GARBAGE", emptyList(), start + 1000)
+    assertEquals(listOf(start), occ)
+  }
+
+  // --- windowing (anchored to local noon so day boundaries are deterministic) ---
+
+  private fun localNoon(): Long {
+    val c = Calendar.getInstance()
+    c.set(Calendar.HOUR_OF_DAY, 12)
+    c.set(Calendar.MINUTE, 0)
+    c.set(Calendar.SECOND, 0)
+    c.set(Calendar.MILLISECOND, 0)
+    return c.timeInMillis
+  }
+
+  private fun ev(start: Long, title: String) =
+      CalendarFeed.Event(start, start + 60L * 60 * 1000, title, false)
+
+  @Test
+  fun window_dayRangeKeepsOnlyToday() {
+    val now = localNoon()
+    val hour = 60L * 60 * 1000
+    val day = 24 * hour
+    val events =
+        listOf(
+            ev(now - 2 * hour, "ended"), // already over
+            ev(now + hour, "today"), // 1pm today
+            ev(now + 30 * hour, "tomorrow"), // ~next day
+            ev(now + 8 * day, "next week"),
+        )
+    val shown = CalendarFeed.window(events, CalendarFeed.RANGE_DAY, now)
+    assertEquals(listOf("today"), shown.map { it.title })
+  }
+
+  @Test
+  fun window_weekRangeKeepsThroughSevenDays() {
+    val now = localNoon()
+    val day = 24L * 60 * 60 * 1000
+    val events =
+        listOf(
+            ev(now + 2 * 60 * 60 * 1000, "today"),
+            ev(now + 2 * day, "in 2 days"),
+            ev(now + 5 * day, "in 5 days"),
+            ev(now + 10 * day, "in 10 days"),
+        )
+    val shown = CalendarFeed.window(events, CalendarFeed.RANGE_WEEK, now)
+    assertEquals(listOf("today", "in 2 days", "in 5 days"), shown.map { it.title })
+  }
+
+  @Test
+  fun window_agendaIgnoresDateAndCaps() {
+    val now = localNoon()
+    val day = 24L * 60 * 60 * 1000
+    val events = (1..12).map { ev(now + it * day, "event $it") }
+    val shown = CalendarFeed.window(events, CalendarFeed.RANGE_AGENDA, now)
+    assertEquals(CalendarFeed.MAX_EVENTS, shown.size)
+    assertEquals("event 1", shown.first().title)
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/DevModeTest.kt
+++ b/app/src/test/java/com/immortal/launcher/DevModeTest.kt
@@ -1,0 +1,22 @@
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure status-shaping for the fleet `/dev` endpoint (no Context needed). */
+class DevModeTest {
+
+  @Test
+  fun statusJson_reportsEnabledAndVersion() {
+    val on = DevMode.statusJson(true, 4207, "1.4.2-dev")
+    assertTrue(on.getBoolean("enabled"))
+    assertEquals(4207L, on.getLong("versionCode"))
+    assertEquals("1.4.2-dev", on.getString("versionName"))
+
+    val off = DevMode.statusJson(false, 100, "1.0.0")
+    assertFalse(off.getBoolean("enabled"))
+    assertEquals(100L, off.getLong("versionCode"))
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/FleetCalendarTest.kt
+++ b/app/src/test/java/com/immortal/launcher/FleetCalendarTest.kt
@@ -1,0 +1,86 @@
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure JSON-shaping for the fleet `/calendar` endpoint (no Context needed). */
+class FleetCalendarTest {
+
+  @Test
+  fun toJson_emptyWhenNoLink() {
+    val json = FleetCalendar.toJson(ScreensaverConfig.Settings())
+    assertFalse(json.getBoolean("enabled"))
+    assertEquals("", json.getString("url"))
+    assertEquals(CalendarFeed.RANGE_DAY, json.getString("range"))
+    assertEquals("", json.getString("provider"))
+    assertFalse(json.getBoolean("supported"))
+    // Advertises the four selectable ranges for the client UI.
+    assertEquals(4, json.getJSONArray("ranges").length())
+  }
+
+  @Test
+  fun toJson_reportsGoogleLink() {
+    val url = "https://calendar.google.com/calendar/ical/x%40group.calendar.google.com/private-y/basic.ics"
+    val json =
+        FleetCalendar.toJson(
+            ScreensaverConfig.Settings(calendarUrl = url, calendarRange = CalendarFeed.RANGE_WEEK))
+    assertTrue(json.getBoolean("enabled"))
+    assertEquals(url, json.getString("url"))
+    assertEquals(CalendarFeed.RANGE_WEEK, json.getString("range"))
+    assertEquals("Google Calendar", json.getString("provider"))
+    assertTrue(json.getBoolean("supported"))
+  }
+
+  @Test
+  fun toJson_flagsUnsupportedLinkButStaysEnabled() {
+    val json =
+        FleetCalendar.toJson(ScreensaverConfig.Settings(calendarUrl = "https://example.com/not-a-feed"))
+    // A link is set, so the widget is "enabled", but it doesn't look fetchable.
+    assertTrue(json.getBoolean("enabled"))
+    assertFalse(json.getBoolean("supported"))
+    assertEquals("Calendar feed", json.getString("provider"))
+  }
+
+  @Test
+  fun toJson_reportsDisabledWidgetKeepingLink() {
+    // A link is saved but the on/off toggle is off: the widget is hidden, so the
+    // effective "enabled" is false, while "hasLink" stays true and "widgetOn" false.
+    val url = "https://calendar.google.com/calendar/ical/x/basic.ics"
+    val json =
+        FleetCalendar.toJson(
+            ScreensaverConfig.Settings(calendarUrl = url, calendarEnabled = false))
+    assertFalse(json.getBoolean("enabled"))
+    assertFalse(json.getBoolean("widgetOn"))
+    assertTrue(json.getBoolean("hasLink"))
+    assertEquals(url, json.getString("url"))
+  }
+
+  @Test
+  fun toJson_reportsSizeAndSide() {
+    val def = FleetCalendar.toJson(ScreensaverConfig.Settings(calendarUrl = "https://x/basic.ics"))
+    assertEquals(1, def.getInt("size")) // medium default
+    assertEquals(ScreensaverConfig.CAL_SIDE_RIGHT, def.getString("side"))
+
+    val custom =
+        FleetCalendar.toJson(
+            ScreensaverConfig.Settings(
+                calendarUrl = "https://x/basic.ics",
+                calendarSize = 2,
+                calendarSide = ScreensaverConfig.CAL_SIDE_LEFT))
+    assertEquals(2, custom.getInt("size"))
+    assertEquals(ScreensaverConfig.CAL_SIDE_LEFT, custom.getString("side"))
+  }
+
+  @Test
+  fun ranges_coverAllDisplayOptions() {
+    assertEquals(
+        listOf(
+            CalendarFeed.RANGE_DAY,
+            CalendarFeed.RANGE_3DAY,
+            CalendarFeed.RANGE_WEEK,
+            CalendarFeed.RANGE_AGENDA),
+        FleetCalendar.RANGES)
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/FleetScreensaverTest.kt
+++ b/app/src/test/java/com/immortal/launcher/FleetScreensaverTest.kt
@@ -66,30 +66,12 @@ class FleetScreensaverTest {
   }
 
   @Test
-  fun coercePresenceMode_parsesOrDefaults() {
+  fun coercePresenceMode_parsesOrNull() {
     assertEquals(FrameMode.PRESENCE, FleetScreensaver.coercePresenceMode("PRESENCE"))
     assertEquals(FrameMode.PRESENCE, FleetScreensaver.coercePresenceMode("presence"))
     assertEquals(FrameMode.ALWAYS_ON, FleetScreensaver.coercePresenceMode("ALWAYS_ON"))
-    assertEquals(FrameMode.ALWAYS_ON, FleetScreensaver.coercePresenceMode("garbage"))
-    assertEquals(FrameMode.ALWAYS_ON, FleetScreensaver.coercePresenceMode(null))
-  }
-
-  @Test
-  fun recognizedKeys_coverTheSettableFields() {
-    val keys = FleetScreensaver.RECOGNIZED_KEYS
-    listOf(
-            "enabled",
-            "source",
-            "fit",
-            "intervalSec",
-            "shuffle",
-            "includeVideo",
-            "showNowPlaying",
-            "presenceMode",
-            "idleSleepMin",
-            "overnightEnabled",
-            "overnightStartMin",
-            "overnightEndMin")
-        .forEach { assertTrue("missing $it", keys.contains(it)) }
+    // Unknown / null → null, so apply() skips it instead of flipping the mode.
+    assertNull(FleetScreensaver.coercePresenceMode("garbage"))
+    assertNull(FleetScreensaver.coercePresenceMode(null))
   }
 }

--- a/app/src/test/java/com/immortal/launcher/FleetScreensaverTest.kt
+++ b/app/src/test/java/com/immortal/launcher/FleetScreensaverTest.kt
@@ -1,0 +1,95 @@
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure JSON-shaping + coercion for the fleet `/screensaver` endpoint (no Context). */
+class FleetScreensaverTest {
+
+  @Test
+  fun toJson_mirrorsDefaults() {
+    val json = FleetScreensaver.toJson(ScreensaverConfig.Settings())
+    assertTrue(json.getBoolean("enabled"))
+    assertEquals(ScreensaverConfig.SOURCE_DEFAULT, json.getString("source"))
+    assertEquals("", json.getString("folderPath"))
+    assertEquals("", json.getString("albumUrl"))
+    assertEquals(ScreensaverConfig.FIT_FILL, json.getString("fit"))
+    assertEquals(ScreensaverConfig.DEFAULT_INTERVAL, json.getInt("intervalSec"))
+    assertFalse(json.getBoolean("shuffle"))
+    assertTrue(json.getBoolean("includeVideo"))
+    assertTrue(json.getBoolean("showNowPlaying"))
+    assertEquals(FrameMode.ALWAYS_ON.name, json.getString("presenceMode"))
+    assertEquals(0, json.getInt("idleSleepMin"))
+    assertFalse(json.getBoolean("overnightEnabled"))
+  }
+
+  @Test
+  fun toJson_reflectsCustomSettings() {
+    val s =
+        ScreensaverConfig.Settings(
+            enabled = false,
+            source = ScreensaverConfig.SOURCE_URL,
+            albumUrl = "https://photos.app.goo.gl/abc",
+            fit = ScreensaverConfig.FIT_FIT,
+            intervalSec = 45,
+            shuffle = true,
+            includeVideo = false,
+            presenceMode = FrameMode.PRESENCE,
+            idleSleepMin = 30,
+            overnightEnabled = true,
+            overnightStartMin = 22 * 60,
+            overnightEndMin = 7 * 60)
+    val json = FleetScreensaver.toJson(s)
+    assertFalse(json.getBoolean("enabled"))
+    assertEquals(ScreensaverConfig.SOURCE_URL, json.getString("source"))
+    assertEquals("https://photos.app.goo.gl/abc", json.getString("albumUrl"))
+    assertEquals(ScreensaverConfig.FIT_FIT, json.getString("fit"))
+    assertEquals(45, json.getInt("intervalSec"))
+    assertTrue(json.getBoolean("shuffle"))
+    assertFalse(json.getBoolean("includeVideo"))
+    assertEquals(FrameMode.PRESENCE.name, json.getString("presenceMode"))
+    assertEquals(30, json.getInt("idleSleepMin"))
+    assertTrue(json.getBoolean("overnightEnabled"))
+    assertEquals(1320, json.getInt("overnightStartMin"))
+    assertEquals(420, json.getInt("overnightEndMin"))
+  }
+
+  @Test
+  fun coerceFit_acceptsKnownElseNull() {
+    assertEquals(ScreensaverConfig.FIT_FILL, FleetScreensaver.coerceFit("fill"))
+    assertEquals(ScreensaverConfig.FIT_FIT, FleetScreensaver.coerceFit("fit"))
+    assertNull(FleetScreensaver.coerceFit("stretch"))
+    assertNull(FleetScreensaver.coerceFit(null))
+  }
+
+  @Test
+  fun coercePresenceMode_parsesOrDefaults() {
+    assertEquals(FrameMode.PRESENCE, FleetScreensaver.coercePresenceMode("PRESENCE"))
+    assertEquals(FrameMode.PRESENCE, FleetScreensaver.coercePresenceMode("presence"))
+    assertEquals(FrameMode.ALWAYS_ON, FleetScreensaver.coercePresenceMode("ALWAYS_ON"))
+    assertEquals(FrameMode.ALWAYS_ON, FleetScreensaver.coercePresenceMode("garbage"))
+    assertEquals(FrameMode.ALWAYS_ON, FleetScreensaver.coercePresenceMode(null))
+  }
+
+  @Test
+  fun recognizedKeys_coverTheSettableFields() {
+    val keys = FleetScreensaver.RECOGNIZED_KEYS
+    listOf(
+            "enabled",
+            "source",
+            "fit",
+            "intervalSec",
+            "shuffle",
+            "includeVideo",
+            "showNowPlaying",
+            "presenceMode",
+            "idleSleepMin",
+            "overnightEnabled",
+            "overnightStartMin",
+            "overnightEndMin")
+        .forEach { assertTrue("missing $it", keys.contains(it)) }
+  }
+}

--- a/provisioning/.gitignore
+++ b/provisioning/.gitignore
@@ -7,3 +7,11 @@ alexa/
 
 # Downloaded/staged client APKs (immortal.apk is fetched from the release on first run)
 apks/*.apk
+
+# Compiled fleet CLI (build locally with rustc/cargo; never commit the binary)
+fleetctl
+target/
+Cargo.lock
+
+# Device backups from fleet-backup.sh (tokens + cleartext credentials — never commit)
+backups/

--- a/provisioning/Cargo.toml
+++ b/provisioning/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fleetctl"
+version = "0.1.0"
+edition = "2021"
+description = "Lightweight CLI for the Immortal Fleet Agent (manage Portals over WiFi)."
+
+# Single-file, std-only — no dependencies. `cargo build --release` produces
+# target/release/fleetctl; or compile directly with `rustc -O fleet.rs -o fleetctl`.
+[[bin]]
+name = "fleetctl"
+path = "fleet.rs"
+
+[profile.release]
+opt-level = 3

--- a/provisioning/README.md
+++ b/provisioning/README.md
@@ -110,6 +110,170 @@ gitignored.)
 You're prompted for a friendly name (e.g. "Living Room Left") unless you preset
 `FLEET_NAME`. After a reboot the agent comes back on its own — nothing to re-arm.
 
+#### Calendar widget over the air
+
+The screensaver's calendar widget is managed through the agent too, so you can
+point a whole wall of frames at a calendar without touching each one. The agent
+exposes a `/calendar` endpoint (bearer-token auth, like every fleet route):
+
+```bash
+TOKEN=$(jq -r .token fleet/<serial>.json)   # recorded by --fleet
+DEV=http://<device-ip>:8723
+
+# Read the current calendar config
+curl -s -H "Authorization: Bearer $TOKEN" $DEV/calendar
+
+# Push a public iCalendar (.ics) feed link and a display range
+curl -s -X POST -H "Authorization: Bearer $TOKEN" $DEV/calendar \
+  -d '{"url":"https://calendar.google.com/calendar/ical/…/basic.ics","range":"week"}'
+
+# Turn the widget off again (clear the link)
+curl -s -X POST -H "Authorization: Bearer $TOKEN" $DEV/calendar -d '{"url":""}'
+```
+
+`url` takes a Google "secret address in iCal format" or an Apple iCloud
+public-calendar / `webcal://` link (empty string clears it). `range` is one of
+`day`, `3day`, `week`, or `agenda` (unknown values fall back to `day`). Both
+fields are optional in a POST, so `{"range":"agenda"}` re-ranges without
+re-sending the link. The response echoes the stored config plus `provider` and a
+`supported` flag (whether the link looks like a fetchable feed). Pushes apply
+**live** — the running photo frame reloads the calendar on its next refresh, no
+reboot or re-dream needed.
+
+#### Screensaver over the air
+
+The whole photo-frame configuration is managed the same way, via a `/screensaver`
+endpoint (GET reads it, POST pushes a partial update — only the fields you send
+change). Recognised fields mirror the in-app Screensaver settings: `enabled`,
+`source` (`default`; `folderPath`/`albumUrl` set the folder/URL sources), `fit`
+(`fill`/`fit`), `intervalSec`, `albumRefreshMin`, `shuffle`, `includeVideo`,
+`showNowPlaying`, `batterySaver`, `presenceMode` (`ALWAYS_ON`/`PRESENCE`),
+`idleSleepMin` (0 = never), and the overnight window (`overnightEnabled`,
+`overnightStartMin`, `overnightEndMin`, minutes-from-midnight). Display changes take
+effect on the next screensaver cycle (as in the in-app settings); `enabled` and the
+overnight window apply immediately. The calendar widget keeps its own `/calendar`
+endpoint above. The `fleetctl` CLI below wraps all of this.
+
+#### Dev mode + local builds (iterate over WiFi)
+
+When you're hacking on Immortal itself, you don't want to cut a GitHub release for
+every change — and you don't want the device's official self-updater to clobber your
+test build. Dev mode + the local-install path handle both:
+
+```bash
+./fleetctl dev on  --device "Living Room"      # pause the official self-updater
+./fleetctl dev update ./app/build/outputs/apk/release/app-release.apk --device "Living Room"
+./fleetctl dev status --device "Living Room"
+./fleetctl dev off --device "Living Room"       # resume official updates
+```
+
+`dev update` enables dev mode (unless `--no-pause`), pushes the local APK to the
+device, and installs it over Immortal via the same silent path the store uses — no
+cable, no `version.json`, no catalog/versionCode gate. `--package`/`--path` override
+the defaults (`com.immortal.launcher` and a temp path in the app's files dir).
+
+**Sign with the same key.** An in-place update is signature-checked by Android, so
+your local build must be signed with the **same key** as the installed Immortal (the
+release key in `keystore.properties` — see the top-level README's *Releasing*) or
+the install is rejected. Reinstalling the same `versionCode` is fine; a *lower*
+versionCode is a downgrade and needs an uninstall first. On the device side this is
+just a flag (`/dev`) and a local-path option on `/install`. The local-path install
+is **only honoured while dev mode is on** (otherwise `/install` returns
+`403 dev_mode_required` and the token can still only install known catalog apps) —
+`dev update` enables it for you. Dev mode itself pauses `UpdateManager` and nothing
+else.
+
+#### The `fleetctl` CLI
+
+`fleetctl` is a fast, **zero-dependency** CLI — a single-file Rust program (standard
+library only, no crates) that drives the agent for you so you don't hand-write
+`curl` calls. It's in the same native-code spirit as the Portal's own hand-rolled
+HTTP, compiles to a small static-ish binary, and starts instantly. Build it once:
+
+```bash
+rustc -O fleet.rs -o fleetctl     # no Cargo needed; or:
+cargo build --release             # produces target/release/fleetctl
+```
+
+It reads the same `fleet/<serial>.json` files that `--fleet` records, so you can
+target devices by name:
+
+```bash
+./fleetctl devices                       # list registered Portals
+./fleetctl info --device all             # identity/version/state for every device
+./fleetctl apps --device "Living Room"   # catalog + what's installed
+./fleetctl install org.videolan.vlc --device all
+./fleetctl update --check                # dry-run: what has updates
+./fleetctl update --all --device all
+./fleetctl dev on --device "Living Room"            # pause official self-update
+./fleetctl dev update ./app/build/outputs/apk/release/app-release.apk --device "Living Room"
+./fleetctl dev off --device "Living Room"           # resume official self-update
+./fleetctl calendar set --url 'https://…/basic.ics' --range week --device all
+./fleetctl calendar off --device "Living Room"
+./fleetctl screensaver get --device "Living Room"
+./fleetctl screensaver set --enabled true --fit fill --interval 45 --shuffle true --device all
+./fleetctl screensaver set --overnight true --overnight-start 22:00 --overnight-end 07:00 --device all
+./fleetctl screensaver set --album-url 'https://www.icloud.com/sharedalbum/#…' --device all
+./fleetctl push ./frame.jpg /sdcard/Android/data/com.immortal.launcher/files/frame.jpg
+./fleetctl pull /sdcard/some.log ./some.log
+./fleetctl ls /sdcard/Android/data/com.immortal.launcher/files
+./fleetctl logcat --lines 200 --device Kitchen
+./fleetctl diag --device all
+./fleetctl action reaffirm --device all  # re-assert launcher/screensaver ownership
+./fleetctl raw POST /calendar '{"range":"agenda"}'   # call any endpoint directly
+```
+
+Pick a target with `--device NAME|serial|all` (a single registered device is used
+by default). To reach a Portal that isn't in the registry, skip it with
+`--host <ip> --token <token> [--port 8723]`. Point at a different registry folder
+with `$IMMORTAL_FLEET_DIR`.
+
+**What it can and can't touch.** The agent runs as the *app* user, so the CLI
+reaches everything the agent exposes — installing/updating apps, reading and
+writing files on shared and app-external storage (`push`/`pull`/`ls`/`cat`),
+Immortal's own config and the screensaver calendar, logcat, and diagnostics. It is
+**not** a full adb shell: it can't read other apps' private data dirs or run
+`pm` / `appops` / `settings` directly — those need the shell user (a USB adb run or
+the provisioning kit). The `raw` subcommand calls any endpoint the agent grows
+later, so the CLI keeps working as the API expands.
+
+#### Back up & restore a Portal (before a risky reinstall)
+
+A clean reinstall — e.g. switching a Portal onto a build signed with a **different
+key** (your own debug/release key instead of the one currently installed) — requires
+an uninstall first, which **wipes that Portal's app data**: Immortal's config, its
+saved credentials (Immich / SMB / WebDAV, multiroom user/pass, …), and the list of
+apps you'd installed. `fleet-backup.sh` snapshots all of that first, and
+`fleet-restore.sh` puts it back afterward.
+
+```bash
+./fleet-backup.sh                 # snapshot every registered Portal
+./fleet-backup.sh "Portal Mini"   # …or one (by name or serial)
+```
+
+Each run writes `backups/<serial>/<timestamp>/` with `info.json`, `apps.json`
+(the installed-app list), `registry.json` (host/port/token), and every readable
+`shared_prefs/*.xml` — the agent runs *as* Immortal, so it reads its own
+`/data/data/.../shared_prefs` over `/fs/read`, no root or adb needed. **The
+`backups/` tree holds tokens and cleartext credentials, so it is git-ignored —
+keep it private.**
+
+After reinstalling the new build and re-registering the agent
+(`./provision.sh --fleet` over USB, which mints a fresh token):
+
+```bash
+./fleet-restore.sh "Portal Mini"                 # reinstall apps + restore prefs, then reboot
+./fleet-restore.sh "Portal Mini" --config        # instead: re-apply only screensaver/calendar
+./fleet-restore.sh "Portal Mini" --apps --dry-run # preview what would run
+```
+
+By default restore reinstalls the third-party apps that were present and pushes the
+saved `shared_prefs` back **verbatim** (full fidelity, including stored credentials),
+skipping `fleet_agent.xml` so the freshly-provisioned token is kept, then reboots so
+the app reloads them from disk. `--config` is a lighter alternative that re-applies
+only the endpoint-covered screensaver + calendar subset (no stored credentials, no
+reboot). `--prefs`, `--apps`, and `--dry-run` can be combined as needed.
+
 Provisioning deliberately does **not** switch the Portal into raw adb-over-WiFi:
 `adb tcpip` restarts adbd, which would stop Shizuku, and it doesn't survive a
 reboot anyway. The agent is the persistent channel. If

--- a/provisioning/fleet-backup.sh
+++ b/provisioning/fleet-backup.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# fleet-backup.sh — snapshot a Portal's Immortal state before a risky operation
+# (e.g. a debug-key reinstall, which wipes app data). Pairs with fleet-restore.sh.
+#
+# For each target it saves, under backups/<serial>/<timestamp>/:
+#   info.json       — /info (identity, version, install state, installed apps)
+#   apps.json       — /apps (catalog + what's installed → the reinstall list)
+#   registry.json   — the local fleet/<serial>.json (host/port/token)
+#   shared_prefs/*.xml — every readable Immortal pref file. THIS is the config +
+#                        credential store (fleet token, screensaver sources incl.
+#                        Immich/SMB/WebDAV creds, multiroom user/pass, weather, …).
+#
+# The agent runs as com.immortal.launcher, so it can read its own /data/data
+# shared_prefs over /fs/read — no root or adb needed.
+#
+# Usage:
+#   ./fleet-backup.sh                 # back up every registered device
+#   ./fleet-backup.sh all             # same
+#   ./fleet-backup.sh "Portal Mini"   # one device by name
+#   ./fleet-backup.sh 819LCM01Z09E4D12  # …or by serial
+#
+# The backups/ tree holds tokens + passwords in cleartext — it is git-ignored;
+# keep it private and treat it like any other secret store.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+FLEETCTL="${FLEETCTL:-./fleetctl}"
+FLEET_DIR="${IMMORTAL_FLEET_DIR:-./fleet}"
+PREFS_DIR="/data/data/com.immortal.launcher/shared_prefs"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+
+[ -x "$FLEETCTL" ] || {
+  echo "error: $FLEETCTL not found/executable — build it first:" >&2
+  echo "       rustc -O fleet.rs -o fleetctl   (or: cargo build --release)" >&2
+  exit 1
+}
+
+target="${1:-all}"
+
+# Resolve the set of serials to back up from the registry filenames.
+serials=()
+if [ "$target" = "all" ]; then
+  for f in "$FLEET_DIR"/*.json; do
+    [ -e "$f" ] || continue
+    serials+=("$(basename "$f" .json)")
+  done
+elif [ -f "$FLEET_DIR/$target.json" ]; then
+  serials+=("$target")                       # matched a serial directly
+else
+  for f in "$FLEET_DIR"/*.json; do            # try to match a friendly name
+    [ -e "$f" ] || continue
+    nm="$(sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$f" | head -1)"
+    [ "$nm" = "$target" ] && serials+=("$(basename "$f" .json)")
+  done
+fi
+[ ${#serials[@]} -gt 0 ] || { echo "error: no device matching '$target' in $FLEET_DIR" >&2; exit 1; }
+
+backed_up=0
+for serial in "${serials[@]}"; do
+  echo "=== backing up $serial ==="
+  out="backups/$serial/$STAMP"
+  mkdir -p "$out/shared_prefs"
+
+  "$FLEETCTL" info --device "$serial" > "$out/info.json" 2>/dev/null \
+    || { echo "  warn: /info unreachable — skipping $serial"; rm -rf "$out"; continue; }
+  "$FLEETCTL" apps --device "$serial" > "$out/apps.json" 2>/dev/null || echo "  warn: /apps failed"
+  cp "$FLEET_DIR/$serial.json" "$out/registry.json" 2>/dev/null || true
+
+  names="$("$FLEETCTL" ls "$PREFS_DIR" --device "$serial" 2>/dev/null \
+            | sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\.xml\)".*/\1/p')"
+  if [ -z "$names" ]; then
+    echo "  warn: no readable shared_prefs on $serial"
+  else
+    while IFS= read -r n; do
+      [ -n "$n" ] || continue
+      if "$FLEETCTL" pull "$PREFS_DIR/$n" "$out/shared_prefs/$n" --device "$serial" >/dev/null 2>&1; then
+        echo "  saved shared_prefs/$n"
+      else
+        echo "  warn: could not pull $n"
+      fi
+    done <<< "$names"
+  fi
+
+  {
+    echo "device:  $serial"
+    echo "stamp:   $STAMP"
+    grep -E '"versionCode"|"versionName"|"model"' "$out/info.json" 2>/dev/null | sed 's/^[[:space:]]*//'
+    echo "installed apps:"
+    awk '
+      /"packageName"/ { line=$0; sub(/.*"packageName"[ \t]*:[ \t]*"/,"",line); sub(/".*/,"",line); pkg=line }
+      /"installed"/   { if ($0 !~ /false/ && pkg != "") print "  " pkg }
+    ' "$out/apps.json" 2>/dev/null | sort -u
+    echo "shared_prefs:"
+    ls -1 "$out/shared_prefs" 2>/dev/null | sed 's/^/  /'
+  } > "$out/MANIFEST.txt"
+
+  ln -sfn "$STAMP" "backups/$serial/latest"
+  echo "  -> $out"
+  backed_up=$((backed_up + 1))
+done
+
+echo
+echo "backed up $backed_up device(s) to $here/backups/"
+echo "WARNING: these files contain tokens and cleartext credentials — keep private (git-ignored)."

--- a/provisioning/fleet-restore.sh
+++ b/provisioning/fleet-restore.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# fleet-restore.sh — restore a Portal after a clean reinstall, from a
+# fleet-backup.sh snapshot.
+#
+# Prereqs: the Portal has been reinstalled with a fleet-capable Immortal build
+# and re-registered (./provision.sh --fleet over USB), so fleet/<serial>.json
+# holds the CURRENT token and the /screensaver & /calendar endpoints exist.
+#
+# Modes (combine freely; default = --apps --prefs):
+#   --apps     reinstall the third-party apps that were installed (from apps.json)
+#   --prefs    push the saved shared_prefs back verbatim → FULL fidelity, restores
+#              every credential (Immich/SMB/WebDAV, multiroom, etc.). fleet_agent.xml
+#              is skipped so the freshly-provisioned token is kept. A reboot follows
+#              so the app reloads prefs from disk.
+#   --config   instead of raw prefs, re-apply only the endpoint-covered screensaver
+#              + calendar subset (no stored credentials). Use when you don't want to
+#              overwrite the fresh install's prefs wholesale.
+#   --dry-run  print what would happen, change nothing.
+#
+# Usage:
+#   ./fleet-restore.sh 819LCM01Z09E4D12                       # apps + prefs + reboot
+#   ./fleet-restore.sh "Portal Mini" --config --dry-run
+#   ./fleet-restore.sh 819LCM01Z09E4D12 --backup backups/819LCM01Z09E4D12/20260620-200000
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+FLEETCTL="${FLEETCTL:-./fleetctl}"
+FLEET_DIR="${IMMORTAL_FLEET_DIR:-./fleet}"
+PREFS_DIR="/data/data/com.immortal.launcher/shared_prefs"
+
+usage() { sed -n '2,30p' "$0"; exit 2; }
+
+target="${1:-}"; [ -n "$target" ] || usage; shift || true
+
+# Map a friendly name to its serial (backups are keyed by serial).
+serial="$target"
+if [ ! -f "$FLEET_DIR/$serial.json" ]; then
+  for f in "$FLEET_DIR"/*.json; do
+    [ -e "$f" ] || continue
+    nm="$(sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$f" | head -1)"
+    [ "$nm" = "$target" ] && serial="$(basename "$f" .json)"
+  done
+fi
+
+backup="backups/$serial/latest"
+do_apps=0; do_prefs=0; do_config=0; dry=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --backup) backup="$2"; shift 2;;
+    --apps)   do_apps=1; shift;;
+    --prefs)  do_prefs=1; shift;;
+    --config) do_config=1; shift;;
+    --dry-run) dry=1; shift;;
+    *) echo "unknown option: $1" >&2; usage;;
+  esac
+done
+# Default: reinstall apps and restore prefs (full-fidelity, incl. credentials).
+[ $do_apps -eq 0 ] && [ $do_prefs -eq 0 ] && [ $do_config -eq 0 ] && { do_apps=1; do_prefs=1; }
+
+[ -d "$backup" ] || { echo "error: backup not found: $backup" >&2; exit 1; }
+[ -x "$FLEETCTL" ] || { echo "error: $FLEETCTL not built (rustc -O fleet.rs -o fleetctl)" >&2; exit 1; }
+
+echo "restoring '$serial' from $backup  (apps=$do_apps prefs=$do_prefs config=$do_config dry-run=$dry)"
+run() { if [ $dry -eq 1 ]; then echo "  + $*"; else "$@"; fi; }
+
+# 1) Reinstall third-party apps (never Immortal itself). apps.json lists the whole
+#    catalog with an "installed" marker (false = not installed, else a versionCode),
+#    so we keep only the ones that were actually installed.
+if [ $do_apps -eq 1 ] && [ -f "$backup/apps.json" ]; then
+  echo "-- apps --"
+  pkgs="$(awk '
+    /"packageName"/ { line=$0; sub(/.*"packageName"[ \t]*:[ \t]*"/,"",line); sub(/".*/,"",line); pkg=line }
+    /"installed"/   { if ($0 !~ /false/ && pkg != "") print pkg }
+  ' "$backup/apps.json" | grep -vx 'com.immortal.launcher' | sort -u)"
+  if [ -z "$pkgs" ]; then echo "  (no third-party apps were installed)"; fi
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    echo "  install $p"
+    run "$FLEETCTL" install "$p" --device "$serial"
+  done <<< "$pkgs"
+fi
+
+# 2) Push raw shared_prefs back = full-fidelity restore of config + credentials.
+if [ $do_prefs -eq 1 ]; then
+  echo "-- prefs (full restore) --"
+  pushed=0
+  for x in "$backup"/shared_prefs/*.xml; do
+    [ -e "$x" ] || continue
+    n="$(basename "$x")"
+    if [ "$n" = "fleet_agent.xml" ]; then
+      echo "  skip $n (keep freshly-provisioned token)"
+      continue
+    fi
+    echo "  push $n"
+    run "$FLEETCTL" push "$x" "$PREFS_DIR/$n" --device "$serial"
+    pushed=$((pushed + 1))
+  done
+  if [ $pushed -gt 0 ]; then
+    echo "  rebooting so prefs reload from disk"
+    run "$FLEETCTL" action reboot --device "$serial"
+  fi
+fi
+
+# 3) Alternative soft restore: re-apply the endpoint-covered screensaver/calendar
+#    subset from the saved prefs (no stored credentials, no reboot).
+if [ $do_config -eq 1 ] && [ -f "$backup/shared_prefs/immortal_screensaver.xml" ]; then
+  echo "-- config (screensaver + calendar via endpoints) --"
+  ss="$backup/shared_prefs/immortal_screensaver.xml"
+  sval() { sed -n "s/.*<string name=\"$1\"[^>]*>\([^<]*\)<.*/\1/p" "$ss" | head -1; }
+  bval() { sed -n "s/.*<boolean name=\"$1\"[^>]*value=\"\([^\"]*\)\".*/\1/p" "$ss" | head -1; }
+  ival() { sed -n "s/.*<int name=\"$1\"[^>]*value=\"\([^\"]*\)\".*/\1/p" "$ss" | head -1; }
+
+  source_v="$(sval source)"; folder_v="$(sval folder_path)"; album_v="$(sval album_url)"
+  fit_v="$(sval fit)"; interval_v="$(ival interval_sec)"; shuffle_v="$(bval shuffle)"
+  video_v="$(bval include_video)"; cal_url="$(sval calendar_url)"; cal_range="$(sval calendar_range)"
+
+  args=()
+  case "$source_v" in default) args+=(--source default);; esac
+  [ -n "$folder_v" ]   && args+=(--folder "$folder_v")
+  [ -n "$album_v" ]    && args+=(--album-url "$album_v")
+  [ -n "$fit_v" ]      && args+=(--fit "$fit_v")
+  [ -n "$interval_v" ] && args+=(--interval "$interval_v")
+  [ -n "$shuffle_v" ]  && args+=(--shuffle "$shuffle_v")
+  [ -n "$video_v" ]    && args+=(--videos "$video_v")
+  if [ ${#args[@]} -gt 0 ]; then
+    echo "  screensaver ${args[*]}"
+    run "$FLEETCTL" screensaver set "${args[@]}" --device "$serial"
+  fi
+  if [ -n "$cal_url" ]; then
+    cargs=(--url "$cal_url"); [ -n "$cal_range" ] && cargs+=(--range "$cal_range")
+    echo "  calendar ${cargs[*]}"
+    run "$FLEETCTL" calendar set "${cargs[@]}" --device "$serial"
+  fi
+  echo "  note: --config does NOT restore Immich/SMB/WebDAV/multiroom credentials;"
+  echo "        use --prefs for those."
+fi
+
+echo "done."

--- a/provisioning/fleet.rs
+++ b/provisioning/fleet.rs
@@ -808,9 +808,9 @@ fn cmd_calendar(args: &Args) -> i32 {
         fields.push(("url", Field::S(String::new())));
     } else if action == "disable" {
         // Hide the widget but keep the saved link (the on/off toggle).
-        fields.push(("enabled", Field::B(false)));
+        fields.push(("widgetOn", Field::B(false)));
     } else if action == "enable" {
-        fields.push(("enabled", Field::B(true)));
+        fields.push(("widgetOn", Field::B(true)));
     } else {
         if let Some(u) = args.flag("url") {
             fields.push(("url", Field::S(u)));

--- a/provisioning/fleet.rs
+++ b/provisioning/fleet.rs
@@ -1,0 +1,1213 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+//
+// fleet — a fast, zero-dependency CLI for the Immortal Fleet Agent.
+//
+// Drives the in-app Fleet Agent's HTTP API over WiFi (the persistent channel that
+// survives reboots, unlike adb-over-WiFi on these non-root Portals), so you can
+// manage a wall of Portals without a USB cable or wireless ADB per device.
+//
+// Rust standard library ONLY — no crates, no Cargo needed. Build it with:
+//     rustc -O provisioning/fleet.rs -o provisioning/fleetctl
+// (or `cargo build --release` if you prefer; see provisioning/README.md).
+//
+// Device registry: targets come from the `fleet/<serial>.json` files that
+// `./provision.sh --fleet` records ({serial,name,model,ip,agentPort,token}). Set
+// $IMMORTAL_FLEET_DIR to point elsewhere, or skip the registry with
+// `--host IP --token TOKEN [--port N]`. Choose a target with
+// `--device NAME|serial|all` (name match is case-insensitive); a lone registered
+// device is used by default.
+
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::path::PathBuf;
+use std::time::Duration;
+
+const DEFAULT_PORT: u16 = 8723;
+// Short connect timeout = fast "device is down" detection; long read timeout so
+// slow server-side work (an install can block ~190s) isn't cut off mid-flight.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const IO_TIMEOUT: Duration = Duration::from_secs(210);
+
+// ===================== minimal JSON (parse + pretty) =====================
+
+#[derive(Clone)]
+enum Json {
+    Null,
+    Bool(bool),
+    Num(f64),
+    Str(String),
+    Arr(Vec<Json>),
+    Obj(Vec<(String, Json)>),
+}
+
+struct Parser<'a> {
+    b: &'a [u8],
+    i: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(b: &'a [u8]) -> Self {
+        Parser { b, i: 0 }
+    }
+    fn ws(&mut self) {
+        while self.i < self.b.len() && matches!(self.b[self.i], b' ' | b'\t' | b'\n' | b'\r') {
+            self.i += 1;
+        }
+    }
+    fn parse(&mut self) -> Result<Json, String> {
+        self.ws();
+        let v = self.value()?;
+        Ok(v)
+    }
+    fn value(&mut self) -> Result<Json, String> {
+        self.ws();
+        if self.i >= self.b.len() {
+            return Err("unexpected end".into());
+        }
+        match self.b[self.i] {
+            b'{' => self.object(),
+            b'[' => self.array(),
+            b'"' => Ok(Json::Str(self.string()?)),
+            b't' => self.lit("true", Json::Bool(true)),
+            b'f' => self.lit("false", Json::Bool(false)),
+            b'n' => self.lit("null", Json::Null),
+            _ => self.number(),
+        }
+    }
+    fn lit(&mut self, s: &str, v: Json) -> Result<Json, String> {
+        if self.b[self.i..].starts_with(s.as_bytes()) {
+            self.i += s.len();
+            Ok(v)
+        } else {
+            Err(format!("invalid literal at {}", self.i))
+        }
+    }
+    fn object(&mut self) -> Result<Json, String> {
+        self.i += 1; // {
+        let mut out = Vec::new();
+        self.ws();
+        if self.i < self.b.len() && self.b[self.i] == b'}' {
+            self.i += 1;
+            return Ok(Json::Obj(out));
+        }
+        loop {
+            self.ws();
+            let key = self.string()?;
+            self.ws();
+            if self.i >= self.b.len() || self.b[self.i] != b':' {
+                return Err("expected ':'".into());
+            }
+            self.i += 1;
+            let val = self.value()?;
+            out.push((key, val));
+            self.ws();
+            match self.b.get(self.i) {
+                Some(b',') => {
+                    self.i += 1;
+                }
+                Some(b'}') => {
+                    self.i += 1;
+                    break;
+                }
+                _ => return Err("expected ',' or '}'".into()),
+            }
+        }
+        Ok(Json::Obj(out))
+    }
+    fn array(&mut self) -> Result<Json, String> {
+        self.i += 1; // [
+        let mut out = Vec::new();
+        self.ws();
+        if self.i < self.b.len() && self.b[self.i] == b']' {
+            self.i += 1;
+            return Ok(Json::Arr(out));
+        }
+        loop {
+            let val = self.value()?;
+            out.push(val);
+            self.ws();
+            match self.b.get(self.i) {
+                Some(b',') => {
+                    self.i += 1;
+                }
+                Some(b']') => {
+                    self.i += 1;
+                    break;
+                }
+                _ => return Err("expected ',' or ']'".into()),
+            }
+        }
+        Ok(Json::Arr(out))
+    }
+    /// Read exactly four hex digits of a `\u` escape and advance past them.
+    fn read_hex4(&mut self) -> Result<u32, String> {
+        if self.i + 4 > self.b.len() {
+            return Err("bad \\u".into());
+        }
+        let hex = std::str::from_utf8(&self.b[self.i..self.i + 4]).map_err(|_| "bad \\u")?;
+        let cp = u32::from_str_radix(hex, 16).map_err(|_| "bad \\u")?;
+        self.i += 4;
+        Ok(cp)
+    }
+    fn string(&mut self) -> Result<String, String> {
+        if self.b.get(self.i) != Some(&b'"') {
+            return Err("expected string".into());
+        }
+        self.i += 1;
+        // Accumulate raw bytes and decode as UTF-8 once at the end. Pushing each input
+        // byte as `byte as char` would mis-decode any multi-byte sequence (a byte >= 0x80
+        // becomes a Latin-1 codepoint, not its UTF-8 character), so device names / file
+        // contents with non-ASCII would come out garbled.
+        let mut buf: Vec<u8> = Vec::new();
+        let mut tmp = [0u8; 4];
+        while self.i < self.b.len() {
+            let c = self.b[self.i];
+            self.i += 1;
+            match c {
+                b'"' => return String::from_utf8(buf).map_err(|_| "invalid utf-8 in string".into()),
+                b'\\' => {
+                    let e = *self.b.get(self.i).ok_or("bad escape")?;
+                    self.i += 1;
+                    match e {
+                        b'"' => buf.push(b'"'),
+                        b'\\' => buf.push(b'\\'),
+                        b'/' => buf.push(b'/'),
+                        b'n' => buf.push(b'\n'),
+                        b't' => buf.push(b'\t'),
+                        b'r' => buf.push(b'\r'),
+                        b'b' => buf.push(0x08),
+                        b'f' => buf.push(0x0c),
+                        b'u' => {
+                            let cp = self.read_hex4()?;
+                            // Combine a UTF-16 surrogate pair (e.g. emoji) into one scalar;
+                            // a lone/half surrogate becomes U+FFFD.
+                            let ch = if (0xD800..=0xDBFF).contains(&cp) {
+                                if self.b.get(self.i) == Some(&b'\\') && self.b.get(self.i + 1) == Some(&b'u') {
+                                    self.i += 2;
+                                    let lo = self.read_hex4()?;
+                                    if (0xDC00..=0xDFFF).contains(&lo) {
+                                        let scalar = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+                                        char::from_u32(scalar).unwrap_or('\u{fffd}')
+                                    } else {
+                                        '\u{fffd}'
+                                    }
+                                } else {
+                                    '\u{fffd}'
+                                }
+                            } else {
+                                char::from_u32(cp).unwrap_or('\u{fffd}')
+                            };
+                            buf.extend_from_slice(ch.encode_utf8(&mut tmp).as_bytes());
+                        }
+                        _ => buf.push(e),
+                    }
+                }
+                _ => {
+                    // Raw UTF-8 byte; decoded together with the rest once the string closes.
+                    buf.push(c);
+                }
+            }
+        }
+        Err("unterminated string".into())
+    }
+    fn number(&mut self) -> Result<Json, String> {
+        let start = self.i;
+        while self.i < self.b.len()
+            && matches!(self.b[self.i], b'0'..=b'9' | b'-' | b'+' | b'.' | b'e' | b'E')
+        {
+            self.i += 1;
+        }
+        let s = std::str::from_utf8(&self.b[start..self.i]).map_err(|_| "bad number")?;
+        s.parse::<f64>().map(Json::Num).map_err(|_| "bad number".into())
+    }
+}
+
+impl Json {
+    fn parse(bytes: &[u8]) -> Result<Json, String> {
+        Parser::new(bytes).parse()
+    }
+    fn get<'a>(&'a self, key: &str) -> Option<&'a Json> {
+        if let Json::Obj(o) = self {
+            o.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+        } else {
+            None
+        }
+    }
+    fn as_str(&self) -> Option<&str> {
+        if let Json::Str(s) = self {
+            Some(s)
+        } else {
+            None
+        }
+    }
+    fn as_i64(&self) -> Option<i64> {
+        if let Json::Num(n) = self {
+            Some(*n as i64)
+        } else {
+            None
+        }
+    }
+    fn pretty(&self, indent: usize, out: &mut String) {
+        let pad = "  ".repeat(indent);
+        let pad1 = "  ".repeat(indent + 1);
+        match self {
+            Json::Null => out.push_str("null"),
+            Json::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+            Json::Num(n) => {
+                if n.fract() == 0.0 && n.is_finite() {
+                    out.push_str(&format!("{}", *n as i64));
+                } else {
+                    out.push_str(&format!("{}", n));
+                }
+            }
+            Json::Str(s) => out.push_str(&encode_str(s)),
+            Json::Arr(a) => {
+                if a.is_empty() {
+                    out.push_str("[]");
+                    return;
+                }
+                out.push_str("[\n");
+                for (i, v) in a.iter().enumerate() {
+                    out.push_str(&pad1);
+                    v.pretty(indent + 1, out);
+                    if i + 1 < a.len() {
+                        out.push(',');
+                    }
+                    out.push('\n');
+                }
+                out.push_str(&pad);
+                out.push(']');
+            }
+            Json::Obj(o) => {
+                if o.is_empty() {
+                    out.push_str("{}");
+                    return;
+                }
+                out.push_str("{\n");
+                for (i, (k, v)) in o.iter().enumerate() {
+                    out.push_str(&pad1);
+                    out.push_str(&encode_str(k));
+                    out.push_str(": ");
+                    v.pretty(indent + 1, out);
+                    if i + 1 < o.len() {
+                        out.push(',');
+                    }
+                    out.push('\n');
+                }
+                out.push_str(&pad);
+                out.push('}');
+            }
+        }
+    }
+}
+
+fn encode_str(s: &str) -> String {
+    let mut o = String::with_capacity(s.len() + 2);
+    o.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => o.push_str("\\\""),
+            '\\' => o.push_str("\\\\"),
+            '\n' => o.push_str("\\n"),
+            '\r' => o.push_str("\\r"),
+            '\t' => o.push_str("\\t"),
+            _ => o.push(c),
+        }
+    }
+    o.push('"');
+    o
+}
+
+// ===================== request-body builders =====================
+
+enum Field {
+    B(bool),
+    I(i64),
+    S(String),
+}
+
+fn build_obj(fields: &[(&str, Field)]) -> String {
+    let mut o = String::from("{");
+    for (i, (k, v)) in fields.iter().enumerate() {
+        if i > 0 {
+            o.push(',');
+        }
+        o.push_str(&encode_str(k));
+        o.push(':');
+        match v {
+            Field::B(b) => o.push_str(if *b { "true" } else { "false" }),
+            Field::I(n) => o.push_str(&n.to_string()),
+            Field::S(s) => o.push_str(&encode_str(s)),
+        }
+    }
+    o.push('}');
+    o
+}
+
+// ===================== device registry =====================
+
+struct Device {
+    name: String,
+    host: String,
+    token: String,
+    port: u16,
+    serial: String,
+    model: String,
+}
+
+impl Device {
+    fn base(&self) -> String {
+        format!("http://{}:{}", self.host, self.port)
+    }
+    fn label(&self) -> String {
+        if self.serial.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{} / {}", self.name, self.serial)
+        }
+    }
+}
+
+fn registry_dir() -> PathBuf {
+    if let Ok(d) = env::var("IMMORTAL_FLEET_DIR") {
+        return PathBuf::from(d);
+    }
+    // Prefer ./fleet (natural when run from provisioning/), then <exe-dir>/fleet.
+    let cwd = PathBuf::from("fleet");
+    if cwd.is_dir() {
+        return cwd;
+    }
+    if let Ok(exe) = env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            return dir.join("fleet");
+        }
+    }
+    cwd
+}
+
+fn load_registry() -> Vec<Device> {
+    let mut out = Vec::new();
+    let dir = registry_dir();
+    let entries = match fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for ent in entries.flatten() {
+        let path = ent.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let text = match fs::read(&path) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let j = match Json::parse(&text) {
+            Ok(j) => j,
+            Err(e) => {
+                eprintln!("warning: skipping {} ({})", path.display(), e);
+                continue;
+            }
+        };
+        let token = j.get("token").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        if token.is_empty() {
+            continue;
+        }
+        let host = j
+            .get("ip")
+            .and_then(|v| v.as_str())
+            .or_else(|| j.get("host").and_then(|v| v.as_str()))
+            .unwrap_or("")
+            .to_string();
+        let port = j
+            .get("agentPort")
+            .and_then(|v| v.as_i64())
+            .or_else(|| j.get("port").and_then(|v| v.as_i64()))
+            .unwrap_or(DEFAULT_PORT as i64) as u16;
+        out.push(Device {
+            name: j.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+            host,
+            token,
+            port,
+            serial: j.get("serial").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+            model: j.get("model").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+        });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+fn resolve_targets(args: &Args) -> Vec<Device> {
+    if let Some(host) = args.flag("host") {
+        let token = args.flag("token").unwrap_or_else(|| die("--host requires --token"));
+        let port = args
+            .flag("port")
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(DEFAULT_PORT);
+        return vec![Device {
+            name: host.clone(),
+            host,
+            token,
+            port,
+            serial: String::new(),
+            model: String::new(),
+        }];
+    }
+    let devices = load_registry();
+    let sel = args.flag("device");
+    match sel.as_deref() {
+        Some("all") => {
+            if devices.is_empty() {
+                die(&format!(
+                    "no devices in registry ({}). Run ./provision.sh --fleet, or use --host/--token.",
+                    registry_dir().display()
+                ));
+            }
+            devices
+        }
+        Some(name) => {
+            let matches: Vec<Device> = devices
+                .into_iter()
+                .filter(|d| d.serial == name || d.name.eq_ignore_ascii_case(name))
+                .collect();
+            if matches.is_empty() {
+                die(&format!("no device named/serial {:?}", name));
+            }
+            matches
+        }
+        None => {
+            if devices.len() == 1 {
+                devices
+            } else if devices.is_empty() {
+                die(&format!(
+                    "no devices in registry ({}). Run ./provision.sh --fleet, or use --host/--token.",
+                    registry_dir().display()
+                ));
+            } else {
+                let names: Vec<String> = devices.iter().map(|d| d.name.clone()).collect();
+                die(&format!(
+                    "multiple devices — pass --device NAME|serial|all (known: {})",
+                    names.join(", ")
+                ));
+            }
+        }
+    }
+}
+
+// ===================== HTTP (std only) =====================
+
+fn pct(s: &str) -> String {
+    let mut o = String::new();
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => o.push(b as char),
+            _ => o.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    o
+}
+
+/// Returns (status, body_bytes). Status 0 means a transport-level error (body holds the message).
+fn request(
+    dev: &Device,
+    method: &str,
+    path: &str,
+    query: &[(&str, String)],
+    body: Option<&[u8]>,
+) -> (u16, Vec<u8>) {
+    let mut target = String::from(path);
+    if !query.is_empty() {
+        target.push('?');
+        for (i, (k, v)) in query.iter().enumerate() {
+            if i > 0 {
+                target.push('&');
+            }
+            target.push_str(k);
+            target.push('=');
+            target.push_str(&pct(v));
+        }
+    }
+
+    let addr = match format!("{}:{}", dev.host, dev.port).to_socket_addrs() {
+        Ok(mut it) => match it.next() {
+            Some(a) => a,
+            None => return (0, b"could not resolve host".to_vec()),
+        },
+        Err(e) => return (0, format!("could not resolve host: {}", e).into_bytes()),
+    };
+    let mut stream = match TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT) {
+        Ok(s) => s,
+        Err(e) => return (0, format!("connect failed: {}", e).into_bytes()),
+    };
+    let _ = stream.set_read_timeout(Some(IO_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(IO_TIMEOUT));
+
+    let mut req = format!("{} {} HTTP/1.1\r\n", method, target);
+    req.push_str(&format!("Host: {}:{}\r\n", dev.host, dev.port));
+    req.push_str(&format!("Authorization: Bearer {}\r\n", dev.token));
+    req.push_str("Connection: close\r\n");
+    if let Some(b) = body {
+        req.push_str("Content-Type: application/octet-stream\r\n");
+        req.push_str(&format!("Content-Length: {}\r\n", b.len()));
+    }
+    req.push_str("\r\n");
+
+    if stream.write_all(req.as_bytes()).is_err() {
+        return (0, b"write failed".to_vec());
+    }
+    if let Some(b) = body {
+        if stream.write_all(b).is_err() {
+            return (0, b"write failed".to_vec());
+        }
+    }
+    let _ = stream.flush();
+
+    let mut raw = Vec::new();
+    if let Err(e) = stream.read_to_end(&mut raw) {
+        // A partial read can still hold a complete response if the peer closed; only
+        // bail when we got nothing.
+        if raw.is_empty() {
+            return (0, format!("read failed: {}", e).into_bytes());
+        }
+    }
+
+    // Split headers / body on the first blank line.
+    let sep = raw.windows(4).position(|w| w == b"\r\n\r\n");
+    let (head, bdy) = match sep {
+        Some(p) => (&raw[..p], raw[p + 4..].to_vec()),
+        None => (&raw[..], Vec::new()),
+    };
+    let status = std::str::from_utf8(head)
+        .ok()
+        .and_then(|h| h.lines().next())
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse::<u16>().ok())
+        .unwrap_or(0);
+    (status, bdy)
+}
+
+// Call + print a (likely JSON) response prettily. Returns process exit code.
+fn show(status: u16, body: Vec<u8>) -> i32 {
+    let text = String::from_utf8_lossy(&body);
+    if let Ok(j) = Json::parse(&body) {
+        let mut s = String::new();
+        j.pretty(0, &mut s);
+        println!("{}", s);
+    } else {
+        println!("{}", text.trim_end());
+    }
+    if (200..300).contains(&status) {
+        0
+    } else {
+        if status == 0 {
+            eprintln!("(transport error)");
+        }
+        1
+    }
+}
+
+fn fanout<F: Fn(&Device) -> i32>(targets: &[Device], f: F) -> i32 {
+    let mut rc = 0;
+    let multi = targets.len() > 1;
+    for d in targets {
+        if multi {
+            println!("\n=== {} ({}) ===", d.label(), d.base());
+        }
+        let r = f(d);
+        if r != 0 {
+            rc = r;
+        }
+    }
+    rc
+}
+
+// ===================== arg parsing =====================
+
+struct Args {
+    cmd: String,
+    positionals: Vec<String>,
+    flags: HashMap<String, String>,
+    sets: Vec<String>, // repeated --set key=value
+}
+
+impl Args {
+    fn flag(&self, name: &str) -> Option<String> {
+        self.flags.get(name).cloned()
+    }
+    fn has(&self, name: &str) -> bool {
+        self.flags.contains_key(name)
+    }
+    fn pos(&self, i: usize) -> Option<&String> {
+        self.positionals.get(i)
+    }
+}
+
+// Flags that don't take a value.
+const VALUELESS: &[&str] = &["all", "check", "help", "no-pause"];
+
+fn parse_args(argv: &[String]) -> Args {
+    let mut cmd = String::new();
+    let mut positionals = Vec::new();
+    let mut flags = HashMap::new();
+    let mut sets = Vec::new();
+    let mut i = 0;
+    while i < argv.len() {
+        let a = &argv[i];
+        if a == "-h" || a == "--help" {
+            flags.insert("help".into(), "true".into());
+            i += 1;
+            continue;
+        }
+        if let Some(rest) = a.strip_prefix("--") {
+            let (key, inline_val) = match rest.split_once('=') {
+                Some((k, v)) => (k.to_string(), Some(v.to_string())),
+                None => (rest.to_string(), None),
+            };
+            if VALUELESS.contains(&key.as_str()) {
+                flags.insert(key, "true".into());
+                i += 1;
+                continue;
+            }
+            let val = if let Some(v) = inline_val {
+                v
+            } else {
+                i += 1;
+                argv.get(i).cloned().unwrap_or_default()
+            };
+            if key == "set" {
+                sets.push(val);
+            } else {
+                flags.insert(key, val);
+            }
+            i += 1;
+        } else if cmd.is_empty() {
+            cmd = a.clone();
+            i += 1;
+        } else {
+            positionals.push(a.clone());
+            i += 1;
+        }
+    }
+    Args { cmd, positionals, flags, sets }
+}
+
+fn die(msg: &str) -> ! {
+    eprintln!("error: {}", msg);
+    std::process::exit(2);
+}
+
+fn parse_bool(v: &str) -> bool {
+    match v.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" | "y" => true,
+        "0" | "false" | "no" | "off" | "n" => false,
+        _ => die(&format!("expected true/false (got {:?})", v)),
+    }
+}
+
+fn hhmm_to_min(v: &str) -> i64 {
+    let parts: Vec<&str> = v.split(':').collect();
+    if parts.len() == 2 {
+        if let (Ok(h), Ok(m)) = (parts[0].parse::<i64>(), parts[1].parse::<i64>()) {
+            return (h.rem_euclid(24)) * 60 + m.rem_euclid(60);
+        }
+    }
+    die(&format!("expected HH:MM (got {:?})", v));
+}
+
+// ===================== commands =====================
+
+fn cmd_devices() -> i32 {
+    let devices = load_registry();
+    if devices.is_empty() {
+        println!(
+            "No devices in {}. Run ./provision.sh --fleet on a connected Portal.",
+            registry_dir().display()
+        );
+        return 0;
+    }
+    for d in &devices {
+        let host = if d.host.is_empty() { "(no ip)" } else { &d.host };
+        println!("{:<22} {:<16} {}:{}  {}", d.name, d.serial, host, d.port, d.model);
+    }
+    0
+}
+
+fn simple_get(args: &Args, path: &'static str) -> i32 {
+    let targets = resolve_targets(args);
+    fanout(&targets, |d| {
+        let (s, b) = request(d, "GET", path, &[], None);
+        show(s, b)
+    })
+}
+
+fn post_json(args: &Args, path: &'static str, body: String) -> i32 {
+    let targets = resolve_targets(args);
+    fanout(&targets, |d| {
+        let (s, b) = request(d, "POST", path, &[], Some(body.as_bytes()));
+        show(s, b)
+    })
+}
+
+fn cmd_install(args: &Args) -> i32 {
+    let pkg = args.pos(0).unwrap_or_else(|| die("install: package name required"));
+    let body = if let Some(url) = args.flag("apk-url") {
+        build_obj(&[("packageName", Field::S(pkg.clone())), ("apkUrl", Field::S(url))])
+    } else {
+        build_obj(&[("packageName", Field::S(pkg.clone()))])
+    };
+    post_json(args, "/install", body)
+}
+
+fn cmd_update(args: &Args) -> i32 {
+    let body = if args.has("check") {
+        build_obj(&[("dryRun", Field::B(true))])
+    } else if args.has("all") {
+        build_obj(&[("all", Field::B(true))])
+    } else if let Some(pkg) = args.pos(0) {
+        build_obj(&[("packageName", Field::S(pkg.clone()))])
+    } else {
+        die("update: pass --all, --check, or a package name");
+    };
+    post_json(args, "/update", body)
+}
+
+fn cmd_config(args: &Args) -> i32 {
+    let body = if let Some(name) = args.flag("name") {
+        build_obj(&[("name", Field::S(name))])
+    } else if !args.sets.is_empty() {
+        let mut inner = String::from("{");
+        for (i, kv) in args.sets.iter().enumerate() {
+            let (k, v) = kv.split_once('=').unwrap_or_else(|| die("config set expects key=value"));
+            if i > 0 {
+                inner.push(',');
+            }
+            inner.push_str(&encode_str(k));
+            inner.push(':');
+            inner.push_str(&encode_str(v));
+        }
+        inner.push('}');
+        format!("{{\"set\":{}}}", inner)
+    } else {
+        String::from("{}")
+    };
+    post_json(args, "/config", body)
+}
+
+fn cmd_calendar(args: &Args) -> i32 {
+    let action = args.pos(0).map(|s| s.as_str()).unwrap_or("get");
+    if action == "get" {
+        return simple_get(args, "/calendar");
+    }
+    let mut fields: Vec<(&str, Field)> = Vec::new();
+    if action == "off" {
+        fields.push(("url", Field::S(String::new())));
+    } else if action == "disable" {
+        // Hide the widget but keep the saved link (the on/off toggle).
+        fields.push(("enabled", Field::B(false)));
+    } else if action == "enable" {
+        fields.push(("enabled", Field::B(true)));
+    } else {
+        if let Some(u) = args.flag("url") {
+            fields.push(("url", Field::S(u)));
+        }
+        if let Some(r) = args.flag("range") {
+            fields.push(("range", Field::S(r)));
+        }
+        if let Some(sz) = args.flag("size") {
+            let i = match sz.to_ascii_lowercase().as_str() {
+                "small" | "0" => 0,
+                "medium" | "1" => 1,
+                "large" | "2" => 2,
+                _ => die("--size expects small|medium|large"),
+            };
+            fields.push(("size", Field::I(i)));
+        }
+        if let Some(side) = args.flag("side") {
+            let s = side.to_ascii_lowercase();
+            if s != "left" && s != "right" {
+                die("--side expects left|right");
+            }
+            fields.push(("side", Field::S(s)));
+        }
+        if fields.is_empty() {
+            die("calendar set: pass --url/--range/--size/--side (or 'calendar enable|disable|off')");
+        }
+    }
+    post_json(args, "/calendar", build_obj(&fields))
+}
+
+fn cmd_screensaver(args: &Args) -> i32 {
+    let action = args.pos(0).map(|s| s.as_str()).unwrap_or("get");
+    if action == "get" {
+        return simple_get(args, "/screensaver");
+    }
+    let mut fields: Vec<(&str, Field)> = Vec::new();
+    if let Some(v) = args.flag("enabled") {
+        fields.push(("enabled", Field::B(parse_bool(&v))));
+    }
+    if let Some(v) = args.flag("source") {
+        fields.push(("source", Field::S(v)));
+    }
+    if let Some(v) = args.flag("folder") {
+        fields.push(("folderPath", Field::S(v)));
+    }
+    if let Some(v) = args.flag("album-url") {
+        fields.push(("albumUrl", Field::S(v)));
+    }
+    if let Some(v) = args.flag("album-refresh") {
+        fields.push(("albumRefreshMin", Field::I(v.parse().unwrap_or_else(|_| die("--album-refresh expects an integer")))));
+    }
+    if let Some(v) = args.flag("fit") {
+        fields.push(("fit", Field::S(v)));
+    }
+    if let Some(v) = args.flag("interval") {
+        fields.push(("intervalSec", Field::I(v.parse().unwrap_or_else(|_| die("--interval expects an integer")))));
+    }
+    if let Some(v) = args.flag("shuffle") {
+        fields.push(("shuffle", Field::B(parse_bool(&v))));
+    }
+    if let Some(v) = args.flag("videos") {
+        fields.push(("includeVideo", Field::B(parse_bool(&v))));
+    }
+    if let Some(v) = args.flag("now-playing") {
+        fields.push(("showNowPlaying", Field::B(parse_bool(&v))));
+    }
+    if let Some(v) = args.flag("battery-saver") {
+        fields.push(("batterySaver", Field::B(parse_bool(&v))));
+    }
+    if let Some(v) = args.flag("presence") {
+        fields.push(("presenceMode", Field::S(v.to_ascii_uppercase())));
+    }
+    if let Some(v) = args.flag("idle-min") {
+        fields.push(("idleSleepMin", Field::I(v.parse().unwrap_or_else(|_| die("--idle-min expects an integer")))));
+    }
+    if let Some(v) = args.flag("overnight") {
+        fields.push(("overnightEnabled", Field::B(parse_bool(&v))));
+    }
+    if let Some(v) = args.flag("overnight-start") {
+        fields.push(("overnightStartMin", Field::I(hhmm_to_min(&v))));
+    }
+    if let Some(v) = args.flag("overnight-end") {
+        fields.push(("overnightEndMin", Field::I(hhmm_to_min(&v))));
+    }
+    if fields.is_empty() {
+        die("screensaver set: pass at least one field to change (see the README)");
+    }
+    post_json(args, "/screensaver", build_obj(&fields))
+}
+
+fn cmd_ls(args: &Args) -> i32 {
+    let path = args.pos(0).cloned().unwrap_or_else(|| "/sdcard".into());
+    let targets = resolve_targets(args);
+    fanout(&targets, |d| {
+        let (s, b) = request(d, "GET", "/fs/list", &[("path", path.clone())], None);
+        show(s, b)
+    })
+}
+
+fn cmd_cat(args: &Args) -> i32 {
+    let path = args.pos(0).cloned().unwrap_or_else(|| die("cat: file path required"));
+    let targets = resolve_targets(args);
+    fanout(&targets, |d| {
+        let (s, b) = request(d, "GET", "/fs/read", &[("path", path.clone())], None);
+        print!("{}", String::from_utf8_lossy(&b));
+        if !b.ends_with(b"\n") {
+            println!();
+        }
+        if (200..300).contains(&s) { 0 } else { 1 }
+    })
+}
+
+fn cmd_logcat(args: &Args) -> i32 {
+    let lines = args.flag("lines").unwrap_or_else(|| "500".into());
+    let targets = resolve_targets(args);
+    fanout(&targets, |d| {
+        let (s, b) = request(d, "GET", "/logcat", &[("lines", lines.clone())], None);
+        print!("{}", String::from_utf8_lossy(&b));
+        if (200..300).contains(&s) { 0 } else { 1 }
+    })
+}
+
+fn cmd_pull(args: &Args) -> i32 {
+    let remote = args.pos(0).cloned().unwrap_or_else(|| die("pull: remote path required"));
+    let local = args.pos(1).cloned();
+    let targets = resolve_targets(args);
+    if targets.len() > 1 && local.as_deref().map_or(false, |l| l != "-") {
+        die("pull to a local file targets one device; use --device NAME (or '-' for stdout)");
+    }
+    fanout(&targets, |d| {
+        let (s, b) = request(d, "GET", "/fs/read", &[("path", remote.clone())], None);
+        if !(200..300).contains(&s) {
+            eprintln!("pull failed ({}): {}", s, String::from_utf8_lossy(&b));
+            return 1;
+        }
+        match local.as_deref() {
+            None | Some("-") => {
+                use std::io::stdout;
+                let _ = stdout().write_all(&b);
+            }
+            Some(p) => match fs::write(p, &b) {
+                Ok(_) => println!("wrote {} bytes to {}", b.len(), p),
+                Err(e) => {
+                    eprintln!("cannot write {} ({})", p, e);
+                    return 1;
+                }
+            },
+        }
+        0
+    })
+}
+
+fn cmd_push(args: &Args) -> i32 {
+    let local = args.pos(0).cloned().unwrap_or_else(|| die("push: local file required"));
+    let remote = args.pos(1).cloned().unwrap_or_else(|| die("push: remote path required"));
+    let data = fs::read(&local).unwrap_or_else(|e| die(&format!("cannot read {} ({})", local, e)));
+    let targets = resolve_targets(args);
+    fanout(&targets, |d| {
+        let (s, b) = request(d, "POST", "/fs/write", &[("path", remote.clone())], Some(&data));
+        show(s, b)
+    })
+}
+
+fn cmd_action(args: &Args) -> i32 {
+    let name = args.pos(0).cloned().unwrap_or_else(|| die("action: name required (reaffirm|identify|reboot)"));
+    post_json(args, "/action", build_obj(&[("action", Field::S(name))]))
+}
+
+fn cmd_dev(args: &Args) -> i32 {
+    let action = args.pos(0).map(|s| s.as_str()).unwrap_or("status");
+    match action {
+        "status" => simple_get(args, "/dev"),
+        "on" => post_json(args, "/dev", build_obj(&[("enabled", Field::B(true))])),
+        "off" => post_json(args, "/dev", build_obj(&[("enabled", Field::B(false))])),
+        "update" => cmd_dev_update(args),
+        other => die(&format!("dev: unknown action {:?} (use status|on|off|update)", other)),
+    }
+}
+
+// Push a locally-built APK and install it over Immortal — the fast iterate loop.
+// By default it first enables dev mode (pauses the official self-updater) so the
+// pushed build isn't overwritten; pass --no-pause to skip that.
+fn cmd_dev_update(args: &Args) -> i32 {
+    let apk = args.pos(1).cloned().unwrap_or_else(|| die("dev update: local APK path required"));
+    let pkg = args.flag("package").unwrap_or_else(|| "com.immortal.launcher".into());
+    let remote = args
+        .flag("path")
+        .unwrap_or_else(|| format!("/sdcard/Android/data/{}/files/dev/immortal-dev.apk", pkg));
+    let no_pause = args.has("no-pause");
+    let data = fs::read(&apk).unwrap_or_else(|e| die(&format!("cannot read {} ({})", apk, e)));
+    let targets = resolve_targets(args);
+    let multi = targets.len() > 1;
+    let mut rc = 0;
+    for d in &targets {
+        if multi {
+            println!("\n=== {} ({}) ===", d.label(), d.base());
+        }
+        // 1. Pause the official self-updater so the dev build sticks.
+        if !no_pause {
+            let body = build_obj(&[("enabled", Field::B(true))]);
+            let (s, _) = request(d, "POST", "/dev", &[], Some(body.as_bytes()));
+            if (200..300).contains(&s) {
+                println!("dev mode: on (official updates paused)");
+            } else {
+                eprintln!("warning: could not enable dev mode (status {})", s);
+                rc = 1;
+            }
+        }
+        // 2. Push the local APK to the device.
+        println!("pushing {} ({} bytes) -> {}", apk, data.len(), remote);
+        let (s, b) = request(d, "POST", "/fs/write", &[("path", remote.clone())], Some(&data));
+        if !(200..300).contains(&s) {
+            eprintln!("push failed (status {}): {}", s, String::from_utf8_lossy(&b));
+            rc = 1;
+            continue;
+        }
+        // 3. Install it over the running Immortal (signature must match — see README).
+        println!("installing {} ...", pkg);
+        let body = build_obj(&[
+            ("path", Field::S(remote.clone())),
+            ("packageName", Field::S(pkg.clone())),
+        ]);
+        let (s2, b2) = request(d, "POST", "/install", &[], Some(body.as_bytes()));
+        let r = show(s2, b2);
+        if r != 0 {
+            rc = r;
+        }
+    }
+    rc
+}
+
+fn cmd_raw(args: &Args) -> i32 {
+    let method = args.pos(0).cloned().unwrap_or_else(|| die("raw: METHOD required"));
+    let mut path = args.pos(1).cloned().unwrap_or_else(|| die("raw: path required"));
+    if !path.starts_with('/') {
+        path = format!("/{}", path);
+    }
+    let body = args.pos(2).cloned();
+    if let Some(ref b) = body {
+        if Json::parse(b.as_bytes()).is_err() {
+            die("raw body must be valid JSON");
+        }
+    }
+    let targets = resolve_targets(args);
+    let method_up = method.to_uppercase();
+    fanout(&targets, |d| {
+        let (s, b) = request(
+            d,
+            &method_up,
+            &path,
+            &[],
+            body.as_ref().map(|x| x.as_bytes()),
+        );
+        show(s, b)
+    })
+}
+
+const HELP: &str = "fleetctl — manage Immortal Portals over WiFi (Fleet Agent client)
+
+USAGE:
+  fleetctl <command> [--device NAME|serial|all] [options]
+  fleetctl <command> --host <ip> --token <token> [--port 8723]
+
+COMMANDS:
+  devices                       list devices in the local registry (fleet/*.json)
+  info                          device identity, version, install/presence state
+  apps                          catalog apps and what's installed
+  diag                          diagnostics snapshot
+  install <pkg> [--apk-url URL] install a catalog package (or a direct APK URL)
+  update [<pkg>|--all|--check]  update apps (or dry-run available updates)
+  config [--name N|--set k=v]   read or push the agent's free-form config
+  dev <status|on|off|update>    developer mode + local-build install (see below)
+  calendar <get|set|enable|disable|off>
+                                screensaver calendar (--url, --range day|3day|week|agenda,
+                                --size small|medium|large, --side left|right;
+                                enable/disable toggle the widget, off clears the link)
+  screensaver <get|set>         photo-frame config (see options below)
+  ls [path]                     list a directory (default /sdcard)
+  cat <path>                    print a text file from the device
+  pull <remote> [local|-]       download a file (default: stdout)
+  push <local> <remote>         upload a local file
+  logcat [--lines N]            fetch recent logs (default 500)
+  action <reaffirm|identify|reboot>
+  raw <METHOD> <path> [json]    call any endpoint directly (escape hatch)
+
+SCREENSAVER set options:
+  --enabled BOOL --source default --folder PATH --album-url URL
+  --album-refresh MIN --fit fill|fit --interval SEC --shuffle BOOL
+  --videos BOOL --now-playing BOOL --battery-saver BOOL
+  --presence always_on|presence --idle-min N
+  --overnight BOOL --overnight-start HH:MM --overnight-end HH:MM
+
+DEV (iterate on Immortal over WiFi):
+  dev status                    show dev mode + installed version
+  dev on | dev off              pause / resume the official self-updater
+  dev update <local.apk>        push a local build and install it over Immortal
+                                (enables dev mode first unless --no-pause;
+                                 --package PKG and --path REMOTE override defaults)
+  NOTE: an in-place update is signature-checked by Android — build/sign your local
+  APK with the SAME key as the installed Immortal, or the install is rejected.
+
+Register a device first with `./provision.sh --fleet` on a connected Portal.";
+
+fn main() {
+    let argv: Vec<String> = env::args().skip(1).collect();
+    let args = parse_args(&argv);
+    if args.cmd.is_empty() || args.cmd == "help" || (args.has("help") && args.positionals.is_empty() && args.cmd.is_empty()) {
+        println!("{}", HELP);
+        std::process::exit(if args.cmd.is_empty() { 2 } else { 0 });
+    }
+    // `fleet <cmd> --help` prints general help too (keeps the binary tiny).
+    if args.has("help") {
+        println!("{}", HELP);
+        std::process::exit(0);
+    }
+    let rc = match args.cmd.as_str() {
+        "devices" => cmd_devices(),
+        "info" => simple_get(&args, "/info"),
+        "apps" => simple_get(&args, "/apps"),
+        "diag" => simple_get(&args, "/diag"),
+        "install" => cmd_install(&args),
+        "update" => cmd_update(&args),
+        "config" => cmd_config(&args),
+        "dev" => cmd_dev(&args),
+        "calendar" => cmd_calendar(&args),
+        "screensaver" => cmd_screensaver(&args),
+        "ls" => cmd_ls(&args),
+        "cat" => cmd_cat(&args),
+        "pull" => cmd_pull(&args),
+        "push" => cmd_push(&args),
+        "logcat" => cmd_logcat(&args),
+        "action" => cmd_action(&args),
+        "raw" => cmd_raw(&args),
+        other => {
+            eprintln!("unknown command: {}\n\n{}", other, HELP);
+            std::process::exit(2);
+        }
+    };
+    std::process::exit(rc);
+}
+
+// ===================== tests =====================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(s: &str) -> Json {
+        Json::parse(s.as_bytes()).expect("valid json")
+    }
+
+    #[test]
+    fn string_decodes_multibyte_utf8() {
+        // Raw (already-UTF-8) bytes must survive verbatim, not be mangled into
+        // Latin-1 — this is the bug the byte-buffer rewrite fixes.
+        let j = parse("{\"name\":\"Wohnzimmer-Süd 🛋️\"}");
+        assert_eq!(j.get("name").and_then(|v| v.as_str()), Some("Wohnzimmer-Süd 🛋️"));
+    }
+
+    #[test]
+    fn string_decodes_unicode_escapes() {
+        // BMP escape and a surrogate-pair escape (😀 = \uD83D\uDE00).
+        let j = parse("{\"a\":\"\\u00fc\",\"b\":\"\\uD83D\\uDE00\"}");
+        assert_eq!(j.get("a").and_then(|v| v.as_str()), Some("ü"));
+        assert_eq!(j.get("b").and_then(|v| v.as_str()), Some("😀"));
+    }
+
+    #[test]
+    fn string_handles_simple_escapes() {
+        let j = parse("{\"s\":\"a\\tb\\nc\\\"d\\\\e\\/f\"}");
+        assert_eq!(j.get("s").and_then(|v| v.as_str()), Some("a\tb\nc\"d\\e/f"));
+    }
+
+    #[test]
+    fn parses_scalars_and_nesting() {
+        let j = parse("{\"n\":42,\"f\":1.5,\"ok\":true,\"z\":null,\"arr\":[1,2,3]}");
+        assert_eq!(j.get("n").and_then(|v| v.as_i64()), Some(42));
+        if let Some(Json::Arr(a)) = j.get("arr") {
+            assert_eq!(a.len(), 3);
+        } else {
+            panic!("arr missing");
+        }
+    }
+
+    #[test]
+    fn pretty_round_trips_unicode() {
+        // pretty-print then re-parse must preserve a non-ASCII value exactly.
+        let j = parse("{\"name\":\"Café 北京\"}");
+        let mut out = String::new();
+        j.pretty(0, &mut out);
+        let again = parse(&out);
+        assert_eq!(again.get("name").and_then(|v| v.as_str()), Some("Café 北京"));
+    }
+
+    #[test]
+    fn hhmm_parsing() {
+        assert_eq!(hhmm_to_min("22:00"), 1320);
+        assert_eq!(hhmm_to_min("07:30"), 450);
+    }
+}


### PR DESCRIPTION
## `fleetctl` CLI + dev-mode, screensaver & calendar agent endpoints

A fast, **zero-dependency** CLI for the existing in-app **Fleet Agent**, plus the agent endpoints it drives. This is primarily a **development & debugging aid**: it lets you manage and iterate on a wall of Portals over WiFi — install/update apps, push local builds, read logs/diagnostics, and tweak the screensaver/calendar — **without per-device wireless ADB**.

> ⚠️ **Stacked on #31 (calendar widget).** The `/calendar` endpoint (`FleetCalendar`) builds on the calendar settings added there, so please **review/merge #31 first** — this PR will then reduce to just the fleet changes. Everything else here (the CLI core, dev mode, and the `/screensaver` endpoint) is independent of #31, so if you'd prefer I can split the `/calendar` glue into a third PR — just say so.

### `fleetctl` (`provisioning/fleet.rs`)
Single-file Rust, **standard library only** — `rustc -O fleet.rs -o fleetctl` (or `cargo build --release`). Reads the `fleet/<serial>.json` registry the kit records; targets by `--device NAME|serial|all` or `--host/--token`. Std-only HTTP client + tiny JSON parser/printer.
Commands: `devices, info, apps, diag, install, update, config, dev, calendar, screensaver, ls, cat, pull, push, logcat, action, raw`.

### Agent endpoints (`FleetRoutes`)
- **`/dev`** (`DevMode`) — toggle developer mode, which **pauses the official self-updater** so a locally-built APK isn't overwritten; `/install` gains a **dev-mode-gated** local-path install (`403 dev_mode_required` otherwise, so the token can't silently install arbitrary off-catalog APKs).
- **`/screensaver`** (`FleetScreensaver`) — read/push the full photo-frame config (source, fit, interval, shuffle, videos, presence, idle/overnight).
- **`/calendar`** (`FleetCalendar`) — read/push the calendar widget link/range/size/side *(depends on #31)*.

### Backup / restore
`fleet-backup.sh` / `fleet-restore.sh` snapshot a Portal's config, credentials, and installed-app list before a risky reinstall (e.g. moving to a self-signed build), and restore them after — all over the agent, no root/ADB.

### Why this is useful
The dev loop — `fleetctl dev update ./app-release.apk --device "Living Room"` — pushes a local build and installs it in place over WiFi, so you can iterate on Immortal across real devices without a cable. (In-place updates are signature-checked, so the local build must be signed with the same key.)

### Tested
Pure helpers unit-tested (`FleetCalendarTest`, `FleetScreensaverTest`, `DevModeTest`); `fleetctl` has std-only parser tests and compiles clean with `rustc` and `cargo`. `./gradlew :app:testDebugUnitTest :app:assembleDebug` green on top of #31.
