### PR TITLE
Start multi-room relay after Music Assistant sign-in

### DIFF
--- a/app/src/main/java/com/immortal/launcher/MaControl.kt
+++ b/app/src/main/java/com/immortal/launcher/MaControl.kt
@@ -60,7 +60,12 @@ object MaControl {
       try {
         ws.readText()
         token = null // force a fresh login so we actually test the typed credentials
-        authStatus(if (authorize(ws, user, pass)) "Signed in to Music Assistant ✓" else "Invalid username or password")
+        val ok = authorize(ws, user, pass)
+        authStatus(if (ok) "Signed in to Music Assistant ✓" else "Invalid username or password")
+        // Sign-in is the last piece of setup, so kick the relay now that the config is
+        // complete — same as the Apply button. Without this the service stays as it was
+        // (often stuck "Connecting…") until the app is restarted.
+        if (ok) main.post { MultiRoomService.sync(context.applicationContext) }
       } finally {
         ws.close()
       }


### PR DESCRIPTION
## Problem

In multi-room settings, entering the server IP, Music Assistant username and password and clicking **Sign in** confirms a successful login (green "Signed in to Music Assistant ✓"), but the relay service never actually starts — the status at the bottom stays stuck at "Connecting…". The only workaround was restarting Immortal, after which the service starts and connects normally.

## Root cause

The **Sign in** button calls `MaControl.testLogin()`, which only *validates* the credentials and updates the auth status. It never starts or refreshes the relay, so the service stays in whatever state it was already in until the next app launch (where `MultiRoomService.sync()` runs unconditionally at startup).

By contrast, the **Apply** button next to the server IP and the multi-room **On/Off** toggle both call `MultiRoomService.sync()` — but sign-in, which is the last piece of setup, did not.

## Fix

On a successful login, `testLogin()` now triggers `MultiRoomService.sync(context)` — the same call the Apply button makes. This re-runs the service's `connect()` with the now-complete configuration, so the relay starts/reconnects immediately without an app restart.

- Only fires on a successful sign-in.
- Posted to the main thread.
- `sync()` is a no-op unless multi-room is enabled and a server is configured, so Snapcast-only setups are unaffected.

## Testing

Compile verification wasn't possible in this environment (no Android SDK), but the change is small and everything it references (`context`, the `main` Handler, `MultiRoomService.sync`) is already in scope in `MaControl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015mrmJbVudmDHt2CQswi4Ev)_