### PR TITLE
Fix web-view screensavers eating touch (no tap-to-exit / swipe)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/FlipWebClockFaceView.kt
+++ b/app/src/main/java/com/immortal/launcher/FlipWebClockFaceView.kt
@@ -10,6 +10,7 @@ package com.immortal.launcher
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
+import android.view.MotionEvent
 import android.view.View
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -32,14 +33,19 @@ class FlipWebClockFaceView(
 
   @SuppressLint("SetJavaScriptEnabled")
   private val web =
-      WebView(context).apply {
+      // Touch is handled by the host (tap = exit, swipe = next). Overriding onTouchEvent/
+      // performClick (not just setOnTouchListener, which WebView ignores in its own onTouchEvent)
+      // is the only way to stop the WebView eating it.
+      object : WebView(context) {
+            override fun onTouchEvent(event: MotionEvent): Boolean = false
+            override fun performClick(): Boolean = false
+          }
+          .apply {
         // Matches the page's slate backdrop so there's no black flash before it paints.
         setBackgroundColor(0xFF0F1012.toInt())
         isVerticalScrollBarEnabled = false
         isHorizontalScrollBarEnabled = false
         overScrollMode = View.OVER_SCROLL_NEVER
-        // Touch is handled by the host (tap = exit, swipe = next); don't let the WebView eat it.
-        setOnTouchListener { _, _ -> false }
         settings.apply {
           javaScriptEnabled = true
           domStorageEnabled = true // the page persists its config via localStorage

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -293,12 +293,17 @@ class PhotoFrameController(
    *  whole frame; the host's touch handling still gives tap-to-exit. */
   @android.annotation.SuppressLint("SetJavaScriptEnabled")
   private fun startWebPage(url: String) {
-    val wv = android.webkit.WebView(context)
+    // Override onTouchEvent/performClick (not just setOnTouchListener, which WebView ignores in its
+    // own onTouchEvent) so the page never eats touch — the host needs it for tap-to-exit / swipe.
+    val wv =
+        object : android.webkit.WebView(context) {
+          override fun onTouchEvent(event: MotionEvent): Boolean = false
+          override fun performClick(): Boolean = false
+        }
     wv.setBackgroundColor(Color.BLACK)
     wv.isVerticalScrollBarEnabled = false
     wv.isHorizontalScrollBarEnabled = false
     wv.overScrollMode = View.OVER_SCROLL_NEVER
-    wv.setOnTouchListener { _, _ -> false } // host consumes touch for tap-to-exit
     wv.settings.apply {
       javaScriptEnabled = true
       domStorageEnabled = true


### PR DESCRIPTION
## Problem

Issue #34: the **Web Page** screensaver starts but ignores a single tap or swipe — the dream just re-dreams (`verdict = REDREAM`). `adb input keyevent` works (system path) but physical touches do nothing.

## Root cause

The dream host (`PhotoDreamService`) is interactive and attaches a touch listener to the root frame for tap-to-exit / swipe-to-change. But the web-view screensavers add a fullscreen `WebView` on top of that frame and relied on `setOnTouchListener { _, _ -> false }` to stay touch-transparent. `WebView` ignores that listener's return value inside its own `onTouchEvent` and consumes the gesture anyway, so the host never sees the tap.

This is the **same root cause** as the flip-clock fix in fork commit `f3026d2` — both are fullscreen WebViews layered over the host.

## Fix

Subclass `WebView` and override `onTouchEvent`/`performClick` to return `false` so touches pass through to the host. Applied to both affected sites:

- `PhotoFrameController.startWebPage()` — the Web Page screensaver mode (the direct fix for #34).
- `FlipWebClockFaceView` — ports in the fork's fix, which had not been merged here, keeping the two WebView surfaces in sync.

These are the only two interactive WebView screensaver surfaces.

## Testing

Not built in this environment (no Android SDK available). The change mirrors the fork's already device-verified pattern.

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hfm5PQnXrXsQERAoC3mKWH)_