### PR TITLE
Phone remote: media controls (now-playing, transport, album art)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/MediaSessionReader.kt
+++ b/app/src/main/java/com/immortal/launcher/MediaSessionReader.kt
@@ -109,6 +109,8 @@ object MediaSessionReader {
 
   fun previous() = active?.transportControls?.skipToPrevious() ?: Unit
 
+  fun seek(positionMs: Long) = active?.transportControls?.seekTo(positionMs) ?: Unit
+
   // --- session plumbing (all on the handler thread) ---------------------------
 
   private fun attach() {

--- a/app/src/main/java/com/immortal/launcher/NowPlayingHub.kt
+++ b/app/src/main/java/com/immortal/launcher/NowPlayingHub.kt
@@ -58,4 +58,6 @@ object NowPlayingHub {
   fun next() = MediaSessionReader.next()
 
   fun previous() = MediaSessionReader.previous()
+
+  fun seek(positionMs: Long) = MediaSessionReader.seek(positionMs)
 }

--- a/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
@@ -65,9 +65,11 @@ object RemoteHtml {
   .npbar input{width:100%;accent-color:#2e6be6}
   .nptimes{display:flex;justify-content:space-between;width:100%;max-width:340px;font-size:12px;color:#7c7c7c}
   .npctrl{display:flex;align-items:center;gap:22px;margin-top:20px}
-  .npctrl button{background:#1c1c1e;color:#fff;border-radius:50%;width:60px;height:60px;font-size:22px}
-  .npctrl button.play{width:76px;height:76px;background:#2e6be6;font-size:26px}
+  .npctrl button{background:#1c1c1e;color:#fff;border-radius:50%;width:60px;height:60px;display:flex;align-items:center;justify-content:center}
+  .npctrl button.play{width:76px;height:76px;background:#2e6be6}
   .npctrl button:active{background:#2a2a2c}
+  .npctrl button svg{width:26px;height:26px;display:block}
+  .npctrl button.play svg{width:32px;height:32px}
   .npempty{color:#7c7c7c;font-size:15px;text-align:center;padding:56px 16px}
 
   .toprow{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
@@ -237,9 +239,9 @@ object RemoteHtml {
         <div class=npbar><input id=npSeek type=range min=0 max=1000 value=0 oninput="npScrubInput()" onchange="npScrubCommit()"></div>
         <div class=nptimes><span id=npPos>0:00</span><span id=npDur></span></div>
         <div class=npctrl>
-          <button onclick="media('prev')" aria-label="Previous">&#9198;</button>
-          <button id=npPlay class=play onclick="media('playpause')" aria-label="Play or pause">&#9654;</button>
-          <button onclick="media('next')" aria-label="Next">&#9197;</button>
+          <button onclick="media('prev')" aria-label="Previous"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M7 6h2v12H7zM18 6v12l-9-6z"/></svg></button>
+          <button id=npPlay class=play onclick="media('playpause')" aria-label="Play or pause"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg></button>
+          <button onclick="media('next')" aria-label="Next"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 6v12l9-6zM15 6h2v12h-2z"/></svg></button>
         </div>
       </div>
     </div>
@@ -344,6 +346,10 @@ object RemoteHtml {
     if(name==='media')startNowPlaying();else stopNowPlaying();
   }
   // --- now playing (media controls) ---
+  // Inline SVG (not Unicode ▶/⏸) so the controls render as crisp monochrome glyphs everywhere —
+  // iOS renders the media-symbol codepoints as colour emoji.
+  var SVG_PLAY='<svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>';
+  var SVG_PAUSE='<svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 5h4v14H6zM14 5h4v14h-4z"/></svg>';
   var npTimer=null,npTick=null,npData=null,npFetchedAt=0,npArtVer=null,npSeeking=false;
   function fmt(ms){if(!ms||ms<0)ms=0;var s=Math.floor(ms/1000),m=Math.floor(s/60);s=s%60;return m+':'+(s<10?'0':'')+s;}
   function curPos(){ // interpolate between polls so the bar moves smoothly without hammering
@@ -360,7 +366,7 @@ object RemoteHtml {
     card.classList.remove('hide');empty.classList.add('hide');
     document.getElementById('npTitle').textContent=npData.title||'';
     document.getElementById('npSub').textContent=[npData.artist,npData.album].filter(Boolean).join(' — ');
-    document.getElementById('npPlay').innerHTML=npData.playing?'&#9208;':'&#9654;';
+    document.getElementById('npPlay').innerHTML=npData.playing?SVG_PAUSE:SVG_PLAY;
     var img=document.getElementById('npArt');
     if(npData.hasArt){
       if(npArtVer!==npData.artVersion){npArtVer=npData.artVersion;var a=active();img.src=(a?a.base:'')+'/remote/art?v='+npData.artVersion;}

--- a/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
@@ -57,6 +57,19 @@ object RemoteHtml {
   .tabbar button{flex:1;padding:10px 0;background:none;color:#777;font-size:12px}
   .tabbar button.on{color:#fff;box-shadow:inset 0 2px 0 #2e6be6}
 
+  .np{display:flex;flex-direction:column;align-items:center;text-align:center;padding:6px 4px}
+  .npart{width:240px;max-width:72vw;height:240px;max-height:72vw;border-radius:16px;background:#1c1c1e;object-fit:cover}
+  .nptitle{font-size:18px;font-weight:600;margin-top:18px;max-width:92%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .npsub{font-size:14px;color:#9a9a9a;margin-top:4px;max-width:92%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .npbar{width:100%;max-width:340px;margin:20px 0 2px}
+  .npbar input{width:100%;accent-color:#2e6be6}
+  .nptimes{display:flex;justify-content:space-between;width:100%;max-width:340px;font-size:12px;color:#7c7c7c}
+  .npctrl{display:flex;align-items:center;gap:22px;margin-top:20px}
+  .npctrl button{background:#1c1c1e;color:#fff;border-radius:50%;width:60px;height:60px;font-size:22px}
+  .npctrl button.play{width:76px;height:76px;background:#2e6be6;font-size:26px}
+  .npctrl button:active{background:#2a2a2c}
+  .npempty{color:#7c7c7c;font-size:15px;text-align:center;padding:56px 16px}
+
   .toprow{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
   .botrow{display:grid;grid-template-columns:1fr 1fr;gap:8px}
   .toprow button,.botrow button{padding:14px 4px;font-size:14px;background:#1c1c1e;color:#fff;border-radius:13px}
@@ -215,9 +228,26 @@ object RemoteHtml {
       </div>
     </div>
 
+    <div id=tabMedia class="panel scroll hide">
+      <div id=npEmpty class=npempty>Nothing playing right now.</div>
+      <div id=npCard class="np hide">
+        <img id=npArt class=npart alt="">
+        <div id=npTitle class=nptitle></div>
+        <div id=npSub class=npsub></div>
+        <div class=npbar><input id=npSeek type=range min=0 max=1000 value=0 oninput="npScrubInput()" onchange="npScrubCommit()"></div>
+        <div class=nptimes><span id=npPos>0:00</span><span id=npDur></span></div>
+        <div class=npctrl>
+          <button onclick="media('prev')" aria-label="Previous">&#9198;</button>
+          <button id=npPlay class=play onclick="media('playpause')" aria-label="Play or pause">&#9654;</button>
+          <button onclick="media('next')" aria-label="Next">&#9197;</button>
+        </div>
+      </div>
+    </div>
+
     <div class=tabbar>
       <button id=tb_remote class=on onclick="showTab('remote')">Remote</button>
       <button id=tb_apps onclick="showTab('apps')">Apps</button>
+      <button id=tb_media onclick="showTab('media')">Media</button>
       <button id=tb_setup onclick="showTab('setup')">Setup</button>
     </div>
   </div>
@@ -233,7 +263,13 @@ object RemoteHtml {
   function show(view){
     document.getElementById('pairView').classList.toggle('hide',view!=='pair');
     document.getElementById('remoteView').classList.toggle('hide',view!=='remote');
+    if(view!=='remote'&&typeof stopNowPlaying==='function')stopNowPlaying();
   }
+  // Pause media polling while the phone screen/tab is backgrounded; resume if Media is open.
+  document.addEventListener('visibilitychange',function(){
+    if(document.hidden)stopNowPlaying();
+    else if(document.getElementById('tb_media').classList.contains('on'))startNowPlaying();
+  });
   function api(path,opts){
     opts=opts||{};opts.headers=opts.headers||{};
     var a=active();
@@ -299,12 +335,59 @@ object RemoteHtml {
       .catch(function(){document.getElementById('addErr').textContent='Couldn\'t reach that device.';});
   }
   function showTab(name){
-    ['remote','apps','setup'].forEach(function(t){
+    ['remote','apps','media','setup'].forEach(function(t){
       document.getElementById('tab'+t.charAt(0).toUpperCase()+t.slice(1)).classList.toggle('hide',t!==name);
       document.getElementById('tb_'+t).classList.toggle('on',t===name);
     });
     if(name==='apps'){loadApps();loadPresets();}
     if(name==='setup'){loadSources();}
+    if(name==='media')startNowPlaying();else stopNowPlaying();
+  }
+  // --- now playing (media controls) ---
+  var npTimer=null,npTick=null,npData=null,npFetchedAt=0,npArtVer=null,npSeeking=false;
+  function fmt(ms){if(!ms||ms<0)ms=0;var s=Math.floor(ms/1000),m=Math.floor(s/60);s=s%60;return m+':'+(s<10?'0':'')+s;}
+  function curPos(){ // interpolate between polls so the bar moves smoothly without hammering
+    if(!npData||!npData.active)return 0;
+    var p=npData.positionMs||0;if(npData.playing)p+=Date.now()-npFetchedAt;
+    var d=npData.durationMs||0;return d>0?Math.min(p,d):p;
+  }
+  function startNowPlaying(){stopNowPlaying();loadNowPlaying();npTimer=setInterval(loadNowPlaying,1500);npTick=setInterval(npRender,500);}
+  function stopNowPlaying(){if(npTimer)clearInterval(npTimer);if(npTick)clearInterval(npTick);npTimer=npTick=null;}
+  function loadNowPlaying(){api('/remote/nowplaying').then(function(d){npData=(d&&d.np)||{active:false};npFetchedAt=Date.now();npApply();}).catch(function(){});}
+  function npApply(){
+    var card=document.getElementById('npCard'),empty=document.getElementById('npEmpty');
+    if(!npData||!npData.active){card.classList.add('hide');empty.classList.remove('hide');npArtVer=null;return;}
+    card.classList.remove('hide');empty.classList.add('hide');
+    document.getElementById('npTitle').textContent=npData.title||'';
+    document.getElementById('npSub').textContent=[npData.artist,npData.album].filter(Boolean).join(' — ');
+    document.getElementById('npPlay').innerHTML=npData.playing?'&#9208;':'&#9654;';
+    var img=document.getElementById('npArt');
+    if(npData.hasArt){
+      if(npArtVer!==npData.artVersion){npArtVer=npData.artVersion;var a=active();img.src=(a?a.base:'')+'/remote/art?v='+npData.artVersion;}
+      img.style.visibility='visible';
+    } else {img.removeAttribute('src');img.style.visibility='hidden';npArtVer=null;}
+    var hasDur=(npData.durationMs||0)>0;
+    document.getElementById('npSeek').style.visibility=hasDur?'visible':'hidden';
+    document.getElementById('npDur').textContent=hasDur?fmt(npData.durationMs):'';
+    npRender();
+  }
+  function npRender(){
+    if(!npData||!npData.active)return;
+    var d=npData.durationMs||0,p=curPos();
+    document.getElementById('npPos').textContent=fmt(p);
+    if(d>0&&!npSeeking)document.getElementById('npSeek').value=Math.round(p/d*1000);
+  }
+  function npScrubInput(){npSeeking=true;var d=npData&&npData.durationMs||0;if(d>0)document.getElementById('npPos').textContent=fmt(document.getElementById('npSeek').value/1000*d);}
+  function npScrubCommit(){
+    var d=npData&&npData.durationMs||0;if(d<=0){npSeeking=false;return;}
+    var pos=Math.round(document.getElementById('npSeek').value/1000*d);
+    api('/remote/media',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:'seek',positionMs:pos})}).catch(function(){});
+    if(npData){npData.positionMs=pos;npFetchedAt=Date.now();} // optimistic: keep interpolating from the new spot
+    npSeeking=false;
+  }
+  function media(action){
+    api('/remote/media',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:action})})
+      .then(function(){setTimeout(loadNowPlaying,250);}).catch(function(){});
   }
   function key(action){
     api('/remote/key',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:action})}).catch(function(){});

--- a/app/src/main/java/com/immortal/launcher/RemoteMedia.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteMedia.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import java.io.ByteArrayOutputStream
+import java.net.URL
+import org.json.JSONObject
+
+/**
+ * The phone remote's media surface, bridged onto the launcher's existing now-playing stack
+ * ([NowPlayingHub] / [MediaSessionReader]). The remote reads [stateJson] to render a now-playing
+ * card, fetches [artPng] for the cover, and posts transport via [command] — all reusing the same
+ * media-session controller that drives the on-TV header mini-player. No new permissions: it rides
+ * the notification-listener access already held for now-playing.
+ */
+object RemoteMedia {
+  /** Cap on re-encoded URI art; matches the on-TV art size closely enough for a phone card. */
+  private const val MAX_EDGE = 384
+
+  // Lazy so merely loading this object (e.g. the pure stateJson serializer in tests) doesn't
+  // touch the Android main looper; only command() — on-device — ever needs it.
+  private val main by lazy { Handler(Looper.getMainLooper()) }
+
+  /** Current now-playing as JSON for `/remote/nowplaying`. `{active:false}` when nothing plays. */
+  fun stateJson(): JSONObject = stateJson(NowPlayingHub.current)
+
+  /** Pure serializer (testable): the live [stateJson] delegates here with [NowPlayingHub.current]. */
+  internal fun stateJson(s: NowPlayingState?): JSONObject {
+    if (s == null) return JSONObject().put("active", false)
+    return JSONObject()
+        .put("active", true)
+        .put("title", s.title)
+        .put("artist", s.artist)
+        .put("album", s.album)
+        .put("durationMs", s.durationMs)
+        .put("positionMs", s.positionMs)
+        .put("playing", s.state == PlaybackState.PLAYING)
+        .put("source", s.source)
+        .put("hasArt", s.artBitmap != null || s.artUrl.isNotBlank())
+        // Changes only when the track changes, so the phone caches the cover and refetches
+        // /remote/art (a fresh ?v=) just once per track instead of every poll.
+        .put("artVersion", artVersion(s))
+  }
+
+  /**
+   * Dispatch a transport command. Posts to the main thread because [MediaSessionReader]'s
+   * transport is documented as UI-thread-only. Returns whether a session is currently active
+   * (so the route can report 409 when there's nothing to control). [positionMs] is used by "seek".
+   */
+  fun command(action: String, positionMs: Long): Boolean {
+    val active = NowPlayingHub.current != null
+    main.post {
+      when (action) {
+        "playpause" -> NowPlayingHub.playPause()
+        "next" -> NowPlayingHub.next()
+        "prev", "previous" -> NowPlayingHub.previous()
+        "seek" -> NowPlayingHub.seek(positionMs)
+      }
+    }
+    return active
+  }
+
+  /**
+   * The current cover as PNG bytes, or null if there's no art. Prefers the in-memory bitmap the
+   * session already gave us; otherwise resolves the metadata's art **URI** — which is often a
+   * device-local `content://`/`file://` the phone itself can't fetch, so the Portal reads it here
+   * and relays the bytes. `http(s)://` URIs are fetched directly. Bounded + downscaled.
+   */
+  fun artPng(context: Context): ByteArray? {
+    val s = NowPlayingHub.current ?: return null
+    val bmp = s.artBitmap ?: resolveUriArt(context, s.artUrl) ?: return null
+    return runCatching {
+          ByteArrayOutputStream().use { out ->
+            bmp.compress(Bitmap.CompressFormat.PNG, 100, out)
+            out.toByteArray()
+          }
+        }
+        .getOrNull()
+  }
+
+  private fun artVersion(s: NowPlayingState): Int =
+      listOf(s.title, s.artist, s.album, s.artUrl).joinToString("").hashCode()
+
+  /** Load art bytes from a metadata URI and decode them downscaled. Any failure → null (placeholder). */
+  private fun resolveUriArt(context: Context, url: String): Bitmap? {
+    if (url.isBlank()) return null
+    return runCatching {
+          val bytes =
+              if (url.startsWith("http://") || url.startsWith("https://")) {
+                val conn = URL(url).openConnection()
+                conn.connectTimeout = 4000
+                conn.readTimeout = 4000
+                conn.getInputStream().use { it.readBytes() }
+              } else {
+                // content://, file://, android.resource:// — device-local, only we can read it.
+                context.contentResolver.openInputStream(Uri.parse(url))?.use { it.readBytes() }
+              }
+          bytes?.let { decodeDownscaled(it) }
+        }
+        .getOrNull()
+  }
+
+  /** Decode [bytes] with an inSampleSize that keeps the longest edge near [MAX_EDGE]. */
+  private fun decodeDownscaled(bytes: ByteArray): Bitmap? {
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+    val longest = maxOf(bounds.outWidth, bounds.outHeight)
+    val opts =
+        BitmapFactory.Options().apply {
+          inSampleSize = if (longest > MAX_EDGE) Integer.highestOneBit(longest / MAX_EDGE) else 1
+        }
+    return BitmapFactory.decodeByteArray(bytes, 0, bytes.size, opts)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/RemoteRoutes.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteRoutes.kt
@@ -34,8 +34,13 @@ class RemoteRoutes(private val context: Context) {
         // App icons aren't sensitive; serving them unauthenticated keeps the token out
         // of <img> URLs. Still behind the server's LAN-only peer guard.
         "/remote/icon" -> requireMethod("GET", req) { icon(req) }
+        // Album art isn't sensitive either — served unauthenticated like icons so the cover
+        // can be an <img src> without leaking the token. LAN-guarded like everything else.
+        "/remote/art" -> requireMethod("GET", req) { art() }
         // Authenticated: anything that reads the app list or drives input.
         "/remote/apps" -> authed(req) { apps() }
+        "/remote/nowplaying" -> authed(req) { json(200, ok().put("np", RemoteMedia.stateJson())) }
+        "/remote/media" -> authed(req) { media(req) }
         "/remote/key" -> authed(req) { key(req) }
         "/remote/launch" -> authed(req) { launch(req) }
         "/remote/text" -> authed(req) { text(req) }
@@ -65,6 +70,23 @@ class RemoteRoutes(private val context: Context) {
     val pkg = req.queryParam("pkg") ?: return json(400, err("pkg_required"))
     val png = RemoteApps.iconPng(context, pkg) ?: return json(404, err("no_icon"))
     return FleetHttpServer.Response.stream(200, "image/png", png.size.toLong()) { it.write(png) }
+  }
+
+  /** The current album art as PNG (in-memory bitmap, or a resolved metadata URI). */
+  private fun art(): FleetHttpServer.Response {
+    val png = RemoteMedia.artPng(context) ?: return json(404, err("no_art"))
+    return FleetHttpServer.Response.stream(200, "image/png", png.size.toLong()) { it.write(png) }
+  }
+
+  /** Transport for the active media session: `{"action":"playpause|next|prev|seek","positionMs":…}`. */
+  private fun media(req: FleetHttpServer.Request): FleetHttpServer.Response {
+    val body = parseJson(req.bodyText()) ?: return json(400, err("bad_json"))
+    val action = body.optString("action")
+    if (action !in setOf("playpause", "next", "prev", "previous", "seek"))
+        return json(400, err("unknown_action"))
+    val dispatched = RemoteMedia.command(action, body.optLong("positionMs", 0L))
+    // 409 when nothing is playing — the action was understood but there's no session to drive.
+    return json(if (dispatched) 200 else 409, JSONObject().put("ok", dispatched).put("action", action))
   }
 
   private fun key(req: FleetHttpServer.Request): FleetHttpServer.Response {

--- a/app/src/test/java/com/immortal/launcher/RemoteMediaTest.kt
+++ b/app/src/test/java/com/immortal/launcher/RemoteMediaTest.kt
@@ -1,0 +1,62 @@
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RemoteMediaTest {
+
+  @Test
+  fun stateJson_nullIsInactive() {
+    val j = RemoteMedia.stateJson(null)
+    assertFalse(j.getBoolean("active"))
+  }
+
+  @Test
+  fun stateJson_playingTrackSerialisesFields() {
+    val s =
+        NowPlayingState(
+            state = PlaybackState.PLAYING,
+            title = "Song",
+            artist = "Band",
+            album = "Record",
+            durationMs = 240_000,
+            positionMs = 30_000,
+            source = "com.spotify.music")
+    val j = RemoteMedia.stateJson(s)
+    assertTrue(j.getBoolean("active"))
+    assertTrue(j.getBoolean("playing"))
+    assertEquals("Song", j.getString("title"))
+    assertEquals("Band", j.getString("artist"))
+    assertEquals("Record", j.getString("album"))
+    assertEquals(240_000, j.getLong("durationMs"))
+    assertEquals(30_000, j.getLong("positionMs"))
+  }
+
+  @Test
+  fun stateJson_pausedIsNotPlaying() {
+    val j = RemoteMedia.stateJson(NowPlayingState(state = PlaybackState.PAUSED, title = "x"))
+    assertTrue(j.getBoolean("active"))
+    assertFalse(j.getBoolean("playing"))
+  }
+
+  @Test
+  fun stateJson_hasArtFromUriEvenWithoutBitmap() {
+    // A URI-only cover (no embedded bitmap) still counts as art — the Portal resolves it.
+    val withUri = RemoteMedia.stateJson(NowPlayingState(PlaybackState.PLAYING, title = "t", artUrl = "content://media/art/1"))
+    assertTrue(withUri.getBoolean("hasArt"))
+    val none = RemoteMedia.stateJson(NowPlayingState(PlaybackState.PLAYING, title = "t"))
+    assertFalse(none.getBoolean("hasArt"))
+  }
+
+  @Test
+  fun artVersion_stableForSameTrackChangesAcrossTracks() {
+    fun ver(title: String) =
+        RemoteMedia.stateJson(NowPlayingState(PlaybackState.PLAYING, title = title, artist = "A")).getInt("artVersion")
+    // Position/playback changes shouldn't churn the cover; the title (track) changing should.
+    assertEquals(ver("Track One"), ver("Track One"))
+    assertNotEquals(ver("Track One"), ver("Track Two"))
+  }
+}

--- a/docs/features/remote.md
+++ b/docs/features/remote.md
@@ -13,6 +13,12 @@ the same always-on [fleet agent](fleet.md) that already manages the device over 
   anywhere) — this is the universal navigation primitive.
 - **Keyboard** — type on the phone; text lands in the focused field on the Portal (set / append /
   backspace / clear), no on-Portal typing.
+- **Media controls** — a **Now Playing** tab mirrors whatever's playing on the Portal (any media
+  app): album art, title/artist, a scrubber, and play/pause/skip/seek. It reads the device's media
+  session — the same source as the on-TV header mini-player — so it works with any app, and across
+  the device switcher you can control each Portal's playback from the phone. Album art comes from the
+  session bitmap when present, otherwise the Portal resolves the metadata art **URI** (often a
+  device-local `content://` the phone can't fetch itself) and relays it.
 - **App launcher grid** — every launchable app on the Portal, tap to open.
 - **Screensaver & calendar setup** — set the photo source (Immich / NAS / WebDAV / web / album /
   default feed) and the calendar feed from the phone, instead of typing URLs and credentials on the
@@ -88,8 +94,9 @@ automatically (via `WRITE_SECURE_SETTINGS`) and which comes back on its own afte
 
 ## API
 
-All under the agent's port (default `8723`). `/remote/ui` and `/remote/pair` are open on the LAN;
-the rest require `Authorization: Bearer <session-or-fleet-token>`.
+All under the agent's port (default `8723`). `/remote/ui`, `/remote/pair`, `/remote/icon` and
+`/remote/art` are open on the LAN (no secrets); the rest require
+`Authorization: Bearer <session-or-fleet-token>`.
 
 | Method | Path | Purpose |
 |---|---|---|
@@ -104,6 +111,9 @@ the rest require `Authorization: Bearer <session-or-fleet-token>`.
 | `POST` | `/remote/tap` | tap at the pointer (synthesized touch) |
 | `POST` | `/remote/swipe` | `{"dx":0.0,"dy":-300.0}` → swipe from the pointer |
 | `POST` | `/remote/scroll` | `{"dir":"up"\|"down"}` → page-scroll (one big center swipe) |
+| `GET` | `/remote/nowplaying` | current track `{active, title, artist, album, durationMs, positionMs, playing, hasArt, artVersion}` |
+| `GET` | `/remote/art` | current album art (PNG) — session bitmap, or a resolved metadata URI |
+| `POST` | `/remote/media` | `{"action":"playpause\|next\|prev\|seek","positionMs":…}` → transport on the active session |
 | `GET`/`POST` | `/remote/presets` | list, or replace with `{"presets":[{id,name,steps[]}]}` |
 | `POST` | `/remote/preset` | `{"id":"…"}` → run a saved preset's steps in order |
 | `GET` | `/remote/devices` | this device's name + mDNS-discovered peers `[{name,host,port}]` |


### PR DESCRIPTION
Requested by a remote user: media controls from the phone. Adds a **Now Playing** tab — album art, title/artist, a scrubber, and play/pause/skip/seek — bridged onto the launcher's existing now-playing stack (`NowPlayingHub` / `MediaSessionReader`, the same session that drives the on-TV header mini-player). Works with any media app, across the device switcher, with **no new permissions** (rides the notification-listener access already held).

## Backend
- **`RemoteMedia`** — `stateJson` (now-playing → JSON), `command` (transport, dispatched on the main thread), `artPng`.
- **Album art** prefers the in-memory session bitmap; otherwise **resolves the metadata art URI** — `content://`/`file://` via `ContentResolver` (device-local, the phone *can't* fetch it itself), `http(s)://` via a bounded fetch — downscaled and relayed. `artVersion` lets the phone cache the cover and refetch only on track change.
- **`seek()`** added to `NowPlayingHub`/`MediaSessionReader` for the scrubber.
- **Routes:** `GET /remote/nowplaying` (authed), `GET /remote/art` (open, like icons), `POST /remote/media` (authed; 409 when idle, 400 on bad action).

## UI
A Media tab that polls **only while visible** and **interpolates position** between polls so the scrubber moves smoothly without hammering. Pauses polling when the page is backgrounded.

## Verification (on the Portal+, against a live session)
There was real audio playing (Alexa/Falcon → Hamilton), so I tested the live path:
- `nowplaying` returned full metadata; `media` toggled `playing` true↔false; `art` returned a real **600×600 PNG** — and because it exceeded the in-memory bitmap cap, it came **through the URI-resolution path**, confirming that case end-to-end. Idle → graceful (`active:false`, 409, 404); bad action → 400. (Left their playback as found.)
- Media tab UI rendered at phone width: art, title, artist—album, scrubber + times, ⏮/⏸/⏭.
- `RemoteMediaTest` (pure serializer) + the rest of the remote suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)