### PR TITLE
Screensaver: Ken Burns motion, EXIF date/place captions, and shared-album refresh fix

### DIFF
--- a/app/src/main/java/com/immortal/launcher/PhotoCaption.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoCaption.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) 2026 Starbright Lab.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/app/src/main/java/com/immortal/launcher/PhotoCaption.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoCaption.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import androidx.exifinterface.media.ExifInterface
+import java.net.HttpURLConnection
+import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import org.json.JSONObject
+
+/**
+ * Photo metadata for the screensaver caption — the "taken at <place> · <date>" line,
+ * tvOS-style. Read from EXIF, so it only exists for the user's *own* photos: the local
+ * folder and SMB (NAS) sources, which decode real image files. The web/CDN sources
+ * (Picsum/Unsplash, iCloud/Google shared albums, Immich) serve re-encoded images with
+ * EXIF stripped, so there's nothing to show there and the caption is simply hidden.
+ *
+ * Everything is best-effort: a missing date, absent GPS, or a failed lookup just means
+ * less (or no) caption — never a crash and never a blocked slideshow.
+ */
+object PhotoCaption {
+
+  /** Capture date (epoch millis) and GPS coordinates pulled from a photo's EXIF block. */
+  data class Meta(val dateMillis: Long?, val lat: Double?, val lng: Double?) {
+    val hasLocation: Boolean
+      get() = lat != null && lng != null
+
+    val isEmpty: Boolean
+      get() = dateMillis == null && !hasLocation
+  }
+
+  /** Pull capture date + GPS from an already-opened [ExifInterface]. Best-effort. */
+  fun read(exif: ExifInterface): Meta {
+    val dateMillis =
+        runCatching {
+              val raw =
+                  exif.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL)
+                      ?: exif.getAttribute(ExifInterface.TAG_DATETIME)
+              raw?.let { synchronized(EXIF_DATE) { EXIF_DATE.parse(it) }?.time }
+            }
+            .getOrNull()
+    val latLng = runCatching { exif.getLatLong() }.getOrNull()
+    return Meta(dateMillis, latLng?.get(0), latLng?.get(1))
+  }
+
+  // EXIF stores capture time as "yyyy:MM:dd HH:mm:ss". SimpleDateFormat isn't thread-safe,
+  // so callers (which run on a background thread) synchronize on it.
+  private val EXIF_DATE = SimpleDateFormat("yyyy:MM:dd HH:mm:ss", Locale.US)
+
+  /** Friendly capture date, e.g. "June 22, 2026" in the device locale. Null when absent. */
+  fun formatDate(millis: Long?): String? =
+      millis?.let { SimpleDateFormat("MMMM d, yyyy", Locale.getDefault()).format(Date(it)) }
+
+  // --- reverse geocoding (keyless) -------------------------------------------
+  // BigDataCloud's reverse-geocode-client endpoint needs no key — the same keyless-web-service
+  // approach Immortal already uses for weather (Open-Meteo) and IP geolocation. Results are
+  // cached by a coarse (~1km) lat/lng key, and misses are cached too, so a place is looked up
+  // at most once and the slideshow never re-hits the network for the same spot.
+  private val cache = ConcurrentHashMap<String, String>()
+
+  /**
+   * Reverse-geocode coordinates to a "City, Country" label. Network call, best-effort:
+   * returns null on any failure. MUST be called off the main thread.
+   */
+  fun placeName(lat: Double, lng: Double): String? {
+    val key = "%.2f,%.2f".format(Locale.US, lat, lng)
+    cache[key]?.let { return it.ifEmpty { null } }
+    val place = runCatching { fetchPlace(lat, lng) }.getOrNull()
+    cache[key] = place ?: "" // cache misses too, so a dead/edge lookup isn't retried each photo
+    return place
+  }
+
+  private fun fetchPlace(lat: Double, lng: Double): String? {
+    val spec =
+        "https://api.bigdatacloud.net/data/reverse-geocode-client" +
+            "?latitude=$lat&longitude=$lng&localityLanguage=en"
+    val c = URL(spec).openConnection() as HttpURLConnection
+    c.connectTimeout = 8000
+    c.readTimeout = 8000
+    c.setRequestProperty("User-Agent", "PortalPhotoFrame/1.0")
+    val body = c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
+    val o = JSONObject(body)
+    val city = o.optString("city", "").ifBlank { o.optString("locality", "") }
+    val region = o.optString("principalSubdivision", "")
+    val country = o.optString("countryName", "")
+    val primary = city.ifBlank { region }
+    return when {
+      primary.isNotBlank() && country.isNotBlank() -> "$primary, $country"
+      primary.isNotBlank() -> primary
+      country.isNotBlank() -> country
+      else -> null
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -7,6 +7,8 @@
 
 package com.immortal.launcher
 
+import android.animation.AnimatorSet
+import android.animation.ObjectAnimator
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -21,6 +23,7 @@ import android.util.Log
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
+import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -67,10 +70,26 @@ class PhotoFrameController(
     private val calendarRefreshMs: Long = 30 * 60_000L,
 ) {
   private val io = Executors.newSingleThreadExecutor()
+  // A separate single-thread executor for caption work (EXIF read + the reverse-geocode
+  // network call), so an 8s geocode lookup can never stall the image-decode pipeline on [io].
+  private val metaIo = Executors.newSingleThreadExecutor()
   private val ui = Handler(Looper.getMainLooper())
 
   private lateinit var photo: ImageView
   private lateinit var videoView: VideoView
+
+  // tvOS-style slow zoom/pan ("Ken Burns") on the photo layer. Runs over the dwell time and is
+  // cancelled/restarted on each advance; only in fill mode (fit/letterbox is "show the whole
+  // image", which zooming would crop into). [kenBurnsStyle] cycles the motion so consecutive
+  // photos don't all move the same way.
+  private var kenBurns: AnimatorSet? = null
+  private var kenBurnsStyle = 0
+
+  // Caption ("taken at <place> · <date>") shown bottom-right for the user's own photos (local
+  // folder / SMB), hidden when there's no EXIF date or location. Built lazily in [buildCaption].
+  private lateinit var captionPanel: LinearLayout
+  private lateinit var captionPlace: TextView
+  private lateinit var captionDate: TextView
 
   // The overlay (clock / date / weather / battery / now-playing) is built and driven by the
   // FaceRenderer from a Face descriptor; this controller owns only the photo/video layer.
@@ -104,6 +123,13 @@ class PhotoFrameController(
   private var remoteUrls: List<String> = emptyList()
   private var remoteIndex = -1
   private var remoteFailStreak = 0
+  // Shared-album signed image URLs (iCloud/Google) expire over time. When a whole loop of
+  // downloads fails we re-mint fresh URLs and keep playing instead of dropping to the built-in
+  // feed; [remoteReresolveStreak] caps consecutive re-resolves so a genuine outage still settles
+  // on the fallback rather than re-fetching forever. [remoteReresolving] guards against
+  // overlapping re-fetches.
+  private var remoteReresolveStreak = 0
+  private var remoteReresolving = false
   // Auth headers sent with each remote image download — empty for public shares, the
   // x-api-key for Immich. Applied in [advanceRemote]/[downloadBitmap].
   private var remoteHeaders: Map<String, String> = emptyMap()
@@ -333,6 +359,7 @@ class PhotoFrameController(
 
   fun stop() {
     ui.removeCallbacksAndMessages(null)
+    cancelKenBurns()
     faceRenderer.stop()
     if (this::videoView.isInitialized) runCatching { videoView.stopPlayback() }
     webView?.let { runCatching { it.stopLoading(); it.destroy() } }
@@ -341,6 +368,7 @@ class PhotoFrameController(
     smbSource?.let { s -> Thread { runCatching { s.close() } }.start() }
     smbSource = null
     io.shutdownNow()
+    metaIo.shutdownNow()
   }
 
   // --- UI ---------------------------------------------------------------------
@@ -360,7 +388,92 @@ class PhotoFrameController(
 
     root.addView(faceRenderer.view)
     buildCalendar(root)
+    buildCaption(root)
     return root
+  }
+
+  /** A tvOS-style "taken at <place> · <date>" caption, bottom-right over the photo (the clock
+   *  cluster lives bottom-left, the calendar top). Two lines — bold place over a lighter date —
+   *  with a soft shadow for legibility, no backing plate. Hidden until a photo with EXIF lands. */
+  private fun buildCaption(root: FrameLayout) {
+    captionPanel = LinearLayout(context)
+    captionPanel.orientation = LinearLayout.VERTICAL
+    captionPanel.gravity = Gravity.END
+    captionPanel.visibility = View.GONE
+
+    captionPlace = text(19f, Color.WHITE, false)
+    captionPlace.typeface = Typeface.DEFAULT_BOLD
+    captionPlace.gravity = Gravity.END
+    captionPlace.maxLines = 1
+    captionPlace.ellipsize = TextUtils.TruncateAt.END
+
+    captionDate = text(14f, 0xCCFFFFFF.toInt(), true)
+    captionDate.gravity = Gravity.END
+    captionDate.maxLines = 1
+
+    captionPanel.addView(captionPlace)
+    captionPanel.addView(captionDate)
+    val lp = FrameLayout.LayoutParams(WRAP, WRAP, Gravity.BOTTOM or Gravity.END)
+    lp.setMargins(0, 0, dp(40), dp(36))
+    root.addView(captionPanel, lp)
+  }
+
+  private fun hideCaption() {
+    if (this::captionPanel.isInitialized) captionPanel.visibility = View.GONE
+  }
+
+  /** Show whatever caption data we have: place line (if any) over the date line (if any).
+   *  Hidden entirely when neither is present. */
+  private fun showCaption(meta: PhotoCaption.Meta, place: String?) {
+    if (!this::captionPanel.isInitialized) return
+    val date = PhotoCaption.formatDate(meta.dateMillis)
+    if (place.isNullOrBlank() && date == null) {
+      captionPanel.visibility = View.GONE
+      return
+    }
+    if (place.isNullOrBlank()) {
+      captionPlace.visibility = View.GONE
+    } else {
+      captionPlace.visibility = View.VISIBLE
+      captionPlace.text = place
+    }
+    if (date == null) {
+      captionDate.visibility = View.GONE
+    } else {
+      captionDate.visibility = View.VISIBLE
+      captionDate.text = date
+    }
+    captionPanel.visibility = View.VISIBLE
+  }
+
+  /** Read EXIF date/GPS for a local file off [metaIo], reverse-geocode the place, then publish
+   *  the caption — guarded by [gen] so a slow lookup for a superseded photo is dropped. */
+  private fun loadCaptionForLocal(path: String, g: Int) {
+    metaIo.execute {
+      val meta = runCatching { PhotoCaption.read(ExifInterface(path)) }.getOrNull()
+      publishCaption(meta, g)
+    }
+  }
+
+  /** Same as [loadCaptionForLocal] but for an SMB file: a fresh read stream feeds EXIF. */
+  private fun loadCaptionForSmb(path: String, g: Int) {
+    val src = smbSource ?: return
+    metaIo.execute {
+      val meta =
+          runCatching { src.openStream(path)?.use { PhotoCaption.read(ExifInterface(it)) } }
+              .getOrNull()
+      publishCaption(meta, g)
+    }
+  }
+
+  private fun publishCaption(meta: PhotoCaption.Meta?, g: Int) {
+    if (meta == null || meta.isEmpty) {
+      ui.post { if (g == gen) hideCaption() }
+      return
+    }
+    // Resolve the place name on this background thread (network) before touching the UI.
+    val place = if (meta.hasLocation) PhotoCaption.placeName(meta.lat!!, meta.lng!!) else null
+    ui.post { if (g == gen) showCaption(meta, place) }
   }
 
   /** A clean upcoming-events panel top-right, over the photo. Its own translucent
@@ -628,6 +741,7 @@ class PhotoFrameController(
         }
         photo.visibility = View.VISIBLE
         show(bmp)
+        loadCaptionForLocal(path, g)
         ui.postDelayed(localTick, intervalMs())
       }
     }
@@ -678,6 +792,8 @@ class PhotoFrameController(
   }
 
   private fun showVideo(path: String, g: Int) {
+    cancelKenBurns()
+    hideCaption()
     photo.setImageDrawable(null)
     photo.visibility = View.GONE
     videoView.visibility = View.VISIBLE
@@ -751,10 +867,11 @@ class PhotoFrameController(
       startWeb()
       return
     }
-    // One failure per URL = the whole album is unreachable; bail to the web feed
-    // so a dead share doesn't spin 8-12s timeouts indefinitely.
+    // One failure per URL = the whole album is unreachable. For a public-album share this
+    // usually means its signed image URLs have simply expired, so try to re-mint fresh ones
+    // before giving up to the built-in feed (see [reresolveOrFallback]).
     if (remoteFailStreak >= remoteUrls.size) {
-      startWeb()
+      reresolveOrFallback()
       return
     }
     gen++
@@ -775,9 +892,53 @@ class PhotoFrameController(
           return@post
         }
         remoteFailStreak = 0
+        remoteReresolveStreak = 0
         photo.visibility = View.VISIBLE
         show(bmp)
+        // EXIF caption only for SMB here — it reads the user's own files. The HTTP remote sources
+        // (iCloud/Google/Immich/DAV) serve EXIF-stripped images, so they carry no caption.
+        if (smbSource != null) loadCaptionForSmb(url, g) else hideCaption()
         ui.postDelayed(remoteTick, intervalMs())
+      }
+    }
+  }
+
+  /**
+   * A full loop of failed downloads on a public-album share almost always means its signed image
+   * URLs have expired (iCloud/Google hand out short-lived links), not that the album is gone. So
+   * re-fetch fresh URLs and keep playing rather than reverting to the built-in feed — the bug
+   * where a "refresh" silently dropped a working shared album back to the stock screensaver.
+   *
+   * Only the public-album URL source mints expiring links; the others (Immich/DAV/SMB) use stable
+   * endpoints, so a full failure loop there is a genuine outage and falls back as before.
+   * [remoteReresolveStreak] caps consecutive re-resolves (reset on any successful photo) so a real,
+   * sustained outage still settles on the fallback instead of re-fetching forever.
+   */
+  private fun reresolveOrFallback() {
+    if (remoteReresolving) return
+    val shareUrl = settings.albumUrl
+    if (!settings.usesUrl || shareUrl.isNullOrBlank() || remoteReresolveStreak >= MAX_RERESOLVE) {
+      startWeb()
+      return
+    }
+    remoteReresolving = true
+    remoteReresolveStreak++
+    val m = context.resources.displayMetrics
+    io.execute {
+      val fresh = RemoteAlbum.fetch(shareUrl, m.widthPixels, m.heightPixels)
+      val urls = fresh?.photoUrls.orEmpty()
+      ui.post {
+        remoteReresolving = false
+        if (!remoteMode) return@post // raced with a source change / startWeb()
+        if (urls.isNotEmpty()) {
+          remoteUrls = if (settings.shuffle) urls.shuffled() else urls
+          remoteIndex = -1
+          remoteFailStreak = 0
+          advanceRemote(+1)
+        } else {
+          // Album genuinely unreachable / unshared → don't leave the frame spinning.
+          startWeb()
+        }
       }
     }
   }
@@ -866,15 +1027,76 @@ class PhotoFrameController(
   }
 
   private fun show(bmp: Bitmap) {
+    // The caption belongs to whichever photo is incoming; hide it now and let the per-source
+    // metadata load re-show it (web/CDN photos never re-show it — they carry no EXIF).
+    hideCaption()
     photo
         .animate()
         .alpha(0.15f)
         .setDuration(220)
         .withEndAction {
           photo.setImageBitmap(bmp)
+          startKenBurns()
           photo.animate().alpha(1f).setDuration(420).start()
         }
         .start()
+  }
+
+  /**
+   * Apply a slow tvOS-style zoom/pan to the current photo over the dwell time. Cancelled and
+   * restarted on each advance. Only in fill mode: in fit/letterbox mode the user asked to see the
+   * whole frame, so cropping into it with a zoom would defeat that. A little overscan (scale
+   * [BIG]) gives pan styles room to move without ever exposing the black background.
+   */
+  private fun startKenBurns() {
+    kenBurns?.cancel()
+    // Reset to identity first so a cancelled mid-animation transform never lingers on the new shot.
+    photo.scaleX = 1f
+    photo.scaleY = 1f
+    photo.translationX = 0f
+    photo.translationY = 0f
+    if (settings.fit != ScreensaverConfig.FIT_FILL) return
+    val w = (if (photo.width > 0) photo.width else context.resources.displayMetrics.widthPixels)
+    val h = (if (photo.height > 0) photo.height else context.resources.displayMetrics.heightPixels)
+    photo.pivotX = w / 2f
+    photo.pivotY = h / 2f
+    val pan = (BIG - 1f) / 2f // max translation fraction that stays within the overscan at scale BIG
+    val set = AnimatorSet()
+    when ((kenBurnsStyle++ % 4 + 4) % 4) {
+      0 -> // slow zoom in
+      set.playTogether(
+          ObjectAnimator.ofFloat(photo, View.SCALE_X, 1f, BIG),
+          ObjectAnimator.ofFloat(photo, View.SCALE_Y, 1f, BIG))
+      1 -> // slow zoom out
+      set.playTogether(
+          ObjectAnimator.ofFloat(photo, View.SCALE_X, BIG, 1f),
+          ObjectAnimator.ofFloat(photo, View.SCALE_Y, BIG, 1f))
+      2 -> { // pan down (hold the zoom so the edges stay covered)
+        photo.scaleX = BIG
+        photo.scaleY = BIG
+        set.playTogether(ObjectAnimator.ofFloat(photo, View.TRANSLATION_Y, pan * h, -pan * h))
+      }
+      else -> { // pan up
+        photo.scaleX = BIG
+        photo.scaleY = BIG
+        set.playTogether(ObjectAnimator.ofFloat(photo, View.TRANSLATION_Y, -pan * h, pan * h))
+      }
+    }
+    set.duration = intervalMs() + 1200L // outlast the dwell so the motion never visibly stalls
+    set.interpolator = AccelerateDecelerateInterpolator()
+    set.start()
+    kenBurns = set
+  }
+
+  private fun cancelKenBurns() {
+    kenBurns?.cancel()
+    kenBurns = null
+    if (this::photo.isInitialized) {
+      photo.scaleX = 1f
+      photo.scaleY = 1f
+      photo.translationX = 0f
+      photo.translationY = 0f
+    }
   }
 
   // --- default-feed sources (tried in turn by [fetchWebPhoto]) ----------------
@@ -970,6 +1192,12 @@ class PhotoFrameController(
 
   private val MATCH = FrameLayout.LayoutParams.MATCH_PARENT
   private val WRAP = FrameLayout.LayoutParams.WRAP_CONTENT
+  // Ken Burns overscan: the photo is scaled to this at the zoomed end / throughout a pan, giving
+  // pan styles room to travel without exposing the black background behind the image.
+  private val BIG = 1.12f
+  // Cap on consecutive shared-album re-resolves before yielding to the built-in feed (a real
+  // sustained outage), reset on any successful photo. See [reresolveOrFallback].
+  private val MAX_RERESOLVE = 3
   private fun dp(v: Int): Int = (v * context.resources.displayMetrics.density).toInt()
 
   private companion object {


### PR DESCRIPTION
## Screensaver polish: motion + photo captions, and a shared-album fix

Three improvements to the photo-frame screensaver, in the spirit of the Apple TV / iOS frame.

### 1. Ken Burns motion
Each photo now gets a slow tvOS-style zoom/pan over its dwell time instead of sitting still. The effect cycles through four styles (zoom in, zoom out, pan up, pan down) so consecutive photos don't all move the same way. A small overscan keeps pans within the frame so the black background is never exposed.

- Only active in **fill** mode — in fit/letterbox mode the user explicitly asked to see the whole image, so zooming/cropping into it is skipped.
- Cancelled cleanly for videos and on stop; the transform is reset between photos.

### 2. "Taken at <place> · <date>" caption
A subtle bottom-right caption showing where and when a photo was taken, read from EXIF:
- **Date** from `DateTimeOriginal`.
- **Place** by reverse-geocoding the EXIF GPS coordinates via a **keyless** lookup (BigDataCloud), consistent with the project's existing keyless web services (Open-Meteo, IP geo). Results are cached (misses too) so the slideshow never re-hits the network for the same spot, and the lookup runs on a dedicated thread so it can't stall photo decoding.
- Scoped to the user's **own photos** (local folder + SMB), since web/CDN sources (Picsum/Unsplash, iCloud/Google shared albums, Immich) serve EXIF-stripped images. **Hidden entirely** when a photo has no date or location.

### 3. Fix: shared albums reverting to the built-in feed on refresh
Public iCloud/Google shared albums hand out short-lived **signed** image URLs that expire. Once a full loop of downloads failed (e.g. expired links between refreshes), `advanceRemote` permanently fell back to the built-in feed and never recovered. Now a full-loop failure on a public-album source **re-mints fresh URLs and keeps playing**, only falling back to the built-in feed after repeated re-resolves fail (a genuine outage) or the album comes back empty. Stable-endpoint sources (Immich/DAV/SMB) keep their existing fallback behaviour.

### Notes
- New file `PhotoCaption.kt` (EXIF extraction + keyless reverse geocoding); the rest is in `PhotoFrameController.kt`.
- No `versionCode` bump (left to the release flow).
- Built and verified on a Portal+ (`assembleDebug`/`assembleRelease` clean); motion + captions confirmed against a local photo folder.
