### PR TITLE
Fix cut-release verify: read the tag asset, mark release latest

### DIFF
--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -140,7 +140,9 @@ gh release create "$tag" --repo "$repo" --draft --title "Immortal $version_name"
 # URL is latest/download/immortal.apk). $kit is already named portal-kit.zip.
 cp "$apk" "$tmp/immortal.apk"
 gh release upload "$tag" "$tmp/immortal.apk" "$kit" --repo "$repo" --clobber
-gh release edit "$tag" --repo "$repo" --draft=false >/dev/null
+# --latest is explicit: a draft promoted via edit isn't always auto-marked "latest", and the
+# stable self-update URL (releases/latest/download/…) only points here when this is Latest.
+gh release edit "$tag" --repo "$repo" --draft=false --latest >/dev/null
 echo "  published $tag with immortal.apk + portal-kit.zip"
 
 step "Verify the published release"
@@ -156,10 +158,19 @@ verify_url(){
 }
 verify_url "$stable_apk_url"
 verify_url "$stable_kit_url"
-curl -fsSL -o "$tmp/pub.apk" "$stable_apk_url"
-pub_code="$("$bt/aapt" dump badging "$tmp/pub.apk" | sed -n "s/^package:.*versionCode='\([0-9]*\)'.*/\1/p")"
-[ "$pub_code" = "$new_code" ] || die "published immortal.apk is versionCode $pub_code, expected $new_code"
-echo "  published immortal.apk is versionCode $pub_code ✓"
+# Confirm the uploaded build is the right one by reading the TAG-specific asset directly. Unlike
+# latest/download, this isn't behind the "latest" redirect — whose CDN copy can lag ~30s after
+# publish (a benign transient for self-update, but it would false-fail a one-shot check here).
+pub_code=""
+for i in $(seq 1 6); do
+  if curl -fsSL -o "$tmp/pub.apk" "https://github.com/$repo/releases/download/$tag/immortal.apk" 2>/dev/null; then
+    pub_code="$("$bt/aapt" dump badging "$tmp/pub.apk" 2>/dev/null | sed -n "s/^package:.*versionCode='\([0-9]*\)'.*/\1/p")"
+    [ "$pub_code" = "$new_code" ] && break
+  fi
+  sleep 5
+done
+[ "$pub_code" = "$new_code" ] || die "uploaded immortal.apk is versionCode ${pub_code:-?}, expected $new_code"
+echo "  uploaded immortal.apk is versionCode $pub_code ✓"
 
 echo
 echo "✓ Immortal $version_name (versionCode $new_code) released."


### PR DESCRIPTION
The end-to-end test of the release tooling (cutting **v1.45**) surfaced a false failure on the final gate. The release itself published **correctly** — assets `immortal.apk` + `portal-kit.zip`, `latest/download/immortal.apk` now serves versionCode 46 — but the script's last check downloaded `latest/download/immortal.apk` and read versionCode **45** (the previous build), because GitHub's `latest` redirect keeps serving its **cached copy for ~30s** after publish.

That's a benign transient for device self-update, but it shouldn't fail the script on a correct release.

## Fixes
- **Verify the tag-specific asset** (`releases/download/<tag>/immortal.apk`) instead of `latest/download` — it reflects the bytes just uploaded *immediately*, with no `latest`-redirect lag, and still authoritatively confirms the right build shipped (with a short retry for robustness).
- **Pass `--latest` explicitly** when promoting the draft — a draft promoted via `gh release edit` isn't reliably auto-marked Latest, and the stable self-update URL only resolves when it is.

## Verification
- The earlier `--latest` was confirmed a no-op on v1.45 (it was already Latest), so the real defect was purely the content-lag check.
- Ran the **fixed** verify logic against live v1.45: `latest/download` apk+kit → 200, tag-asset → versionCode 46 == 46 → **would pass**.

Net: v1.45 is live and correct; this makes the next cut exit cleanly first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)