### PR TITLE
Add release-faithful 'dev' buildType for on-device iteration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,16 @@ Immortal is a single Android app (Jetpack Compose, minSdk 24, targetSdk 36).
 The debug build uses a `.debug` application-id suffix so it installs alongside a
 provisioned release. The provisioning kit lives in [`provisioning/`](provisioning/).
 
+To iterate against **real release conditions** (home role, device admin, self-update
+signature checks) without the install friction, build the **`dev`** variant:
+`./gradlew :app:assembleDev`. It is the release build plus `debuggable = true` — same
+application-id, same signing key, minify off — so it provisions identically, but
+`adb install -r -d` can freely replace or *downgrade* it. That sidesteps the two walls a pure
+release build hits on a dev device: a feature branch is always a lower `versionCode`
+(downgrade-blocked), and the device admin blocks `adb uninstall`. To set up a dev unit, drop the
+dev APK in `provisioning/apks/` and run provisioning as usual, then iterate with
+`adb install -r -d`. Validate the true `release` artifact before shipping.
+
 A few things worth knowing:
 
 - **Release builds must be signed with the same key every time** — in-place

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,6 +71,18 @@ android {
       // Lets a debug build install alongside a provisioned release for testing.
       applicationIdSuffix = ".debug"
     }
+    // Release-faithful iteration build. Same applicationId + same signing key + minify off
+    // (inherited from release via initWith), so it provisions identically — home role, device
+    // admin, and self-update signature checks all behave exactly as on a release build. The ONLY
+    // difference is `debuggable = true`, which lets `adb install -r -d` freely replace or downgrade
+    // it. That sidesteps the two walls a pure release build hits on a dev device: version-code
+    // downgrades (a feature branch is always a lower code) and the device admin blocking uninstall.
+    // Use for on-device iteration; validate the true `release` artifact before shipping.
+    create("dev") {
+      initWith(getByName("release"))
+      isDebuggable = true
+      matchingFallbacks += "release"
+    }
   }
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
Sets up the foundation for parallel dev workstreams: a build you can iterate on a *provisioned* device without the install friction that wedged a test unit this session.

## Why
Iterating with pure release builds on a provisioned device hits two walls:
- A feature branch is always a lower `versionCode` than the installed release, so `adb install -r` fails with `INSTALL_FAILED_VERSION_DOWNGRADE`.
- The device admin (set during provisioning) blocks `adb uninstall`, so you can't clear it to re-install.

Together there's no clean way to swap builds.

## What
A `dev` buildType: `initWith(release)` + `debuggable = true`.
- **Same applicationId, same signing key, minify off** (release already has minify off) → it provisions identically: home role, device admin, and self-update signature checks all behave exactly as on release. You test real release conditions.
- **`debuggable = true`** → `adb install -r -d` freely replaces or downgrades it. Both walls gone.

The only difference from the release artifact is the debuggable flag, which gates almost nothing here.

## Workflow (documented in CONTRIBUTING.md)
- `./gradlew :app:assembleDev` → release-faithful debuggable APK.
- Provision a dev unit by dropping the dev APK in `provisioning/apks/` (the kit installs the local APK if present) and running provisioning as usual.
- Iterate with `adb install -r -d`.
- Validate the true `release` artifact before shipping.

## Verified
`assembleDev` produces `com.immortal.launcher` (same id), signed with the release key (`1b8f8cac…`), `application-debuggable` set, versionCode matching `defaultConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)