### PR TITLE
Screensaver: photo caption coexists with now-playing (grid element)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
+++ b/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
@@ -97,6 +97,11 @@ class FaceRenderer(
   private var lastArtBitmap: Bitmap? = null
   private var npListener: NowPlayingHub.Listener? = null
 
+  // Photo caption (place / date). A grid element like the rest, fed per-photo via [setCaption].
+  private var captionPanel: LinearLayout? = null
+  private var captionPlace: TextView? = null
+  private var captionDate: TextView? = null
+
   fun start(face: Face) {
     this.face = face
     buildOverlay()
@@ -122,6 +127,11 @@ class FaceRenderer(
   private fun buildOverlay() {
     view.removeAllViews()
     buckets.clear()
+    // Caption views are rebuilt below (or not, on a full-bleed face) — drop stale refs so a
+    // late setCaption() can't poke a detached view from the previous face.
+    captionPanel = null
+    captionPlace = null
+    captionDate = null
 
     buildClockCluster(face.clock)
     val fullBleed = clockFace?.fullBleed == true
@@ -138,6 +148,8 @@ class FaceRenderer(
           )
       view.addView(scrim, 0, FrameLayout.LayoutParams(MATCH, dp(320), Gravity.BOTTOM))
       buildStandaloneWidgets(face)
+      // Photo caption is photo metadata, so (like the widgets) it's skipped on a full-bleed clock.
+      if (face.caption.enabled) buildCaption(face.caption)
     }
 
     // Now-playing is independent of the face: it shows on EVERY face — including the full-bleed
@@ -296,6 +308,57 @@ class FaceRenderer(
             ui.post { if (lastArtUrl == want) art.setImageBitmap(bmp) }
           }
     }
+  }
+
+  /**
+   * The photo caption ("place" bold over a lighter "date") as a grid element, so it stacks with
+   * whatever else lands in the same cell (notably the now-playing card — both default to
+   * bottom-right) instead of overlapping it. Hidden until [setCaption] gets real metadata.
+   */
+  private fun buildCaption(spec: CaptionSpec) {
+    val align = horizontalGravity(spec.position)
+    val col = LinearLayout(context)
+    col.orientation = LinearLayout.VERTICAL
+    col.gravity = align
+    col.visibility = View.GONE
+    val place = text(19f, Color.WHITE, false)
+    place.typeface = Typeface.DEFAULT_BOLD
+    place.maxLines = 1
+    place.ellipsize = TextUtils.TruncateAt.END
+    place.gravity = align
+    val date = text(14f, 0xCCFFFFFF.toInt(), true)
+    date.maxLines = 1
+    date.gravity = align
+    col.addView(place, LinearLayout.LayoutParams(WRAP, WRAP))
+    col.addView(date, LinearLayout.LayoutParams(WRAP, WRAP))
+    bucket(spec.position).addView(col, LinearLayout.LayoutParams(WRAP, WRAP))
+    captionPanel = col
+    captionPlace = place
+    captionDate = date
+  }
+
+  /**
+   * Push the latest photo caption (main thread). A blank/absent place AND date hides it; otherwise
+   * each line shows only when it has content. No-op when the caption isn't built (disabled, or a
+   * full-bleed face).
+   */
+  fun setCaption(place: String?, date: String?) {
+    val col = captionPanel ?: return
+    val p = place?.takeIf { it.isNotBlank() }
+    val d = date?.takeIf { it.isNotBlank() }
+    if (p == null && d == null) {
+      col.visibility = View.GONE
+      return
+    }
+    captionPlace?.apply {
+      visibility = if (p == null) View.GONE else View.VISIBLE
+      text = p ?: ""
+    }
+    captionDate?.apply {
+      visibility = if (d == null) View.GONE else View.VISIBLE
+      text = d ?: ""
+    }
+    col.visibility = View.VISIBLE
   }
 
   // --- periodic loops ---------------------------------------------------------

--- a/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
+++ b/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
@@ -136,6 +136,13 @@ class FaceRenderer(
     buildClockCluster(face.clock)
     val fullBleed = clockFace?.fullBleed == true
 
+    // Now-playing shows on EVERY face — including the full-bleed flip clock — whenever the user has
+    // the setting on (it's high-value enough to be its own switch, not tied to face selection). It's
+    // built BEFORE the caption so that when they share a cell (both default bottom-right) the
+    // now-playing card sits on top and the smaller photo caption tucks beneath it. Self-hides until
+    // music is playing.
+    if (ScreensaverConfig.load(context).showNowPlaying) buildNowPlaying(face.nowPlaying)
+
     // A full-bleed clock (e.g. the Fliqlo flip clock) owns the whole frame on its own near-black
     // background, so skip the scrim and the date/battery/weather widgets — none should overlay it.
     if (!fullBleed) {
@@ -151,11 +158,6 @@ class FaceRenderer(
       // Photo caption is photo metadata, so (like the widgets) it's skipped on a full-bleed clock.
       if (face.caption.enabled) buildCaption(face.caption)
     }
-
-    // Now-playing is independent of the face: it shows on EVERY face — including the full-bleed
-    // flip clock — whenever the user has the now-playing setting on (it's high-value enough to be
-    // its own switch, not tied to face selection). The card self-hides until music is playing.
-    if (ScreensaverConfig.load(context).showNowPlaying) buildNowPlaying(face.nowPlaying)
   }
 
   /**

--- a/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
+++ b/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
@@ -267,7 +267,10 @@ class FaceRenderer(
     artLp.setMarginStart(dp(16))
     if (spec.showArt) card.addView(art, artLp)
 
-    bucket(spec.position).addView(card)
+    // Explicit WRAP width: a vertical LinearLayout (the bucket) otherwise hands children
+    // MATCH_PARENT by default, which would squeeze the card to a narrower cell-mate's width
+    // (e.g. the photo caption now sharing this cell) and truncate the track title.
+    bucket(spec.position).addView(card, LinearLayout.LayoutParams(WRAP, WRAP))
     nowPlayingCard = card
     npTitle = title
     npArtist = artist

--- a/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
+++ b/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
@@ -336,7 +336,10 @@ class FaceRenderer(
     date.gravity = align
     col.addView(place, LinearLayout.LayoutParams(WRAP, WRAP))
     col.addView(date, LinearLayout.LayoutParams(WRAP, WRAP))
-    bucket(spec.position).addView(col, LinearLayout.LayoutParams(WRAP, WRAP))
+    // Top margin gives breathing room from whatever sits above in the same cell (the now-playing
+    // card). A GONE sibling contributes no space, so a lone caption isn't pushed off the bottom.
+    bucket(spec.position)
+        .addView(col, LinearLayout.LayoutParams(WRAP, WRAP).apply { topMargin = dp(18) })
     captionPanel = col
     captionPlace = place
     captionDate = date

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -85,11 +85,9 @@ class PhotoFrameController(
   private var kenBurns: AnimatorSet? = null
   private var kenBurnsStyle = 0
 
-  // Caption ("taken at <place> · <date>") shown bottom-right for the user's own photos (local
-  // folder / SMB), hidden when there's no EXIF date or location. Built lazily in [buildCaption].
-  private lateinit var captionPanel: LinearLayout
-  private lateinit var captionPlace: TextView
-  private lateinit var captionDate: TextView
+  // The "place · date" caption is now a FaceRenderer grid element (so it stacks with the
+  // now-playing card instead of overlapping it). This controller still reads the EXIF here
+  // (own photos only — local folder / SMB) and pushes it via [FaceRenderer.setCaption].
 
   // The overlay (clock / date / weather / battery / now-playing) is built and driven by the
   // FaceRenderer from a Face descriptor; this controller owns only the photo/video layer.
@@ -388,62 +386,7 @@ class PhotoFrameController(
 
     root.addView(faceRenderer.view)
     buildCalendar(root)
-    buildCaption(root)
     return root
-  }
-
-  /** A tvOS-style "taken at <place> · <date>" caption, bottom-right over the photo (the clock
-   *  cluster lives bottom-left, the calendar top). Two lines — bold place over a lighter date —
-   *  with a soft shadow for legibility, no backing plate. Hidden until a photo with EXIF lands. */
-  private fun buildCaption(root: FrameLayout) {
-    captionPanel = LinearLayout(context)
-    captionPanel.orientation = LinearLayout.VERTICAL
-    captionPanel.gravity = Gravity.END
-    captionPanel.visibility = View.GONE
-
-    captionPlace = text(19f, Color.WHITE, false)
-    captionPlace.typeface = Typeface.DEFAULT_BOLD
-    captionPlace.gravity = Gravity.END
-    captionPlace.maxLines = 1
-    captionPlace.ellipsize = TextUtils.TruncateAt.END
-
-    captionDate = text(14f, 0xCCFFFFFF.toInt(), true)
-    captionDate.gravity = Gravity.END
-    captionDate.maxLines = 1
-
-    captionPanel.addView(captionPlace)
-    captionPanel.addView(captionDate)
-    val lp = FrameLayout.LayoutParams(WRAP, WRAP, Gravity.BOTTOM or Gravity.END)
-    lp.setMargins(0, 0, dp(40), dp(36))
-    root.addView(captionPanel, lp)
-  }
-
-  private fun hideCaption() {
-    if (this::captionPanel.isInitialized) captionPanel.visibility = View.GONE
-  }
-
-  /** Show whatever caption data we have: place line (if any) over the date line (if any).
-   *  Hidden entirely when neither is present. */
-  private fun showCaption(meta: PhotoCaption.Meta, place: String?) {
-    if (!this::captionPanel.isInitialized) return
-    val date = PhotoCaption.formatDate(meta.dateMillis)
-    if (place.isNullOrBlank() && date == null) {
-      captionPanel.visibility = View.GONE
-      return
-    }
-    if (place.isNullOrBlank()) {
-      captionPlace.visibility = View.GONE
-    } else {
-      captionPlace.visibility = View.VISIBLE
-      captionPlace.text = place
-    }
-    if (date == null) {
-      captionDate.visibility = View.GONE
-    } else {
-      captionDate.visibility = View.VISIBLE
-      captionDate.text = date
-    }
-    captionPanel.visibility = View.VISIBLE
   }
 
   /** Read EXIF date/GPS for a local file off [metaIo], reverse-geocode the place, then publish
@@ -468,12 +411,13 @@ class PhotoFrameController(
 
   private fun publishCaption(meta: PhotoCaption.Meta?, g: Int) {
     if (meta == null || meta.isEmpty) {
-      ui.post { if (g == gen) hideCaption() }
+      ui.post { if (g == gen) faceRenderer.setCaption(null, null) }
       return
     }
     // Resolve the place name on this background thread (network) before touching the UI.
     val place = if (meta.hasLocation) PhotoCaption.placeName(meta.lat!!, meta.lng!!) else null
-    ui.post { if (g == gen) showCaption(meta, place) }
+    val date = PhotoCaption.formatDate(meta.dateMillis)
+    ui.post { if (g == gen) faceRenderer.setCaption(place, date) }
   }
 
   /** A clean upcoming-events panel top-right, over the photo. Its own translucent
@@ -793,7 +737,7 @@ class PhotoFrameController(
 
   private fun showVideo(path: String, g: Int) {
     cancelKenBurns()
-    hideCaption()
+    faceRenderer.setCaption(null, null)
     photo.setImageDrawable(null)
     photo.visibility = View.GONE
     videoView.visibility = View.VISIBLE
@@ -897,7 +841,7 @@ class PhotoFrameController(
         show(bmp)
         // EXIF caption only for SMB here — it reads the user's own files. The HTTP remote sources
         // (iCloud/Google/Immich/DAV) serve EXIF-stripped images, so they carry no caption.
-        if (smbSource != null) loadCaptionForSmb(url, g) else hideCaption()
+        if (smbSource != null) loadCaptionForSmb(url, g) else faceRenderer.setCaption(null, null)
         ui.postDelayed(remoteTick, intervalMs())
       }
     }
@@ -1029,7 +973,7 @@ class PhotoFrameController(
   private fun show(bmp: Bitmap) {
     // The caption belongs to whichever photo is incoming; hide it now and let the per-source
     // metadata load re-show it (web/CDN photos never re-show it — they carry no EXIF).
-    hideCaption()
+    faceRenderer.setCaption(null, null)
     photo
         .animate()
         .alpha(0.15f)

--- a/app/src/main/java/com/immortal/launcher/ScreensaverFace.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverFace.kt
@@ -29,6 +29,7 @@ data class Face(
     val weather: WeatherSpec = WeatherSpec(),
     val nowPlaying: NowPlayingSpec = NowPlayingSpec(),
     val battery: BatterySpec = BatterySpec(),
+    val caption: CaptionSpec = CaptionSpec(),
 ) {
   companion object {
     /**
@@ -95,6 +96,7 @@ data class Face(
       val weather = json.optJSONObject("weather") ?: JSONObject()
       val np = json.optJSONObject("nowPlaying")
       val batt = json.optJSONObject("battery")
+      val cap = json.optJSONObject("caption")
       return Face(
           id = id,
           name = json.optString("name", ""),
@@ -103,6 +105,7 @@ data class Face(
           weather = WeatherSpec.fromJson(weather),
           nowPlaying = if (np != null) NowPlayingSpec.fromJson(np) else NowPlayingSpec(),
           battery = if (batt != null) BatterySpec.fromJson(batt) else BatterySpec(),
+          caption = if (cap != null) CaptionSpec.fromJson(cap) else CaptionSpec(),
       )
     }
   }
@@ -323,6 +326,24 @@ data class BatterySpec(
         BatterySpec(
             enabled = o.optBoolean("enabled", true),
             position = GridPosition.fromWire(o.optString("position", "bottom-left")),
+        )
+  }
+}
+
+/**
+ * Immortal extension: the "place · date" photo caption (own-photos only; see [PhotoCaption]).
+ * A grid element like the rest, so it stacks with whatever shares its cell — notably the
+ * now-playing card, which also defaults to bottom-right — instead of overlapping it.
+ */
+data class CaptionSpec(
+    val enabled: Boolean = true,
+    val position: GridPosition = GridPosition.BOTTOM_RIGHT,
+) {
+  companion object {
+    fun fromJson(o: JSONObject): CaptionSpec =
+        CaptionSpec(
+            enabled = o.optBoolean("enabled", true),
+            position = GridPosition.fromWire(o.optString("position", "bottom-right")),
         )
   }
 }


### PR DESCRIPTION
Follow-up to #43. MrFruitDude's EXIF "place · date" caption was added to the overlay root with a fixed bottom-right gravity, *outside* the FaceRenderer 9-point grid. The now-playing card lives *in* the grid's bottom-right bucket, so the two overlapped when music played on the default layout.

## Fix
Move the caption into the grid as a first-class element:
- `CaptionSpec` (enabled + `GridPosition`, default bottom-right) added to the `Face` model, parsed in `Face.fromJson` — so the caption is **face-configurable** like clock/now-playing/battery.
- `FaceRenderer` builds the caption (bold place over lighter date) into `bucket(spec.position)` and exposes `setCaption(place, date)`. Because a bucket is a vertical `LinearLayout`, the caption now **stacks** with the now-playing card (and anything else sharing the cell) instead of overlapping — the same mechanism that already stacks clock/date/battery/weather bottom-left.
- `PhotoFrameController` keeps the EXIF read (`PhotoCaption`) and just feeds `setCaption`; its own caption view is removed. Skipped on full-bleed faces (photo metadata).

## Verified on-device (Portal+ dev build)
Folder source + a media session: the caption (**Arezzo, Italy / October 22, 2008**) and the now-playing card (**Dev Test Track / Immortal**) render **stacked** in the bottom-right, no overlap. Compiles; unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)