### PR TITLE
Remote: a11y rebind-on-update fix + volume/screensaver controls + mini-player URI art

### DIFF
--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -908,6 +908,18 @@ private fun HeaderBar(onScreensaver: () -> Unit) {
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun MiniPlayer(state: NowPlayingState, modifier: Modifier = Modifier) {
+  val context = androidx.compose.ui.platform.LocalContext.current
+  // Some media apps hand cover art as a URI rather than an embedded bitmap. Resolve it off the
+  // main thread (content:// or http) so the header shows the cover too — the screensaver and the
+  // phone remote already do this via [MediaArt]; the mini-player was the one place that didn't.
+  var urlArt by remember(state.artUrl, state.artBitmap) { mutableStateOf<android.graphics.Bitmap?>(null) }
+  androidx.compose.runtime.LaunchedEffect(state.artUrl, state.artBitmap) {
+    urlArt =
+        if (state.artBitmap == null && state.artUrl.isNotBlank())
+            withContext(Dispatchers.IO) { MediaArt.resolveUri(context, state.artUrl) }
+        else null
+  }
+  val cover = state.artBitmap ?: urlArt
   Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
     // The album art IS the play/pause button — same 56dp circle as the other header
     // buttons, just filled with the cover instead of a flat tint.
@@ -915,7 +927,7 @@ private fun MiniPlayer(state: NowPlayingState, modifier: Modifier = Modifier) {
         modifier = Modifier.size(56.dp).clip(CircleShape).tvFocusable(CircleShape) { NowPlayingHub.playPause() },
         contentAlignment = Alignment.Center,
     ) {
-      val bmp = state.artBitmap
+      val bmp = cover
       if (bmp != null) {
         Image(
             bitmap = bmp.asImageBitmap(),

--- a/app/src/main/java/com/immortal/launcher/MediaArt.kt
+++ b/app/src/main/java/com/immortal/launcher/MediaArt.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import java.net.URL
+
+/**
+ * Resolve album art that a media session hands over as a **URI** rather than an embedded bitmap.
+ * Shared by everything that shows now-playing cover art — the screensaver card, the home-header
+ * mini-player, and the phone remote — so they all behave the same: prefer the in-memory bitmap,
+ * and otherwise resolve the URI (a device-local `content://`/`file://` only this app can read, or
+ * an `http(s)://` URL). Best-effort, off the main thread; any failure returns null (placeholder).
+ */
+object MediaArt {
+  /** Cap on the re-decoded edge — enough for a header thumb or a frame card, cheap to decode. */
+  private const val MAX_EDGE = 384
+
+  /** Load and downscale the art at [url]. Returns null for a blank URL or any read/decode failure. */
+  fun resolveUri(context: Context, url: String): Bitmap? {
+    if (url.isBlank()) return null
+    return runCatching {
+          val bytes =
+              if (url.startsWith("http://") || url.startsWith("https://")) {
+                val conn = URL(url).openConnection()
+                conn.connectTimeout = 4000
+                conn.readTimeout = 4000
+                conn.getInputStream().use { it.readBytes() }
+              } else {
+                // content://, file://, android.resource:// — device-local, only this app can read it.
+                context.contentResolver.openInputStream(Uri.parse(url))?.use { it.readBytes() }
+              }
+          bytes?.let { decodeDownscaled(it) }
+        }
+        .getOrNull()
+  }
+
+  /** Decode [bytes] with an inSampleSize that keeps the longest edge near [MAX_EDGE]. */
+  private fun decodeDownscaled(bytes: ByteArray): Bitmap? {
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+    val longest = maxOf(bounds.outWidth, bounds.outHeight)
+    val opts =
+        BitmapFactory.Options().apply {
+          inSampleSize = if (longest > MAX_EDGE) Integer.highestOneBit(longest / MAX_EDGE) else 1
+        }
+    return BitmapFactory.decodeByteArray(bytes, 0, bytes.size, opts)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
@@ -70,13 +70,16 @@ object RemoteHtml {
   .npctrl button:active{background:#2a2a2c}
   .npctrl button svg{width:26px;height:26px;display:block}
   .npctrl button.play svg{width:32px;height:32px}
+  .npvol{display:flex;align-items:center;justify-content:center;gap:20px;margin-top:18px}
+  .npvol button{background:#1c1c1e;color:#fff;border-radius:50%;width:52px;height:52px;display:flex;align-items:center;justify-content:center}
+  .npvol button:active{background:#2a2a2c}
+  .npvol button svg{width:24px;height:24px;display:block}
   .npempty{color:#7c7c7c;font-size:15px;text-align:center;padding:56px 16px}
 
   .toprow{display:grid;grid-template-columns:repeat(4,1fr);gap:8px}
   .botrow{display:grid;grid-template-columns:1fr 1fr;gap:8px}
-  .volrow{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:8px}
-  .toprow button,.botrow button,.volrow button{padding:14px 4px;font-size:14px;background:#1c1c1e;color:#fff;border-radius:13px}
-  .toprow button:active,.botrow button:active,.volrow button:active{background:#2e6be6}
+  .toprow button,.botrow button{padding:14px 4px;font-size:14px;background:#1c1c1e;color:#fff;border-radius:13px}
+  .toprow button:active,.botrow button:active{background:#2e6be6}
   .kbpanel{margin-top:10px}
   .kbd{display:flex;gap:8px}
   .kbd input{flex:1;min-width:0;padding:13px;font-size:16px;background:#0e0e10;border:1px solid #3a3a3c;border-radius:12px;color:#fff}
@@ -166,11 +169,6 @@ object RemoteHtml {
           <button onclick="scrollDir('down')" aria-label="Page down">&#9660;</button>
         </div>
       </div>
-      <div class=volrow>
-        <button onclick="vol('down')" aria-label="Volume down">Vol &#8722;</button>
-        <button onclick="vol('mute')" aria-label="Mute">Mute</button>
-        <button onclick="vol('up')" aria-label="Volume up">Vol &#43;</button>
-      </div>
       <div id=padHint class=padhint></div>
     </div>
 
@@ -249,6 +247,11 @@ object RemoteHtml {
           <button onclick="media('prev')" aria-label="Previous"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M7 6h2v12H7zM18 6v12l-9-6z"/></svg></button>
           <button id=npPlay class=play onclick="media('playpause')" aria-label="Play or pause"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg></button>
           <button onclick="media('next')" aria-label="Next"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 6v12l9-6zM15 6h2v12h-2z"/></svg></button>
+        </div>
+        <div class=npvol>
+          <button onclick="vol('down')" aria-label="Volume down"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z"/></svg></button>
+          <button onclick="vol('mute')" aria-label="Mute"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73 4.27 3zM12 4L9.91 6.09 12 8.18V4z"/></svg></button>
+          <button onclick="vol('up')" aria-label="Volume up"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/></svg></button>
         </div>
       </div>
     </div>

--- a/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
@@ -72,10 +72,11 @@ object RemoteHtml {
   .npctrl button.play svg{width:32px;height:32px}
   .npempty{color:#7c7c7c;font-size:15px;text-align:center;padding:56px 16px}
 
-  .toprow{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+  .toprow{display:grid;grid-template-columns:repeat(4,1fr);gap:8px}
   .botrow{display:grid;grid-template-columns:1fr 1fr;gap:8px}
-  .toprow button,.botrow button{padding:14px 4px;font-size:14px;background:#1c1c1e;color:#fff;border-radius:13px}
-  .toprow button:active,.botrow button:active{background:#2e6be6}
+  .volrow{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:8px}
+  .toprow button,.botrow button,.volrow button{padding:14px 4px;font-size:14px;background:#1c1c1e;color:#fff;border-radius:13px}
+  .toprow button:active,.botrow button:active,.volrow button:active{background:#2e6be6}
   .kbpanel{margin-top:10px}
   .kbd{display:flex;gap:8px}
   .kbd input{flex:1;min-width:0;padding:13px;font-size:16px;background:#0e0e10;border:1px solid #3a3a3c;border-radius:12px;color:#fff}
@@ -138,6 +139,7 @@ object RemoteHtml {
     <div id=tabRemote class=panel>
       <div class=toprow>
         <button onclick="key('power')">Power</button>
+        <button onclick="key('screensaver')">Screensaver</button>
         <button onclick="key('apps')">Recents</button>
         <button onclick=toggleKb()>Keyboard</button>
       </div>
@@ -163,6 +165,11 @@ object RemoteHtml {
           <button onclick="scrollDir('up')" aria-label="Page up">&#9650;</button>
           <button onclick="scrollDir('down')" aria-label="Page down">&#9660;</button>
         </div>
+      </div>
+      <div class=volrow>
+        <button onclick="vol('down')" aria-label="Volume down">Vol &#8722;</button>
+        <button onclick="vol('mute')" aria-label="Mute">Mute</button>
+        <button onclick="vol('up')" aria-label="Volume up">Vol &#43;</button>
       </div>
       <div id=padHint class=padhint></div>
     </div>
@@ -397,6 +404,9 @@ object RemoteHtml {
   }
   function key(action){
     api('/remote/key',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:action})}).catch(function(){});
+  }
+  function vol(dir){
+    api('/remote/volume',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({dir:dir})}).catch(function(){});
   }
   function scrollDir(dir){
     api('/remote/scroll',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({dir:dir})}).then(gestureGone).catch(function(){});

--- a/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
@@ -248,11 +248,13 @@ object RemoteHtml {
           <button id=npPlay class=play onclick="media('playpause')" aria-label="Play or pause"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg></button>
           <button onclick="media('next')" aria-label="Next"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M6 6v12l9-6zM15 6h2v12h-2z"/></svg></button>
         </div>
-        <div class=npvol>
-          <button onclick="vol('down')" aria-label="Volume down"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z"/></svg></button>
-          <button onclick="vol('mute')" aria-label="Mute"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73 4.27 3zM12 4L9.91 6.09 12 8.18V4z"/></svg></button>
-          <button onclick="vol('up')" aria-label="Volume up"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/></svg></button>
-        </div>
+      </div>
+      <!-- Volume sits outside the now-playing card so it's available even with nothing playing
+           (e.g. set the level before starting media). -->
+      <div class=npvol>
+        <button onclick="vol('down')" aria-label="Volume down"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z"/></svg></button>
+        <button onclick="vol('mute')" aria-label="Mute"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73 4.27 3zM12 4L9.91 6.09 12 8.18V4z"/></svg></button>
+        <button onclick="vol('up')" aria-label="Volume up"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/></svg></button>
       </div>
     </div>
 

--- a/app/src/main/java/com/immortal/launcher/RemoteMedia.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteMedia.kt
@@ -9,12 +9,9 @@ package com.immortal.launcher
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import java.io.ByteArrayOutputStream
-import java.net.URL
 import org.json.JSONObject
 
 /**
@@ -25,9 +22,6 @@ import org.json.JSONObject
  * the notification-listener access already held for now-playing.
  */
 object RemoteMedia {
-  /** Cap on re-encoded URI art; matches the on-TV art size closely enough for a phone card. */
-  private const val MAX_EDGE = 384
-
   // Lazy so merely loading this object (e.g. the pure stateJson serializer in tests) doesn't
   // touch the Android main looper; only command() — on-device — ever needs it.
   private val main by lazy { Handler(Looper.getMainLooper()) }
@@ -79,7 +73,7 @@ object RemoteMedia {
    */
   fun artPng(context: Context): ByteArray? {
     val s = NowPlayingHub.current ?: return null
-    val bmp = s.artBitmap ?: resolveUriArt(context, s.artUrl) ?: return null
+    val bmp = s.artBitmap ?: MediaArt.resolveUri(context, s.artUrl) ?: return null
     return runCatching {
           ByteArrayOutputStream().use { out ->
             bmp.compress(Bitmap.CompressFormat.PNG, 100, out)
@@ -91,35 +85,4 @@ object RemoteMedia {
 
   private fun artVersion(s: NowPlayingState): Int =
       listOf(s.title, s.artist, s.album, s.artUrl).joinToString("").hashCode()
-
-  /** Load art bytes from a metadata URI and decode them downscaled. Any failure → null (placeholder). */
-  private fun resolveUriArt(context: Context, url: String): Bitmap? {
-    if (url.isBlank()) return null
-    return runCatching {
-          val bytes =
-              if (url.startsWith("http://") || url.startsWith("https://")) {
-                val conn = URL(url).openConnection()
-                conn.connectTimeout = 4000
-                conn.readTimeout = 4000
-                conn.getInputStream().use { it.readBytes() }
-              } else {
-                // content://, file://, android.resource:// — device-local, only we can read it.
-                context.contentResolver.openInputStream(Uri.parse(url))?.use { it.readBytes() }
-              }
-          bytes?.let { decodeDownscaled(it) }
-        }
-        .getOrNull()
-  }
-
-  /** Decode [bytes] with an inSampleSize that keeps the longest edge near [MAX_EDGE]. */
-  private fun decodeDownscaled(bytes: ByteArray): Bitmap? {
-    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-    BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
-    val longest = maxOf(bounds.outWidth, bounds.outHeight)
-    val opts =
-        BitmapFactory.Options().apply {
-          inSampleSize = if (longest > MAX_EDGE) Integer.highestOneBit(longest / MAX_EDGE) else 1
-        }
-    return BitmapFactory.decodeByteArray(bytes, 0, bytes.size, opts)
-  }
 }

--- a/app/src/main/java/com/immortal/launcher/RemotePairUi.kt
+++ b/app/src/main/java/com/immortal/launcher/RemotePairUi.kt
@@ -42,6 +42,9 @@ import androidx.compose.ui.unit.sp
 fun enableRemoteAndMintPin(context: Context): Pair<String?, String?> {
   RemotePairing.setEnabled(context, true)
   SettingsGuard.reconcileBarWatch(context)
+  // The nav buttons + touchpad route through the accessibility service; if an app update left it
+  // enabled-but-unbound, force a rebind now so the remote isn't half-dead on connect.
+  SettingsGuard.ensureBarWatchConnected(context)
   FleetAgentService.ensureRunning(context)
   val pin = RemotePairing.newPin()
   val ip = lanIp()

--- a/app/src/main/java/com/immortal/launcher/RemoteRoutes.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteRoutes.kt
@@ -9,6 +9,7 @@ package com.immortal.launcher
 
 import android.content.Context
 import android.content.Intent
+import android.media.AudioManager
 import kotlin.concurrent.thread
 import org.json.JSONArray
 import org.json.JSONObject
@@ -41,6 +42,7 @@ class RemoteRoutes(private val context: Context) {
         "/remote/apps" -> authed(req) { apps() }
         "/remote/nowplaying" -> authed(req) { json(200, ok().put("np", RemoteMedia.stateJson())) }
         "/remote/media" -> authed(req) { media(req) }
+        "/remote/volume" -> authed(req) { volume(req) }
         "/remote/key" -> authed(req) { key(req) }
         "/remote/launch" -> authed(req) { launch(req) }
         "/remote/text" -> authed(req) { text(req) }
@@ -89,11 +91,30 @@ class RemoteRoutes(private val context: Context) {
     return json(if (dispatched) 200 else 409, JSONObject().put("ok", dispatched).put("action", action))
   }
 
+  /** Media volume for the active (music) stream: `{"dir":"up|down|mute"}`. Shows the system
+   *  volume UI on the TV. Uses AudioManager directly — no accessibility needed. */
+  private fun volume(req: FleetHttpServer.Request): FleetHttpServer.Response {
+    val body = parseJson(req.bodyText()) ?: return json(400, err("bad_json"))
+    val dir = body.optString("dir")
+    val adjust =
+        when (dir) {
+          "up" -> AudioManager.ADJUST_RAISE
+          "down" -> AudioManager.ADJUST_LOWER
+          "mute" -> AudioManager.ADJUST_TOGGLE_MUTE
+          else -> return json(400, err("unknown_dir"))
+        }
+    val am = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    runCatching { am.adjustStreamVolume(AudioManager.STREAM_MUSIC, adjust, AudioManager.FLAG_SHOW_UI) }
+    return json(200, ok().put("dir", dir))
+  }
+
   private fun key(req: FleetHttpServer.Request): FleetHttpServer.Response {
     val body = parseJson(req.bodyText()) ?: return json(400, err("bad_json"))
     val action = body.optString("action")
     // The Portal has no system Recents; "apps" opens the launcher's own app switcher instead.
     if (action == "apps") return openAppSwitcher()
+    // "screensaver" starts the photo frame (same as the home-screen screensaver button).
+    if (action == "screensaver") return openScreensaver()
     if (RemoteInput.globalActionCode(action) == null) return json(400, err("unknown_action"))
     if (!RemoteInput.available()) return json(503, err("no_accessibility"))
     val dispatched = RemoteInput.globalAction(action)
@@ -115,6 +136,20 @@ class RemoteRoutes(private val context: Context) {
             true
           }
           .getOrDefault(false)
+
+  /** Start the photo-frame screensaver ([PhotoFramePreviewActivity]) — the same thing the
+   *  home-screen screensaver button does. Same-app start, so the non-exported activity is fine. */
+  private fun openScreensaver(): FleetHttpServer.Response {
+    val ok =
+        runCatching {
+              context.startActivity(
+                  Intent(context, PhotoFramePreviewActivity::class.java)
+                      .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+              true
+            }
+            .getOrDefault(false)
+    return json(if (ok) 200 else 500, JSONObject().put("ok", ok).put("action", "screensaver"))
+  }
 
   private fun launch(req: FleetHttpServer.Request): FleetHttpServer.Response {
     val body = parseJson(req.bodyText()) ?: return json(400, err("bad_json"))

--- a/app/src/main/java/com/immortal/launcher/SettingsGuard.kt
+++ b/app/src/main/java/com/immortal/launcher/SettingsGuard.kt
@@ -9,6 +9,8 @@ package com.immortal.launcher
 
 import android.content.ComponentName
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.provider.Settings
 
 /**
@@ -207,5 +209,43 @@ object SettingsGuard {
    */
   fun reconcileBarWatch(context: Context) {
     setBarWatchEnabled(context, true)
+  }
+
+  /**
+   * Force [BarWatchService] to (re)bind if it's enabled in settings but not actually connected.
+   * An app update (a real self-update, or `install -r` in dev) unbinds the service while LEAVING
+   * it in `enabled_accessibility_services`, so [setBarWatchEnabled]'s "already listed" early-return
+   * won't rebind it — the service stays inert and the phone remote's nav buttons and touchpad
+   * (which all route through it) go dead, while volume / screensaver / app-launch (which don't)
+   * keep working. Toggling our component out of the list and back in makes the system rebind.
+   *
+   * Call from a USER action (enabling the remote) — NOT from the frequent app-start reconcile,
+   * where the service is simply mid-bind and [RemoteInput.available] is briefly false anyway.
+   */
+  fun ensureBarWatchConnected(context: Context) {
+    if (RemoteInput.available()) return // already connected — don't churn the binding
+    runCatching {
+      val comp = ComponentName(context, BarWatchService::class.java).flattenToString()
+      val cr = context.contentResolver
+      val others =
+          (Settings.Secure.getString(cr, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES) ?: "")
+              .split(':')
+              .filter { it.isNotBlank() && !it.equals(comp, ignoreCase = true) }
+      Settings.Secure.putInt(cr, Settings.Secure.ACCESSIBILITY_ENABLED, 1)
+      // Drop our component, then re-add it after a real beat. The system's settings observer
+      // coalesces back-to-back writes into the unchanged final value (no rebind) — it has to
+      // observe the service LEAVE the list before it'll bind it on rejoin, so the gap must clear
+      // the observer's debounce window (a few hundred ms proved too short; ~2s is reliable).
+      Settings.Secure.putString(cr, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES, others.joinToString(":"))
+      Handler(Looper.getMainLooper()).postDelayed({
+        runCatching {
+          Settings.Secure.putInt(cr, Settings.Secure.ACCESSIBILITY_ENABLED, 1)
+          Settings.Secure.putString(
+              cr, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES, (others + comp).joinToString(":"))
+          android.util.Log.i("ImmortalQuickBar", "BarWatch a11y re-bound (was enabled but not connected)")
+        }
+      }, 2000)
+    }
+        .onFailure { android.util.Log.w("ImmortalQuickBar", "couldn't re-bind BarWatch a11y", it) }
   }
 }


### PR DESCRIPTION
Three changes, discovered/built while testing the phone remote.

### 1. Re-bind the accessibility service when it's enabled but disconnected (regression fix)
The remote's nav buttons (Power/Back/Home), touchpad, and page up/down all route through `BarWatchService` (accessibility); volume, screensaver, recents, and media transport don't. An **app update unbinds the a11y service while leaving it listed** in `enabled_accessibility_services`, so `reconcileBarWatch`'s "already listed" early-return never rebinds it — exactly that cluster of buttons goes dead while the rest keep working. Also affects the Calls→home bridge and the quick-button cluster, which share the service.

`enableRemoteAndMintPin` now calls **`SettingsGuard.ensureBarWatchConnected()`**: gated on `!RemoteInput.available()`, it drops our component from the list and re-adds it after a **~2s gap**. The gap is load-bearing — back-to-back writes coalesce in the system's settings observer (no rebind); it must see the service leave before binding on rejoin.

### 2. Phone remote: volume controls + a screensaver button
- **Volume** — `POST /remote/volume {dir:up|down|mute}` adjusts `STREAM_MUSIC` via `AudioManager` (no accessibility needed). Rendered as circular icon buttons (volume_down / mute / volume_up) on the **Media tab**, styled to match the transport controls, and **always visible** (even with nothing playing).
- **Screensaver** — the Remote-tab top row is now **Power / Screensaver / Recents / Keyboard**; the new `screensaver` key action starts `PhotoFramePreviewActivity`.

### 3. Header mini-player shows URI album art
Some apps hand cover art as a **URI** rather than a bitmap. Extracted resolution into a shared **`MediaArt.resolveUri`** (`content://`/`file://` via `ContentResolver`, `http(s)://` via URL, downscaled), now reused by `RemoteMedia` and the mini-player (loaded off-thread via `LaunchedEffect`).

## Verified on-device (Portal+ dev build, A10)
- **A11y rebind:** `install -r` (unbinds a11y) → tap remote button → `back`/`home`/`power` → `dispatched:true`, `cursor`/`scroll` → `ok`. Mechanism isolated with a clean adb remove→gap→re-add test.
- **Volume:** up/down/mute → `{ok:true}` (bogus → 400); row shows in the empty/nothing-playing state.
- **Screensaver action** launches the photo frame.
- Compiles; existing unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)