### PR TITLE
Settings registry P1: declarative spec foundation + screensaver/calendar reads

### DIFF
--- a/app/src/main/java/com/immortal/launcher/FleetCalendar.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetCalendar.kt
@@ -8,18 +8,17 @@
 package com.immortal.launcher
 
 import android.content.Context
-import org.json.JSONArray
+import com.immortal.launcher.settings.SettingsDomains
 import org.json.JSONObject
 
 /**
- * Calendar-widget slice of the Fleet Agent API (see [FleetRoutes] `/calendar`). Lets
- * the laptop fleet tool read and push the screensaver calendar's feed link and
- * display range over WiFi — no wireless ADB, no per-device tap-through.
+ * Calendar-widget slice of the Fleet Agent API (see [FleetRoutes] `/calendar`). Lets the laptop
+ * fleet tool read and push the screensaver calendar's feed link and display range over WiFi.
  *
- * Kept tiny and split from the socket/routing layer so the JSON shaping is
- * JVM-unit-testable: [toJson] is a pure `Settings → JSON` mapping, and [apply] is the
- * only Context-touching part (it just funnels recognised keys to the existing
- * [ScreensaverConfig] setters, which already clamp/validate).
+ * This is now a thin façade over the `calendar` [com.immortal.launcher.settings.SettingsDomain]
+ * (see [SettingsDomains.calendar]) — the wire format and validation live there, declaratively,
+ * so the same definition also drives `/remote/settings` and the on-device renderer. [toJson] folds
+ * the domain's specs into the flat legacy payload; [apply] funnels present keys through them.
  *
  * Wire format (both directions use the same field names):
  * ```
@@ -38,63 +37,13 @@ object FleetCalendar {
           CalendarFeed.RANGE_AGENDA,
       )
 
-  /** Pure render of the calendar settings the agent reports back. */
-  fun toJson(s: ScreensaverConfig.Settings): JSONObject {
-    val url = s.calendarUrl.orEmpty()
-    return JSONObject()
-        // "enabled" = effective: a link is set AND the on/off toggle is on (the widget
-        // actually shows). "widgetOn" is the toggle alone, "hasLink" whether a link is
-        // saved — so a client can tell "linked but hidden" from "no link".
-        .put("enabled", s.usesCalendar)
-        .put("widgetOn", s.calendarEnabled)
-        .put("hasLink", s.hasCalendarLink)
-        .put("url", url)
-        .put("range", s.calendarRange)
-        .put("size", s.calendarSize)
-        .put("side", s.calendarSide)
-        .put("provider", if (url.isBlank()) "" else CalendarFeed.providerName(url))
-        // True when the link looks like a fetchable ICS feed; a client can warn the
-        // operator before saving an obviously-wrong link (the device stores it either way).
-        .put("supported", url.isNotBlank() && CalendarFeed.isSupported(url))
-        .put("ranges", JSONArray(RANGES))
-  }
+  /** Pure render of the calendar settings the agent reports back (the flat legacy payload). */
+  fun toJson(s: ScreensaverConfig.Settings): JSONObject = SettingsDomains.calendar.flatJson(s)
 
   /**
-   * Apply a pushed calendar config. Only the keys actually present are touched, so a
-   * partial push (e.g. just `{"range":"week"}`) leaves the link untouched. Returns the
-   * list of applied keys for the response.
+   * Apply a pushed calendar config. Only the keys actually present are touched, so a partial push
+   * (e.g. just `{"range":"week"}`) leaves the link untouched. Returns the list of applied keys.
    */
-  fun apply(context: Context, body: JSONObject): List<String> {
-    val applied = ArrayList<String>(3)
-    if (body.has("url")) {
-      // setCalendarUrl trims and clears the widget when blank.
-      ScreensaverConfig.setCalendarUrl(context, body.optString("url"))
-      applied.add("url")
-    }
-    // The on/off toggle. Preferred write key is "widgetOn", which round-trips
-    // symmetrically with the GET payload's "widgetOn"; "enabled" is accepted as an
-    // alias for it (note: GET "enabled" is the *effective* value — link set AND toggle
-    // on — so writing "enabled" sets only the toggle, by design).
-    if (body.has("widgetOn") || body.has("enabled")) {
-      val on = if (body.has("widgetOn")) body.optBoolean("widgetOn") else body.optBoolean("enabled")
-      ScreensaverConfig.setCalendarEnabled(context, on)
-      applied.add("widgetOn")
-    }
-    if (body.has("range")) {
-      // setCalendarRange clamps unknown values back to a single day.
-      ScreensaverConfig.setCalendarRange(context, body.optString("range"))
-      applied.add("range")
-    }
-    if (body.has("size")) {
-      // setCalendarSize clamps to 0..2 (Small/Medium/Large).
-      ScreensaverConfig.setCalendarSize(context, body.optInt("size"))
-      applied.add("size")
-    }
-    if (body.has("side")) {
-      // setCalendarSide normalises anything but "left" to "right".
-      ScreensaverConfig.setCalendarSide(context, body.optString("side"))
-      applied.add("side")
-    }
-    return applied
-  }
+  fun apply(context: Context, body: JSONObject): List<String> =
+      SettingsDomains.calendar.apply(context, body).toList()
 }

--- a/app/src/main/java/com/immortal/launcher/FleetScreensaver.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetScreensaver.kt
@@ -31,25 +31,14 @@ import org.json.JSONObject
  */
 object FleetScreensaver {
 
-  /** Pure render of the screensaver settings the agent reports back. */
+  /**
+   * Pure render of the screensaver display settings — delegates to the `screensaver` settings
+   * domain ([com.immortal.launcher.settings.SettingsDomains.screensaver]), which owns the flat wire
+   * format declaratively. (`apply` below is not yet routed through the domain — see that domain's
+   * note — so this is the read half of the façade only.)
+   */
   fun toJson(s: ScreensaverConfig.Settings): JSONObject =
-      JSONObject()
-          .put("enabled", s.enabled)
-          .put("source", s.source)
-          .put("folderPath", s.folderPath ?: "")
-          .put("albumUrl", s.albumUrl ?: "")
-          .put("albumRefreshMin", s.albumRefreshMin)
-          .put("fit", s.fit)
-          .put("intervalSec", s.intervalSec)
-          .put("shuffle", s.shuffle)
-          .put("includeVideo", s.includeVideo)
-          .put("batterySaver", s.batterySaver)
-          .put("showNowPlaying", s.showNowPlaying)
-          .put("presenceMode", s.presenceMode.name)
-          .put("idleSleepMin", s.idleSleepMin)
-          .put("overnightEnabled", s.overnightEnabled)
-          .put("overnightStartMin", s.overnightStartMin)
-          .put("overnightEndMin", s.overnightEndMin)
+      com.immortal.launcher.settings.SettingsDomains.screensaver.flatJson(s)
 
   /**
    * The photo-source setup the remote's Setup form reads to pre-fill — the active source type plus

--- a/app/src/main/java/com/immortal/launcher/settings/SettingSpec.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingSpec.kt
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher.settings
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * One declarative setting. A spec binds to an existing `*Config` object: [putValue] reads the
+ * current value from an already-loaded snapshot `S`, and [applyFrom] writes a pushed value through
+ * the existing (clamping, side-effect-free) setter. A [SettingsDomain] folds its specs three ways —
+ * [putValue] builds the flat legacy wire payload, [metaJson] builds the generic schema that drives
+ * both the phone-remote PWA and (later) the on-device renderer, and [applyFrom] performs a partial,
+ * validated apply. Storage is never reimplemented here, so the persisted SharedPreferences keys and
+ * their clamps are untouched. See docs / the settings-standardization plan.
+ */
+sealed interface SettingSpec<S> {
+  /** Canonical wire + UI key. */
+  val key: String
+
+  /** Whether this control should be shown, given the snapshot and the environment. */
+  fun visibleWhen(c: Context, s: S): Boolean
+
+  /** Put this spec's current value into [out] under its wire key. Pure (reads only the snapshot). */
+  fun putValue(out: JSONObject, s: S)
+
+  /**
+   * The control's schema entry for a generic renderer (`{key,type,title,value,…constraints}`), or
+   * null when this spec contributes a flat value but isn't itself a rendered control (e.g. a
+   * read-only derived field that exists only for the legacy wire format).
+   */
+  fun metaJson(c: Context, s: S): JSONObject?
+
+  /** Apply from a wire [body] iff this spec's [key] (or an alias) is present and valid. */
+  fun applyFrom(c: Context, body: JSONObject): Boolean
+}
+
+/** How a [StringSpec] / group is edited on-device: in place, or by launching a dedicated screen. */
+sealed interface Entry {
+  object Inline : Entry
+
+  data class Nav(val activity: Class<*>) : Entry
+}
+
+private fun Entry.wire(): String =
+    when (this) {
+      is Entry.Inline -> "inline"
+      is Entry.Nav -> "nav"
+    }
+
+/** Pick the present wire key from [key] + [aliases], or null if none is in [body]. */
+private fun firstPresent(key: String, aliases: List<String>, body: JSONObject): String? =
+    (listOf(key) + aliases).firstOrNull { body.has(it) }
+
+private fun JSONObject.withHelp(help: String?): JSONObject = apply { help?.let { put("help", it) } }
+
+class BoolSpec<S>(
+    override val key: String,
+    val title: String,
+    val get: (S) -> Boolean,
+    val set: (Context, Boolean) -> Unit,
+    val help: String? = null,
+    /** Extra accepted write-keys (e.g. the calendar's `enabled` aliasing the `widgetOn` toggle). */
+    val aliases: List<String> = emptyList(),
+    val visible: (Context, S) -> Boolean = { _, _ -> true },
+) : SettingSpec<S> {
+  override fun visibleWhen(c: Context, s: S) = visible(c, s)
+
+  override fun putValue(out: JSONObject, s: S) {
+    out.put(key, get(s))
+  }
+
+  override fun metaJson(c: Context, s: S): JSONObject =
+      JSONObject().put("key", key).put("type", "bool").put("title", title).withHelp(help).put("value", get(s))
+
+  override fun applyFrom(c: Context, body: JSONObject): Boolean {
+    val k = firstPresent(key, aliases, body) ?: return false
+    set(c, body.optBoolean(k))
+    return true
+  }
+}
+
+class IntSpec<S>(
+    override val key: String,
+    val title: String,
+    val get: (S) -> Int,
+    val set: (Context, Int) -> Unit,
+    val min: Int,
+    val max: Int,
+    val step: Int = 1,
+    /** Time-of-day values wrap at the bounds; everything else clamps. Drives the UI stepper only. */
+    val wrap: Boolean = false,
+    val format: (Int) -> String = { it.toString() },
+    val help: String? = null,
+    val aliases: List<String> = emptyList(),
+    val visible: (Context, S) -> Boolean = { _, _ -> true },
+) : SettingSpec<S> {
+  override fun visibleWhen(c: Context, s: S) = visible(c, s)
+
+  override fun putValue(out: JSONObject, s: S) {
+    out.put(key, get(s))
+  }
+
+  override fun metaJson(c: Context, s: S): JSONObject =
+      JSONObject()
+          .put("key", key)
+          .put("type", "int")
+          .put("title", title)
+          .withHelp(help)
+          .put("value", get(s))
+          .put("display", format(get(s)))
+          .put("min", min)
+          .put("max", max)
+          .put("step", step)
+          .put("wrap", wrap)
+
+  override fun applyFrom(c: Context, body: JSONObject): Boolean {
+    val k = firstPresent(key, aliases, body) ?: return false
+    set(c, body.optInt(k)) // the underlying setter clamps/wraps
+    return true
+  }
+}
+
+class EnumSpec<S>(
+    override val key: String,
+    val title: String,
+    val get: (S) -> String,
+    val set: (Context, String) -> Unit,
+    /** Allowed values paired with display labels. */
+    val options: List<Pair<String, String>>,
+    /**
+     * Map a pushed value to the value to store, or null to *skip* it (leave the setting unchanged).
+     * Default applies the raw value and lets the setter clamp it — matching settings whose setter
+     * normalises any input (e.g. calendar range/side). Pass a stricter coercer for settings that
+     * should ignore an unrecognised value rather than flip on a typo (e.g. fit, presence mode).
+     */
+    val coerce: (String) -> String? = { it },
+    val help: String? = null,
+    val aliases: List<String> = emptyList(),
+    val visible: (Context, S) -> Boolean = { _, _ -> true },
+) : SettingSpec<S> {
+  override fun visibleWhen(c: Context, s: S) = visible(c, s)
+
+  override fun putValue(out: JSONObject, s: S) {
+    out.put(key, get(s))
+  }
+
+  override fun metaJson(c: Context, s: S): JSONObject {
+    val opts = JSONArray()
+    options.forEach { (v, label) -> opts.put(JSONObject().put("value", v).put("label", label)) }
+    return JSONObject()
+        .put("key", key)
+        .put("type", "enum")
+        .put("title", title)
+        .withHelp(help)
+        .put("value", get(s))
+        .put("options", opts)
+  }
+
+  override fun applyFrom(c: Context, body: JSONObject): Boolean {
+    val k = firstPresent(key, aliases, body) ?: return false
+    val v = coerce(body.optString(k)) ?: return false
+    set(c, v)
+    return true
+  }
+}
+
+class StringSpec<S>(
+    override val key: String,
+    val title: String,
+    val get: (S) -> String,
+    val set: (Context, String) -> Unit,
+    val secret: Boolean = false,
+    val entry: Entry = Entry.Inline,
+    /** Apply guard — e.g. only write when non-blank (the value keys that also flip a source). */
+    val applyWhen: (String) -> Boolean = { true },
+    val help: String? = null,
+    val aliases: List<String> = emptyList(),
+    val visible: (Context, S) -> Boolean = { _, _ -> true },
+) : SettingSpec<S> {
+  override fun visibleWhen(c: Context, s: S) = visible(c, s)
+
+  override fun putValue(out: JSONObject, s: S) {
+    out.put(key, get(s))
+  }
+
+  override fun metaJson(c: Context, s: S): JSONObject =
+      JSONObject()
+          .put("key", key)
+          .put("type", "string")
+          .put("title", title)
+          .withHelp(help)
+          .put("value", get(s))
+          .put("secret", secret)
+          .put("entry", entry.wire())
+
+  override fun applyFrom(c: Context, body: JSONObject): Boolean {
+    val k = firstPresent(key, aliases, body) ?: return false
+    val v = body.optString(k)
+    if (!applyWhen(v)) return false
+    set(c, v)
+    return true
+  }
+}
+
+/**
+ * A read-only computed field. Contributes a value to the flat wire payload (so the legacy format
+ * round-trips) but is never written and renders, if at all, as a non-interactive value. [get] MUST
+ * be pure over the snapshot and must never trigger a side-effecting/identity-minting read.
+ */
+class DerivedSpec<S>(
+    override val key: String,
+    /** Returns a JSON-ready value: Boolean, Int, String, or [JSONArray]. */
+    val get: (S) -> Any,
+    val title: String? = null,
+    /** Whether to surface it in the schema at all (some derived fields are flat-payload-only). */
+    val render: Boolean = false,
+) : SettingSpec<S> {
+  override fun visibleWhen(c: Context, s: S) = render
+
+  override fun putValue(out: JSONObject, s: S) {
+    out.put(key, get(s))
+  }
+
+  override fun metaJson(c: Context, s: S): JSONObject? {
+    if (!render) return null
+    return JSONObject()
+        .put("key", key)
+        .put("type", "info")
+        .apply { title?.let { put("title", it) } }
+        .put("value", get(s))
+        .put("readOnly", true)
+  }
+
+  override fun applyFrom(c: Context, body: JSONObject): Boolean = false
+}

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomain.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomain.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher.settings
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * A coherent group of [SettingSpec]s over one config snapshot type `S` (e.g. the screensaver or the
+ * calendar). A domain is the unit of remote exposure and on-device rendering. It folds its specs
+ * three ways:
+ *  - [flatJson] — the flat `{key:value}` wire payload (what the legacy `Fleet*` serializers emit;
+ *    the façades delegate here so existing tests stay green).
+ *  - [schemaJson] — the generic, self-describing schema (controls + metadata) a renderer builds from.
+ *  - [apply] — a partial, validated write: each present key is applied through its spec, then
+ *    [onApplied] fires ONCE with the set of applied keys (so a domain's side effects — reaffirming
+ *    the dream, reconnecting MQTT, etc. — run a single time per batch, not per key).
+ */
+class SettingsDomain<S>(
+    val id: String,
+    val title: String,
+    val load: (Context) -> S,
+    val specs: List<SettingSpec<S>>,
+    /** When true, the on-device renderer batches edits behind an explicit Apply (e.g. MQTT). */
+    val explicitApply: Boolean = false,
+    val onApplied: (Context, Set<String>) -> Unit = { _, _ -> },
+) {
+  /** The flat legacy wire payload — every spec's current value. Pure over the snapshot. */
+  fun flatJson(s: S): JSONObject {
+    val out = JSONObject()
+    specs.forEach { it.putValue(out, s) }
+    return out
+  }
+
+  fun flatJson(c: Context): JSONObject = flatJson(load(c))
+
+  /** The self-describing schema (visible controls + their metadata/values) for a generic renderer. */
+  fun schemaJson(c: Context): JSONObject {
+    val s = load(c)
+    val controls = JSONArray()
+    specs.forEach { spec -> if (spec.visibleWhen(c, s)) spec.metaJson(c, s)?.let { controls.put(it) } }
+    return JSONObject().put("id", id).put("title", title).put("controls", controls)
+  }
+
+  /** Apply every present key, then fire [onApplied] once. Returns the set of applied keys. */
+  fun apply(c: Context, body: JSONObject): Set<String> {
+    val applied = LinkedHashSet<String>()
+    specs.forEach { if (it.applyFrom(c, body)) applied.add(it.key) }
+    if (applied.isNotEmpty()) onApplied(c, applied)
+    return applied
+  }
+}
+
+/**
+ * The single registry of every settings domain — the one source of truth the persistence layer,
+ * the on-device settings UI, and the phone-remote PWA all read from. Domains are registered in
+ * [SettingsDomains].
+ */
+object SettingsRegistry {
+  val domains: List<SettingsDomain<*>>
+    get() = SettingsDomains.all
+
+  fun domain(id: String): SettingsDomain<*>? = domains.firstOrNull { it.id == id }
+
+  /** Every domain's schema, for a client that renders all settings generically. */
+  fun schemaJson(c: Context): JSONObject {
+    val arr = JSONArray()
+    domains.forEach { arr.put(it.schemaJson(c)) }
+    return JSONObject().put("domains", arr)
+  }
+
+  /** Apply a body to one domain by id; null if no such domain. */
+  fun apply(c: Context, domainId: String, body: JSONObject): Set<String>? =
+      domain(domainId)?.apply(c, body)
+}

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher.settings
+
+import com.immortal.launcher.CalendarFeed
+import com.immortal.launcher.CalendarUrlEntryActivity
+import com.immortal.launcher.FleetCalendar
+import com.immortal.launcher.FleetScreensaver
+import com.immortal.launcher.FrameMode
+import com.immortal.launcher.ScreensaverConfig
+import org.json.JSONArray
+
+/**
+ * The registered settings domains — the single source of truth that the persistence façades, the
+ * phone-remote PWA, and (later) the on-device settings UI all read from. Each domain binds to an
+ * existing `*Config` object's getters/setters, so storage and its clamps are untouched.
+ */
+object SettingsDomains {
+
+  private val CAL_SIZE_LABELS = listOf("Small", "Medium", "Large")
+
+  private fun rangeLabel(range: String): String =
+      when (range) {
+        CalendarFeed.RANGE_DAY -> "Day"
+        CalendarFeed.RANGE_3DAY -> "3 days"
+        CalendarFeed.RANGE_WEEK -> "Week"
+        CalendarFeed.RANGE_AGENDA -> "Agenda"
+        else -> range
+      }
+
+  /**
+   * The screensaver calendar widget. Mirrors the legacy `FleetCalendar` wire format exactly: the
+   * writable controls are `widgetOn` (the on/off toggle, also accepted as the legacy alias
+   * `enabled`), the feed `url`, and the `range`/`size`/`side`. The remaining keys are derived,
+   * read-only views the client uses to distinguish "linked but hidden" from "no link" and to warn
+   * on an unfetchable feed — `enabled` (effective: link set AND toggle on), `hasLink`, `provider`,
+   * `supported`, and the advertised `ranges`.
+   */
+  val calendar: SettingsDomain<ScreensaverConfig.Settings> =
+      SettingsDomain(
+          id = "calendar",
+          title = "Calendar",
+          load = ScreensaverConfig::load,
+          specs =
+              listOf(
+                  BoolSpec(
+                      key = "widgetOn",
+                      title = "Show calendar",
+                      get = { it.calendarEnabled },
+                      set = ScreensaverConfig::setCalendarEnabled,
+                      aliases = listOf("enabled"),
+                  ),
+                  StringSpec(
+                      key = "url",
+                      title = "Calendar feed (.ics)",
+                      get = { it.calendarUrl ?: "" },
+                      set = ScreensaverConfig::setCalendarUrl,
+                      entry = Entry.Nav(CalendarUrlEntryActivity::class.java),
+                  ),
+                  EnumSpec(
+                      key = "range",
+                      title = "Show",
+                      get = { it.calendarRange },
+                      set = ScreensaverConfig::setCalendarRange,
+                      options = FleetCalendar.RANGES.map { it to rangeLabel(it) },
+                  ),
+                  IntSpec(
+                      key = "size",
+                      title = "Size",
+                      get = { it.calendarSize },
+                      set = ScreensaverConfig::setCalendarSize,
+                      min = 0,
+                      max = 2,
+                      step = 1,
+                      format = { CAL_SIZE_LABELS.getOrElse(it) { _ -> it.toString() } },
+                  ),
+                  EnumSpec(
+                      key = "side",
+                      title = "Side",
+                      get = { it.calendarSide },
+                      set = ScreensaverConfig::setCalendarSide,
+                      options =
+                          listOf(
+                              ScreensaverConfig.CAL_SIDE_LEFT to "Left",
+                              ScreensaverConfig.CAL_SIDE_RIGHT to "Right"),
+                  ),
+                  // Read-only derived views (flat-payload-only — they round-trip the legacy format).
+                  DerivedSpec(key = "enabled", get = { it.usesCalendar }),
+                  DerivedSpec(key = "hasLink", get = { it.hasCalendarLink }),
+                  DerivedSpec(
+                      key = "provider",
+                      get = {
+                        val u = it.calendarUrl.orEmpty()
+                        if (u.isBlank()) "" else CalendarFeed.providerName(u)
+                      }),
+                  DerivedSpec(
+                      key = "supported",
+                      get = {
+                        val u = it.calendarUrl.orEmpty()
+                        u.isNotBlank() && CalendarFeed.isSupported(u)
+                      }),
+                  DerivedSpec(key = "ranges", get = { JSONArray(FleetCalendar.RANGES) }),
+              ),
+      )
+
+  private fun hhmm(min: Int): String = "%02d:%02d".format(min / 60, min % 60)
+
+  /**
+   * The photo-frame display settings — the slice the legacy `FleetScreensaver.toJson` reports.
+   * Mirrors that flat wire format exactly (16 keys). The 13 plain display controls are writable
+   * specs bound to the proven `ScreensaverConfig` setters; `source`/`folderPath`/`albumUrl` are
+   * read-only here because their writes flip the active source atomically and belong to the
+   * credential-group apply path (migrated, with the `/remote/settings` work, in a later phase).
+   *
+   * NOTE: this domain's [SettingsDomain.apply] is not yet wired into `FleetScreensaver.apply`; only
+   * the read side ([SettingsDomain.flatJson]) backs the façade today. When apply migrates (with the
+   * `/remote/settings` work), this domain gains the credential `GroupSpec`s and an `onApplied` hook
+   * lifting the route-layer side effects (FleetRoutes reaffirm + overnight reschedule).
+   */
+  val screensaver: SettingsDomain<ScreensaverConfig.Settings> =
+      SettingsDomain(
+          id = "screensaver",
+          title = "Screensaver",
+          load = ScreensaverConfig::load,
+          specs =
+              listOf(
+                  BoolSpec("enabled", "Photo frame", get = { it.enabled }, set = ScreensaverConfig::setEnabled),
+                  DerivedSpec("source", get = { it.source }),
+                  DerivedSpec("folderPath", get = { it.folderPath ?: "" }),
+                  DerivedSpec("albumUrl", get = { it.albumUrl ?: "" }),
+                  IntSpec(
+                      "albumRefreshMin",
+                      "Album refresh",
+                      get = { it.albumRefreshMin },
+                      set = ScreensaverConfig::setAlbumRefreshMin,
+                      min = 15,
+                      max = 24 * 60,
+                      step = 15,
+                      format = { "$it min" }),
+                  EnumSpec(
+                      "fit",
+                      "Fit",
+                      get = { it.fit },
+                      set = ScreensaverConfig::setFit,
+                      options =
+                          listOf(ScreensaverConfig.FIT_FILL to "Fill", ScreensaverConfig.FIT_FIT to "Fit"),
+                      coerce = { FleetScreensaver.coerceFit(it) }),
+                  IntSpec(
+                      "intervalSec",
+                      "Photo interval",
+                      get = { it.intervalSec },
+                      set = ScreensaverConfig::setInterval,
+                      min = 5,
+                      max = 600,
+                      step = 5,
+                      format = { "${it}s" }),
+                  BoolSpec("shuffle", "Shuffle", get = { it.shuffle }, set = ScreensaverConfig::setShuffle),
+                  BoolSpec(
+                      "includeVideo",
+                      "Play videos",
+                      get = { it.includeVideo },
+                      set = ScreensaverConfig::setIncludeVideo),
+                  BoolSpec(
+                      "batterySaver",
+                      "Battery saver",
+                      get = { it.batterySaver },
+                      set = ScreensaverConfig::setBatterySaver),
+                  BoolSpec(
+                      "showNowPlaying",
+                      "Show now playing",
+                      get = { it.showNowPlaying },
+                      set = ScreensaverConfig::setShowNowPlaying),
+                  EnumSpec(
+                      "presenceMode",
+                      "Power",
+                      get = { it.presenceMode.name },
+                      set = { c, v -> ScreensaverConfig.setPresenceMode(c, FrameMode.valueOf(v)) },
+                      options =
+                          listOf(
+                              FrameMode.ALWAYS_ON.name to "Always on",
+                              FrameMode.PRESENCE.name to "Follow presence"),
+                      coerce = { FleetScreensaver.coercePresenceMode(it)?.name }),
+                  IntSpec(
+                      "idleSleepMin",
+                      "Idle screen-off",
+                      get = { it.idleSleepMin },
+                      set = ScreensaverConfig::setIdleSleepMin,
+                      min = 0,
+                      max = 120,
+                      step = 5,
+                      format = { if (it <= 0) "Off" else "$it min" }),
+                  BoolSpec(
+                      "overnightEnabled",
+                      "Overnight screen-off",
+                      get = { it.overnightEnabled },
+                      set = ScreensaverConfig::setOvernightEnabled),
+                  IntSpec(
+                      "overnightStartMin",
+                      "Off from",
+                      get = { it.overnightStartMin },
+                      set = ScreensaverConfig::setOvernightStartMin,
+                      min = 0,
+                      max = 24 * 60 - 1,
+                      step = 15,
+                      wrap = true,
+                      format = ::hhmm,
+                      visible = { _, s -> s.overnightEnabled }),
+                  IntSpec(
+                      "overnightEndMin",
+                      "Off until",
+                      get = { it.overnightEndMin },
+                      set = ScreensaverConfig::setOvernightEndMin,
+                      min = 0,
+                      max = 24 * 60 - 1,
+                      step = 15,
+                      wrap = true,
+                      format = ::hhmm,
+                      visible = { _, s -> s.overnightEnabled }),
+              ),
+      )
+
+  /** Every registered domain. */
+  val all: List<SettingsDomain<*>> = listOf(screensaver, calendar)
+}

--- a/app/src/test/java/com/immortal/launcher/FleetScreensaverTest.kt
+++ b/app/src/test/java/com/immortal/launcher/FleetScreensaverTest.kt
@@ -74,4 +74,79 @@ class FleetScreensaverTest {
     assertNull(FleetScreensaver.coercePresenceMode("garbage"))
     assertNull(FleetScreensaver.coercePresenceMode(null))
   }
+
+  // --- sourcesJson: the photo-source setup the remote's Setup form pre-fills. Pure. ------------
+  // Characterization of the current wire shape — pins the secret/source fields before they move
+  // to a credential GroupSpec, since they had no coverage previously.
+
+  @Test
+  fun sourcesJson_defaultsBlank() {
+    val json = FleetScreensaver.sourcesJson(ScreensaverConfig.Settings())
+    assertEquals("default", json.getString("source"))
+    for (k in
+        listOf(
+            "immichUrl",
+            "immichKey",
+            "smbHost",
+            "smbShare",
+            "smbPath",
+            "smbUser",
+            "smbPass",
+            "davUrl",
+            "davUser",
+            "davPass",
+            "webUrl",
+            "albumUrl")) {
+      assertEquals("blank field $k", "", json.getString(k))
+    }
+  }
+
+  @Test
+  fun sourcesJson_reportsImmichWithSecret() {
+    val s =
+        ScreensaverConfig.Settings(
+            source = ScreensaverConfig.SOURCE_IMMICH,
+            immichUrl = "https://immich.example",
+            immichKey = "secret-key")
+    val json = FleetScreensaver.sourcesJson(s)
+    assertEquals("immich", json.getString("source"))
+    assertEquals("https://immich.example", json.getString("immichUrl"))
+    assertEquals("secret-key", json.getString("immichKey"))
+  }
+
+  @Test
+  fun sourcesJson_reportsSmbWithPassword() {
+    val s =
+        ScreensaverConfig.Settings(
+            source = ScreensaverConfig.SOURCE_SMB,
+            smbHost = "nas.local",
+            smbShare = "photos",
+            smbPass = "hunter2")
+    val json = FleetScreensaver.sourcesJson(s)
+    assertEquals("smb", json.getString("source"))
+    assertEquals("nas.local", json.getString("smbHost"))
+    assertEquals("photos", json.getString("smbShare"))
+    assertEquals("hunter2", json.getString("smbPass"))
+  }
+
+  @Test
+  fun currentSource_mapsActiveSource() {
+    fun src(s: ScreensaverConfig.Settings) = FleetScreensaver.currentSource(s)
+    assertEquals("default", src(ScreensaverConfig.Settings()))
+    assertEquals(
+        "album",
+        src(
+            ScreensaverConfig.Settings(
+                source = ScreensaverConfig.SOURCE_URL, albumUrl = "https://photos.app.goo.gl/x")))
+    assertEquals(
+        "web",
+        src(
+            ScreensaverConfig.Settings(
+                source = ScreensaverConfig.SOURCE_WEBURL, webUrl = "https://kiosk.local")))
+    assertEquals(
+        "dav",
+        src(
+            ScreensaverConfig.Settings(
+                source = ScreensaverConfig.SOURCE_DAV, davUrl = "https://dav.example/photos")))
+  }
 }

--- a/app/src/test/java/com/immortal/launcher/settings/SettingSpecTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingSpecTest.kt
@@ -1,0 +1,59 @@
+package com.immortal.launcher.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.json.JSONArray
+
+/**
+ * Pure machinery tests for the settings spec fold (no Context). Exercises [SettingsDomain.flatJson]
+ * — the legacy wire payload every `Fleet*` façade now delegates to — across every spec type, so the
+ * foundation is locked independently of any one domain. The Context-touching apply path is verified
+ * end-to-end on-device (the suite has no Robolectric, matching the existing pure-test convention).
+ */
+class SettingSpecTest {
+
+  private data class Snap(val on: Boolean, val n: Int, val choice: String, val text: String)
+
+  private val domain =
+      SettingsDomain<Snap>(
+          id = "demo",
+          title = "Demo",
+          load = { Snap(true, 5, "b", "hi") }, // unused here; flatJson takes an explicit snapshot
+          specs =
+              listOf(
+                  BoolSpec("on", "On", get = { it.on }, set = { _, _ -> }),
+                  IntSpec("n", "N", get = { it.n }, set = { _, _ -> }, min = 0, max = 10, step = 5),
+                  EnumSpec(
+                      "choice",
+                      "Choice",
+                      get = { it.choice },
+                      set = { _, _ -> },
+                      options = listOf("a" to "A", "b" to "B")),
+                  StringSpec("text", "Text", get = { it.text }, set = { _, _ -> }),
+                  DerivedSpec("ready", get = { it.on && it.n > 0 }),
+                  DerivedSpec("tags", get = { JSONArray(listOf("x", "y")) }),
+              ))
+
+  @Test
+  fun flatJson_foldsEverySpecType() {
+    val j = domain.flatJson(Snap(on = true, n = 5, choice = "b", text = "hi"))
+    assertTrue(j.getBoolean("on"))
+    assertEquals(5, j.getInt("n"))
+    assertEquals("b", j.getString("choice"))
+    assertEquals("hi", j.getString("text"))
+    assertTrue(j.getBoolean("ready")) // derived: on && n>0
+    assertEquals(2, j.getJSONArray("tags").length()) // derived JSONArray round-trips
+  }
+
+  @Test
+  fun flatJson_reflectsSnapshot() {
+    val j = domain.flatJson(Snap(on = false, n = 0, choice = "a", text = ""))
+    assertFalse(j.getBoolean("on"))
+    assertEquals(0, j.getInt("n"))
+    assertEquals("a", j.getString("choice"))
+    assertEquals("", j.getString("text"))
+    assertFalse(j.getBoolean("ready")) // derived recomputed: off
+  }
+}


### PR DESCRIPTION
First phase of the **settings standardization** initiative — one declarative registry that becomes the single source of truth for persistence, the on-device Compose UI, and the phone-remote PWA, so the *next* feature's settings get cheaper instead of dearer. Plan: three phases (this is P1).

## Foundation — `com.immortal.launcher.settings`
- **`SettingSpec`** — a sealed type per control kind (`BoolSpec` / `IntSpec` / `EnumSpec` / `StringSpec` / read-only `DerivedSpec`) that **binds to the existing `*Config` getters/setters** rather than reimplementing storage. SharedPreferences keys and their clamps are untouched, so P1 is a pure refactor. Each spec folds three ways: `putValue` (flat wire payload), `metaJson` (self-describing schema for a generic renderer), `applyFrom` (partial validated write, with key `aliases` + a `coerce`/skip rule).
- **`SettingsDomain`** groups specs over one config snapshot: `flatJson` (legacy payload), `schemaJson` (generic), `apply` (writes present keys, then fires a single per-batch `onApplied`). **`SettingsRegistry`** is the registry.

## Migrated behind the registry (no wire / UI / storage change)
- **`FleetCalendar.toJson` + `apply`** → thin façades over the `calendar` domain. The domain models the effective-vs-raw contract exactly: `widgetOn` is the writable toggle (accepting the legacy `enabled` alias on write); the effective `enabled`/`hasLink`/`provider`/`supported`/`ranges` are read-only `DerivedSpec`s. `FleetCalendarTest` stays green untouched.
- **`FleetScreensaver.toJson`** → façade over the `screensaver` domain (16 display fields). Its credential-group `apply` + `sourcesJson` stay legacy here; the `GroupSpec`/apply migration moves to **P2** (remote parity), paired with on-device verification.

## Tests
- `SettingSpecTest` — pure machinery coverage of `flatJson` across every spec type.
- `FleetScreensaverTest` — added the missing **`sourcesJson` characterization tests** (the secret/source fields had no coverage) before they move to a `GroupSpec`.
- All existing `Fleet*Test` pass unchanged — the byte-identical wire-format guard.

## Notes
- No Robolectric: compileSdk 36 / AGP 9 has no instrumented `android-all` yet, so Context-dependent `apply` follows the suite's existing pure-test convention and is verified on-device. The calendar `apply` façade is a faithful 1:1 of the prior logic.
- This is a no-behavior-change refactor; the visible win (remote settings parity) lands in P2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)