### PR TITLE
Settings UI: extract shared SettingsComponents (P3b step 1)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/FacePickerActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/FacePickerActivity.kt
@@ -13,26 +13,21 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -41,7 +36,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -161,52 +155,6 @@ private fun FacePickerScreen() {
   }
 }
 
-// --- self-contained row/card composables (same style as the other settings screens) ----------
-@Composable
-private fun Card(content: @Composable () -> Unit) {
-  Surface(
-      color = Color(0xFF1C1C1E),
-      shape = RoundedCornerShape(18.dp),
-      modifier = Modifier.fillMaxWidth(),
-  ) {
-    Column { content() }
-  }
-}
-
-@Composable
-private fun Divider() {
-  Spacer(Modifier.fillMaxWidth().height(1.dp).background(Color(0x14FFFFFF)))
-}
-
-@Composable
-private fun ToggleRow(title: String, checked: Boolean, onChange: (Boolean) -> Unit) {
-  Row(
-      modifier =
-          Modifier.fillMaxWidth().tvFocusableRow { onChange(!checked) }
-              .padding(start = 18.dp, end = 18.dp, top = 14.dp, bottom = 14.dp),
-      verticalAlignment = Alignment.CenterVertically,
-  ) {
-    Text(title, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
-    Switch(checked = checked, onCheckedChange = null)
-  }
-}
-
-@Composable
-private fun SelectableRow(title: String, subtitle: String, selected: Boolean, onClick: () -> Unit) {
-  Row(
-      modifier =
-          Modifier.fillMaxWidth().tvFocusableRow { onClick() }
-              .padding(start = 18.dp, end = 12.dp, top = 14.dp, bottom = 14.dp),
-      verticalAlignment = Alignment.CenterVertically,
-  ) {
-    Column(modifier = Modifier.weight(1f)) {
-      Text(title, color = Color.White, fontSize = 17.sp)
-      Text(subtitle, color = Color(0xFF9A9A9A), fontSize = 13.sp, modifier = Modifier.padding(top = 2.dp))
-    }
-    RadioButton(selected = selected, onClick = null)
-  }
-}
-
 /** Small ◀ Small/Medium/Large ▶ stepper for the clock size (D-pad and touch). */
 @Composable
 private fun SizeStepper(index: Int, onChange: (Int) -> Unit) {
@@ -247,21 +195,6 @@ private fun SizeStepper(index: Int, onChange: (Int) -> Unit) {
         modifier = Modifier.widthIn(min = 110.dp),
     )
     ArrowButton("▶", focused) { if (index < last) onChange(index + 1) }
-  }
-}
-
-@Composable
-private fun ArrowButton(glyph: String, rowFocused: Boolean, onClick: () -> Unit) {
-  Box(
-      modifier = Modifier.size(48.dp).clip(RoundedCornerShape(12.dp)).clickable(onClick = onClick),
-      contentAlignment = Alignment.Center,
-  ) {
-    Text(
-        glyph,
-        color = if (rowFocused) Color.White else Color(0xFFBBBBBB),
-        fontSize = 20.sp,
-        fontWeight = FontWeight.SemiBold,
-    )
   }
 }
 

--- a/app/src/main/java/com/immortal/launcher/ImmichConnectActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmichConnectActivity.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -235,9 +234,4 @@ private fun CancelRow(onDone: () -> Unit) {
         modifier = Modifier.padding(vertical = 14.dp).fillMaxWidth(),
     )
   }
-}
-
-@Composable
-private fun Divider() {
-  Spacer(Modifier.fillMaxWidth().size(1.dp).background(Color(0x14FFFFFF)))
 }

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -16,13 +16,11 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -355,61 +353,6 @@ private fun SettingsMain(
           fontSize = 13.sp,
           modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
       )
-    }
-  }
-}
-
-@Composable
-private fun SectionLabel(text: String) {
-  Text(
-      text.uppercase(),
-      color = Color(0xFF7C7C7C),
-      fontSize = 13.sp,
-      fontWeight = FontWeight.SemiBold,
-      modifier = Modifier.padding(start = 4.dp, bottom = 8.dp),
-  )
-}
-
-@Composable
-private fun Card(content: @Composable () -> Unit) {
-  Surface(
-      color = Color(0xFF1C1C1E),
-      shape = RoundedCornerShape(18.dp),
-      modifier = Modifier.fillMaxWidth(),
-  ) {
-    Column { content() }
-  }
-}
-
-@Composable
-private fun Divider() {
-  Spacer(Modifier.fillMaxWidth().height(1.dp).background(Color(0x14FFFFFF)))
-}
-
-@Composable
-private fun Segmented(
-    options: List<Pair<String, String>>,
-    selected: String,
-    onSelect: (String) -> Unit,
-) {
-  Row(
-      modifier = Modifier.background(Color(0xFF2A2A2C), RoundedCornerShape(12.dp)).padding(3.dp),
-      horizontalArrangement = Arrangement.spacedBy(2.dp),
-  ) {
-    options.forEach { (label, value) ->
-      val on = value == selected
-      Surface(
-          color = if (on) Color(0xFF2E6BE6) else Color.Transparent,
-          shape = RoundedCornerShape(10.dp),
-          modifier = Modifier.tvFocusable(RoundedCornerShape(10.dp)) { onSelect(value) },
-      ) {
-        Text(
-            label,
-            color = if (on) Color.White else Color(0xFFBBBBBB),
-            fontSize = 15.sp,
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
-        )
-      }
     }
   }
 }

--- a/app/src/main/java/com/immortal/launcher/ScreensaverDismissAppActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverDismissAppActivity.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -36,7 +35,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -384,33 +382,6 @@ private fun DismissRow(
     // Visual only — the whole row is the focus/click target.
     RadioButton(selected = selected, onClick = null)
   }
-}
-
-@Composable
-private fun SectionLabel(text: String) {
-  Text(
-      text.uppercase(),
-      color = Color(0xFF7C7C7C),
-      fontSize = 13.sp,
-      fontWeight = FontWeight.SemiBold,
-      modifier = Modifier.padding(start = 4.dp, bottom = 8.dp),
-  )
-}
-
-@Composable
-private fun Card(content: @Composable () -> Unit) {
-  Surface(
-      color = Color(0xFF1C1C1E),
-      shape = RoundedCornerShape(18.dp),
-      modifier = Modifier.fillMaxWidth(),
-  ) {
-    Column { content() }
-  }
-}
-
-@Composable
-private fun Divider() {
-  Spacer(Modifier.fillMaxWidth().height(1.dp).background(Color(0x14FFFFFF)))
 }
 
 /**

--- a/app/src/main/java/com/immortal/launcher/ScreensaverSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverSettingsActivity.kt
@@ -15,17 +15,13 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.focusGroup
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -34,7 +30,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -45,7 +40,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
@@ -517,81 +511,6 @@ private fun calendarRangeLabel(range: String): String =
       else -> "1 day"
     }
 
-@Composable
-private fun SectionLabel(text: String) {
-  Text(
-      text.uppercase(),
-      color = Color(0xFF7C7C7C),
-      fontSize = 13.sp,
-      fontWeight = FontWeight.SemiBold,
-      modifier = Modifier.padding(start = 4.dp, bottom = 8.dp),
-  )
-}
-
-@Composable
-private fun ArrowButton(glyph: String, rowFocused: Boolean, onClick: () -> Unit) {
-  Box(
-      modifier =
-          Modifier.size(48.dp)
-              .clip(RoundedCornerShape(12.dp))
-              .focusProperties { canFocus = false }
-              .clickable(onClick = onClick),
-      contentAlignment = Alignment.Center,
-  ) {
-    Text(
-        glyph,
-        color = if (rowFocused) Color.White else Color(0xFFBBBBBB),
-        fontSize = 20.sp,
-        fontWeight = FontWeight.SemiBold,
-    )
-  }
-}
-
-@Composable
-private fun Card(content: @Composable () -> Unit) {
-  Surface(
-      color = Color(0xFF1C1C1E),
-      shape = RoundedCornerShape(18.dp),
-      modifier = Modifier.fillMaxWidth(),
-  ) {
-    Column { content() }
-  }
-}
-
-@Composable
-private fun Divider() {
-  Spacer(Modifier.fillMaxWidth().height(1.dp).background(Color(0x14FFFFFF)))
-}
-
-/** A row that opens a sub-page; shows the current [value] and a chevron. */
-@Composable
-private fun NavRow(title: String, value: String, onClick: () -> Unit) {
-  Row(
-      modifier =
-          Modifier.fillMaxWidth().tvFocusableRow { onClick() }
-              .padding(start = 18.dp, end = 18.dp, top = 16.dp, bottom = 16.dp),
-      verticalAlignment = Alignment.CenterVertically,
-  ) {
-    Text(title, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
-    Text(value, color = Color(0xFF9A9A9A), fontSize = 15.sp)
-    Text("  ›", color = Color(0xFF7C7C7C), fontSize = 20.sp)
-  }
-}
-
-@Composable
-private fun ToggleRow(title: String, checked: Boolean, onChange: (Boolean) -> Unit) {
-  Row(
-      modifier =
-          Modifier.fillMaxWidth().tvFocusableRow { onChange(!checked) }
-              .padding(horizontal = 18.dp, vertical = 14.dp),
-      verticalAlignment = Alignment.CenterVertically,
-  ) {
-    Text(title, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
-    // Visual only — the row toggles it (so the remote's center button works).
-    Switch(checked = checked, onCheckedChange = null)
-  }
-}
-
 /**
  * Remote-friendly replacement for a slider: focusable, with LEFT/RIGHT adjusting the
  * value and UP/DOWN passing through so the remote can move off it (a focused Slider
@@ -716,32 +635,4 @@ private fun TimeStepper(label: String, minuteOfDay: Int, onChange: (Int) -> Unit
 private fun formatMinuteOfDay(min: Int): String {
   val m = ((min % 1440) + 1440) % 1440
   return "%02d:%02d".format(m / 60, m % 60)
-}
-
-@Composable
-private fun Segmented(
-    options: List<Pair<String, String>>,
-    selected: String,
-    onSelect: (String) -> Unit,
-) {
-  Row(
-      modifier = Modifier.background(Color(0xFF2A2A2C), RoundedCornerShape(12.dp)).padding(3.dp),
-      horizontalArrangement = Arrangement.spacedBy(2.dp),
-  ) {
-    options.forEach { (label, value) ->
-      val on = value == selected
-      Surface(
-          color = if (on) Color(0xFF2E6BE6) else Color.Transparent,
-          shape = RoundedCornerShape(10.dp),
-          modifier = Modifier.tvFocusable(RoundedCornerShape(10.dp)) { onSelect(value) },
-      ) {
-        Text(
-            label,
-            color = if (on) Color.White else Color(0xFFBBBBBB),
-            fontSize = 15.sp,
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
-        )
-      }
-    }
-  }
 }

--- a/app/src/main/java/com/immortal/launcher/ScreensaverSourcesActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverSourcesActivity.kt
@@ -13,26 +13,20 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -43,9 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
@@ -339,55 +331,6 @@ private fun shortUrl(url: String): String {
   return if (trimmed.length <= 56) trimmed else trimmed.take(53) + "…"
 }
 
-// --- shared row/card composables (same style as the main settings screen) ----
-@Composable
-private fun SectionLabel(text: String) {
-  Text(
-      text.uppercase(),
-      color = Color(0xFF7C7C7C),
-      fontSize = 13.sp,
-      fontWeight = FontWeight.SemiBold,
-      modifier = Modifier.padding(start = 4.dp, bottom = 8.dp),
-  )
-}
-
-@Composable
-private fun Card(content: @Composable () -> Unit) {
-  Surface(
-      color = Color(0xFF1C1C1E),
-      shape = RoundedCornerShape(18.dp),
-      modifier = Modifier.fillMaxWidth(),
-  ) {
-    Column { content() }
-  }
-}
-
-@Composable
-private fun Divider() {
-  Spacer(Modifier.fillMaxWidth().height(1.dp).background(Color(0x14FFFFFF)))
-}
-
-@Composable
-private fun SelectableRow(title: String, subtitle: String, selected: Boolean, onClick: () -> Unit) {
-  Row(
-      modifier =
-          Modifier.fillMaxWidth().tvFocusableRow { onClick() }
-              .padding(start = 18.dp, end = 12.dp, top = 14.dp, bottom = 14.dp),
-      verticalAlignment = Alignment.CenterVertically,
-  ) {
-    Column(modifier = Modifier.weight(1f)) {
-      Text(title, color = Color.White, fontSize = 17.sp)
-      Text(
-          subtitle,
-          color = Color(0xFF9A9A9A),
-          fontSize = 13.sp,
-          modifier = Modifier.padding(top = 2.dp),
-      )
-    }
-    RadioButton(selected = selected, onClick = null)
-  }
-}
-
 @Composable
 private fun TextButtonRow(label: String, onClick: () -> Unit) {
   Text(
@@ -396,25 +339,6 @@ private fun TextButtonRow(label: String, onClick: () -> Unit) {
       fontSize = 16.sp,
       modifier = Modifier.fillMaxWidth().tvFocusableRow { onClick() }.padding(18.dp),
   )
-}
-
-@Composable
-private fun ArrowButton(glyph: String, rowFocused: Boolean, onClick: () -> Unit) {
-  Box(
-      modifier =
-          Modifier.size(48.dp)
-              .clip(RoundedCornerShape(12.dp))
-              .focusProperties { canFocus = false }
-              .clickable(onClick = onClick),
-      contentAlignment = Alignment.Center,
-  ) {
-    Text(
-        glyph,
-        color = if (rowFocused) Color.White else Color(0xFFBBBBBB),
-        fontSize = 20.sp,
-        fontWeight = FontWeight.SemiBold,
-    )
-  }
 }
 
 // Non-uniform steps so every LEFT/RIGHT tap lands on a value users think in (15m … 24h).

--- a/app/src/main/java/com/immortal/launcher/SettingsComponents.kt
+++ b/app/src/main/java/com/immortal/launcher/SettingsComponents.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * The shared settings-screen UI vocabulary. Every settings Activity was carrying its own private
+ * copies of these rows (a `ToggleRow` here, a `Card` there, the same palette hardcoded six times);
+ * they're consolidated here so there's one definition to evolve and the screens can't drift. All
+ * are built on the D-pad focus primitives in [TvFocus] ([tvFocusable] / [tvFocusableRow]).
+ *
+ * The bespoke steppers (interval, time-of-day, clock size, album refresh) stay with their screens
+ * for now — they share [ArrowButton] but encode per-control step/format/bounds.
+ */
+
+/** Uppercase grey section header. */
+@Composable
+internal fun SectionLabel(text: String) {
+  Text(
+      text.uppercase(),
+      color = Color(0xFF7C7C7C),
+      fontSize = 13.sp,
+      fontWeight = FontWeight.SemiBold,
+      modifier = Modifier.padding(start = 4.dp, bottom = 8.dp),
+  )
+}
+
+/** A rounded card surface that groups a column of rows. */
+@Composable
+internal fun Card(content: @Composable () -> Unit) {
+  Surface(
+      color = Color(0xFF1C1C1E),
+      shape = RoundedCornerShape(18.dp),
+      modifier = Modifier.fillMaxWidth(),
+  ) {
+    Column { content() }
+  }
+}
+
+/** A hairline divider between rows in a [Card]. */
+@Composable
+internal fun Divider() {
+  Spacer(Modifier.fillMaxWidth().height(1.dp).background(Color(0x14FFFFFF)))
+}
+
+/**
+ * A tappable ◀ / ▶ arrow for the steppers. Excluded from D-pad focus traversal
+ * (`canFocus = false`) so on the remote the parent row keeps handling LEFT/RIGHT — the value
+ * adjusts the same way with either input.
+ */
+@Composable
+internal fun ArrowButton(glyph: String, rowFocused: Boolean, onClick: () -> Unit) {
+  Box(
+      modifier =
+          Modifier.size(48.dp)
+              .clip(RoundedCornerShape(12.dp))
+              .focusProperties { canFocus = false }
+              .clickable(onClick = onClick),
+      contentAlignment = Alignment.Center,
+  ) {
+    Text(
+        glyph,
+        color = if (rowFocused) Color.White else Color(0xFFBBBBBB),
+        fontSize = 20.sp,
+        fontWeight = FontWeight.SemiBold,
+    )
+  }
+}
+
+/** A row that opens a sub-page; shows the current [value] and a chevron. */
+@Composable
+internal fun NavRow(title: String, value: String, onClick: () -> Unit) {
+  Row(
+      modifier =
+          Modifier.fillMaxWidth().tvFocusableRow { onClick() }
+              .padding(start = 18.dp, end = 18.dp, top = 16.dp, bottom = 16.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(title, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+    Text(value, color = Color(0xFF9A9A9A), fontSize = 15.sp)
+    Text("  ›", color = Color(0xFF7C7C7C), fontSize = 20.sp)
+  }
+}
+
+/** A title + on/off switch. The whole row is the click target (so the remote's centre works). */
+@Composable
+internal fun ToggleRow(title: String, checked: Boolean, onChange: (Boolean) -> Unit) {
+  Row(
+      modifier =
+          Modifier.fillMaxWidth().tvFocusableRow { onChange(!checked) }
+              .padding(horizontal = 18.dp, vertical = 14.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(title, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+    // Visual only — the row toggles it (so the remote's center button works).
+    Switch(checked = checked, onCheckedChange = null)
+  }
+}
+
+/** A single-select row with a title + subtitle and a radio dot. The whole row is the click target. */
+@Composable
+internal fun SelectableRow(title: String, subtitle: String, selected: Boolean, onClick: () -> Unit) {
+  Row(
+      modifier =
+          Modifier.fillMaxWidth().tvFocusableRow { onClick() }
+              .padding(start = 18.dp, end = 12.dp, top = 14.dp, bottom = 14.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Column(modifier = Modifier.weight(1f)) {
+      Text(title, color = Color.White, fontSize = 17.sp)
+      Text(subtitle, color = Color(0xFF9A9A9A), fontSize = 13.sp, modifier = Modifier.padding(top = 2.dp))
+    }
+    RadioButton(selected = selected, onClick = null)
+  }
+}
+
+/** A compact segmented control: [options] are `label to value`, the selected one is highlighted. */
+@Composable
+internal fun Segmented(
+    options: List<Pair<String, String>>,
+    selected: String,
+    onSelect: (String) -> Unit,
+) {
+  Row(
+      modifier = Modifier.background(Color(0xFF2A2A2C), RoundedCornerShape(12.dp)).padding(3.dp),
+      horizontalArrangement = Arrangement.spacedBy(2.dp),
+  ) {
+    options.forEach { (label, value) ->
+      val on = value == selected
+      Surface(
+          color = if (on) Color(0xFF2E6BE6) else Color.Transparent,
+          shape = RoundedCornerShape(10.dp),
+          modifier = Modifier.tvFocusable(RoundedCornerShape(10.dp)) { onSelect(value) },
+      ) {
+        Text(
+            label,
+            color = if (on) Color.White else Color(0xFFBBBBBB),
+            fontSize = 15.sp,
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
First, safe increment of the on-device UI unification — pure dedup, no behaviour change. This is the high-confidence piece I flagged; the riskier generic-renderer + nav-collapse work is deliberately **not** in here.

## What
Every settings Activity carried its own `private` copies of the same rows — `ToggleRow`, `SelectableRow`, `NavRow`, `Segmented`, `ArrowButton`, `Card`, `Divider`, `SectionLabel` — with the colour palette hardcoded six times over. Consolidated into one **`SettingsComponents.kt`** (built on the `TvFocus` D-pad primitives), removing **21 duplicate definitions across 6 files** (~320 lines). One definition to evolve; the screens can't drift.

## Two latent bugs fold out
- FacePicker's `ArrowButton` was missing `canFocus = false` (its stepper arrows were individually D-pad-focusable, unlike every other screen).
- ImmichConnect's `Divider` used `.size(1.dp)` — a 1×1 dot rather than a full-width line.

Both now match the canonical version.

The bespoke steppers (interval, time-of-day, clock size, album refresh) stay with their screens — they share the extracted `ArrowButton` but encode per-control step/format/bounds.

## Verified on a Portal Go (Android 10)
- **Screensaver Settings** — `ToggleRow`, `SectionLabel`, `NavRow` (chevron+value), `Segmented` (Image fit), the stepper (◀ 30s ▶), `Card`/`Divider` — all render identically.
- **FacePicker** — `ToggleRow`, `SelectableRow` ×5 (radio selection), `Card`/`Divider` — identical.
- Compile + unit suite green.

Net **−170 lines**. Pure refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)