### PR TITLE
Deepen launcher architecture seams

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -303,6 +303,13 @@
             android:name=".SleepReceiver"
             android:exported="false" />
 
+        <!-- Timer "time's up" alarm: an exact AlarmManager alarm fires here when a
+             countdown started in the Timers widget reaches zero, so it rings even if
+             neither the home screen nor the screensaver is in the foreground. -->
+        <receiver
+            android:name=".TimerAlarmReceiver"
+            android:exported="false" />
+
         <!-- WiFi fleet-management agent. Reached over the LAN by the laptop tool;
              started by ImmortalApp / BootReceiver, off until provisioning enables
              it. Not exported (it's an HTTP server, not an Android-component entry). -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,11 @@
          WiFi). With requestLegacyExternalStorage it governs legacy write access on
          these Android-10 Portals. Granted by provisioning. -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- Home-screen widgets: normal apps cannot hold this directly, so Android
+         shows the one-time ACTION_APPWIDGET_BIND consent dialog the first time
+         Immortal hosts a widget. -->
+    <uses-permission android:name="android.permission.BIND_APPWIDGET"
+        tools:ignore="ProtectedPermissions" />
 
     <!-- "hey" trigger guard. Millennium's TriggerReceiver requires this permission, so only
          the launcher may fire the push-to-talk trigger (not arbitrary apps). It's signature-

--- a/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
+++ b/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
@@ -20,6 +20,7 @@ import android.os.Handler
 import android.os.Looper
 import android.text.TextUtils
 import android.view.Gravity
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewOutlineProvider
 import android.widget.FrameLayout
@@ -32,6 +33,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.Executors
+import kotlin.math.abs
 
 /**
  * Builds and drives the screensaver **overlay** from a [Face] — clock, date, weather,
@@ -87,6 +89,17 @@ class FaceRenderer(
   private var weatherDivider: View? = null
   private var weatherText: String = ""
   private var blinkOn = true
+
+  // A running countdown timer (started from the home-screen Timers widget), shown top-center so it
+  // stays visible on every face; hidden whenever no timer is active.
+  private var timerView: TextView? = null
+  // Fullscreen "time's up" alarm overlay (swipe to stop), shown while the timer is ringing.
+  private var timerAlarmOverlay: View? = null
+  private var timerThumb: View? = null
+  private var timerSlideText: View? = null
+  private var alarmMaxX = 0f
+  private var alarmTouchDownX = 0f
+  private var alarmThumbStart = 0f
 
   // Now-playing card.
   private var nowPlayingCard: LinearLayout? = null
@@ -144,6 +157,138 @@ class FaceRenderer(
     // flip clock — whenever the user has the now-playing setting on (it's high-value enough to be
     // its own switch, not tied to face selection). The card self-hides until music is playing.
     if (ScreensaverConfig.load(context).showNowPlaying) buildNowPlaying(face.nowPlaying)
+
+    // A running countdown timer is also face-independent: it surfaces top-center on every face and
+    // self-hides when no timer is active (see [tick]).
+    buildTimer()
+  }
+
+  /** Top-center countdown readout, hidden until a timer is running (driven by [tick]). */
+  private fun buildTimer() {
+    val t = textView(baseSp = 30f, spec = face.clock, light = false)
+    t.visibility = View.GONE
+    bucket(GridPosition.TOP_CENTER).addView(t)
+    timerView = t
+
+    // Fullscreen "time's up" alarm with an iOS-style slide-to-stop, shown while ringing.
+    // It's intentionally NOT touch-consuming: on a DreamService the host owns the touch stream, so
+    // the slide is driven by [handleAlarmTouch] (called from PhotoFrameController.onTouch) instead
+    // of child touch listeners, which the dream's root listener would otherwise pre-empt.
+    val overlay =
+        FrameLayout(context).apply {
+          setBackgroundColor(0xF2000000.toInt())
+          visibility = View.GONE
+        }
+    val col =
+        LinearLayout(context).apply {
+          orientation = LinearLayout.VERTICAL
+          gravity = Gravity.CENTER_HORIZONTAL
+        }
+    col.addView(
+        TextView(context).apply {
+          text = "⏰  Timer"
+          setTextColor(0xFFDDDDDD.toInt())
+          textSize = 20f
+          gravity = Gravity.CENTER
+        })
+    col.addView(
+        TextView(context).apply {
+          text = "Time's up"
+          setTextColor(Color.WHITE)
+          textSize = 48f
+          typeface = Typeface.DEFAULT_BOLD
+          gravity = Gravity.CENTER
+          setPadding(0, dp(10), 0, 0)
+        })
+    overlay.addView(
+        col,
+        FrameLayout.LayoutParams(WRAP, WRAP, Gravity.CENTER_HORIZONTAL).apply { topMargin = dp(120) })
+
+    // Slide-to-stop pill: a draggable thumb you slide to the right end to silence (iOS-style).
+    val trackW = dp(520)
+    val trackH = dp(72)
+    val thumbSize = dp(64)
+    val inset = dp(4)
+    val maxX = (trackW - thumbSize - inset * 2).toFloat()
+    val track =
+        FrameLayout(context).apply {
+          background =
+              GradientDrawable().apply {
+                cornerRadius = trackH / 2f
+                setColor(0x33FFFFFF)
+              }
+        }
+    val slideText =
+        TextView(context).apply {
+          text = "slide to stop"
+          setTextColor(0xFFCFCFCF.toInt())
+          textSize = 18f
+          gravity = Gravity.CENTER
+        }
+    track.addView(slideText, FrameLayout.LayoutParams(MATCH, MATCH))
+    val thumb =
+        TextView(context).apply {
+          text = "■"
+          setTextColor(0xFF111111.toInt())
+          textSize = 18f
+          gravity = Gravity.CENTER
+          background =
+              GradientDrawable().apply {
+                cornerRadius = dp(16).toFloat()
+                setColor(Color.WHITE)
+              }
+        }
+    track.addView(
+        thumb,
+        FrameLayout.LayoutParams(thumbSize, thumbSize, Gravity.START or Gravity.CENTER_VERTICAL).apply {
+          marginStart = inset
+        })
+    overlay.addView(
+        track,
+        FrameLayout.LayoutParams(trackW, trackH, Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL).apply {
+          bottomMargin = dp(80)
+        })
+    view.addView(overlay, FrameLayout.LayoutParams(MATCH, MATCH))
+    timerAlarmOverlay = overlay
+    timerThumb = thumb
+    timerSlideText = slideText
+    alarmMaxX = maxX
+  }
+
+  /**
+   * Drives the screensaver slide-to-stop from the host's touch stream (the dream/preview forwards
+   * every event to [PhotoFrameController.onTouch], which calls this first). Returns true while the
+   * alarm is showing so the host doesn't also treat the gesture as a tap-to-exit / swipe-photo.
+   * Forgiving by design: a horizontal drag anywhere moves the thumb, and sliding ~80% silences it.
+   */
+  fun handleAlarmTouch(ev: MotionEvent): Boolean {
+    val overlay = timerAlarmOverlay ?: return false
+    if (overlay.visibility != View.VISIBLE) return false
+    val thumb = timerThumb ?: return true
+    when (ev.actionMasked) {
+      MotionEvent.ACTION_DOWN -> {
+        alarmTouchDownX = ev.rawX
+        alarmThumbStart = thumb.translationX
+      }
+      MotionEvent.ACTION_MOVE -> {
+        val x = (alarmThumbStart + (ev.rawX - alarmTouchDownX)).coerceIn(0f, alarmMaxX)
+        thumb.translationX = x
+        timerSlideText?.alpha = 1f - (if (alarmMaxX > 0f) x / alarmMaxX else 0f)
+      }
+      MotionEvent.ACTION_UP,
+      MotionEvent.ACTION_CANCEL -> {
+        if (alarmMaxX > 0f && thumb.translationX >= alarmMaxX * 0.8f) {
+          TimerAlarm.stop(context)
+          overlay.visibility = View.GONE
+          thumb.translationX = 0f
+          timerSlideText?.alpha = 1f
+        } else {
+          thumb.animate().translationX(0f).setDuration(160).start()
+          timerSlideText?.alpha = 1f
+        }
+      }
+    }
+    return true
   }
 
   /**
@@ -317,6 +462,26 @@ class FaceRenderer(
           weatherView?.text = weatherText
           weatherView?.visibility = if (hasWeather) View.VISIBLE else View.GONE
           weatherDivider?.visibility = if (hasWeather) View.VISIBLE else View.GONE
+          // Shared countdown timer: show "M:SS" while running, the alarm banner while ringing.
+          val timerState = TimerStore.load(context)
+          val timerRemaining = timerState.remaining(now.time)
+          if (timerRemaining > 0L && !timerState.ringing) {
+            val tm = (timerRemaining / 60_000).toInt()
+            val ts = ((timerRemaining / 1000) % 60).toInt()
+            timerView?.text = "⏱ %d:%02d".format(tm, ts)
+            timerView?.visibility = View.VISIBLE
+          } else {
+            timerView?.visibility = View.GONE
+          }
+          if (timerState.ringing) {
+            if (timerAlarmOverlay?.visibility != View.VISIBLE) {
+              timerThumb?.translationX = 0f
+              timerSlideText?.alpha = 1f
+            }
+            timerAlarmOverlay?.visibility = View.VISIBLE
+          } else {
+            timerAlarmOverlay?.visibility = View.GONE
+          }
           // Burn-in: drift the whole overlay a few px so no pixel stays lit in place.
           val drift = AntiBurnIn.shift(now.time, burnInMaxPx.toFloat())
           view.translationX = drift.x

--- a/app/src/main/java/com/immortal/launcher/FleetRoutes.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetRoutes.kt
@@ -478,24 +478,7 @@ class FleetRoutes(private val context: Context) {
           }
           .getOrDefault(0L to "")
 
-  private data class InstallModeInfo(
-      val mode: String,
-      val daemonAvailable: Boolean,
-      val legacy: Boolean,
-      val dialogFixed: Boolean,
-      val paused: Boolean,
-  )
-
-  private fun installMode(): InstallModeInfo {
-    val daemon = InstallDaemon.isAvailable(context)
-    val paused = InstallDaemon.installPaused(context)
-    return InstallModeInfo(
-        modeFor(daemon, paused),
-        daemon,
-        InstallDaemon.legacyInstaller(),
-        InstallDaemon.installerDialogFixed(context),
-        paused)
-  }
+  private fun installMode(): InstallLifecycle.Plan = InstallDaemon.installPlan(context)
 
   /** Current LAN IPv4, preferring the wlan interface (computed fresh — DHCP-safe). */
   private fun currentIp(): String? =
@@ -540,19 +523,10 @@ class FleetRoutes(private val context: Context) {
 
     /** Derive the install-mode label reported in /info and gating /install. Pure. */
     internal fun modeFor(daemonAvailable: Boolean, paused: Boolean): String =
-        when {
-          daemonAvailable -> "silent"
-          paused -> "paused"
-          else -> "dialog"
-        }
+        InstallLifecycle.modeFor(daemonAvailable, paused)
 
     /** Map a store status string to a terminal result, or null for progress updates. Pure. */
-    internal fun terminalResult(msg: String): Boolean? =
-        when {
-          msg.contains("Installed ✓") -> true
-          msg.startsWith("Install failed") || msg.startsWith("Error") || msg.startsWith("Paused") -> false
-          else -> null
-        }
+    internal fun terminalResult(msg: String): Boolean? = InstallLifecycle.terminalResult(msg)
 
     /** Length-checked constant-time token compare. Pure. */
     internal fun constantTimeEquals(a: String, b: String): Boolean {

--- a/app/src/main/java/com/immortal/launcher/FleetScreensaver.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetScreensaver.kt
@@ -31,6 +31,56 @@ import org.json.JSONObject
  */
 object FleetScreensaver {
 
+  internal interface Writer {
+    fun setEnabled(value: Boolean)
+    fun useDefault()
+    fun setFolder(path: String)
+    fun setAlbumUrl(url: String)
+    fun setImmich(url: String, key: String)
+    fun setSmb(host: String, share: String, path: String, user: String, pass: String)
+    fun setDav(url: String, user: String, pass: String)
+    fun setWebUrl(url: String)
+    fun setAlbumRefreshMin(value: Int)
+    fun setFit(value: String)
+    fun setInterval(value: Int)
+    fun setShuffle(value: Boolean)
+    fun setIncludeVideo(value: Boolean)
+    fun setBatterySaver(value: Boolean)
+    fun setShowNowPlaying(value: Boolean)
+    fun setPresenceMode(value: FrameMode)
+    fun setIdleSleepMin(value: Int)
+    fun setOvernightEnabled(value: Boolean)
+    fun setOvernightStartMin(value: Int)
+    fun setOvernightEndMin(value: Int)
+  }
+
+  private class AndroidWriter(private val context: Context) : Writer {
+    override fun setEnabled(value: Boolean) = ScreensaverConfig.setEnabled(context, value)
+    override fun useDefault() = ScreensaverConfig.useDefault(context)
+    override fun setFolder(path: String) = ScreensaverConfig.setFolder(context, path)
+    override fun setAlbumUrl(url: String) = ScreensaverConfig.setAlbumUrl(context, url)
+    override fun setImmich(url: String, key: String) = ScreensaverConfig.setImmich(context, url, key)
+    override fun setSmb(host: String, share: String, path: String, user: String, pass: String) =
+        ScreensaverConfig.setSmb(context, host, share, path, user, pass)
+    override fun setDav(url: String, user: String, pass: String) =
+        ScreensaverConfig.setDav(context, url, user, pass)
+    override fun setWebUrl(url: String) = ScreensaverConfig.setWebUrl(context, url)
+    override fun setAlbumRefreshMin(value: Int) = ScreensaverConfig.setAlbumRefreshMin(context, value)
+    override fun setFit(value: String) = ScreensaverConfig.setFit(context, value)
+    override fun setInterval(value: Int) = ScreensaverConfig.setInterval(context, value)
+    override fun setShuffle(value: Boolean) = ScreensaverConfig.setShuffle(context, value)
+    override fun setIncludeVideo(value: Boolean) = ScreensaverConfig.setIncludeVideo(context, value)
+    override fun setBatterySaver(value: Boolean) = ScreensaverConfig.setBatterySaver(context, value)
+    override fun setShowNowPlaying(value: Boolean) = ScreensaverConfig.setShowNowPlaying(context, value)
+    override fun setPresenceMode(value: FrameMode) = ScreensaverConfig.setPresenceMode(context, value)
+    override fun setIdleSleepMin(value: Int) = ScreensaverConfig.setIdleSleepMin(context, value)
+    override fun setOvernightEnabled(value: Boolean) =
+        ScreensaverConfig.setOvernightEnabled(context, value)
+    override fun setOvernightStartMin(value: Int) =
+        ScreensaverConfig.setOvernightStartMin(context, value)
+    override fun setOvernightEndMin(value: Int) = ScreensaverConfig.setOvernightEndMin(context, value)
+  }
+
   /**
    * Pure render of the screensaver display settings — delegates to the `screensaver` settings
    * domain ([com.immortal.launcher.settings.SettingsDomains.screensaver]), which owns the flat wire
@@ -63,15 +113,7 @@ object FleetScreensaver {
           .put("albumUrl", s.albumUrl ?: "")
 
   /** The active photo-source as a Setup-form key (immich/smb/dav/web/album/default). Pure. */
-  internal fun currentSource(s: ScreensaverConfig.Settings): String =
-      when {
-        s.usesImmich -> "immich"
-        s.usesSmb -> "smb"
-        s.usesDav -> "dav"
-        s.usesWebUrl -> "web"
-        s.usesUrl -> "album"
-        else -> "default"
-      }
+  internal fun currentSource(s: ScreensaverConfig.Settings): String = PhotoFrameSource.from(s).setupKey
 
   /** Coerce a fit string to a known value, or null if unrecognised. Pure. */
   internal fun coerceFit(v: String?): String? =
@@ -93,31 +135,33 @@ object FleetScreensaver {
    * (via [applied] containing any "overnight*" key) the caller uses to reschedule the
    * overnight window.
    */
-  fun apply(context: Context, body: JSONObject): List<String> {
+  fun apply(context: Context, body: JSONObject): List<String> = apply(AndroidWriter(context), body)
+
+  internal fun apply(writer: Writer, body: JSONObject): List<String> {
     val applied = ArrayList<String>()
 
     if (body.has("enabled")) {
-      ScreensaverConfig.setEnabled(context, body.optBoolean("enabled"))
+      writer.setEnabled(body.optBoolean("enabled"))
       applied.add("enabled")
     }
     // Source: "default" resets to the built-in feed; folder/url are driven by their
     // value keys below (which also flip the source), so an explicit folder/url here
     // is a no-op unless its path/url is supplied.
     if (body.has("source") && body.optString("source") == ScreensaverConfig.SOURCE_DEFAULT) {
-      ScreensaverConfig.useDefault(context)
+      writer.useDefault()
       applied.add("source")
     }
     if (body.has("folderPath")) {
       val p = body.optString("folderPath")
       if (p.isNotBlank()) {
-        ScreensaverConfig.setFolder(context, p)
+        writer.setFolder(p)
         applied.add("folderPath")
       }
     }
     if (body.has("albumUrl")) {
       val u = body.optString("albumUrl")
       if (u.isNotBlank()) {
-        ScreensaverConfig.setAlbumUrl(context, u)
+        writer.setAlbumUrl(u)
         applied.add("albumUrl")
       }
     }
@@ -129,7 +173,7 @@ object FleetScreensaver {
       val url = body.optString("immichUrl")
       val key = body.optString("immichKey")
       if (url.isNotBlank() && key.isNotBlank()) {
-        ScreensaverConfig.setImmich(context, url, key)
+        writer.setImmich(url, key)
         applied.add("immich")
       }
     }
@@ -137,75 +181,75 @@ object FleetScreensaver {
       val host = body.optString("smbHost")
       val share = body.optString("smbShare")
       if (host.isNotBlank() && share.isNotBlank()) {
-        ScreensaverConfig.setSmb(
-            context, host, share, body.optString("smbPath"), body.optString("smbUser"), body.optString("smbPass"))
+        writer.setSmb(
+            host, share, body.optString("smbPath"), body.optString("smbUser"), body.optString("smbPass"))
         applied.add("smb")
       }
     }
     run {
       val url = body.optString("davUrl")
       if (url.isNotBlank()) {
-        ScreensaverConfig.setDav(context, url, body.optString("davUser"), body.optString("davPass"))
+        writer.setDav(url, body.optString("davUser"), body.optString("davPass"))
         applied.add("dav")
       }
     }
     run {
       val url = body.optString("webUrl")
       if (url.isNotBlank()) {
-        ScreensaverConfig.setWebUrl(context, url)
+        writer.setWebUrl(url)
         applied.add("webUrl")
       }
     }
     if (body.has("albumRefreshMin")) {
-      ScreensaverConfig.setAlbumRefreshMin(context, body.optInt("albumRefreshMin"))
+      writer.setAlbumRefreshMin(body.optInt("albumRefreshMin"))
       applied.add("albumRefreshMin")
     }
     coerceFit(if (body.has("fit")) body.optString("fit") else null)?.let {
-      ScreensaverConfig.setFit(context, it)
+      writer.setFit(it)
       applied.add("fit")
     }
     if (body.has("intervalSec")) {
-      ScreensaverConfig.setInterval(context, body.optInt("intervalSec"))
+      writer.setInterval(body.optInt("intervalSec"))
       applied.add("intervalSec")
     }
     if (body.has("shuffle")) {
-      ScreensaverConfig.setShuffle(context, body.optBoolean("shuffle"))
+      writer.setShuffle(body.optBoolean("shuffle"))
       applied.add("shuffle")
     }
     if (body.has("includeVideo")) {
-      ScreensaverConfig.setIncludeVideo(context, body.optBoolean("includeVideo"))
+      writer.setIncludeVideo(body.optBoolean("includeVideo"))
       applied.add("includeVideo")
     }
     if (body.has("batterySaver")) {
-      ScreensaverConfig.setBatterySaver(context, body.optBoolean("batterySaver"))
+      writer.setBatterySaver(body.optBoolean("batterySaver"))
       applied.add("batterySaver")
     }
     if (body.has("showNowPlaying")) {
-      ScreensaverConfig.setShowNowPlaying(context, body.optBoolean("showNowPlaying"))
+      writer.setShowNowPlaying(body.optBoolean("showNowPlaying"))
       applied.add("showNowPlaying")
     }
     if (body.has("presenceMode")) {
       // Ignore an unrecognised mode rather than defaulting (which would silently flip
       // the setting on a typo); a valid value is applied.
       coercePresenceMode(body.optString("presenceMode"))?.let {
-        ScreensaverConfig.setPresenceMode(context, it)
+        writer.setPresenceMode(it)
         applied.add("presenceMode")
       }
     }
     if (body.has("idleSleepMin")) {
-      ScreensaverConfig.setIdleSleepMin(context, body.optInt("idleSleepMin"))
+      writer.setIdleSleepMin(body.optInt("idleSleepMin"))
       applied.add("idleSleepMin")
     }
     if (body.has("overnightEnabled")) {
-      ScreensaverConfig.setOvernightEnabled(context, body.optBoolean("overnightEnabled"))
+      writer.setOvernightEnabled(body.optBoolean("overnightEnabled"))
       applied.add("overnightEnabled")
     }
     if (body.has("overnightStartMin")) {
-      ScreensaverConfig.setOvernightStartMin(context, body.optInt("overnightStartMin"))
+      writer.setOvernightStartMin(body.optInt("overnightStartMin"))
       applied.add("overnightStartMin")
     }
     if (body.has("overnightEndMin")) {
-      ScreensaverConfig.setOvernightEndMin(context, body.optInt("overnightEndMin"))
+      writer.setOvernightEndMin(body.optInt("overnightEndMin"))
       applied.add("overnightEndMin")
     }
     return applied

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -581,14 +581,12 @@ private fun LauncherScreen(
   LaunchedEffect(Unit) { assignments.putAll(UserLayout.load(context)) }
   val appsEff =
       remember(apps, assignments.toMap()) {
-        apps.map { a ->
-          val pkg = a.component.packageName
-          val eff = if (assignments.containsKey(pkg)) assignments[pkg]!!.ifEmpty { null } else a.folder
-          a.copy(folder = eff)
-        }
+        val effective = HomeLayoutModel.effectiveApps(apps.toLayoutRefs(), assignments)
+        val foldersByPackage = effective.associate { it.packageName to it.folder }
+        apps.map { it.copy(folder = foldersByPackage[it.component.packageName]) }
       }
   val ungrouped = remember(appsEff) { appsEff.filter { it.folder == null } }
-  val folderNames = remember(appsEff) { appsEff.mapNotNull { it.folder }.distinct().sorted() }
+  val folderNames = remember(appsEff) { HomeLayoutModel.folderNames(appsEff.toLayoutRefs()) }
 
   // --- unified, fully-reorderable home grid -----------------------------------
   // Every top-level tile — built-ins, widgets, folders, and ungrouped apps — has a stable key and
@@ -637,32 +635,29 @@ private fun LauncherScreen(
   var renaming by remember { mutableStateOf<String?>(null) }
 
   fun persist() = UserLayout.save(context, assignments.toMap())
+  fun replaceAssignments(next: Map<String, String>) {
+    assignments.clear()
+    assignments.putAll(next)
+    persist()
+  }
   fun assign(pkg: String, folder: String) {
     assignments[pkg] = folder
     persist()
   }
   fun createFolder(a: String, b: String, name: String) {
-    val n = name.trim().ifEmpty { "Folder" }
-    assignments[a] = n
-    assignments[b] = n
-    persist()
-    openFolder = n
+    val result = HomeLayoutModel.createFolder(assignments, a, b, name)
+    replaceAssignments(result.assignments)
+    openFolder = result.folderName
   }
   fun renameFolder(old: String, raw: String) {
-    val new = raw.trim()
-    if (new.isEmpty() || new == old) return
-    appsEff.filter { it.folder == old }.forEach { assignments[it.component.packageName] = new }
-    persist()
-    openFolder = new
+    val result = HomeLayoutModel.renameFolder(appsEff.toLayoutRefs(), assignments, old, raw) ?: return
+    replaceAssignments(result.assignments)
+    openFolder = result.folderName
   }
   fun moveOut(pkg: String) {
-    val folder = appsEff.firstOrNull { it.component.packageName == pkg }?.folder ?: return
-    assignments[pkg] = "" // explicit ungroup
-    // No single-app folders: if only one remains, pop it out too.
-    val remaining = appsEff.filter { it.folder == folder && it.component.packageName != pkg }
-    if (remaining.size == 1) assignments[remaining[0].component.packageName] = ""
-    persist()
-    if (remaining.size <= 1) openFolder = null
+    val result = HomeLayoutModel.moveOut(appsEff.toLayoutRefs(), assignments, pkg) ?: return
+    replaceAssignments(result.assignments)
+    if (result.closeFolder) openFolder = null
   }
   fun targetSlotAt(pos: Offset): Int? =
       slotBounds.entries.firstOrNull { it.value.contains(pos) }?.key
@@ -1243,6 +1238,9 @@ private const val BUILTIN_STORE = "builtin:store"
 private const val BUILTIN_UPDATES = "builtin:updates"
 
 private const val UPDATE_CHECK_INTERVAL_MS = 6L * 60 * 60 * 1000 // 6 hours
+
+private fun List<AppEntry>.toLayoutRefs(): List<HomeLayoutModel.AppRef> =
+    map { HomeLayoutModel.AppRef(it.component.packageName, it.folder) }
 
 // --- tile sizing ----------------------------------------------------------------
 // The grid's tile edge, provided once at the top of the tree so every tile

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -26,6 +26,13 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import android.content.pm.PackageInstaller
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.StartOffset
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -42,12 +49,17 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.drag
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -91,16 +103,20 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.PathParser
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.TextStyle
@@ -131,6 +147,7 @@ import java.util.TimeZone
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 
 private data class AppEntry(
@@ -367,6 +384,13 @@ private fun LauncherScreen(
   var showWidgetPicker by remember { mutableStateOf(false) }
   var widgetStatus by remember { mutableStateOf<String?>(null) }
   var widgets by remember { mutableStateOf(HomeWidgetStore.load(context)) }
+  // Whether the shared timer is currently ringing — drives the swipe-to-stop alarm overlay.
+  var timerRinging by remember { mutableStateOf(TimerStore.load(context).ringing) }
+  DisposableEffect(Unit) {
+    val l: () -> Unit = { timerRinging = TimerStore.load(context).ringing }
+    TimerStore.addListener(l)
+    onDispose { TimerStore.removeListener(l) }
+  }
 
   // Immortal Settings the home screen reflects (tile size, and the optional weather
   // widget's mode/unit), re-read on resume so a change applies the moment the user
@@ -424,12 +448,6 @@ private fun LauncherScreen(
     if (widget.isAppWidget) runCatching { appWidgetHost.deleteAppWidgetId(widget.appWidgetId) }
     saveWidgets(HomeWidgetStore.without(widgets, widget.key))
     widgetStatus = "Widget removed"
-  }
-
-  fun resizeWidget(widget: HomeWidgetStore.HomeWidget, spanX: Int, spanY: Int) {
-    val resized = widget.copy(spanX = spanX, spanY = spanY)
-    if (resized.isAppWidget) updateWidgetSizeOptions(appWidgetManager, resized, tileDpFor(tileSize))
-    saveWidgets(HomeWidgetStore.resized(widgets, widget.key, spanX, spanY))
   }
 
   fun addCustomWidget(kind: String) {
@@ -561,7 +579,6 @@ private fun LauncherScreen(
   // folder), so it beats a curated default too.
   val assignments = remember { mutableStateMapOf<String, String>() }
   LaunchedEffect(Unit) { assignments.putAll(UserLayout.load(context)) }
-  var appOrder by remember { mutableStateOf(UserLayout.loadOrder(context)) }
   val appsEff =
       remember(apps, assignments.toMap()) {
         apps.map { a ->
@@ -571,26 +588,49 @@ private fun LauncherScreen(
         }
       }
   val ungrouped = remember(appsEff) { appsEff.filter { it.folder == null } }
-  LaunchedEffect(ungrouped) {
-    val ids = ungrouped.map { it.component.packageName }
-    val normalized = (appOrder.filter { it in ids } + ids.filter { it !in appOrder }).distinct()
-    if (normalized != appOrder) {
-      appOrder = normalized
-      UserLayout.saveOrder(context, normalized)
-    }
-  }
-  val orderedUngrouped =
-      remember(ungrouped, appOrder) {
-        UserLayout.applyOrder(ungrouped, appOrder) { it.component.packageName }
-      }
   val folderNames = remember(appsEff) { appsEff.mapNotNull { it.folder }.distinct().sorted() }
 
-  // --- drag-and-drop folder management (Manage mode) --------------------------
-  val tileBounds = remember { mutableStateMapOf<String, Rect>() }
-  var containerOrigin by remember { mutableStateOf(Offset.Zero) }
-  var dragPkg by remember { mutableStateOf<String?>(null) }
+  // --- unified, fully-reorderable home grid -----------------------------------
+  // Every top-level tile — built-ins, widgets, folders, and ungrouped apps — has a stable key and
+  // lives in one ordered list, so ALL of them can be dragged (not just apps).
+  val allTileKeys =
+      remember(widgets, folderNames, ungrouped) {
+        buildList {
+          add(BUILTIN_CALLS)
+          add(BUILTIN_STORE)
+          widgets.forEach { add(WIDGET_KEY + it.key) }
+          folderNames.forEach { add(FOLDER_KEY + it) }
+          ungrouped.forEach { add(APP_KEY + it.component.packageName) }
+          add(BUILTIN_UPDATES)
+        }
+      }
+  var gridSlots by remember { mutableStateOf(UserLayout.loadGridSlots(context)) }
+  val gridColumns = gridColumnsFor(tileSize)
+  // Keep the saved slot list in step with what's actually present, preserving the user's blanks.
+  LaunchedEffect(allTileKeys, gridColumns) {
+    val normalized = HomeGrid.normalizeSlots(gridSlots, allTileKeys, gridColumns)
+    if (normalized != gridSlots) {
+      gridSlots = normalized
+      UserLayout.saveGridSlots(context, normalized)
+    }
+  }
+  val widgetByKey = remember(widgets) { widgets.associateBy { WIDGET_KEY + it.key } }
+  val appByKey = remember(ungrouped) { ungrouped.associateBy { APP_KEY + it.component.packageName } }
+  // A tile's column footprint: widgets span their width, everything else is 1.
+  fun widthOf(key: String?): Int =
+      if (key != null && key.startsWith(WIDGET_KEY))
+          (widgetByKey[key]?.spanX ?: 1).coerceIn(1, gridColumns)
+      else 1
+
+  // --- drag-and-drop (Manage mode): free placement over a fixed slot grid ------
+  val slotBounds = remember { mutableStateMapOf<Int, Rect>() }
+  var dragKey by remember { mutableStateOf<String?>(null) }
   var dragPos by remember { mutableStateOf(Offset.Zero) }
-  var dragOriginalOrder by remember { mutableStateOf<List<String>?>(null) }
+  var dragOriginalSlots by remember { mutableStateOf<List<String?>?>(null) }
+  // The drag gesture lives on a stable container that wraps the pager (not on the tile), so it
+  // survives page flips — that's what lets a tile be dragged onto a different page.
+  var containerOrigin by remember { mutableStateOf(Offset.Zero) }
+  var containerDragging by remember { mutableStateOf(false) }
   // Pending folder creation awaiting a name (source+target packages).
   var pendingPair by remember { mutableStateOf<Pair<String, String>?>(null) }
   // Folder currently being renamed.
@@ -624,13 +664,99 @@ private fun LauncherScreen(
     persist()
     if (remaining.size <= 1) openFolder = null
   }
-  fun onDrop(sourcePkg: String, targetKey: String?) {
-    if (targetKey == null) return
-    when {
-      targetKey.startsWith(FOLDER_KEY) -> assign(sourcePkg, targetKey.removePrefix(FOLDER_KEY))
-      targetKey.startsWith(APP_KEY) -> {
-        UserLayout.saveOrder(context, appOrder)
+  fun targetSlotAt(pos: Offset): Int? =
+      slotBounds.entries.firstOrNull { it.value.contains(pos) }?.key
+
+  // --- horizontal paging (iOS-style swipeable app pages) ----------------------
+  var pageCapacity by remember { mutableStateOf(1) }
+  val pageCount = ((gridSlots.size + pageCapacity - 1) / pageCapacity).coerceAtLeast(1)
+  val pagerState = rememberPagerState { pageCount }
+  // While dragging, drift toward the screen edge auto-advances to the next/previous page.
+  var edgeDir by remember { mutableStateOf(0) }
+
+  fun startTileDrag(key: String, win: Offset) {
+    // Long-pressing a tile enters Manage mode AND begins dragging it in the same gesture, so the
+    // user doesn't have to lift and press again.
+    if (!editMode) editMode = true
+    dragKey = key
+    dragPos = win
+    dragOriginalSlots = gridSlots
+  }
+  fun moveTileDrag(amount: Offset) {
+    val dm = context.resources.displayMetrics
+    val screenW = dm.widthPixels.toFloat()
+    val screenH = dm.heightPixels.toFloat()
+    // Clamp to the screen so a finger riding the very edge (or briefly off it) still maps to the
+    // edge column instead of drifting into nowhere — keeps target detection and edge-flip working.
+    dragPos =
+        Offset(
+            (dragPos.x + amount.x).coerceIn(0f, screenW),
+            (dragPos.y + amount.y).coerceIn(0f, screenH),
+        )
+    edgeDir =
+        when {
+          dragPos.x > screenW * 0.86f -> 1
+          dragPos.x < screenW * 0.14f -> -1
+          else -> 0
+        }
+    val src = dragKey ?: return
+    val srcIdx = gridSlots.indexOf(src)
+    if (srcIdx < 0) return
+    val tgtIdx = targetSlotAt(dragPos) ?: return
+    if (tgtIdx == srcIdx) return
+    // Hovering an app over a folder files it in (handled on drop) — don't live-swap into it.
+    val tgt = gridSlots.getOrNull(tgtIdx)
+    if (src.startsWith(APP_KEY) && tgt != null && tgt.startsWith(FOLDER_KEY)) return
+    val next = HomeGrid.swap(gridSlots, srcIdx, tgtIdx)
+    if (next != gridSlots) gridSlots = next
+  }
+  fun endTileDrag() {
+    edgeDir = 0
+    val src = dragKey
+    if (src != null) {
+      val tgtIdx = targetSlotAt(dragPos)
+      val tgt = tgtIdx?.let { gridSlots.getOrNull(it) }
+      if (src.startsWith(APP_KEY) && tgt != null && tgt.startsWith(FOLDER_KEY)) {
+        // File the app into the folder; undo any live swaps so the folder stays put.
+        dragOriginalSlots?.let { gridSlots = it }
+        assignments[src.removePrefix(APP_KEY)] = tgt.removePrefix(FOLDER_KEY)
+        persist()
       }
+      UserLayout.saveGridSlots(context, gridSlots)
+    }
+    dragKey = null
+    dragOriginalSlots = null
+  }
+  fun cancelTileDrag() {
+    // Don't revert — commit the tiles where they were last dragged, so a brief finger-off-screen
+    // (which the OS reports as a cancel) never snaps everything back to where it started.
+    edgeDir = 0
+    if (dragKey != null) UserLayout.saveGridSlots(context, gridSlots)
+    dragKey = null
+    dragOriginalSlots = null
+  }
+  // Debounced page flip while a drag rests against a screen edge.
+  LaunchedEffect(edgeDir) {
+    if (edgeDir != 0 && dragKey != null) {
+      delay(450)
+      if (dragKey != null && edgeDir != 0) {
+        val target = (pagerState.currentPage + edgeDir).coerceIn(0, (pageCount - 1).coerceAtLeast(0))
+        if (target != pagerState.currentPage) pagerState.animateScrollToPage(target)
+      }
+      edgeDir = 0
+    }
+  }
+  // Auto-arrange: pack every tile into the clean default order (built-ins, widgets, folders, then
+  // apps alphabetically), removing blanks and empty pages.
+  fun tidyGrid() {
+    val packed = HomeGrid.normalizeToPages(allTileKeys, allTileKeys, pageCapacity, keepSpare = false)
+    gridSlots = packed
+    UserLayout.saveGridSlots(context, packed)
+  }
+  // If pages were removed (e.g. auto-deleted empties), don't leave the pager stranded past the end.
+  LaunchedEffect(pageCount) {
+    if (pagerState.currentPage >= pageCount) {
+      pagerState.scrollToPage((pageCount - 1).coerceAtLeast(0))
     }
   }
 
@@ -680,7 +806,8 @@ private fun LauncherScreen(
   }
 
   CompositionLocalProvider(LocalTileDp provides tileDpFor(tileSize)) {
-  Box(modifier = Modifier.fillMaxSize().background(Color(0xFF1A1A1A))) {
+  Box(modifier = Modifier.fillMaxSize()) {
+    HomeBackground(Modifier.fillMaxSize())
     Column(
         modifier =
             Modifier.fillMaxHeight()
@@ -705,127 +832,184 @@ private fun LauncherScreen(
               Modifier.fillMaxWidth()
                   .weight(1f)
                   .onGloballyPositioned { containerOrigin = it.boundsInWindow().topLeft }
-                  .pointerInput(editMode) {
-                    if (!editMode) return@pointerInput
-                    detectDragGesturesAfterLongPress(
-                        onDragStart = { local ->
-                          val win = local + containerOrigin
-                          dragPkg =
-                              tileBounds.entries
-                                  .firstOrNull {
-                                    it.key.startsWith(APP_KEY) && it.value.contains(win)
-                                  }
-                                  ?.key
-                                  ?.removePrefix(APP_KEY)
-                          if (dragPkg != null) dragOriginalOrder = appOrder
-                          dragPos = win
-                        },
-                        onDrag = { change, delta ->
-                          change.consume()
-                          dragPos += delta
-                          val src = dragPkg ?: return@detectDragGesturesAfterLongPress
-                          val target =
-                              tileBounds.entries
-                                  .firstOrNull {
-                                    it.key.startsWith(APP_KEY) &&
-                                        it.key != APP_KEY + src &&
-                                        it.value.contains(dragPos)
-                                  }
-                                  ?.key
-                                  ?.removePrefix(APP_KEY)
-                          if (target != null) {
-                            val next = UserLayout.moveOrder(appOrder, src, target)
-                            if (next != appOrder) appOrder = next
+                  // One stable, page-flip-proof drag detector for EVERY tile (apps, folders,
+                  // built-ins AND widgets). It watches for a long-press in the pointer Initial pass,
+                  // so it grabs the tile under the finger before a hosted widget's AndroidView can
+                  // swallow the touch — without consuming anything until the long-press actually
+                  // fires, so normal taps / widget interaction / page swipes still work.
+                  .pointerInput(Unit) {
+                    awaitEachGesture {
+                      val down =
+                          awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+                      val slop = viewConfiguration.touchSlop
+                      // Wait for the long-press without consuming. Returns non-null if the gesture
+                      // was a tap/move/swipe instead (let children handle it); null on timeout = a
+                      // genuine long-press.
+                      val aborted =
+                          withTimeoutOrNull(viewConfiguration.longPressTimeoutMillis) {
+                            var done = false
+                            while (!done) {
+                              val e = awaitPointerEvent(PointerEventPass.Initial)
+                              val c = e.changes.firstOrNull { it.id == down.id }
+                              if (c == null ||
+                                  !c.pressed ||
+                                  (c.position - down.position).getDistance() > slop) {
+                                done = true
+                              }
+                            }
+                            true
                           }
-                        },
-                        onDragEnd = {
-                          dragPkg?.let { src ->
-                            val target =
-                                tileBounds.entries
-                                    .firstOrNull {
-                                      it.key != APP_KEY + src && it.value.contains(dragPos)
-                                    }
-                                    ?.key
-                            onDrop(src, target)
-                            if (dragOriginalOrder != appOrder) UserLayout.saveOrder(context, appOrder)
+                      if (aborted != null) return@awaitEachGesture
+                      val win = down.position + containerOrigin
+                      val hitIdx =
+                          slotBounds.entries.firstOrNull { it.value.contains(win) }?.key
+                      val hitKey = hitIdx?.let { gridSlots.getOrNull(it) }
+                      if (hitKey == null) return@awaitEachGesture
+                      containerDragging = true
+                      startTileDrag(hitKey, win)
+                      val endedNormally =
+                          drag(down.id) { change ->
+                            change.consume()
+                            moveTileDrag(change.position - change.previousPosition)
                           }
-                          dragPkg = null
-                          dragOriginalOrder = null
-                        },
-                        onDragCancel = {
-                          dragOriginalOrder?.let { appOrder = it }
-                          dragPkg = null
-                          dragOriginalOrder = null
-                        },
-                    )
+                      if (endedNormally) endTileDrag() else cancelTileDrag()
+                      containerDragging = false
+                    }
                   },
       ) {
-        val gridColumns = gridColumnsFor(tileSize)
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(gridColumns),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp),
-            modifier = Modifier.focusRequester(homeGridFocus).focusGroup(),
-        ) {
-          // Special + folder tiles persist in Manage mode (non-uninstallable);
-          // only regular apps get a delete badge and become draggable.
-          item { PortalHomeTile(onExitHome) }
-          item { StoreTile(onOpenStore) }
-          items(
-              widgets,
-              key = { it.key },
-              span = { GridItemSpan(it.spanX.coerceIn(1, gridColumns)) },
-          ) { widget ->
-            WidgetTile(
-                widget = widget,
-                host = appWidgetHost,
-                manager = appWidgetManager,
-                editMode = editMode,
-                tileDp = LocalTileDp.current,
-                onRemove = { removeWidget(widget) },
-                onResize = { x, y -> resizeWidget(widget, x, y) },
-            )
+        val tileDp = LocalTileDp.current
+        BoxWithConstraints(Modifier.fillMaxSize()) {
+          // Fit whole rows per page from the available height, then page horizontally (iOS-style).
+          // Use a safe row height (icon + spacer + label + padding) and reserve the page-dots strip
+          // below the pager, so the bottom row is never clipped in half.
+          val rowH = tileDp + 42.dp
+          val dotsReserve = 30.dp
+          val avail = (maxHeight - dotsReserve).coerceAtLeast(rowH)
+          val rows = ((avail.value + 20f) / (rowH.value + 20f)).toInt().coerceAtLeast(1)
+          val cap = (gridColumns * rows).coerceAtLeast(1)
+          LaunchedEffect(cap) { pageCapacity = cap }
+          LaunchedEffect(allTileKeys, cap, dragKey != null) {
+            // Keep a spare empty page only while arranging; otherwise empty pages are removed.
+            val normalized =
+                HomeGrid.normalizeToPages(gridSlots, allTileKeys, cap, keepSpare = dragKey != null)
+            if (normalized != gridSlots) {
+              gridSlots = normalized
+              UserLayout.saveGridSlots(context, normalized)
+            }
           }
-          items(folderNames, key = { it }) { name ->
-            FolderTile(
-                name = name,
-                apps = appsEff.filter { it.folder == name },
-                modifier =
-                    Modifier.onGloballyPositioned {
-                      tileBounds[FOLDER_KEY + name] = it.boundsInWindow()
-                    },
-                onClick = { openFolder = name },
-            )
-          }
-          items(orderedUngrouped, key = { it.component.packageName }) { app ->
-            val pkg = app.component.packageName
-            AppTile(
-                app = app,
-                editMode = editMode,
-                dimmed = dragPkg == pkg,
-                modifier =
-                    Modifier.onGloballyPositioned {
-                      tileBounds[APP_KEY + pkg] = it.boundsInWindow()
-                    },
-                onDelete = { onUninstall(pkg) },
-                onClick = { onLaunch(app.component) },
-            )
-          }
-          // Always-present Updates tile, parked at the end of the grid. Tapping
-          // installs a ready update, or forces a fresh check when up to date.
-          item {
-            UpdatesTile(update = update, status = updateStatus) {
-              val info = update
-              if (info != null) {
-                UpdateManager.installUpdate(context, info) { updateStatus = it }
-              } else {
-                updateStatus = "Checking…"
-                UpdateManager.checkForUpdate(context) {
-                  update = it
-                  updateStatus = if (it == null) "Up to date" else null
+          Column(Modifier.fillMaxSize()) {
+            HorizontalPager(
+                state = pagerState,
+                // Disable horizontal page-swipe while a tile is being dragged (edge auto-advance
+                // takes over then); otherwise swiping flips between app pages.
+                userScrollEnabled = dragKey == null,
+                // Keep the neighbouring page composed so a drag survives a single edge page-flip
+                // (the dragged tile's gesture node isn't disposed when the page scrolls).
+                beyondViewportPageCount = 1,
+                modifier = Modifier.weight(1f).focusRequester(homeGridFocus).focusGroup(),
+            ) { page ->
+              LazyVerticalGrid(
+                  columns = GridCells.Fixed(gridColumns),
+                  horizontalArrangement = Arrangement.spacedBy(16.dp),
+                  verticalArrangement = Arrangement.spacedBy(20.dp),
+                  userScrollEnabled = false,
+                  modifier = Modifier.fillMaxSize(),
+              ) {
+                val pageStart = page * pageCapacity
+                val pageEnd = minOf(pageStart + pageCapacity, gridSlots.size)
+                val pageSize = (pageEnd - pageStart).coerceAtLeast(0)
+                // Free-placement grid: every cell is a slot — a tile or an intentional blank.
+                // Dragging a tile swaps slots, so blanks stay where the user left them. A long-press
+                // both enters Manage mode AND starts the drag in one gesture (see startTileDrag).
+                items(
+                    count = pageSize,
+                    key = { li -> gridSlots[pageStart + li] ?: "blank:${pageStart + li}" },
+                    span = { li -> GridItemSpan(widthOf(gridSlots[pageStart + li])) },
+                ) { li ->
+                  val i = pageStart + li
+                  val key = gridSlots[i]
+            val boundsMod = Modifier.onGloballyPositioned { slotBounds[i] = it.boundsInWindow() }
+            if (key == null) {
+              // Blank cell — an invisible drop target with the same footprint as a tile so the
+              // grid lines up perfectly whether a cell is filled or empty.
+              Column(
+                  horizontalAlignment = Alignment.CenterHorizontally,
+                  modifier = boundsMod.fillMaxWidth().padding(4.dp),
+              ) {
+                Box(Modifier.size(tileDp))
+                Spacer(Modifier.size(8.dp))
+                Text(" ", color = Color.Transparent, fontSize = 15.sp, maxLines = 1)
+              }
+            } else {
+              val isDragged = dragKey == key
+              when {
+                key == BUILTIN_CALLS ->
+                    HomeTileFrame(boundsMod, isDragged) { PortalHomeTile(onExitHome) }
+                key == BUILTIN_STORE ->
+                    HomeTileFrame(boundsMod, isDragged) { StoreTile(onOpenStore) }
+                key == BUILTIN_UPDATES ->
+                    HomeTileFrame(boundsMod, isDragged) {
+                      UpdatesTile(update = update, status = updateStatus) {
+                        val info = update
+                        if (info != null) {
+                          UpdateManager.installUpdate(context, info) { updateStatus = it }
+                        } else {
+                          updateStatus = "Checking…"
+                          UpdateManager.checkForUpdate(context) {
+                            update = it
+                            updateStatus = if (it == null) "Up to date" else null
+                          }
+                        }
+                      }
+                    }
+                key.startsWith(WIDGET_KEY) ->
+                    widgetByKey[key]?.let { w ->
+                      WidgetCell(
+                          widget = w,
+                          host = appWidgetHost,
+                          manager = appWidgetManager,
+                          editMode = editMode,
+                          tileDp = tileDp,
+                          dimmed = isDragged,
+                          modifier = boundsMod.alpha(if (isDragged) 0f else 1f),
+                          onRemove = { removeWidget(w) },
+                      )
+                    }
+                key.startsWith(FOLDER_KEY) -> {
+                  val name = key.removePrefix(FOLDER_KEY)
+                  HomeTileFrame(boundsMod, isDragged) {
+                    FolderTile(
+                        name = name,
+                        apps = appsEff.filter { it.folder == name },
+                        editMode = editMode,
+                        onClick = { openFolder = name },
+                    )
+                  }
+                }
+                key.startsWith(APP_KEY) ->
+                    appByKey[key]?.let { app ->
+                      AppTile(
+                          app = app,
+                          editMode = editMode,
+                          dimmed = isDragged,
+                          modifier = boundsMod.alpha(if (isDragged) 0f else 1f),
+                          onClick = { onLaunch(app.component) },
+                      )
+                    }
+                  }
                 }
               }
             }
+          }
+          if (pageCount > 1) {
+            Spacer(Modifier.size(10.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+              PageDots(selected = pagerState.currentPage, count = pageCount)
+            }
+          }
           }
         }
       }
@@ -837,27 +1021,6 @@ private fun LauncherScreen(
       }
     }
 
-    // Floating ghost of the app being dragged.
-    dragPkg?.let { pkg ->
-      appsEff.firstOrNull { it.component.packageName == pkg }?.let { dragged ->
-        val ghostDp = LocalTileDp.current
-        val half = with(androidx.compose.ui.platform.LocalDensity.current) { (ghostDp / 2).toPx() }
-        Image(
-            bitmap = dragged.icon,
-            contentDescription = null,
-            modifier =
-                Modifier.offset {
-                      IntOffset(
-                          (dragPos.x - half).roundToInt(),
-                          (dragPos.y - half).roundToInt(),
-                      )
-                    }
-                    .size(ghostDp)
-                    .clip(RoundedCornerShape(20.dp)),
-        )
-      }
-    }
-
     // Manage / Done toggle lives in the bottom-right corner. While managing, a
     // sibling + button opens the widget picker so widgets are an edit action, not
     // a permanent launcher tile.
@@ -866,8 +1029,37 @@ private fun LauncherScreen(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.align(Alignment.BottomEnd).padding(end = 36.dp, bottom = 32.dp),
     ) {
+      if (editMode) TidyButton { tidyGrid() }
       if (editMode) AddWidgetButton { showWidgetPicker = true }
       EditButton(editMode = editMode, onClick = { editMode = !editMode })
+    }
+
+    // Floating ghost of the tile being dragged — it follows the finger while the grid reflows
+    // beneath it (the source cell is hidden via alpha while dragging).
+    dragKey?.let { key ->
+      val ghostDp = LocalTileDp.current
+      val half = with(androidx.compose.ui.platform.LocalDensity.current) { (ghostDp / 2).toPx() }
+      val ghostMod =
+          Modifier.offset {
+                IntOffset((dragPos.x - half).roundToInt(), (dragPos.y - half).roundToInt())
+              }
+              .size(ghostDp)
+      val app = appByKey[key]
+      if (app != null) {
+        Image(
+            bitmap = app.icon,
+            contentDescription = null,
+            modifier = ghostMod.clip(RoundedCornerShape(20.dp)),
+        )
+      } else {
+        // Folders / built-ins / widgets: a simple lifted tile stand-in.
+        Box(
+            modifier =
+                ghostMod
+                    .clip(RoundedCornerShape(20.dp))
+                    .background(Color(0xF23A3A3C)),
+        )
+      }
     }
 
     openFolder?.let { name ->
@@ -954,12 +1146,101 @@ private fun LauncherScreen(
           },
       )
     }
+
+    // Timer "time's up" alarm: a full-screen swipe-to-stop overlay while ringing.
+    if (timerRinging) {
+      TimerAlarmOverlay(onStop = { TimerAlarm.stop(context) })
+    }
   }
   } // CompositionLocalProvider(LocalTileDp)
 }
 
+/**
+ * Full-screen "time's up" alarm overlay with an iOS-style slide-to-stop. Blocks touches from
+ * reaching the grid beneath, so the only way out is the slider (or the 60s auto-silence).
+ */
+@Composable
+private fun TimerAlarmOverlay(onStop: () -> Unit) {
+  val noRipple = remember { MutableInteractionSource() }
+  Box(
+      contentAlignment = Alignment.Center,
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Color(0xE6000000))
+              // Swallow taps so nothing behind the alarm reacts.
+              .clickable(interactionSource = noRipple, indication = null) {},
+  ) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+      Text("⏰", fontSize = 68.sp)
+      Spacer(Modifier.size(18.dp))
+      Text("Timer", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.Bold)
+      Text(
+          "Time's up",
+          color = Color(0xFFBFBFBF),
+          fontSize = 18.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+      Spacer(Modifier.size(44.dp))
+      SlideToStop(onStop = onStop)
+    }
+  }
+}
+
+/** A draggable thumb on a track; sliding it to the far end fires [onStop] (else it snaps back). */
+@Composable
+private fun SlideToStop(onStop: () -> Unit) {
+  val density = androidx.compose.ui.platform.LocalDensity.current
+  val trackWidth = 320.dp
+  val thumbSize = 56.dp
+  val inset = 4.dp
+  val maxOffset =
+      with(density) { (trackWidth - thumbSize - inset * 2).toPx() }.coerceAtLeast(0f)
+  val insetPx = with(density) { inset.roundToPx() }
+  var offsetX by remember { mutableStateOf(0f) }
+  Box(
+      modifier =
+          Modifier.width(trackWidth)
+              .height(64.dp)
+              .clip(RoundedCornerShape(32.dp))
+              .background(Color(0x33FFFFFF)),
+      contentAlignment = Alignment.CenterStart,
+  ) {
+    Text(
+        "Slide to stop",
+        color = Color(0xFFE8E8E8),
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Medium,
+        modifier = Modifier.align(Alignment.Center).alpha(1f - (offsetX / maxOffset).coerceIn(0f, 1f)),
+    )
+    Box(
+        modifier =
+            Modifier.offset { IntOffset(offsetX.roundToInt() + insetPx, 0) }
+                .size(thumbSize)
+                .clip(CircleShape)
+                .background(Color(0xFFE53935))
+                .pointerInput(Unit) {
+                  detectDragGestures(
+                      onDragEnd = { if (offsetX >= maxOffset * 0.9f) onStop() else offsetX = 0f },
+                      onDragCancel = { offsetX = 0f },
+                      onDrag = { change, dragAmount ->
+                        change.consume()
+                        offsetX = (offsetX + dragAmount.x).coerceIn(0f, maxOffset)
+                      },
+                  )
+                },
+        contentAlignment = Alignment.Center,
+    ) {
+      Text("›", color = Color.White, fontSize = 30.sp, fontWeight = FontWeight.Bold)
+    }
+  }
+}
+
 private const val APP_KEY = "app:"
 private const val FOLDER_KEY = "folder:"
+private const val WIDGET_KEY = "widget-tile:"
+private const val BUILTIN_CALLS = "builtin:calls"
+private const val BUILTIN_STORE = "builtin:store"
+private const val BUILTIN_UPDATES = "builtin:updates"
 
 private const val UPDATE_CHECK_INTERVAL_MS = 6L * 60 * 60 * 1000 // 6 hours
 
@@ -1566,6 +1847,27 @@ private fun EditButton(editMode: Boolean, modifier: Modifier = Modifier, onClick
   }
 }
 
+/** Edit-mode "clean up" button — re-packs every tile into a tidy ordered grid. */
+@Composable
+private fun TidyButton(onClick: () -> Unit) {
+  val path = remember { PathParser().parsePathString(ICON_WIDGETS).toPath() }
+  Surface(
+      color = Color(0xCC2B2B2B),
+      shape = androidx.compose.foundation.shape.CircleShape,
+      modifier =
+          Modifier.size(60.dp).tvFocusable(androidx.compose.foundation.shape.CircleShape) {
+            onClick()
+          },
+  ) {
+    Box(contentAlignment = Alignment.Center) {
+      Canvas(Modifier.size(26.dp)) {
+        val s = size.minDimension / 24f
+        scale(s, s, pivot = Offset.Zero) { drawPath(path, Color.White) }
+      }
+    }
+  }
+}
+
 private data class BatteryReading(val present: Boolean, val percent: Int, val charging: Boolean)
 
 /** Reads the device battery, updating live. Returns present=false on devices
@@ -1693,7 +1995,7 @@ private fun BuiltInTile(
   val tileDp = LocalTileDp.current
   Column(
       horizontalAlignment = Alignment.CenterHorizontally,
-      modifier = Modifier.padding(4.dp).tvFocusable(RoundedCornerShape(22.dp)) { onClick() },
+      modifier = Modifier.fillMaxWidth().padding(4.dp).tvFocusable(RoundedCornerShape(22.dp)) { onClick() },
   ) {
     Surface(
         color = background,
@@ -1717,18 +2019,19 @@ private fun FolderTile(
     name: String,
     apps: List<AppEntry>,
     modifier: Modifier = Modifier,
+    editMode: Boolean = false,
     onClick: () -> Unit,
 ) {
   val tileDp = LocalTileDp.current
   val scale = tileDp / 88.dp // mini-icon grid scales with the tile
   Column(
       horizontalAlignment = Alignment.CenterHorizontally,
-      modifier = modifier.padding(4.dp).tvFocusable(RoundedCornerShape(22.dp)) { onClick() },
+      modifier = modifier.fillMaxWidth().padding(4.dp).tvFocusable(RoundedCornerShape(22.dp)) { onClick() },
   ) {
     Surface(
         color = Color(0xFF3A3A3A),
         shape = RoundedCornerShape(20.dp),
-        modifier = Modifier.size(tileDp),
+        modifier = Modifier.size(tileDp).jiggle(editMode, name.hashCode()),
     ) {
       Column(
           modifier = Modifier.padding(13.dp * scale),
@@ -1993,7 +2296,7 @@ private fun UpdatesTile(update: UpdateInfo?, status: String?, onClick: () -> Uni
   val tileDp = LocalTileDp.current
   Column(
       horizontalAlignment = Alignment.CenterHorizontally,
-      modifier = Modifier.padding(4.dp).tvFocusable(RoundedCornerShape(22.dp)) { onClick() },
+      modifier = Modifier.fillMaxWidth().padding(4.dp).tvFocusable(RoundedCornerShape(22.dp)) { onClick() },
   ) {
     Box {
       Surface(
@@ -2065,8 +2368,8 @@ private fun WidgetTile(
     manager: AppWidgetManager,
     editMode: Boolean,
     tileDp: Dp,
-    onRemove: () -> Unit,
-    onResize: (Int, Int) -> Unit,
+    modifier: Modifier = Modifier,
+    dimmed: Boolean = false,
 ) {
   val info = remember(widget.appWidgetId) {
     if (widget.isAppWidget) manager.getAppWidgetInfo(widget.appWidgetId) else null
@@ -2079,11 +2382,14 @@ private fun WidgetTile(
     if (widget.isAppWidget) updateWidgetSizeOptions(manager, widget, tileDp)
   }
 
-  Box(modifier = Modifier.fillMaxWidth().height(height).padding(4.dp)) {
+  Box(modifier = modifier.fillMaxWidth().height(height).padding(4.dp)) {
     Surface(
         color = Color(0xFF252527),
         shape = RoundedCornerShape(20.dp),
-        modifier = Modifier.fillMaxSize(),
+        modifier =
+            Modifier.fillMaxSize()
+                .alpha(if (dimmed) 0.3f else 1f)
+                .jiggle(editMode && !dimmed, widget.key.hashCode()),
     ) {
       if (!widget.isAppWidget) {
         ImmortalWidgetContent(widget = widget, modifier = Modifier.fillMaxSize())
@@ -2131,73 +2437,13 @@ private fun WidgetTile(
       }
     }
     if (editMode) {
-      Box(Modifier.fillMaxSize().clip(RoundedCornerShape(20.dp)).background(Color(0x66000000)))
-      Surface(
-          color = Color(0xFFE53935),
-          shape = CircleShape,
-          modifier =
-              Modifier.size(34.dp).align(Alignment.TopEnd).tvFocusable(CircleShape) { onRemove() },
-      ) {
-        Box(contentAlignment = Alignment.Center) {
-          Text("✕", color = Color.White, fontSize = 18.sp, fontWeight = FontWeight.Bold)
-        }
-      }
-      ResizeHandle(
-          widget = widget,
-          tileDp = tileDp,
-          onResize = onResize,
-          modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp),
-      )
-    }
-  }
-}
-
-@Composable
-private fun ResizeHandle(
-    widget: HomeWidgetStore.HomeWidget,
-    tileDp: Dp,
-    modifier: Modifier = Modifier,
-    onResize: (Int, Int) -> Unit,
-) {
-  val density = androidx.compose.ui.platform.LocalDensity.current
-  var remainder by remember(widget.key) { mutableStateOf(Offset.Zero) }
-  Surface(
-      color = Color(0xEEFFFFFF),
-      shape = CircleShape,
-      modifier =
-          modifier
-              .size(34.dp)
-              .pointerInput(widget.key, widget.spanX, widget.spanY, tileDp) {
-                detectDragGestures(
-                    onDragStart = { remainder = Offset.Zero },
-                    onDrag = { change, delta ->
-                      change.consume()
-                      remainder += delta
-                      val threshold = with(density) { tileDp.toPx() * 0.55f }
-                      var spanX = widget.spanX
-                      var spanY = widget.spanY
-                      if (abs(remainder.x) > threshold) {
-                        val step = if (remainder.x > 0) 1 else -1
-                        spanX = HomeWidgetStore.normalizeSpan(spanX + step)
-                        remainder = remainder.copy(x = 0f)
-                      }
-                      if (abs(remainder.y) > threshold) {
-                        val step = if (remainder.y > 0) 1 else -1
-                        spanY = HomeWidgetStore.normalizeSpan(spanY + step)
-                        remainder = remainder.copy(y = 0f)
-                      }
-                      if (spanX != widget.spanX || spanY != widget.spanY) onResize(spanX, spanY)
-                    },
-                    onDragEnd = { remainder = Offset.Zero },
-                    onDragCancel = { remainder = Offset.Zero },
-                )
-              },
-  ) {
-    Canvas(Modifier.size(34.dp)) {
-      val stroke = Stroke(width = 2.dp.toPx(), cap = androidx.compose.ui.graphics.StrokeCap.Round)
-      val c = Color(0xFF2C2C2E)
-      drawLine(c, Offset(size.width * 0.38f, size.height * 0.70f), Offset(size.width * 0.70f, size.height * 0.38f), strokeWidth = stroke.width, cap = stroke.cap)
-      drawLine(c, Offset(size.width * 0.54f, size.height * 0.76f), Offset(size.width * 0.76f, size.height * 0.54f), strokeWidth = stroke.width, cap = stroke.cap)
+      // Dim/scrim only — the drag scrim and ✕ / resize controls are added by the enclosing
+      // WidgetCell so they layer correctly above the hosted widget's own touch handling.
+      Box(
+          Modifier.fillMaxSize()
+              .jiggle(!dimmed, widget.key.hashCode())
+              .clip(RoundedCornerShape(20.dp))
+              .background(Color(0x66000000)))
     }
   }
 }
@@ -2207,7 +2453,7 @@ private fun ImmortalWidgetContent(widget: HomeWidgetStore.HomeWidget, modifier: 
   when (widget.kind) {
     HomeWidgetStore.KIND_WEATHER -> ImmortalWeatherWidget(modifier)
     HomeWidgetStore.KIND_WORLD_CLOCK -> ImmortalWorldClockWidget(modifier)
-    HomeWidgetStore.KIND_TIMERS -> ImmortalTimersWidget(widget.key, modifier)
+    HomeWidgetStore.KIND_TIMERS -> ImmortalTimersWidget(modifier)
     else -> UnknownImmortalWidget(widget.kind, modifier)
   }
 }
@@ -2240,49 +2486,109 @@ private fun ImmortalWidgetShell(
 @Composable
 private fun ImmortalWeatherWidget(modifier: Modifier = Modifier) {
   val context = androidx.compose.ui.platform.LocalContext.current
-  val current by produceState(initialValue = "", Unit) {
-    while (true) {
-      value = withContext(Dispatchers.IO) { Weather.fetch(context) }
-      delay(if (value.isBlank()) 60_000L else 30L * 60 * 1000)
+  var fahrenheit by remember { mutableStateOf(ImmortalSettings.useFahrenheit(context)) }
+  val lifecycleOwner = LocalLifecycleOwner.current
+  DisposableEffect(lifecycleOwner) {
+    val obs = LifecycleEventObserver { _, e ->
+      if (e == Lifecycle.Event.ON_RESUME) fahrenheit = ImmortalSettings.useFahrenheit(context)
     }
+    lifecycleOwner.lifecycle.addObserver(obs)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
   }
-  val forecast by produceState<Weather.Forecast?>(initialValue = null, Unit) {
-    value = withContext(Dispatchers.IO) { Weather.fetchForecast(context) }
-  }
-  ImmortalWidgetShell(title = "Weather", accent = Color(0xFF79B8FF), modifier = modifier) {
-    Text(
-        current.ifBlank { "Weather" },
-        color = Color.White,
-        fontSize = 30.sp,
-        fontWeight = FontWeight.SemiBold,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-    )
-    val hours = forecast?.hours?.take(4).orEmpty()
-    if (hours.isNotEmpty()) {
-      Spacer(Modifier.size(12.dp))
-      Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
-        hours.forEach { h ->
-          Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.weight(1f)) {
-            Text(h.label, color = Color(0xFFB8B8B8), fontSize = 11.sp, maxLines = 1)
-            Text(Weather.emoji(h.code), fontSize = 20.sp, modifier = Modifier.padding(top = 3.dp))
-            Text("${h.temp}°", color = Color.White, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+  val current by
+      produceState<Weather.Current?>(initialValue = null, fahrenheit) {
+        while (true) {
+          value = withContext(Dispatchers.IO) { Weather.fetchCurrent(context) }
+          delay(if (value == null) 60_000L else 30L * 60 * 1000)
+        }
+      }
+  val forecast by
+      produceState<Weather.Forecast?>(initialValue = null, fahrenheit) {
+        value = withContext(Dispatchers.IO) { Weather.fetchForecast(context) }
+      }
+  val code = current?.code ?: 0
+  val isDay = java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY) in 6..18
+  val (gTop, gBottom) = weatherGradient(code, isDay)
+  // Dynamic gradient card that matches the weather (iOS-style), city + big temp top-left,
+  // condition glyph top-right, and an hourly strip along the bottom.
+  Box(
+      modifier =
+          modifier
+              .clip(RoundedCornerShape(24.dp))
+              .background(Brush.linearGradient(listOf(gTop, gBottom)))
+              .padding(18.dp),
+  ) {
+    Column(Modifier.fillMaxSize()) {
+      Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
+        Column(Modifier.weight(1f)) {
+          Text(
+              current?.city?.ifBlank { "Weather" } ?: "Weather",
+              color = Color.White,
+              fontSize = 18.sp,
+              fontWeight = FontWeight.SemiBold,
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis,
+          )
+          Text(
+              current?.let { "${it.temp}°" } ?: "—",
+              color = Color.White,
+              fontSize = 46.sp,
+              fontWeight = FontWeight.Light,
+          )
+        }
+        Text(Weather.emoji(code), fontSize = 34.sp)
+      }
+      Spacer(Modifier.weight(1f))
+      val hours = forecast?.hours?.take(5).orEmpty()
+      if (hours.isNotEmpty()) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          hours.forEach { h ->
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.weight(1f),
+            ) {
+              Text(h.label, color = Color(0xCCFFFFFF), fontSize = 11.sp, maxLines = 1)
+              Text(Weather.emoji(h.code), fontSize = 18.sp, modifier = Modifier.padding(vertical = 3.dp))
+              Text("${h.temp}°", color = Color.White, fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
+            }
           }
         }
       }
-    } else {
-      Text(
-          "Forecast appears when the Portal is online.",
-          color = Color(0xFF9A9A9A),
-          fontSize = 13.sp,
-          modifier = Modifier.padding(top = 8.dp),
-      )
     }
+  }
+}
+
+/** A weather-matching two-stop gradient (top → bottom), varying with the condition and day/night. */
+private fun weatherGradient(code: Int, isDay: Boolean): Pair<Color, Color> {
+  if (!isDay) {
+    return when {
+      code in 51..99 -> Color(0xFF2A3340) to Color(0xFF49586B)
+      code == 3 || code in 45..48 -> Color(0xFF263041) to Color(0xFF3C4A5E)
+      else -> Color(0xFF18233F) to Color(0xFF36527E)
+    }
+  }
+  return when {
+    code in 71..77 -> Color(0xFF7E93A8) to Color(0xFFBFCEDC) // snow
+    code in 51..67 || code in 80..82 -> Color(0xFF45607A) to Color(0xFF7791A6) // rain
+    code in 95..99 -> Color(0xFF3A4A5C) to Color(0xFF5E7286) // thunder
+    code == 3 -> Color(0xFF5E7E98) to Color(0xFF93ABC0) // overcast
+    code in 45..48 -> Color(0xFF7E8E9C) to Color(0xFFAEBBC6) // fog
+    else -> Color(0xFF3E8BD0) to Color(0xFF77B8E8) // clear / partly (the blue from the mock)
   }
 }
 
 @Composable
 private fun ImmortalWorldClockWidget(modifier: Modifier = Modifier) {
+  val context = androidx.compose.ui.platform.LocalContext.current
+  var zones by remember { mutableStateOf(ImmortalSettings.worldClockZones(context)) }
+  val lifecycleOwner = LocalLifecycleOwner.current
+  DisposableEffect(lifecycleOwner) {
+    val obs = LifecycleEventObserver { _, e ->
+      if (e == Lifecycle.Event.ON_RESUME) zones = ImmortalSettings.worldClockZones(context)
+    }
+    lifecycleOwner.lifecycle.addObserver(obs)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+  }
   var now by remember { mutableStateOf(Date()) }
   LaunchedEffect(Unit) {
     while (true) {
@@ -2290,76 +2596,219 @@ private fun ImmortalWorldClockWidget(modifier: Modifier = Modifier) {
       delay(1000)
     }
   }
-  val zones =
-      listOf(
-          "Local" to TimeZone.getDefault().id,
-          "New York" to "America/New_York",
-          "London" to "Europe/London",
-          "Tokyo" to "Asia/Tokyo",
-      )
   ImmortalWidgetShell(title = "World Clock", accent = Color(0xFFFFC857), modifier = modifier) {
-    zones.forEachIndexed { i, (label, zoneId) ->
-      val fmt =
-          remember(zoneId) {
-            SimpleDateFormat("h:mm a", Locale.getDefault()).apply {
-              timeZone = TimeZone.getTimeZone(zoneId)
-            }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+      zones.take(4).forEach { zone ->
+        Column(
+            modifier = Modifier.weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+          AnalogClock(zone, now, Modifier.fillMaxWidth().aspectRatio(1f))
+          Spacer(Modifier.size(6.dp))
+          Text(
+              worldClockLabel(zone),
+              color = Color.White,
+              fontSize = 12.sp,
+              fontWeight = FontWeight.Medium,
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis,
+          )
+          Text(worldClockOffset(zone, now), color = Color(0xFF9A9A9A), fontSize = 10.sp, maxLines = 1)
+        }
+      }
+    }
+  }
+}
+
+/** Short city label from a tz id, e.g. "America/New_York" → "New York". */
+private fun worldClockLabel(zoneId: String): String =
+    zoneId.substringAfterLast('/').replace('_', ' ')
+
+/** Offset of [zoneId] vs the device's zone, e.g. "+5h" / "-3h" / "same". */
+private fun worldClockOffset(zoneId: String, now: Date): String {
+  val local = TimeZone.getDefault().getOffset(now.time)
+  val there = TimeZone.getTimeZone(zoneId).getOffset(now.time)
+  val diffH = (there - local) / 3_600_000
+  return when {
+    diffH == 0 -> "same"
+    diffH > 0 -> "+${diffH}h"
+    else -> "${diffH}h"
+  }
+}
+
+/** A small analog clock face for [zoneId], white by day / dark by night, with an orange seconds hand. */
+@Composable
+private fun AnalogClock(zoneId: String, now: Date, modifier: Modifier = Modifier) {
+  val cal = remember(zoneId) { java.util.Calendar.getInstance(TimeZone.getTimeZone(zoneId)) }
+  cal.time = now
+  val hour = cal.get(java.util.Calendar.HOUR)
+  val minute = cal.get(java.util.Calendar.MINUTE)
+  val second = cal.get(java.util.Calendar.SECOND)
+  val night = cal.get(java.util.Calendar.HOUR_OF_DAY) !in 6..18
+  val face = if (night) Color(0xFF1F1F22) else Color.White
+  val ink = if (night) Color.White else Color(0xFF1A1A1A)
+  val tick = if (night) Color(0x66FFFFFF) else Color(0x55000000)
+  Canvas(modifier) {
+    val r = size.minDimension / 2f
+    val c = Offset(size.width / 2f, size.height / 2f)
+    drawCircle(face, radius = r, center = c)
+    // Hour ticks.
+    for (i in 0 until 12) {
+      val a = Math.toRadians(i * 30.0)
+      val sin = kotlin.math.sin(a).toFloat()
+      val cos = kotlin.math.cos(a).toFloat()
+      drawLine(
+          tick,
+          start = Offset(c.x + sin * r * 0.82f, c.y - cos * r * 0.82f),
+          end = Offset(c.x + sin * r * 0.94f, c.y - cos * r * 0.94f),
+          strokeWidth = r * 0.05f,
+      )
+    }
+    fun hand(angleDeg: Double, length: Float, width: Float, color: Color) {
+      val a = Math.toRadians(angleDeg)
+      drawLine(
+          color,
+          start = c,
+          end = Offset(c.x + (kotlin.math.sin(a) * length).toFloat(), c.y - (kotlin.math.cos(a) * length).toFloat()),
+          strokeWidth = width,
+          cap = StrokeCap.Round,
+      )
+    }
+    hand((hour % 12 + minute / 60.0) * 30.0, r * 0.5f, r * 0.10f, ink)
+    hand((minute + second / 60.0) * 6.0, r * 0.78f, r * 0.07f, ink)
+    hand(second * 6.0, r * 0.85f, r * 0.03f, Color(0xFFFF9500))
+    drawCircle(Color(0xFFFF9500), radius = r * 0.06f, center = c)
+  }
+}
+
+@Composable
+private fun ImmortalTimersWidget(modifier: Modifier = Modifier) {
+  val context = androidx.compose.ui.platform.LocalContext.current
+  var state by remember { mutableStateOf(TimerStore.load(context)) }
+  var nowMs by remember { mutableStateOf(System.currentTimeMillis()) }
+  var showCustom by remember { mutableStateOf(false) }
+  // Live updates if the timer is changed elsewhere (e.g. another Timers widget instance).
+  DisposableEffect(Unit) {
+    val l: () -> Unit = {
+      state = TimerStore.load(context)
+      nowMs = System.currentTimeMillis()
+    }
+    TimerStore.addListener(l)
+    onDispose { TimerStore.removeListener(l) }
+  }
+  // Tick the countdown while it's running. When it hits zero we stop ticking but DON'T clear —
+  // the exact alarm ([TimerAlarmReceiver]) flips the timer to ringing, which the listener picks up.
+  LaunchedEffect(state.running, state.endsAt) {
+    while (state.running) {
+      nowMs = System.currentTimeMillis()
+      if (state.remaining(nowMs) <= 0L) break
+      delay(250)
+    }
+  }
+  val remainingMs = state.remaining(nowMs)
+  val mins = (remainingMs / 60_000).toInt()
+  val secs = ((remainingMs / 1000) % 60).toInt()
+  ImmortalWidgetShell(title = "Timers", accent = Color(0xFFFF9F0A), modifier = modifier) {
+    Text(
+        when {
+          state.ringing -> "Time's up"
+          remainingMs > 0 -> "%d:%02d".format(mins, secs)
+          else -> "Ready"
+        },
+        color = if (state.ringing) Color(0xFFFF9F0A) else Color.White,
+        fontSize = 34.sp,
+        fontWeight = FontWeight.SemiBold,
+    )
+    Spacer(Modifier.size(12.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+      if (state.ringing) {
+        TimerChip("Stop") { TimerAlarm.stop(context) }
+      } else {
+        listOf(5, 10, 30).forEach { minutes ->
+          TimerChip("${minutes}m") { TimerStore.start(context, minutes * 60_000L) }
+        }
+        TimerChip("Custom") { showCustom = true }
+        if (remainingMs > 0) {
+          TimerChip(if (state.running) "Pause" else "Start") {
+            if (state.running) TimerStore.pause(context) else TimerStore.resume(context)
           }
-      Row(
-          modifier = Modifier.fillMaxWidth().padding(top = if (i == 0) 0.dp else 8.dp),
-          verticalAlignment = Alignment.CenterVertically,
+        }
+      }
+    }
+  }
+  if (showCustom) {
+    CustomTimerDialog(
+        onStart = { ms ->
+          if (ms > 0) TimerStore.start(context, ms)
+          showCustom = false
+        },
+        onDismiss = { showCustom = false },
+    )
+  }
+}
+
+/** A keyboard-free duration picker (±steppers, remote/touch friendly) for a custom timer. */
+@Composable
+private fun CustomTimerDialog(onStart: (Long) -> Unit, onDismiss: () -> Unit) {
+  var minutes by remember { mutableStateOf(5) }
+  var seconds by remember { mutableStateOf(0) }
+  androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
+    Surface(color = Color(0xFF1C1C1E), shape = RoundedCornerShape(24.dp)) {
+      Column(
+          modifier = Modifier.padding(28.dp),
+          horizontalAlignment = Alignment.CenterHorizontally,
       ) {
-        Text(label, color = Color(0xFFD7D7D7), fontSize = 14.sp, modifier = Modifier.weight(1f))
-        Text(
-            fmt.format(now),
-            color = Color.White,
-            fontSize = if (i == 0) 24.sp else 17.sp,
-            fontWeight = if (i == 0) FontWeight.SemiBold else FontWeight.Medium,
-        )
+        Text("Custom timer", color = Color.White, fontSize = 22.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.size(24.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(18.dp),
+        ) {
+          DurationStepper("min", minutes, step = 1) { minutes = (minutes + it).coerceIn(0, 180) }
+          Text(":", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.Light)
+          DurationStepper("sec", seconds, step = 5) { seconds = (seconds + it + 60) % 60 }
+        }
+        Spacer(Modifier.size(28.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+          TimerChip("Cancel") { onDismiss() }
+          TimerChip("Start ${minutes}:%02d".format(seconds)) {
+            onStart((minutes * 60 + seconds) * 1000L)
+          }
+        }
       }
     }
   }
 }
 
 @Composable
-private fun ImmortalTimersWidget(widgetKey: String, modifier: Modifier = Modifier) {
-  var remainingMs by remember(widgetKey) { mutableStateOf(0L) }
-  var running by remember(widgetKey) { mutableStateOf(false) }
-  var endsAt by remember(widgetKey) { mutableStateOf(0L) }
-  LaunchedEffect(running, endsAt) {
-    while (running) {
-      remainingMs = (endsAt - System.currentTimeMillis()).coerceAtLeast(0L)
-      if (remainingMs == 0L) running = false
-      delay(250)
+private fun DurationStepper(label: String, value: Int, step: Int, onChange: (Int) -> Unit) {
+  Column(horizontalAlignment = Alignment.CenterHorizontally) {
+    Text(label.uppercase(Locale.getDefault()), color = Color(0xFF9A9A9A), fontSize = 11.sp, fontWeight = FontWeight.Bold)
+    Spacer(Modifier.size(8.dp))
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      StepButton("−") { onChange(-step) }
+      Text("%02d".format(value), color = Color.White, fontSize = 30.sp, fontWeight = FontWeight.SemiBold)
+      StepButton("+") { onChange(step) }
     }
   }
-  fun start(minutes: Int) {
-    remainingMs = minutes * 60_000L
-    endsAt = System.currentTimeMillis() + remainingMs
-    running = true
-  }
-  val mins = (remainingMs / 60_000).toInt()
-  val secs = ((remainingMs / 1000) % 60).toInt()
-  ImmortalWidgetShell(title = "Timers", accent = Color(0xFFFF9F0A), modifier = modifier) {
-    Text(
-        if (remainingMs > 0) "%d:%02d".format(mins, secs) else "Ready",
-        color = Color.White,
-        fontSize = 34.sp,
-        fontWeight = FontWeight.SemiBold,
-    )
-    Spacer(Modifier.size(12.dp))
-    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-      listOf(5, 10, 30).forEach { minutes ->
-        TimerChip("${minutes}m") { start(minutes) }
-      }
-      if (remainingMs > 0) TimerChip(if (running) "Pause" else "Start") {
-        if (running) {
-          running = false
-        } else {
-          endsAt = System.currentTimeMillis() + remainingMs
-          running = true
-        }
-      }
+}
+
+@Composable
+private fun StepButton(label: String, onClick: () -> Unit) {
+  Surface(
+      color = Color(0x22FFFFFF),
+      shape = CircleShape,
+      modifier = Modifier.size(44.dp).tvFocusable(CircleShape) { onClick() },
+  ) {
+    Box(contentAlignment = Alignment.Center) {
+      Text(label, color = Color.White, fontSize = 26.sp, fontWeight = FontWeight.Light)
     }
   }
 }
@@ -2557,6 +3006,129 @@ private fun WidgetGlyph() {
   }
 }
 
+/**
+ * iOS-style "jiggle": a gentle continuous wobble applied to editable tiles while Manage mode is on.
+ * Each tile is given a [seed] so they fall slightly out of phase (rather than wobbling in lockstep).
+ * The animation only exists while [enabled]; it leaves composition when Manage mode ends so the
+ * long-lived launcher isn't animating in the background.
+ */
+@Composable
+private fun Modifier.jiggle(enabled: Boolean, seed: Int): Modifier {
+  if (!enabled) return this
+  val transition = rememberInfiniteTransition(label = "jiggle")
+  val phase = (abs(seed) % 6) * 28
+  val angle by
+      transition.animateFloat(
+          initialValue = -2.0f,
+          targetValue = 2.0f,
+          animationSpec =
+              infiniteRepeatable(
+                  animation = tween(durationMillis = 170, easing = LinearEasing),
+                  repeatMode = RepeatMode.Reverse,
+                  initialStartOffset = StartOffset(phase),
+              ),
+          label = "jiggle-angle",
+      )
+  val bob by
+      transition.animateFloat(
+          initialValue = -1.4f,
+          targetValue = 1.4f,
+          animationSpec =
+              infiniteRepeatable(
+                  animation = tween(durationMillis = 230, easing = LinearEasing),
+                  repeatMode = RepeatMode.Reverse,
+                  initialStartOffset = StartOffset(phase + 60),
+              ),
+          label = "jiggle-bob",
+      )
+  return this.graphicsLayer {
+    rotationZ = angle
+    translationY = bob
+  }
+}
+
+/**
+ * Round red delete affordance with a crisply-drawn, perfectly-centered ✕ (the unicode glyph
+ * isn't vertically centered inside its line box, so it's drawn as two crossing strokes instead).
+ */
+@Composable
+private fun RemoveBadge(size: Dp, modifier: Modifier = Modifier, onClick: () -> Unit) {
+  Surface(
+      color = Color(0xFFE53935),
+      shape = CircleShape,
+      modifier = modifier.size(size).tvFocusable(CircleShape) { onClick() },
+  ) {
+    Canvas(Modifier.fillMaxSize()) {
+      val cx = this.size.width / 2f
+      val cy = this.size.height / 2f
+      val arm = this.size.minDimension * 0.21f
+      val stroke = this.size.minDimension * 0.11f
+      drawLine(
+          Color.White,
+          Offset(cx - arm, cy - arm),
+          Offset(cx + arm, cy + arm),
+          strokeWidth = stroke,
+          cap = StrokeCap.Round,
+      )
+      drawLine(
+          Color.White,
+          Offset(cx - arm, cy + arm),
+          Offset(cx + arm, cy - arm),
+          strokeWidth = stroke,
+          cap = StrokeCap.Round,
+      )
+    }
+  }
+}
+
+/**
+ * Wraps a tile whose own content does NOT swallow touches (built-ins, folders, apps) with a
+ * dragged-dim. The drag itself is handled by the stable container detector that wraps the pager, so
+ * the gesture survives a page flip (letting a tile be dragged onto another page). Hosted widgets
+ * still use their own in-page scrim handle (see [WidgetCell]), since their AndroidView swallows it.
+ */
+@Composable
+private fun HomeTileFrame(
+    modifier: Modifier,
+    dragged: Boolean,
+    content: @Composable () -> Unit,
+) {
+  Box(modifier = modifier.fillMaxWidth().alpha(if (dragged) 0f else 1f)) { content() }
+}
+
+/** Widget tile + the ✕ remove badge in edit mode. Drag is handled by the stable container detector
+ * (which grabs widgets via the pointer Initial pass), so widgets drag and move across pages like
+ * apps. Widgets are not user-resizable — they keep the size their provider declares. */
+@Composable
+private fun WidgetCell(
+    widget: HomeWidgetStore.HomeWidget,
+    host: AppWidgetHost,
+    manager: AppWidgetManager,
+    editMode: Boolean,
+    tileDp: Dp,
+    dimmed: Boolean,
+    modifier: Modifier,
+    onRemove: () -> Unit,
+) {
+  Box(modifier = modifier) {
+    WidgetTile(
+        widget = widget,
+        host = host,
+        manager = manager,
+        editMode = editMode,
+        tileDp = tileDp,
+        dimmed = dimmed,
+    )
+    if (editMode) {
+      RemoveBadge(
+          size = 30.dp,
+          modifier = Modifier.align(Alignment.TopEnd).offset(x = 7.dp, y = (-7).dp),
+          onClick = onRemove,
+      )
+    }
+  }
+}
+
 @Composable
 private fun AppTile(
     app: AppEntry,
@@ -2564,18 +3136,24 @@ private fun AppTile(
     modifier: Modifier = Modifier,
     dimmed: Boolean = false,
     onDelete: () -> Unit = {},
+    onLongPress: (() -> Unit)? = null,
     onClick: () -> Unit,
 ) {
   Column(
       horizontalAlignment = Alignment.CenterHorizontally,
-      // In Manage mode the body tap is inert (drag to fold, ✕ to remove); the
-      // icon launches normally otherwise.
+      // In Manage mode the body tap is inert (drag to reorder, ✕ to remove); the
+      // icon launches normally otherwise. A long-press enters Manage mode (iOS-style).
       modifier =
-          modifier.padding(4.dp).tvFocusable(RoundedCornerShape(22.dp), enabled = !editMode) {
+          modifier.fillMaxWidth().padding(4.dp).tvFocusable(
+              RoundedCornerShape(22.dp),
+              enabled = !editMode,
+              onLongClick = onLongPress,
+          ) {
             onClick()
           },
   ) {
-    Box {
+    // The icon (and its delete badge) jiggle as a unit in Manage mode; the label stays still.
+    Box(modifier = Modifier.jiggle(editMode && !dimmed, app.component.packageName.hashCode())) {
       Image(
           bitmap = app.icon,
           contentDescription = app.label,
@@ -2585,15 +3163,12 @@ private fun AppTile(
                   .alpha(if (dimmed) 0.3f else 1f),
       )
       if (editMode) {
-        Surface(
-            color = Color(0xFFE53935),
-            shape = androidx.compose.foundation.shape.CircleShape,
-            modifier = Modifier.size(30.dp).align(Alignment.TopEnd).clickable { onDelete() },
-        ) {
-          Box(contentAlignment = Alignment.Center) {
-            Text("✕", color = Color.White, fontSize = 18.sp)
-          }
-        }
+        // Sits at the icon's outer top-right corner (nudged off the icon, iOS-style).
+        RemoveBadge(
+            size = 26.dp,
+            modifier = Modifier.align(Alignment.TopEnd).offset(x = 9.dp, y = (-9).dp),
+            onClick = onDelete,
+        )
       }
     }
     Spacer(Modifier.size(8.dp))

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -7,6 +7,10 @@
 
 package com.immortal.launcher
 
+import android.app.Activity
+import android.appwidget.AppWidgetHost
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProviderInfo
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -14,7 +18,9 @@ import android.graphics.Bitmap
 import android.net.Uri
 import android.os.BatteryManager
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.MotionEvent
+import android.view.ViewGroup
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
@@ -43,6 +49,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -50,6 +57,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -102,6 +110,7 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import kotlin.math.roundToInt
@@ -127,10 +136,25 @@ private data class AppEntry(
     val folder: String? = null,
 )
 
+private data class WidgetProviderEntry(
+    val label: String,
+    val packageLabel: String,
+    val icon: ImageBitmap?,
+    val info: AppWidgetProviderInfo,
+    val spanX: Int,
+    val spanY: Int,
+)
+
+private data class PendingWidgetAdd(
+    val appWidgetId: Int,
+    val provider: WidgetProviderEntry,
+)
+
 /** Calls→stock-home bridge: how many system Back presses reach Meta's launcher, and the gap
  *  between them (verified on the Portal TV — 5 presses lands on the stock launcher's Apps tab). */
 private const val STOCK_HOME_BACK_PRESSES = 5
 private const val STOCK_HOME_BACK_INTERVAL_MS = 300L
+private const val HOME_APP_WIDGET_HOST_ID = 0x4611
 
 /**
  * The custom Portal home launcher. Replaces the stock Aloha home (selected via
@@ -335,6 +359,9 @@ private fun LauncherScreen(
       }
   var editMode by remember { mutableStateOf(false) }
   var openFolder by remember { mutableStateOf<String?>(null) }
+  var showWidgetPicker by remember { mutableStateOf(false) }
+  var widgetStatus by remember { mutableStateOf<String?>(null) }
+  var widgets by remember { mutableStateOf(HomeWidgetStore.load(context)) }
 
   // Immortal Settings the home screen reflects (tile size, and the optional weather
   // widget's mode/unit), re-read on resume so a change applies the moment the user
@@ -343,6 +370,14 @@ private fun LauncherScreen(
   var weatherWidget by remember { mutableStateOf(ImmortalSettings.load(context).weatherWidget) }
   var weatherFahrenheit by remember { mutableStateOf(ImmortalSettings.useFahrenheit(context)) }
   val lifecycleOwner = LocalLifecycleOwner.current
+  val appWidgetManager = remember(context) { AppWidgetManager.getInstance(context) }
+  val appWidgetHost = remember(context) { AppWidgetHost(context, HOME_APP_WIDGET_HOST_ID) }
+  fun loadLiveWidgets(): List<HomeWidgetStore.HomeWidget> {
+    val loaded = HomeWidgetStore.load(context)
+    val live = loaded.filterLiveWidgets(appWidgetManager, appWidgetHost)
+    if (live.size != loaded.size) HomeWidgetStore.save(context, live)
+    return live
+  }
   DisposableEffect(lifecycleOwner) {
     val obs = LifecycleEventObserver { _, e ->
       if (e == Lifecycle.Event.ON_RESUME) {
@@ -350,10 +385,141 @@ private fun LauncherScreen(
         tileSize = s.tileSize
         weatherWidget = s.weatherWidget
         weatherFahrenheit = ImmortalSettings.useFahrenheit(context)
+        widgets = loadLiveWidgets()
       }
     }
     lifecycleOwner.lifecycle.addObserver(obs)
     onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+  }
+  DisposableEffect(lifecycleOwner, appWidgetHost) {
+    val obs = LifecycleEventObserver { _, e ->
+      when (e) {
+        Lifecycle.Event.ON_START -> runCatching { appWidgetHost.startListening() }
+        Lifecycle.Event.ON_STOP -> runCatching { appWidgetHost.stopListening() }
+        else -> Unit
+      }
+    }
+    lifecycleOwner.lifecycle.addObserver(obs)
+    runCatching { appWidgetHost.startListening() }
+    val live = widgets.filterLiveWidgets(appWidgetManager, appWidgetHost)
+    if (live.size != widgets.size) HomeWidgetStore.save(context, live)
+    widgets = live
+    onDispose {
+      lifecycleOwner.lifecycle.removeObserver(obs)
+      runCatching { appWidgetHost.stopListening() }
+    }
+  }
+
+  fun saveWidgets(next: List<HomeWidgetStore.HomeWidget>) {
+    widgets = next
+    HomeWidgetStore.save(context, next)
+  }
+
+  fun removeWidget(appWidgetId: Int) {
+    runCatching { appWidgetHost.deleteAppWidgetId(appWidgetId) }
+    saveWidgets(HomeWidgetStore.without(widgets, appWidgetId))
+    widgetStatus = "Widget removed"
+  }
+
+  fun commitWidget(pending: PendingWidgetAdd) {
+    val provider = pending.provider
+    val record =
+        HomeWidgetStore.HomeWidget(
+            appWidgetId = pending.appWidgetId,
+            providerPackage = provider.info.provider.packageName,
+            providerClass = provider.info.provider.className,
+            spanX = provider.spanX,
+            spanY = provider.spanY,
+        )
+    updateWidgetSizeOptions(appWidgetManager, record, tileDpFor(tileSize))
+    saveWidgets(HomeWidgetStore.withAdded(widgets, record))
+    showWidgetPicker = false
+    widgetStatus = "Added ${provider.label}"
+  }
+
+  var pendingBind by remember { mutableStateOf<PendingWidgetAdd?>(null) }
+  var pendingConfig by remember { mutableStateOf<PendingWidgetAdd?>(null) }
+  val configLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        val pending = pendingConfig ?: return@rememberLauncherForActivityResult
+        pendingConfig = null
+        if (result.resultCode == Activity.RESULT_OK) {
+          commitWidget(pending)
+        } else {
+          runCatching { appWidgetHost.deleteAppWidgetId(pending.appWidgetId) }
+          widgetStatus = "Widget setup was cancelled"
+        }
+      }
+
+  fun configureOrCommit(pending: PendingWidgetAdd) {
+    val configure = pending.provider.info.configure
+    if (configure != null) {
+      pendingConfig = pending
+      val launched =
+          runCatching {
+                configLauncher.launch(
+                    Intent(AppWidgetManager.ACTION_APPWIDGET_CONFIGURE)
+                        .setComponent(configure)
+                        .putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, pending.appWidgetId))
+                true
+              }
+              .getOrDefault(false)
+      if (!launched) {
+        pendingConfig = null
+        runCatching { appWidgetHost.deleteAppWidgetId(pending.appWidgetId) }
+        widgetStatus = "Widget setup could not open"
+      }
+    } else {
+      commitWidget(pending)
+    }
+  }
+
+  val bindLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        val pending = pendingBind ?: return@rememberLauncherForActivityResult
+        pendingBind = null
+        if (result.resultCode == Activity.RESULT_OK) {
+          configureOrCommit(pending)
+        } else {
+          runCatching { appWidgetHost.deleteAppWidgetId(pending.appWidgetId) }
+          widgetStatus = "Widget permission was cancelled"
+        }
+      }
+
+  fun addWidget(provider: WidgetProviderEntry) {
+    val appWidgetId =
+        runCatching { appWidgetHost.allocateAppWidgetId() }
+            .getOrElse {
+              widgetStatus = "Widget host could not allocate an ID"
+              return
+            }
+    val pending = PendingWidgetAdd(appWidgetId, provider)
+    val bound =
+        runCatching {
+              appWidgetManager.bindAppWidgetIdIfAllowed(appWidgetId, provider.info.provider)
+            }
+            .getOrDefault(false)
+    if (bound) {
+      configureOrCommit(pending)
+      return
+    }
+
+    pendingBind = pending
+    widgetStatus = "Allow Immortal to add widgets in the system dialog."
+    val launched =
+        runCatching {
+              bindLauncher.launch(
+                  Intent(AppWidgetManager.ACTION_APPWIDGET_BIND)
+                      .putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+                      .putExtra(AppWidgetManager.EXTRA_APPWIDGET_PROVIDER, provider.info.provider))
+              true
+            }
+            .getOrDefault(false)
+    if (!launched) {
+      pendingBind = null
+      runCatching { appWidgetHost.deleteAppWidgetId(appWidgetId) }
+      widgetStatus = "Android's widget permission dialog could not open"
+    }
   }
 
   // Remote support: land focus on the grid at startup so the D-pad works on the TV.
@@ -532,8 +698,9 @@ private fun LauncherScreen(
                     )
                   },
       ) {
+        val gridColumns = gridColumnsFor(tileSize)
         LazyVerticalGrid(
-            columns = GridCells.Fixed(gridColumnsFor(tileSize)),
+            columns = GridCells.Fixed(gridColumns),
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
             modifier = Modifier.focusRequester(homeGridFocus).focusGroup(),
@@ -542,6 +709,21 @@ private fun LauncherScreen(
           // only regular apps get a delete badge and become draggable.
           item { PortalHomeTile(onExitHome) }
           item { StoreTile(onOpenStore) }
+          item { WidgetsTile { showWidgetPicker = true } }
+          items(
+              widgets,
+              key = { "widget:${it.appWidgetId}" },
+              span = { GridItemSpan(it.spanX.coerceIn(1, gridColumns)) },
+          ) { widget ->
+            WidgetTile(
+                widget = widget,
+                host = appWidgetHost,
+                manager = appWidgetManager,
+                editMode = editMode,
+                tileDp = LocalTileDp.current,
+                onRemove = { removeWidget(widget.appWidgetId) },
+            )
+          }
           items(folderNames, key = { it }) { name ->
             FolderTile(
                 name = name,
@@ -689,6 +871,22 @@ private fun LauncherScreen(
           onCancel = { renaming = null },
       )
     }
+
+    if (showWidgetPicker) {
+      val providers by
+          produceState(initialValue = emptyList<WidgetProviderEntry>(), reload, tileSize) {
+            value = withContext(Dispatchers.IO) { loadWidgetProviders(context, tileDpFor(tileSize)) }
+          }
+      WidgetPickerOverlay(
+          providers = providers,
+          status = widgetStatus,
+          onPick = { addWidget(it) },
+          onDismiss = {
+            showWidgetPicker = false
+            widgetStatus = null
+          },
+      )
+    }
   }
   } // CompositionLocalProvider(LocalTileDp)
 }
@@ -718,6 +916,12 @@ private fun gridColumnsFor(size: String): Int =
       ImmortalSettings.SIZE_LARGE -> 5
       else -> 6
     }
+
+private fun estimateWidgetSpan(minDp: Int, tileDp: Dp): Int {
+  if (minDp <= 0) return HomeWidgetStore.DEFAULT_SPAN_X
+  val tile = tileDp.value.coerceAtLeast(1f)
+  return HomeWidgetStore.normalizeSpan(((minDp + tile - 1f) / tile).toInt().coerceAtLeast(1))
+}
 
 @Composable
 private fun HeaderBar(onScreensaver: () -> Unit) {
@@ -1391,6 +1595,8 @@ private const val ICON_REFRESH =
     "M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
 private const val ICON_IMAGE =
     "M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"
+private const val ICON_WIDGETS =
+    "M3 3h8v8H3V3zm10 0h8v5h-8V3zM3 13h5v8H3v-8zm7 0h11v8H10v-8z"
 private const val ICON_HELP =
     "M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
 private const val ICON_GEAR =
@@ -1758,6 +1964,267 @@ private fun StoreTile(onClick: () -> Unit) {
 }
 
 @Composable
+private fun WidgetsTile(onClick: () -> Unit) {
+  BuiltInTile(
+      label = "Widgets",
+      background = Color(0xFF5B6BC0),
+      glyph = ICON_WIDGETS,
+      onClick = onClick,
+  )
+}
+
+@Composable
+private fun WidgetTile(
+    widget: HomeWidgetStore.HomeWidget,
+    host: AppWidgetHost,
+    manager: AppWidgetManager,
+    editMode: Boolean,
+    tileDp: Dp,
+    onRemove: () -> Unit,
+) {
+  val info = remember(widget.appWidgetId) { manager.getAppWidgetInfo(widget.appWidgetId) }
+  val height =
+      tileDp * widget.spanY.toFloat() +
+          20.dp * (widget.spanY - 1).coerceAtLeast(0).toFloat()
+
+  LaunchedEffect(widget, tileDp) {
+    updateWidgetSizeOptions(manager, widget, tileDp)
+  }
+
+  Box(modifier = Modifier.fillMaxWidth().height(height).padding(4.dp)) {
+    Surface(
+        color = Color(0xFF252527),
+        shape = RoundedCornerShape(20.dp),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+      if (info != null) {
+        AndroidView(
+            factory = {
+              host.createView(it, widget.appWidgetId, info).apply {
+                setAppWidget(widget.appWidgetId, info)
+                setPadding(0, 0, 0, 0)
+                isFocusable = true
+                isFocusableInTouchMode = true
+                descendantFocusability = ViewGroup.FOCUS_AFTER_DESCENDANTS
+              }
+            },
+            update = { view ->
+              view.setAppWidget(widget.appWidgetId, info)
+              view.isEnabled = !editMode
+            },
+            modifier = Modifier.fillMaxSize(),
+        )
+      } else {
+        Box(
+            Modifier.fillMaxSize().background(Color(0xFF303033)),
+            contentAlignment = Alignment.Center,
+        ) {
+          Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            WidgetGlyph()
+            Text(
+                "Widget unavailable",
+                color = Color.White,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(top = 10.dp),
+            )
+            Text(
+                widget.providerPackage,
+                color = Color(0xFF9A9A9A),
+                fontSize = 13.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(top = 2.dp, start = 18.dp, end = 18.dp),
+            )
+          }
+        }
+      }
+    }
+    if (editMode) {
+      Box(Modifier.fillMaxSize().clip(RoundedCornerShape(20.dp)).background(Color(0x66000000)))
+      Surface(
+          color = Color(0xFFE53935),
+          shape = CircleShape,
+          modifier =
+              Modifier.size(34.dp).align(Alignment.TopEnd).tvFocusable(CircleShape) { onRemove() },
+      ) {
+        Box(contentAlignment = Alignment.Center) {
+          Text("✕", color = Color.White, fontSize = 18.sp, fontWeight = FontWeight.Bold)
+        }
+      }
+      Surface(
+          color = Color(0xCC111111),
+          shape = RoundedCornerShape(10.dp),
+          modifier = Modifier.align(Alignment.BottomStart).padding(10.dp),
+      ) {
+        Text(
+            "Widget",
+            color = Color.White,
+            fontSize = 13.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun WidgetPickerOverlay(
+    providers: List<WidgetProviderEntry>,
+    status: String?,
+    onPick: (WidgetProviderEntry) -> Unit,
+    onDismiss: () -> Unit,
+) {
+  val noRipple = remember { MutableInteractionSource() }
+  BackHandler { onDismiss() }
+  val gridFocus = remember { FocusRequester() }
+  LaunchedEffect(providers) { runCatching { gridFocus.requestFocus() } }
+
+  Box(
+      contentAlignment = Alignment.Center,
+      modifier =
+          Modifier.fillMaxSize()
+              .onPreviewKeyEvent { e ->
+                if (e.key == Key.Back || e.key == Key.Escape) {
+                  if (e.type == KeyEventType.KeyUp) onDismiss()
+                  true
+                } else false
+              }
+              .background(Color(0xDD000000))
+              .clickable(interactionSource = noRipple, indication = null) { onDismiss() },
+  ) {
+    Surface(
+        color = Color(0xFF1C1C1E),
+        shape = RoundedCornerShape(28.dp),
+        modifier =
+            Modifier.widthIn(max = 920.dp)
+                .fillMaxWidth(0.78f)
+                .heightIn(max = 620.dp)
+                .clickable(interactionSource = noRipple, indication = null) {},
+    ) {
+      Column(modifier = Modifier.padding(28.dp)) {
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+          Column(modifier = Modifier.weight(1f)) {
+            Text("Add widget", color = Color.White, fontSize = 28.sp, fontWeight = FontWeight.SemiBold)
+            Text(
+                "Choose a widget provider installed on this Portal.",
+                color = Color(0xFF9A9A9A),
+                fontSize = 14.sp,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+          }
+          Surface(
+              color = Color(0x33FFFFFF),
+              shape = CircleShape,
+              modifier = Modifier.size(44.dp).tvFocusable(CircleShape) { onDismiss() },
+          ) {
+            Box(contentAlignment = Alignment.Center) { Text("✕", color = Color.White, fontSize = 20.sp) }
+          }
+        }
+        if (status != null) {
+          Text(
+              status,
+              color = Color(0xFF8AB4F8),
+              fontSize = 13.sp,
+              modifier = Modifier.padding(top = 14.dp),
+          )
+        }
+        Spacer(Modifier.size(20.dp))
+        if (providers.isEmpty()) {
+          Box(
+              modifier = Modifier.fillMaxWidth().height(220.dp),
+              contentAlignment = Alignment.Center,
+          ) {
+            Text(
+                "No widget providers are installed.",
+                color = Color(0xFFB8B8B8),
+                fontSize = 16.sp,
+            )
+          }
+        } else {
+          LazyVerticalGrid(
+              columns = GridCells.Fixed(3),
+              horizontalArrangement = Arrangement.spacedBy(14.dp),
+              verticalArrangement = Arrangement.spacedBy(14.dp),
+              modifier = Modifier.focusRequester(gridFocus).focusGroup(),
+          ) {
+            items(providers, key = { it.info.provider.flattenToString() }) { provider ->
+              WidgetProviderTile(provider = provider, onClick = { onPick(provider) })
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun WidgetProviderTile(provider: WidgetProviderEntry, onClick: () -> Unit) {
+  Surface(
+      color = Color(0xFF29292C),
+      shape = RoundedCornerShape(18.dp),
+      modifier = Modifier.tvFocusable(RoundedCornerShape(18.dp)) { onClick() },
+  ) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Surface(
+          color = Color(0xFF38383C),
+          shape = RoundedCornerShape(14.dp),
+          modifier = Modifier.size(58.dp),
+      ) {
+        Box(contentAlignment = Alignment.Center) {
+          if (provider.icon != null) {
+            Image(
+                bitmap = provider.icon,
+                contentDescription = null,
+                modifier = Modifier.size(42.dp).clip(RoundedCornerShape(10.dp)),
+            )
+          } else {
+            WidgetGlyph()
+          }
+        }
+      }
+      Column(modifier = Modifier.padding(start = 14.dp).weight(1f)) {
+        Text(
+            provider.label,
+            color = Color.White,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            provider.packageLabel,
+            color = Color(0xFF9A9A9A),
+            fontSize = 12.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(top = 3.dp),
+        )
+        Text(
+            "${provider.spanX} x ${provider.spanY}",
+            color = Color(0xFF7C7C7C),
+            fontSize = 11.sp,
+            modifier = Modifier.padding(top = 5.dp),
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun WidgetGlyph() {
+  val path = remember { PathParser().parsePathString(ICON_WIDGETS).toPath() }
+  Canvas(Modifier.size(28.dp)) {
+    val s = size.minDimension / 24f
+    scale(s, s, pivot = Offset.Zero) { drawPath(path, Color.White) }
+  }
+}
+
+@Composable
 private fun AppTile(
     app: AppEntry,
     editMode: Boolean,
@@ -1841,3 +2308,84 @@ private fun loadApps(context: Context): List<AppEntry> {
       .sortedBy { it.label.lowercase(Locale.getDefault()) }
 }
 
+private fun loadWidgetProviders(context: Context, tileDp: Dp): List<WidgetProviderEntry> {
+  val pm = context.packageManager
+  val density = context.resources.displayMetrics.densityDpi
+  return AppWidgetManager.getInstance(context)
+      .installedProviders
+      .mapNotNull { info ->
+        runCatching {
+              val packageLabel =
+                  pm.getApplicationLabel(pm.getApplicationInfo(info.provider.packageName, 0))
+                      .toString()
+              val icon =
+                  runCatching { info.loadIcon(context, density) }
+                      .getOrNull()
+                      ?: runCatching { pm.getApplicationIcon(info.provider.packageName) }.getOrNull()
+              val iconBitmap = icon?.toBitmap(96, 96)?.asImageBitmap()
+              WidgetProviderEntry(
+                  label = info.loadLabel(pm).toString().ifBlank { packageLabel },
+                  packageLabel = packageLabel,
+                  icon = iconBitmap,
+                  info = info,
+                  spanX =
+                      estimateWidgetSpan(appWidgetMinDp(context, info.minWidth), tileDp)
+                          .coerceAtLeast(HomeWidgetStore.DEFAULT_SPAN_X),
+                  spanY =
+                      estimateWidgetSpan(appWidgetMinDp(context, info.minHeight), tileDp)
+                          .coerceAtLeast(HomeWidgetStore.DEFAULT_SPAN_Y),
+              )
+            }
+            .getOrNull()
+      }
+      .sortedWith(
+          compareBy(
+              { it.packageLabel.lowercase(Locale.getDefault()) },
+              { it.label.lowercase(Locale.getDefault()) }))
+}
+
+private fun List<HomeWidgetStore.HomeWidget>.filterLiveWidgets(
+    manager: AppWidgetManager,
+    host: AppWidgetHost,
+): List<HomeWidgetStore.HomeWidget> {
+  val live = filter { manager.getAppWidgetInfo(it.appWidgetId) != null }
+  if (live.size != size) {
+    val liveIds = live.map { it.appWidgetId }.toSet()
+    filterNot { it.appWidgetId in liveIds }.forEach {
+      runCatching { host.deleteAppWidgetId(it.appWidgetId) }
+    }
+  }
+  return live
+}
+
+private fun updateWidgetSizeOptions(
+    manager: AppWidgetManager,
+    widget: HomeWidgetStore.HomeWidget,
+    tileDp: Dp,
+) {
+  val width =
+      (tileDp.value * widget.spanX + 16f * (widget.spanX - 1).coerceAtLeast(0)).roundToInt()
+  val height =
+      (tileDp.value * widget.spanY + 20f * (widget.spanY - 1).coerceAtLeast(0)).roundToInt()
+  runCatching {
+    manager.updateAppWidgetOptions(
+        widget.appWidgetId,
+        Bundle().apply {
+          putInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, width)
+          putInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH, width)
+          putInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, height)
+          putInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, height)
+        })
+  }
+}
+
+private fun appWidgetMinDp(context: Context, raw: Int): Int {
+  if (raw <= 0) return 0
+  // Android 9/10 on Portal reports AppWidgetProviderInfo sizes as raw complex
+  // dimension values (for example, 10241 == 40dp). Newer framework builds may
+  // already hand back dp integers, so only decode values that are clearly not
+  // plain dp sizes.
+  if (raw < 1000) return raw
+  val metrics = context.resources.displayMetrics
+  return (TypedValue.complexToDimensionPixelSize(raw, metrics) / metrics.density).roundToInt()
+}

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -41,9 +41,11 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -113,6 +115,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import kotlin.math.abs
 import kotlin.math.roundToInt
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.WindowCompat
@@ -124,6 +127,7 @@ import java.net.URL
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -140,9 +144,10 @@ private data class WidgetProviderEntry(
     val label: String,
     val packageLabel: String,
     val icon: ImageBitmap?,
-    val info: AppWidgetProviderInfo,
+    val info: AppWidgetProviderInfo?,
     val spanX: Int,
     val spanY: Int,
+    val customKind: String? = null,
 )
 
 private data class PendingWidgetAdd(
@@ -415,19 +420,37 @@ private fun LauncherScreen(
     HomeWidgetStore.save(context, next)
   }
 
-  fun removeWidget(appWidgetId: Int) {
-    runCatching { appWidgetHost.deleteAppWidgetId(appWidgetId) }
-    saveWidgets(HomeWidgetStore.without(widgets, appWidgetId))
+  fun removeWidget(widget: HomeWidgetStore.HomeWidget) {
+    if (widget.isAppWidget) runCatching { appWidgetHost.deleteAppWidgetId(widget.appWidgetId) }
+    saveWidgets(HomeWidgetStore.without(widgets, widget.key))
     widgetStatus = "Widget removed"
+  }
+
+  fun resizeWidget(widget: HomeWidgetStore.HomeWidget, spanX: Int, spanY: Int) {
+    val resized = widget.copy(spanX = spanX, spanY = spanY)
+    if (resized.isAppWidget) updateWidgetSizeOptions(appWidgetManager, resized, tileDpFor(tileSize))
+    saveWidgets(HomeWidgetStore.resized(widgets, widget.key, spanX, spanY))
+  }
+
+  fun addCustomWidget(kind: String) {
+    val widget =
+        when (kind) {
+          HomeWidgetStore.KIND_TIMERS -> HomeWidgetStore.custom(kind, spanX = 2, spanY = 2)
+          else -> HomeWidgetStore.custom(kind, spanX = 2, spanY = 2)
+        }
+    saveWidgets(HomeWidgetStore.withAdded(widgets, widget))
+    showWidgetPicker = false
+    widgetStatus = "Added ${customWidgetLabel(kind)}"
   }
 
   fun commitWidget(pending: PendingWidgetAdd) {
     val provider = pending.provider
+    val info = provider.info ?: return
     val record =
         HomeWidgetStore.HomeWidget(
             appWidgetId = pending.appWidgetId,
-            providerPackage = provider.info.provider.packageName,
-            providerClass = provider.info.provider.className,
+            providerPackage = info.provider.packageName,
+            providerClass = info.provider.className,
             spanX = provider.spanX,
             spanY = provider.spanY,
         )
@@ -452,7 +475,8 @@ private fun LauncherScreen(
       }
 
   fun configureOrCommit(pending: PendingWidgetAdd) {
-    val configure = pending.provider.info.configure
+    val info = pending.provider.info ?: return
+    val configure = info.configure
     if (configure != null) {
       pendingConfig = pending
       val launched =
@@ -487,6 +511,11 @@ private fun LauncherScreen(
       }
 
   fun addWidget(provider: WidgetProviderEntry) {
+    provider.customKind?.let {
+      addCustomWidget(it)
+      return
+    }
+    val info = provider.info ?: return
     val appWidgetId =
         runCatching { appWidgetHost.allocateAppWidgetId() }
             .getOrElse {
@@ -496,7 +525,7 @@ private fun LauncherScreen(
     val pending = PendingWidgetAdd(appWidgetId, provider)
     val bound =
         runCatching {
-              appWidgetManager.bindAppWidgetIdIfAllowed(appWidgetId, provider.info.provider)
+              appWidgetManager.bindAppWidgetIdIfAllowed(appWidgetId, info.provider)
             }
             .getOrDefault(false)
     if (bound) {
@@ -511,7 +540,7 @@ private fun LauncherScreen(
               bindLauncher.launch(
                   Intent(AppWidgetManager.ACTION_APPWIDGET_BIND)
                       .putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-                      .putExtra(AppWidgetManager.EXTRA_APPWIDGET_PROVIDER, provider.info.provider))
+                      .putExtra(AppWidgetManager.EXTRA_APPWIDGET_PROVIDER, info.provider))
               true
             }
             .getOrDefault(false)
@@ -532,6 +561,7 @@ private fun LauncherScreen(
   // folder), so it beats a curated default too.
   val assignments = remember { mutableStateMapOf<String, String>() }
   LaunchedEffect(Unit) { assignments.putAll(UserLayout.load(context)) }
+  var appOrder by remember { mutableStateOf(UserLayout.loadOrder(context)) }
   val appsEff =
       remember(apps, assignments.toMap()) {
         apps.map { a ->
@@ -541,6 +571,18 @@ private fun LauncherScreen(
         }
       }
   val ungrouped = remember(appsEff) { appsEff.filter { it.folder == null } }
+  LaunchedEffect(ungrouped) {
+    val ids = ungrouped.map { it.component.packageName }
+    val normalized = (appOrder.filter { it in ids } + ids.filter { it !in appOrder }).distinct()
+    if (normalized != appOrder) {
+      appOrder = normalized
+      UserLayout.saveOrder(context, normalized)
+    }
+  }
+  val orderedUngrouped =
+      remember(ungrouped, appOrder) {
+        UserLayout.applyOrder(ungrouped, appOrder) { it.component.packageName }
+      }
   val folderNames = remember(appsEff) { appsEff.mapNotNull { it.folder }.distinct().sorted() }
 
   // --- drag-and-drop folder management (Manage mode) --------------------------
@@ -548,6 +590,7 @@ private fun LauncherScreen(
   var containerOrigin by remember { mutableStateOf(Offset.Zero) }
   var dragPkg by remember { mutableStateOf<String?>(null) }
   var dragPos by remember { mutableStateOf(Offset.Zero) }
+  var dragOriginalOrder by remember { mutableStateOf<List<String>?>(null) }
   // Pending folder creation awaiting a name (source+target packages).
   var pendingPair by remember { mutableStateOf<Pair<String, String>?>(null) }
   // Folder currently being renamed.
@@ -586,9 +629,7 @@ private fun LauncherScreen(
     when {
       targetKey.startsWith(FOLDER_KEY) -> assign(sourcePkg, targetKey.removePrefix(FOLDER_KEY))
       targetKey.startsWith(APP_KEY) -> {
-        val targetPkg = targetKey.removePrefix(APP_KEY)
-        if (targetPkg == sourcePkg) return
-        pendingPair = sourcePkg to targetPkg // ask for a name first
+        UserLayout.saveOrder(context, appOrder)
       }
     }
   }
@@ -676,11 +717,26 @@ private fun LauncherScreen(
                                   }
                                   ?.key
                                   ?.removePrefix(APP_KEY)
+                          if (dragPkg != null) dragOriginalOrder = appOrder
                           dragPos = win
                         },
                         onDrag = { change, delta ->
                           change.consume()
                           dragPos += delta
+                          val src = dragPkg ?: return@detectDragGesturesAfterLongPress
+                          val target =
+                              tileBounds.entries
+                                  .firstOrNull {
+                                    it.key.startsWith(APP_KEY) &&
+                                        it.key != APP_KEY + src &&
+                                        it.value.contains(dragPos)
+                                  }
+                                  ?.key
+                                  ?.removePrefix(APP_KEY)
+                          if (target != null) {
+                            val next = UserLayout.moveOrder(appOrder, src, target)
+                            if (next != appOrder) appOrder = next
+                          }
                         },
                         onDragEnd = {
                           dragPkg?.let { src ->
@@ -691,10 +747,16 @@ private fun LauncherScreen(
                                     }
                                     ?.key
                             onDrop(src, target)
+                            if (dragOriginalOrder != appOrder) UserLayout.saveOrder(context, appOrder)
                           }
                           dragPkg = null
+                          dragOriginalOrder = null
                         },
-                        onDragCancel = { dragPkg = null },
+                        onDragCancel = {
+                          dragOriginalOrder?.let { appOrder = it }
+                          dragPkg = null
+                          dragOriginalOrder = null
+                        },
                     )
                   },
       ) {
@@ -709,10 +771,9 @@ private fun LauncherScreen(
           // only regular apps get a delete badge and become draggable.
           item { PortalHomeTile(onExitHome) }
           item { StoreTile(onOpenStore) }
-          item { WidgetsTile { showWidgetPicker = true } }
           items(
               widgets,
-              key = { "widget:${it.appWidgetId}" },
+              key = { it.key },
               span = { GridItemSpan(it.spanX.coerceIn(1, gridColumns)) },
           ) { widget ->
             WidgetTile(
@@ -721,7 +782,8 @@ private fun LauncherScreen(
                 manager = appWidgetManager,
                 editMode = editMode,
                 tileDp = LocalTileDp.current,
-                onRemove = { removeWidget(widget.appWidgetId) },
+                onRemove = { removeWidget(widget) },
+                onResize = { x, y -> resizeWidget(widget, x, y) },
             )
           }
           items(folderNames, key = { it }) { name ->
@@ -735,7 +797,7 @@ private fun LauncherScreen(
                 onClick = { openFolder = name },
             )
           }
-          items(ungrouped, key = { it.component.packageName }) { app ->
+          items(orderedUngrouped, key = { it.component.packageName }) { app ->
             val pkg = app.component.packageName
             AppTile(
                 app = app,
@@ -796,12 +858,17 @@ private fun LauncherScreen(
       }
     }
 
-    // Manage / Done toggle lives in the bottom-right corner.
-    EditButton(
-        editMode = editMode,
+    // Manage / Done toggle lives in the bottom-right corner. While managing, a
+    // sibling + button opens the widget picker so widgets are an edit action, not
+    // a permanent launcher tile.
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.align(Alignment.BottomEnd).padding(end = 36.dp, bottom = 32.dp),
-        onClick = { editMode = !editMode },
-    )
+    ) {
+      if (editMode) AddWidgetButton { showWidgetPicker = true }
+      EditButton(editMode = editMode, onClick = { editMode = !editMode })
+    }
 
     openFolder?.let { name ->
       val folderApps = appsEff.filter { it.folder == name }
@@ -922,6 +989,14 @@ private fun estimateWidgetSpan(minDp: Int, tileDp: Dp): Int {
   val tile = tileDp.value.coerceAtLeast(1f)
   return HomeWidgetStore.normalizeSpan(((minDp + tile - 1f) / tile).toInt().coerceAtLeast(1))
 }
+
+private fun customWidgetLabel(kind: String): String =
+    when (kind) {
+      HomeWidgetStore.KIND_WEATHER -> "Weather"
+      HomeWidgetStore.KIND_WORLD_CLOCK -> "World Clock"
+      HomeWidgetStore.KIND_TIMERS -> "Timers"
+      else -> "Widget"
+    }
 
 @Composable
 private fun HeaderBar(onScreensaver: () -> Unit) {
@@ -1964,13 +2039,23 @@ private fun StoreTile(onClick: () -> Unit) {
 }
 
 @Composable
-private fun WidgetsTile(onClick: () -> Unit) {
-  BuiltInTile(
-      label = "Widgets",
-      background = Color(0xFF5B6BC0),
-      glyph = ICON_WIDGETS,
-      onClick = onClick,
-  )
+private fun AddWidgetButton(onClick: () -> Unit) {
+  Surface(
+      color = Color(0xFF5B6BC0),
+      shape = RoundedCornerShape(30.dp),
+      modifier = Modifier.width(124.dp).height(60.dp).tvFocusable(RoundedCornerShape(30.dp)) {
+        onClick()
+      },
+  ) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(horizontal = 20.dp),
+    ) {
+      Text("+", color = Color.White, fontSize = 30.sp, fontWeight = FontWeight.Light)
+      Text("Widget", color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+    }
+  }
 }
 
 @Composable
@@ -1981,14 +2066,17 @@ private fun WidgetTile(
     editMode: Boolean,
     tileDp: Dp,
     onRemove: () -> Unit,
+    onResize: (Int, Int) -> Unit,
 ) {
-  val info = remember(widget.appWidgetId) { manager.getAppWidgetInfo(widget.appWidgetId) }
+  val info = remember(widget.appWidgetId) {
+    if (widget.isAppWidget) manager.getAppWidgetInfo(widget.appWidgetId) else null
+  }
   val height =
       tileDp * widget.spanY.toFloat() +
           20.dp * (widget.spanY - 1).coerceAtLeast(0).toFloat()
 
   LaunchedEffect(widget, tileDp) {
-    updateWidgetSizeOptions(manager, widget, tileDp)
+    if (widget.isAppWidget) updateWidgetSizeOptions(manager, widget, tileDp)
   }
 
   Box(modifier = Modifier.fillMaxWidth().height(height).padding(4.dp)) {
@@ -1997,7 +2085,9 @@ private fun WidgetTile(
         shape = RoundedCornerShape(20.dp),
         modifier = Modifier.fillMaxSize(),
     ) {
-      if (info != null) {
+      if (!widget.isAppWidget) {
+        ImmortalWidgetContent(widget = widget, modifier = Modifier.fillMaxSize())
+      } else if (info != null) {
         AndroidView(
             factory = {
               host.createView(it, widget.appWidgetId, info).apply {
@@ -2052,20 +2142,249 @@ private fun WidgetTile(
           Text("✕", color = Color.White, fontSize = 18.sp, fontWeight = FontWeight.Bold)
         }
       }
-      Surface(
-          color = Color(0xCC111111),
-          shape = RoundedCornerShape(10.dp),
-          modifier = Modifier.align(Alignment.BottomStart).padding(10.dp),
+      ResizeHandle(
+          widget = widget,
+          tileDp = tileDp,
+          onResize = onResize,
+          modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp),
+      )
+    }
+  }
+}
+
+@Composable
+private fun ResizeHandle(
+    widget: HomeWidgetStore.HomeWidget,
+    tileDp: Dp,
+    modifier: Modifier = Modifier,
+    onResize: (Int, Int) -> Unit,
+) {
+  val density = androidx.compose.ui.platform.LocalDensity.current
+  var remainder by remember(widget.key) { mutableStateOf(Offset.Zero) }
+  Surface(
+      color = Color(0xEEFFFFFF),
+      shape = CircleShape,
+      modifier =
+          modifier
+              .size(34.dp)
+              .pointerInput(widget.key, widget.spanX, widget.spanY, tileDp) {
+                detectDragGestures(
+                    onDragStart = { remainder = Offset.Zero },
+                    onDrag = { change, delta ->
+                      change.consume()
+                      remainder += delta
+                      val threshold = with(density) { tileDp.toPx() * 0.55f }
+                      var spanX = widget.spanX
+                      var spanY = widget.spanY
+                      if (abs(remainder.x) > threshold) {
+                        val step = if (remainder.x > 0) 1 else -1
+                        spanX = HomeWidgetStore.normalizeSpan(spanX + step)
+                        remainder = remainder.copy(x = 0f)
+                      }
+                      if (abs(remainder.y) > threshold) {
+                        val step = if (remainder.y > 0) 1 else -1
+                        spanY = HomeWidgetStore.normalizeSpan(spanY + step)
+                        remainder = remainder.copy(y = 0f)
+                      }
+                      if (spanX != widget.spanX || spanY != widget.spanY) onResize(spanX, spanY)
+                    },
+                    onDragEnd = { remainder = Offset.Zero },
+                    onDragCancel = { remainder = Offset.Zero },
+                )
+              },
+  ) {
+    Canvas(Modifier.size(34.dp)) {
+      val stroke = Stroke(width = 2.dp.toPx(), cap = androidx.compose.ui.graphics.StrokeCap.Round)
+      val c = Color(0xFF2C2C2E)
+      drawLine(c, Offset(size.width * 0.38f, size.height * 0.70f), Offset(size.width * 0.70f, size.height * 0.38f), strokeWidth = stroke.width, cap = stroke.cap)
+      drawLine(c, Offset(size.width * 0.54f, size.height * 0.76f), Offset(size.width * 0.76f, size.height * 0.54f), strokeWidth = stroke.width, cap = stroke.cap)
+    }
+  }
+}
+
+@Composable
+private fun ImmortalWidgetContent(widget: HomeWidgetStore.HomeWidget, modifier: Modifier = Modifier) {
+  when (widget.kind) {
+    HomeWidgetStore.KIND_WEATHER -> ImmortalWeatherWidget(modifier)
+    HomeWidgetStore.KIND_WORLD_CLOCK -> ImmortalWorldClockWidget(modifier)
+    HomeWidgetStore.KIND_TIMERS -> ImmortalTimersWidget(widget.key, modifier)
+    else -> UnknownImmortalWidget(widget.kind, modifier)
+  }
+}
+
+@Composable
+private fun ImmortalWidgetShell(
+    title: String,
+    modifier: Modifier = Modifier,
+    accent: Color = Color(0xFF7AA7FF),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+  Column(
+      modifier =
+          modifier
+              .background(Color(0xFF161618), RoundedCornerShape(24.dp))
+              .padding(18.dp),
+  ) {
+    Text(
+        title.uppercase(Locale.getDefault()),
+        color = accent,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Bold,
+        maxLines = 1,
+    )
+    Spacer(Modifier.size(8.dp))
+    content()
+  }
+}
+
+@Composable
+private fun ImmortalWeatherWidget(modifier: Modifier = Modifier) {
+  val context = androidx.compose.ui.platform.LocalContext.current
+  val current by produceState(initialValue = "", Unit) {
+    while (true) {
+      value = withContext(Dispatchers.IO) { Weather.fetch(context) }
+      delay(if (value.isBlank()) 60_000L else 30L * 60 * 1000)
+    }
+  }
+  val forecast by produceState<Weather.Forecast?>(initialValue = null, Unit) {
+    value = withContext(Dispatchers.IO) { Weather.fetchForecast(context) }
+  }
+  ImmortalWidgetShell(title = "Weather", accent = Color(0xFF79B8FF), modifier = modifier) {
+    Text(
+        current.ifBlank { "Weather" },
+        color = Color.White,
+        fontSize = 30.sp,
+        fontWeight = FontWeight.SemiBold,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
+    val hours = forecast?.hours?.take(4).orEmpty()
+    if (hours.isNotEmpty()) {
+      Spacer(Modifier.size(12.dp))
+      Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+        hours.forEach { h ->
+          Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.weight(1f)) {
+            Text(h.label, color = Color(0xFFB8B8B8), fontSize = 11.sp, maxLines = 1)
+            Text(Weather.emoji(h.code), fontSize = 20.sp, modifier = Modifier.padding(top = 3.dp))
+            Text("${h.temp}°", color = Color.White, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+          }
+        }
+      }
+    } else {
+      Text(
+          "Forecast appears when the Portal is online.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 8.dp),
+      )
+    }
+  }
+}
+
+@Composable
+private fun ImmortalWorldClockWidget(modifier: Modifier = Modifier) {
+  var now by remember { mutableStateOf(Date()) }
+  LaunchedEffect(Unit) {
+    while (true) {
+      now = Date()
+      delay(1000)
+    }
+  }
+  val zones =
+      listOf(
+          "Local" to TimeZone.getDefault().id,
+          "New York" to "America/New_York",
+          "London" to "Europe/London",
+          "Tokyo" to "Asia/Tokyo",
+      )
+  ImmortalWidgetShell(title = "World Clock", accent = Color(0xFFFFC857), modifier = modifier) {
+    zones.forEachIndexed { i, (label, zoneId) ->
+      val fmt =
+          remember(zoneId) {
+            SimpleDateFormat("h:mm a", Locale.getDefault()).apply {
+              timeZone = TimeZone.getTimeZone(zoneId)
+            }
+          }
+      Row(
+          modifier = Modifier.fillMaxWidth().padding(top = if (i == 0) 0.dp else 8.dp),
+          verticalAlignment = Alignment.CenterVertically,
       ) {
+        Text(label, color = Color(0xFFD7D7D7), fontSize = 14.sp, modifier = Modifier.weight(1f))
         Text(
-            "Widget",
+            fmt.format(now),
             color = Color.White,
-            fontSize = 13.sp,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+            fontSize = if (i == 0) 24.sp else 17.sp,
+            fontWeight = if (i == 0) FontWeight.SemiBold else FontWeight.Medium,
         )
       }
     }
+  }
+}
+
+@Composable
+private fun ImmortalTimersWidget(widgetKey: String, modifier: Modifier = Modifier) {
+  var remainingMs by remember(widgetKey) { mutableStateOf(0L) }
+  var running by remember(widgetKey) { mutableStateOf(false) }
+  var endsAt by remember(widgetKey) { mutableStateOf(0L) }
+  LaunchedEffect(running, endsAt) {
+    while (running) {
+      remainingMs = (endsAt - System.currentTimeMillis()).coerceAtLeast(0L)
+      if (remainingMs == 0L) running = false
+      delay(250)
+    }
+  }
+  fun start(minutes: Int) {
+    remainingMs = minutes * 60_000L
+    endsAt = System.currentTimeMillis() + remainingMs
+    running = true
+  }
+  val mins = (remainingMs / 60_000).toInt()
+  val secs = ((remainingMs / 1000) % 60).toInt()
+  ImmortalWidgetShell(title = "Timers", accent = Color(0xFFFF9F0A), modifier = modifier) {
+    Text(
+        if (remainingMs > 0) "%d:%02d".format(mins, secs) else "Ready",
+        color = Color.White,
+        fontSize = 34.sp,
+        fontWeight = FontWeight.SemiBold,
+    )
+    Spacer(Modifier.size(12.dp))
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+      listOf(5, 10, 30).forEach { minutes ->
+        TimerChip("${minutes}m") { start(minutes) }
+      }
+      if (remainingMs > 0) TimerChip(if (running) "Pause" else "Start") {
+        if (running) {
+          running = false
+        } else {
+          endsAt = System.currentTimeMillis() + remainingMs
+          running = true
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun TimerChip(label: String, onClick: () -> Unit) {
+  Surface(
+      color = Color(0x22FFFFFF),
+      shape = RoundedCornerShape(999.dp),
+      modifier = Modifier.tvFocusable(RoundedCornerShape(999.dp)) { onClick() },
+  ) {
+    Text(
+        label,
+        color = Color.White,
+        fontSize = 13.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp),
+    )
+  }
+}
+
+@Composable
+private fun UnknownImmortalWidget(kind: String, modifier: Modifier = Modifier) {
+  Box(modifier.background(Color(0xFF303033)), contentAlignment = Alignment.Center) {
+    Text(kind, color = Color.White, fontSize = 16.sp)
   }
 }
 
@@ -2149,7 +2468,7 @@ private fun WidgetPickerOverlay(
               verticalArrangement = Arrangement.spacedBy(14.dp),
               modifier = Modifier.focusRequester(gridFocus).focusGroup(),
           ) {
-            items(providers, key = { it.info.provider.flattenToString() }) { provider ->
+            items(providers, key = { it.info?.provider?.flattenToString() ?: "custom:${it.customKind}" }) { provider ->
               WidgetProviderTile(provider = provider, onClick = { onPick(provider) })
             }
           }
@@ -2182,6 +2501,8 @@ private fun WidgetProviderTile(provider: WidgetProviderEntry, onClick: () -> Uni
                 contentDescription = null,
                 modifier = Modifier.size(42.dp).clip(RoundedCornerShape(10.dp)),
             )
+          } else if (provider.customKind != null) {
+            CustomWidgetGlyph(provider.customKind)
           } else {
             WidgetGlyph()
           }
@@ -2213,6 +2534,18 @@ private fun WidgetProviderTile(provider: WidgetProviderEntry, onClick: () -> Uni
       }
     }
   }
+}
+
+@Composable
+private fun CustomWidgetGlyph(kind: String) {
+  val emoji =
+      when (kind) {
+        HomeWidgetStore.KIND_WEATHER -> "☁"
+        HomeWidgetStore.KIND_WORLD_CLOCK -> "◷"
+        HomeWidgetStore.KIND_TIMERS -> "⏱"
+        else -> "+"
+      }
+  Text(emoji, color = Color.White, fontSize = 28.sp, fontWeight = FontWeight.SemiBold)
 }
 
 @Composable
@@ -2311,7 +2644,38 @@ private fun loadApps(context: Context): List<AppEntry> {
 private fun loadWidgetProviders(context: Context, tileDp: Dp): List<WidgetProviderEntry> {
   val pm = context.packageManager
   val density = context.resources.displayMetrics.densityDpi
-  return AppWidgetManager.getInstance(context)
+  val custom =
+      listOf(
+          WidgetProviderEntry(
+              label = "Weather",
+              packageLabel = "Immortal",
+              icon = null,
+              info = null,
+              spanX = 2,
+              spanY = 2,
+              customKind = HomeWidgetStore.KIND_WEATHER,
+          ),
+          WidgetProviderEntry(
+              label = "World Clock",
+              packageLabel = "Immortal",
+              icon = null,
+              info = null,
+              spanX = 2,
+              spanY = 2,
+              customKind = HomeWidgetStore.KIND_WORLD_CLOCK,
+          ),
+          WidgetProviderEntry(
+              label = "Timers",
+              packageLabel = "Immortal",
+              icon = null,
+              info = null,
+              spanX = 2,
+              spanY = 2,
+              customKind = HomeWidgetStore.KIND_TIMERS,
+          ),
+      )
+  val android =
+      AppWidgetManager.getInstance(context)
       .installedProviders
       .mapNotNull { info ->
         runCatching {
@@ -2342,16 +2706,17 @@ private fun loadWidgetProviders(context: Context, tileDp: Dp): List<WidgetProvid
           compareBy(
               { it.packageLabel.lowercase(Locale.getDefault()) },
               { it.label.lowercase(Locale.getDefault()) }))
+  return custom + android
 }
 
 private fun List<HomeWidgetStore.HomeWidget>.filterLiveWidgets(
     manager: AppWidgetManager,
     host: AppWidgetHost,
 ): List<HomeWidgetStore.HomeWidget> {
-  val live = filter { manager.getAppWidgetInfo(it.appWidgetId) != null }
+  val live = filter { !it.isAppWidget || manager.getAppWidgetInfo(it.appWidgetId) != null }
   if (live.size != size) {
     val liveIds = live.map { it.appWidgetId }.toSet()
-    filterNot { it.appWidgetId in liveIds }.forEach {
+    filter { it.isAppWidget && it.appWidgetId !in liveIds }.forEach {
       runCatching { host.deleteAppWidgetId(it.appWidgetId) }
     }
   }

--- a/app/src/main/java/com/immortal/launcher/HomeGrid.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeGrid.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+/**
+ * Pure helpers for the free-placement home grid. The grid is modelled as a flat list of "slots":
+ * each slot is either a tile key or `null` (an intentional blank cell). This lets the user leave
+ * gaps and move tiles freely within the grid (a drop swaps two slots) rather than everything
+ * auto-packing to the top-left.
+ */
+object HomeGrid {
+
+  /** Keep blanks, drop stale/duplicate keys (→ blank), append new tiles, trim trailing blanks. */
+  private fun reconcile(saved: List<String?>, keys: List<String>): MutableList<String?> {
+    val keySet = keys.toHashSet()
+    val seen = HashSet<String>()
+    val out = ArrayList<String?>(saved.size + keys.size)
+    for (s in saved) {
+      if (s != null && s in keySet && seen.add(s)) out.add(s) else out.add(null)
+    }
+    for (k in keys) if (seen.add(k)) out.add(k)
+    while (out.isNotEmpty() && out.last() == null) out.removeAt(out.lastIndex)
+    return out
+  }
+
+  /**
+   * Reconcile a saved slot list with the tiles that currently exist:
+   * - keeps blanks (`null`) where the user left them,
+   * - drops keys that no longer exist or are duplicated (their slot becomes blank),
+   * - appends any brand-new tiles at the end,
+   * - trims trailing blanks, then pads so the last row is full plus one spare blank row to drop into.
+   *
+   * [cols] is the column count; padding is by slot count (wide widgets are an approximation, which
+   * only affects how many trailing blanks appear, never correctness of placement).
+   */
+  fun normalizeSlots(saved: List<String?>, keys: List<String>, cols: Int): List<String?> {
+    val out = reconcile(saved, keys)
+    if (cols > 0) {
+      val rem = out.size % cols
+      if (rem != 0) repeat(cols - rem) { out.add(null) }
+      repeat(cols) { out.add(null) }
+    }
+    return out
+  }
+
+  /**
+   * Like [normalizeSlots] but page-aware: pads to whole [pageCapacity] pages, **auto-deletes any
+   * fully-empty page**, and (when [keepSpare]) appends one trailing empty page so the user can drag
+   * onto a fresh page. In-page blanks (gaps inside a page that still has tiles) are preserved.
+   */
+  fun normalizeToPages(
+      saved: List<String?>,
+      keys: List<String>,
+      pageCapacity: Int,
+      keepSpare: Boolean = true,
+  ): List<String?> {
+    val reconciled = reconcile(saved, keys)
+    if (pageCapacity <= 0) return reconciled
+    val padded = reconciled.toMutableList()
+    val rem = padded.size % pageCapacity
+    if (rem != 0) repeat(pageCapacity - rem) { padded.add(null) }
+    // Drop pages that are entirely blank.
+    val out = ArrayList<String?>(padded.size)
+    padded.chunked(pageCapacity).forEach { page ->
+      if (page.any { it != null }) out.addAll(page)
+    }
+    // Keep one spare empty page to drop into (always at least one page exists).
+    if (keepSpare || out.isEmpty()) repeat(pageCapacity) { out.add(null) }
+    return out
+  }
+
+  /** Swap the contents of two slots (either may be blank). Out-of-range/no-op returns the input. */
+  fun swap(slots: List<String?>, a: Int, b: Int): List<String?> {
+    if (a == b || a !in slots.indices || b !in slots.indices) return slots
+    val m = slots.toMutableList()
+    val tmp = m[a]
+    m[a] = m[b]
+    m[b] = tmp
+    return m
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/HomeLayoutModel.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeLayoutModel.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+/** Pure Launcher layout rules that sit above the free-placement [HomeGrid] slot model. */
+object HomeLayoutModel {
+  data class AppRef(val packageName: String, val folder: String?)
+
+  data class CreateFolderResult(val assignments: Map<String, String>, val folderName: String)
+
+  data class RenameFolderResult(val assignments: Map<String, String>, val folderName: String)
+
+  data class MoveOutResult(val assignments: Map<String, String>, val closeFolder: Boolean)
+
+  fun effectiveFolder(
+      packageName: String,
+      defaultFolder: String?,
+      assignments: Map<String, String>,
+  ): String? =
+      if (assignments.containsKey(packageName)) assignments.getValue(packageName).ifEmpty { null }
+      else defaultFolder
+
+  fun effectiveApps(apps: List<AppRef>, assignments: Map<String, String>): List<AppRef> =
+      apps.map { it.copy(folder = effectiveFolder(it.packageName, it.folder, assignments)) }
+
+  fun folderNames(apps: List<AppRef>): List<String> = apps.mapNotNull { it.folder }.distinct().sorted()
+
+  fun createFolder(
+      assignments: Map<String, String>,
+      firstPackage: String,
+      secondPackage: String,
+      rawName: String,
+  ): CreateFolderResult {
+    val name = rawName.trim().ifEmpty { "Folder" }
+    val next = LinkedHashMap(assignments)
+    next[firstPackage] = name
+    next[secondPackage] = name
+    return CreateFolderResult(next, name)
+  }
+
+  fun renameFolder(
+      effectiveApps: List<AppRef>,
+      assignments: Map<String, String>,
+      oldName: String,
+      rawName: String,
+  ): RenameFolderResult? {
+    val newName = rawName.trim()
+    if (newName.isEmpty() || newName == oldName) return null
+    val next = LinkedHashMap(assignments)
+    effectiveApps.filter { it.folder == oldName }.forEach { next[it.packageName] = newName }
+    return RenameFolderResult(next, newName)
+  }
+
+  fun moveOut(
+      effectiveApps: List<AppRef>,
+      assignments: Map<String, String>,
+      packageName: String,
+  ): MoveOutResult? {
+    val folder = effectiveApps.firstOrNull { it.packageName == packageName }?.folder ?: return null
+    val next = LinkedHashMap(assignments)
+    next[packageName] = "" // explicit ungroup override
+    val remaining = effectiveApps.filter { it.folder == folder && it.packageName != packageName }
+    if (remaining.size == 1) next[remaining[0].packageName] = ""
+    return MoveOutResult(next, closeFolder = remaining.size <= 1)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/HomeWidgetStore.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeWidgetStore.kt
@@ -76,12 +76,6 @@ object HomeWidgetStore {
   fun without(widgets: List<HomeWidget>, key: String): List<HomeWidget> =
       widgets.filterNot { it.key == key }
 
-  fun resized(widgets: List<HomeWidget>, key: String, spanX: Int, spanY: Int): List<HomeWidget> =
-      widgets.map {
-        if (it.key == key) it.copy(spanX = normalizeSpan(spanX), spanY = normalizeSpan(spanY))
-        else it
-      }
-
   fun normalizeSpan(span: Int): Int = span.coerceIn(1, MAX_SPAN)
 
   internal fun serialize(widgets: List<HomeWidget>): String {

--- a/app/src/main/java/com/immortal/launcher/HomeWidgetStore.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeWidgetStore.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.ComponentName
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** Persisted home-screen AppWidget placements owned by Immortal's AppWidgetHost. */
+object HomeWidgetStore {
+
+  private const val PREFS = "immortal_home_widgets"
+  private const val KEY = "widgets"
+
+  data class HomeWidget(
+      val appWidgetId: Int,
+      val providerPackage: String,
+      val providerClass: String,
+      val spanX: Int = DEFAULT_SPAN_X,
+      val spanY: Int = DEFAULT_SPAN_Y,
+  ) {
+    val provider: ComponentName
+      get() = ComponentName(providerPackage, providerClass)
+  }
+
+  const val DEFAULT_SPAN_X = 2
+  const val DEFAULT_SPAN_Y = 2
+  const val MAX_SPAN = 4
+
+  fun load(context: Context): List<HomeWidget> {
+    val raw =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getString(KEY, null)
+            ?: return emptyList()
+    return deserialize(raw)
+  }
+
+  fun save(context: Context, widgets: List<HomeWidget>) {
+    context
+        .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        .edit()
+        .putString(KEY, serialize(widgets))
+        .apply()
+  }
+
+  fun withAdded(widgets: List<HomeWidget>, widget: HomeWidget): List<HomeWidget> =
+      (widgets.filterNot { it.appWidgetId == widget.appWidgetId } + widget)
+          .distinctBy { it.appWidgetId }
+
+  fun without(widgets: List<HomeWidget>, appWidgetId: Int): List<HomeWidget> =
+      widgets.filterNot { it.appWidgetId == appWidgetId }
+
+  fun normalizeSpan(span: Int): Int = span.coerceIn(1, MAX_SPAN)
+
+  internal fun serialize(widgets: List<HomeWidget>): String {
+    val arr = JSONArray()
+    widgets.forEach { w ->
+      arr.put(
+          JSONObject()
+              .put("id", w.appWidgetId)
+              .put("package", w.providerPackage)
+              .put("class", w.providerClass)
+              .put("spanX", normalizeSpan(w.spanX))
+              .put("spanY", normalizeSpan(w.spanY)))
+    }
+    return arr.toString()
+  }
+
+  internal fun deserialize(raw: String): List<HomeWidget> =
+      runCatching {
+            val arr = JSONArray(raw)
+            buildList {
+                  for (i in 0 until arr.length()) {
+                    val obj = arr.optJSONObject(i) ?: continue
+                    val id = obj.optInt("id", -1)
+                    val pkg = obj.optString("package")
+                    val cls = obj.optString("class")
+                    if (id <= 0 || pkg.isBlank() || cls.isBlank()) continue
+                    add(
+                        HomeWidget(
+                            appWidgetId = id,
+                            providerPackage = pkg,
+                            providerClass = cls,
+                            spanX = normalizeSpan(obj.optInt("spanX", DEFAULT_SPAN_X)),
+                            spanY = normalizeSpan(obj.optInt("spanY", DEFAULT_SPAN_Y)),
+                        ))
+                  }
+                }
+                .distinctBy { it.appWidgetId }
+          }
+          .getOrDefault(emptyList())
+}

--- a/app/src/main/java/com/immortal/launcher/HomeWidgetStore.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeWidgetStore.kt
@@ -9,25 +9,39 @@ package com.immortal.launcher
 
 import android.content.ComponentName
 import android.content.Context
+import java.util.UUID
 import org.json.JSONArray
 import org.json.JSONObject
 
-/** Persisted home-screen AppWidget placements owned by Immortal's AppWidgetHost. */
+/** Persisted home-screen widget placements owned by Immortal's home grid. */
 object HomeWidgetStore {
 
   private const val PREFS = "immortal_home_widgets"
   private const val KEY = "widgets"
 
   data class HomeWidget(
-      val appWidgetId: Int,
-      val providerPackage: String,
-      val providerClass: String,
+      val appWidgetId: Int = 0,
+      val providerPackage: String = "",
+      val providerClass: String = "",
       val spanX: Int = DEFAULT_SPAN_X,
       val spanY: Int = DEFAULT_SPAN_Y,
+      val kind: String = KIND_APP_WIDGET,
+      val customId: String = "",
   ) {
     val provider: ComponentName
       get() = ComponentName(providerPackage, providerClass)
+
+    val key: String
+      get() = if (kind == KIND_APP_WIDGET) "widget:$appWidgetId" else "custom:$customId"
+
+    val isAppWidget: Boolean
+      get() = kind == KIND_APP_WIDGET
   }
+
+  const val KIND_APP_WIDGET = "appwidget"
+  const val KIND_WEATHER = "weather"
+  const val KIND_WORLD_CLOCK = "world_clock"
+  const val KIND_TIMERS = "timers"
 
   const val DEFAULT_SPAN_X = 2
   const val DEFAULT_SPAN_Y = 2
@@ -48,12 +62,25 @@ object HomeWidgetStore {
         .apply()
   }
 
-  fun withAdded(widgets: List<HomeWidget>, widget: HomeWidget): List<HomeWidget> =
-      (widgets.filterNot { it.appWidgetId == widget.appWidgetId } + widget)
-          .distinctBy { it.appWidgetId }
+  fun custom(kind: String, spanX: Int = DEFAULT_SPAN_X, spanY: Int = DEFAULT_SPAN_Y): HomeWidget =
+      HomeWidget(
+          kind = kind,
+          customId = "$kind:${UUID.randomUUID()}",
+          spanX = normalizeSpan(spanX),
+          spanY = normalizeSpan(spanY),
+      )
 
-  fun without(widgets: List<HomeWidget>, appWidgetId: Int): List<HomeWidget> =
-      widgets.filterNot { it.appWidgetId == appWidgetId }
+  fun withAdded(widgets: List<HomeWidget>, widget: HomeWidget): List<HomeWidget> =
+      (widgets.filterNot { it.key == widget.key } + widget).distinctBy { it.key }
+
+  fun without(widgets: List<HomeWidget>, key: String): List<HomeWidget> =
+      widgets.filterNot { it.key == key }
+
+  fun resized(widgets: List<HomeWidget>, key: String, spanX: Int, spanY: Int): List<HomeWidget> =
+      widgets.map {
+        if (it.key == key) it.copy(spanX = normalizeSpan(spanX), spanY = normalizeSpan(spanY))
+        else it
+      }
 
   fun normalizeSpan(span: Int): Int = span.coerceIn(1, MAX_SPAN)
 
@@ -66,7 +93,9 @@ object HomeWidgetStore {
               .put("package", w.providerPackage)
               .put("class", w.providerClass)
               .put("spanX", normalizeSpan(w.spanX))
-              .put("spanY", normalizeSpan(w.spanY)))
+              .put("spanY", normalizeSpan(w.spanY))
+              .put("kind", w.kind)
+              .put("customId", w.customId))
     }
     return arr.toString()
   }
@@ -80,7 +109,12 @@ object HomeWidgetStore {
                     val id = obj.optInt("id", -1)
                     val pkg = obj.optString("package")
                     val cls = obj.optString("class")
-                    if (id <= 0 || pkg.isBlank() || cls.isBlank()) continue
+                    val kind = obj.optString("kind", KIND_APP_WIDGET)
+                    val customId = obj.optString("customId")
+                    if (kind == KIND_APP_WIDGET && (id <= 0 || pkg.isBlank() || cls.isBlank())) {
+                      continue
+                    }
+                    if (kind != KIND_APP_WIDGET && customId.isBlank()) continue
                     add(
                         HomeWidget(
                             appWidgetId = id,
@@ -88,10 +122,12 @@ object HomeWidgetStore {
                             providerClass = cls,
                             spanX = normalizeSpan(obj.optInt("spanX", DEFAULT_SPAN_X)),
                             spanY = normalizeSpan(obj.optInt("spanY", DEFAULT_SPAN_Y)),
+                            kind = kind,
+                            customId = customId,
                         ))
                   }
                 }
-                .distinctBy { it.appWidgetId }
+                .distinctBy { it.key }
           }
           .getOrDefault(emptyList())
 }

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
@@ -111,6 +111,19 @@ object ImmortalSettings {
   fun setClockFormat(c: Context, fmt: String) =
       prefs(c).edit().putString("clock_format", fmt).apply()
 
+  // World-clock widget: which time zones to show (ordered). Defaults to a sensible set.
+  val DEFAULT_WORLD_CLOCK_ZONES =
+      listOf("America/New_York", "Europe/London", "Asia/Tokyo")
+
+  fun worldClockZones(c: Context): List<String> {
+    val raw = prefs(c).getString("world_clock_zones", null)
+    val list = raw?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
+    return if (list.isNullOrEmpty()) DEFAULT_WORLD_CLOCK_ZONES else list
+  }
+
+  fun setWorldClockZones(c: Context, zones: List<String>) =
+      prefs(c).edit().putString("world_clock_zones", zones.joinToString(",")).apply()
+
   fun setShowMiniPlayer(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("show_mini_player", on).apply()
 

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -15,7 +15,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -41,8 +43,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
@@ -87,7 +91,13 @@ private fun ImmortalSettingsScreen() {
   var showMultiRoom by remember { mutableStateOf(false) }
   var showMqtt by remember { mutableStateOf(false) }
   var showHealth by remember { mutableStateOf(false) }
+  var showWorldClock by remember { mutableStateOf(false) }
   var bootSelected by remember { mutableStateOf(BootLaunch.packages(context).toSet()) }
+
+  if (showWorldClock) {
+    WorldClockScreen(onBack = { showWorldClock = false })
+    return
+  }
 
   if (showBootApps) {
     BootAppsScreen(
@@ -119,6 +129,7 @@ private fun ImmortalSettingsScreen() {
       onOpenMultiRoom = { showMultiRoom = true },
       onOpenMqtt = { showMqtt = true },
       onOpenHealth = { showHealth = true },
+      onOpenWorldClock = { showWorldClock = true },
   )
 }
 
@@ -129,6 +140,7 @@ private fun SettingsMain(
     onOpenMultiRoom: () -> Unit,
     onOpenMqtt: () -> Unit,
     onOpenHealth: () -> Unit,
+    onOpenWorldClock: () -> Unit,
 ) {
   val context = LocalContext.current
   var settings by remember { mutableStateOf(ImmortalSettings.load(context)) }
@@ -219,6 +231,8 @@ private fun SettingsMain(
           )
         }
       }
+
+      WallpaperSection()
 
       Spacer(Modifier.size(26.dp))
 
@@ -336,6 +350,26 @@ private fun SettingsMain(
         }
       }
 
+      Spacer(Modifier.size(26.dp))
+      SectionLabel("World clock")
+      Card {
+        Row(
+            modifier = Modifier.fillMaxWidth().tvFocusableRow { onOpenWorldClock() }.padding(18.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+          Column(modifier = Modifier.weight(1f)) {
+            Text("World clock locations", color = Color.White, fontSize = 17.sp)
+            Text(
+                "Pick which cities the World Clock widget shows (first four are displayed).",
+                color = Color(0xFF9A9A9A),
+                fontSize = 13.sp,
+                modifier = Modifier.padding(top = 2.dp),
+            )
+          }
+          Text("›", color = Color(0xFF7C7C7C), fontSize = 26.sp)
+        }
+      }
+
       MultiRoomNavRow(onOpen = onOpenMultiRoom)
 
       MqttNavRow(onOpen = onOpenMqtt)
@@ -356,6 +390,133 @@ private fun SettingsMain(
           modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
       )
     }
+  }
+}
+
+@Composable
+private fun WallpaperSection() {
+  val context = LocalContext.current
+  var mode by remember { mutableStateOf(WallpaperConfig.load(context).mode) }
+  var grain by remember { mutableStateOf(WallpaperConfig.load(context).grain) }
+
+  Spacer(Modifier.size(26.dp))
+  SectionLabel("Wallpaper")
+  Card {
+    Column(modifier = Modifier.padding(18.dp)) {
+      Text("Background", color = Color.White, fontSize = 17.sp)
+      Text(
+          "A gradient, a photo, or sync with your screensaver (shown blurred). Tap to choose.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 2.dp),
+      )
+      Spacer(Modifier.size(14.dp))
+      Row(
+          modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+          horizontalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        WallpaperSwatch("Dark", selected = mode == WallpaperConfig.DARK, onClick = {
+          mode = WallpaperConfig.DARK
+          WallpaperConfig.setMode(context, mode)
+        }) {
+          Spacer(Modifier.fillMaxSize().background(Color(0xFF1A1A1A)))
+        }
+        WallpaperConfig.GRADIENTS.forEach { (id, colors) ->
+          WallpaperSwatch(id.removePrefix("g_").replaceFirstChar { it.uppercase() }, selected = mode == id, onClick = {
+            mode = id
+            WallpaperConfig.setMode(context, id)
+          }) {
+            Spacer(Modifier.fillMaxSize().background(Brush.verticalGradient(colors.map { Color(it) })))
+          }
+        }
+        WallpaperConfig.PHOTOS.forEach { (id, label) ->
+          val thumb =
+              remember(id) {
+                runCatching {
+                      context.assets.open("photoframe_fallback/${id.removePrefix(WallpaperConfig.PHOTO_PREFIX)}")
+                          .use { android.graphics.BitmapFactory.decodeStream(it) }
+                          ?.let { android.graphics.Bitmap.createScaledBitmap(it, 96, 96, true).asImageBitmap() }
+                    }
+                    .getOrNull()
+              }
+          WallpaperSwatch(label, selected = mode == id, onClick = {
+            mode = id
+            WallpaperConfig.setMode(context, id)
+          }) {
+            if (thumb != null) {
+              Image(bitmap = thumb, contentDescription = null, modifier = Modifier.fillMaxSize())
+            } else {
+              Spacer(Modifier.fillMaxSize().background(Color(0xFF333740)))
+            }
+          }
+        }
+        WallpaperSwatch("Screensaver", selected = mode == WallpaperConfig.SCREENSAVER, onClick = {
+          mode = WallpaperConfig.SCREENSAVER
+          WallpaperConfig.setMode(context, WallpaperConfig.SCREENSAVER)
+        }) {
+          Spacer(
+              Modifier.fillMaxSize()
+                  .background(Brush.verticalGradient(listOf(Color(0xFF2C3E50), Color(0xFF4CA1AF)))))
+        }
+      }
+      Divider()
+      Row(
+          modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+          verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Column(modifier = Modifier.weight(1f)) {
+          Text("Film grain", color = Color.White, fontSize = 17.sp)
+          Text(
+              "Adds a subtle grain texture over the wallpaper.",
+              color = Color(0xFF9A9A9A),
+              fontSize = 13.sp,
+              modifier = Modifier.padding(top = 2.dp),
+          )
+        }
+        Segmented(
+            options = listOf("Off" to "off", "On" to "on"),
+            selected = if (grain) "on" else "off",
+            onSelect = {
+              val on = it == "on"
+              grain = on
+              WallpaperConfig.setGrain(context, on)
+            },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun WallpaperSwatch(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    preview: @Composable () -> Unit,
+) {
+  Column(
+      horizontalAlignment = Alignment.CenterHorizontally,
+      modifier = Modifier.tvFocusable(RoundedCornerShape(16.dp)) { onClick() },
+  ) {
+    androidx.compose.foundation.layout.Box(
+        modifier =
+            Modifier.size(74.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .border(
+                    width = if (selected) 3.dp else 1.dp,
+                    color = if (selected) Color(0xFF2E6BE6) else Color(0x33FFFFFF),
+                    shape = RoundedCornerShape(16.dp),
+                ),
+    ) {
+      preview()
+    }
+    Text(
+        label,
+        color = if (selected) Color.White else Color(0xFFBBBBBB),
+        fontSize = 12.sp,
+        maxLines = 1,
+        modifier = Modifier.padding(top = 6.dp),
+    )
   }
 }
 
@@ -1115,8 +1276,119 @@ private fun MqttScreen(onBack: () -> Unit) {
   }
 }
 
-private data class BootAppOption(val pkg: String, val label: String, val icon: ImageBitmap)
+/** A curated set of cities for the world-clock picker (label → IANA tz id). */
+private val WORLD_CLOCK_CITIES =
+    listOf(
+        "Cupertino" to "America/Los_Angeles",
+        "Denver" to "America/Denver",
+        "New York" to "America/New_York",
+        "São Paulo" to "America/Sao_Paulo",
+        "London" to "Europe/London",
+        "Paris" to "Europe/Paris",
+        "Berlin" to "Europe/Berlin",
+        "Cape Town" to "Africa/Johannesburg",
+        "Dubai" to "Asia/Dubai",
+        "Mumbai" to "Asia/Kolkata",
+        "Singapore" to "Asia/Singapore",
+        "Tokyo" to "Asia/Tokyo",
+        "Sydney" to "Australia/Sydney",
+    )
 
+/** The world-clock locations picker. Tapping a city toggles it; the widget shows the first four in
+ * selection order. Back returns to the main settings page. */
+@Composable
+private fun WorldClockScreen(onBack: () -> Unit) {
+  val context = LocalContext.current
+  var selected by remember { mutableStateOf(ImmortalSettings.worldClockZones(context)) }
+  val firstFocus = remember { FocusRequester() }
+  LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .onPreviewKeyEvent { e ->
+                if (e.key == Key.Back) {
+                  if (e.type == KeyEventType.KeyUp) onBack()
+                  true
+                } else false
+              }
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp).focusGroup()) {
+      Surface(
+          color = Color(0xFF1C1C1E),
+          shape = RoundedCornerShape(12.dp),
+          modifier =
+              Modifier.focusRequester(firstFocus).tvFocusable(RoundedCornerShape(12.dp)) { onBack() },
+      ) {
+        Text(
+            "‹  Back",
+            color = Color.White,
+            fontSize = 16.sp,
+            modifier = Modifier.padding(horizontal = 18.dp, vertical = 10.dp),
+        )
+      }
+      Spacer(Modifier.size(18.dp))
+      Text("World clock", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+      Text(
+          "Choose locations for the World Clock widget. The first four (in the order you pick them) are shown.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+      Spacer(Modifier.size(26.dp))
+      Card {
+        WORLD_CLOCK_CITIES.forEachIndexed { i, (label, zone) ->
+          if (i > 0) Divider()
+          val on = zone in selected
+          val rank = selected.indexOf(zone)
+          Row(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .tvFocusableRow {
+                        selected = if (on) selected - zone else selected + zone
+                        ImmortalSettings.setWorldClockZones(context, selected)
+                      }
+                      .padding(horizontal = 18.dp, vertical = 14.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Column(modifier = Modifier.weight(1f)) {
+              Text(label, color = Color.White, fontSize = 16.sp)
+              Text(
+                  zone.replace('_', ' '),
+                  color = Color(0xFF9A9A9A),
+                  fontSize = 13.sp,
+                  modifier = Modifier.padding(top = 2.dp),
+              )
+            }
+            if (on && rank in 0..3) {
+              Text(
+                  "#${rank + 1}",
+                  color = Color(0xFF8AB4F8),
+                  fontSize = 14.sp,
+                  fontWeight = FontWeight.SemiBold,
+                  modifier = Modifier.padding(end = 14.dp),
+              )
+            } else if (on) {
+              Text("hidden", color = Color(0xFF7C7C7C), fontSize = 13.sp, modifier = Modifier.padding(end = 14.dp))
+            }
+            Switch(checked = on, onCheckedChange = null)
+          }
+        }
+      }
+      Text(
+          "Tip: the widget shows up to four clocks. Re-pick a city to move it to the end of the order.",
+          color = Color(0xFF7C7C7C),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
+      )
+    }
+  }
+}
+
+private data class BootAppOption(val pkg: String, val label: String, val icon: ImageBitmap)
 /** Every launchable app except our own launcher, for the boot-launch picker. */
 private fun loadLaunchableApps(context: Context): List<BootAppOption> {
   val pm = context.packageManager

--- a/app/src/main/java/com/immortal/launcher/InstallDaemon.kt
+++ b/app/src/main/java/com/immortal/launcher/InstallDaemon.kt
@@ -81,7 +81,10 @@ object InstallDaemon {
   /** Pure paused decision (extracted for testing): paused only when there is no
    *  silent path (daemon) AND no working dialog (overlay fix) on a Gen-1. */
   internal fun isPaused(legacy: Boolean, daemonAvailable: Boolean, dialogFixed: Boolean): Boolean =
-      legacy && !daemonAvailable && !dialogFixed
+      InstallLifecycle.isPaused(legacy, daemonAvailable, dialogFixed)
+
+  fun installPlan(context: Context): InstallLifecycle.Plan =
+      InstallLifecycle.plan(legacyInstaller(), isAvailable(context), installerDialogFixed(context))
 
   /**
    * Gen-1 with the daemon down AND no working dialog: on-device installs are truly
@@ -89,7 +92,7 @@ object InstallDaemon {
    * works, so callers fall through to PackageInstaller rather than refusing.
    */
   fun installPaused(context: Context): Boolean =
-      isPaused(legacyInstaller(), isAvailable(context), installerDialogFixed(context))
+      installPlan(context).paused
 
   /**
    * Queue [apk] for the daemon and block (on a background thread) until it

--- a/app/src/main/java/com/immortal/launcher/InstallLifecycle.kt
+++ b/app/src/main/java/com/immortal/launcher/InstallLifecycle.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+/**
+ * The install lifecycle decision model shared by the App Store, Fleet Agent, APK browser,
+ * and self-updater.
+ *
+ * The Android-specific Adapters still live in [InstallDaemon], [HeadlessInstaller], and
+ * [PackageInstallSessions]. This Module owns the policy: whether an install should use the
+ * silent daemon, the system dialog, or be reported as paused on an unfixed Gen-1 Portal.
+ */
+object InstallLifecycle {
+  const val MODE_SILENT = "silent"
+  const val MODE_DIALOG = "dialog"
+  const val MODE_PAUSED = "paused"
+
+  data class Plan(
+      val mode: String,
+      val daemonAvailable: Boolean,
+      val legacy: Boolean,
+      val dialogFixed: Boolean,
+      val paused: Boolean,
+  )
+
+  fun plan(legacy: Boolean, daemonAvailable: Boolean, dialogFixed: Boolean): Plan {
+    val paused = isPaused(legacy, daemonAvailable, dialogFixed)
+    return Plan(
+        mode = modeFor(daemonAvailable, paused),
+        daemonAvailable = daemonAvailable,
+        legacy = legacy,
+        dialogFixed = dialogFixed,
+        paused = paused,
+    )
+  }
+
+  fun modeFor(daemonAvailable: Boolean, paused: Boolean): String =
+      when {
+        daemonAvailable -> MODE_SILENT
+        paused -> MODE_PAUSED
+        else -> MODE_DIALOG
+      }
+
+  fun isPaused(legacy: Boolean, daemonAvailable: Boolean, dialogFixed: Boolean): Boolean =
+      legacy && !daemonAvailable && !dialogFixed
+
+  /** Map a store status string to a terminal result, or null for progress updates. */
+  fun terminalResult(msg: String): Boolean? =
+      when {
+        msg.contains("Installed ✓") -> true
+        msg.startsWith("Install failed") || msg.startsWith("Error") || msg.startsWith("Paused") -> false
+        else -> null
+      }
+}

--- a/app/src/main/java/com/immortal/launcher/MultiRoomNowPlaying.kt
+++ b/app/src/main/java/com/immortal/launcher/MultiRoomNowPlaying.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+/**
+ * Selects the effective multi-room now-playing state from the Snapcast relay and the
+ * Music Assistant player poll.
+ *
+ * Snapcast wins when it carries real track metadata. Music Assistant fills in when
+ * Snapcast only exposes an idle/bare stream, such as AirPlay bridged into a group.
+ */
+object MultiRoomNowPlaying {
+  fun effective(
+      snapcast: NowPlayingState?,
+      musicAssistant: NowPlayingState?,
+  ): NowPlayingState =
+      when {
+        hasTrack(snapcast) -> snapcast!!
+        hasTrack(musicAssistant) -> musicAssistant!!
+        else -> NowPlayingState(PlaybackState.IDLE)
+      }
+
+  internal fun hasTrack(state: NowPlayingState?): Boolean = state?.active == true
+}

--- a/app/src/main/java/com/immortal/launcher/MultiRoomService.kt
+++ b/app/src/main/java/com/immortal/launcher/MultiRoomService.kt
@@ -48,10 +48,10 @@ class MultiRoomService : Service() {
   @Volatile private var lastCover: Bitmap? = null
   @Volatile private var userPaused = false
 
-  // Two now-playing sources, merged in [effective]: Snapcast carries metadata for MA's own
-  // library/radio streams (via control.py); MA's API fills in for streams that don't — an
-  // AirPlay receiver bridged to the group surfaces a bare Snapcast stream, so its metadata
-  // only exists in MA's player state. We dedupe so the MA poll doesn't re-fetch art each tick.
+  // Two now-playing sources, merged by [MultiRoomNowPlaying]: Snapcast carries metadata for MA's
+  // own library/radio streams (via control.py); MA's API fills in for streams that don't — an
+  // AirPlay receiver bridged to the group surfaces a bare Snapcast stream, so its metadata only
+  // exists in MA's player state. We dedupe so the MA poll doesn't re-fetch art each tick.
   @Volatile private var snapState: NowPlayingState? = null
   @Volatile private var maState: NowPlayingState? = null
   @Volatile private var lastEffectiveKey: String? = null
@@ -118,29 +118,11 @@ class MultiRoomService : Service() {
    * poll re-reports the same track every few seconds). Runs on main so the dedupe is race-free.
    */
   private fun applyEffective() {
-    val eff = effective()
+    val eff = MultiRoomNowPlaying.effective(snapState, maState)
     val key = "${eff.state}|${eff.title}|${eff.artist}|${eff.artUrl}"
     if (key == lastEffectiveKey) return
     lastEffectiveKey = key
     onState(eff)
-  }
-
-  /**
-   * Snapcast metadata wins whenever its stream carries a track (MA library/radio via control.py);
-   * the MA poll fills in otherwise — notably an AirPlay receiver bridged to the group.
-   *
-   * The MA fill-in is inherently device-aware: [MaControl.nowPlaying] reports only THIS Portal's
-   * own player (resolved by our snapclient identity) and only when MA marks that player playing,
-   * so a Portal that isn't playing shows nothing. We deliberately do NOT gate on the Snapcast
-   * stream's status here — that went stale when AirPlay rotated to a new stream id, wrongly
-   * blanking a card that was in fact playing.
-   */
-  private fun effective(): NowPlayingState {
-    fun NowPlayingState.hasTrack() =
-        title.isNotBlank() && (state == PlaybackState.PLAYING || state == PlaybackState.PAUSED)
-    snapState?.let { if (it.hasTrack()) return it }
-    maState?.let { if (it.hasTrack()) return it }
-    return NowPlayingState(PlaybackState.IDLE)
   }
 
   /** Poll MA for our player's current track (the AirPlay fill-in). Always runs while the relay

--- a/app/src/main/java/com/immortal/launcher/PackageInstallSessions.kt
+++ b/app/src/main/java/com/immortal/launcher/PackageInstallSessions.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInstaller
+import android.os.Build
+import java.io.File
+
+/** Android PackageInstaller session Adapter shared by store installs and self-updates. */
+object PackageInstallSessions {
+  fun commit(
+      context: Context,
+      apk: File,
+      resultAction: String,
+      configureResultIntent: Intent.() -> Unit = {},
+  ) {
+    val pi = context.packageManager.packageInstaller
+    val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+    val sessionId = pi.createSession(params)
+    pi.openSession(sessionId).use { session ->
+      session.openWrite("base.apk", 0, apk.length()).use { out ->
+        apk.inputStream().use { it.copyTo(out) }
+        session.fsync(out)
+      }
+      val flags =
+          if (Build.VERSION.SDK_INT >= 31)
+              PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+          else PendingIntent.FLAG_UPDATE_CURRENT
+      val resultIntent =
+          Intent(resultAction)
+              .setPackage(context.packageName)
+              .apply(configureResultIntent)
+      val pending = PendingIntent.getBroadcast(context, sessionId, resultIntent, flags)
+      session.commit(pending.intentSender)
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -190,31 +190,26 @@ class PhotoFrameController(
 
   fun start() {
     settings = ScreensaverConfig.load(context)
-    // Web-page source takes over the whole frame — no photo feed, no Immortal overlay.
-    if (faceOverride == null && settings.usesWebUrl) {
-      startWebPage(settings.webUrl!!)
-      return
-    }
+    val source = PhotoFrameSource.from(settings, allowWebPage = faceOverride == null)
     applyFit()
     refreshCalendar.run()
     calendarTick.run()
     // Build + drive the overlay from the user's selected face ([FaceCatalog]); faceOverride lets
     // the debug preview harness (and the overnight night clock) render a specific face instead.
     faceRenderer.start(faceOverride ?: FaceCatalog.active(context))
-    when {
-      settings.usesFolder -> {
-        val path = settings.folderPath
-        if (path.isNullOrBlank()) {
-          startWeb()
-          return
-        }
+    when (source) {
+      is PhotoFrameSource.WebPage -> {
+        // Web-page source takes over the whole frame — no photo feed, no Immortal overlay.
+        startWebPage(source.url)
+      }
+      is PhotoFrameSource.Folder -> {
         io.execute {
           val list =
-              if (LocalMedia.isAccessible(path)) LocalMedia.enumerate(path, settings.includeVideo)
+              if (LocalMedia.isAccessible(source.path)) LocalMedia.enumerate(source.path, source.includeVideo)
               else emptyList()
           ui.post {
             if (list.isNotEmpty()) {
-              playlist = if (settings.shuffle) list.shuffled() else list
+              playlist = if (source.shuffle) list.shuffled() else list
               localMode = true
               localIndex = -1
               advanceLocal(+1)
@@ -225,19 +220,14 @@ class PhotoFrameController(
           }
         }
       }
-      settings.usesUrl -> {
-        val shareUrl = settings.albumUrl
-        if (shareUrl.isNullOrBlank()) {
-          startWeb()
-          return
-        }
+      is PhotoFrameSource.SharedAlbum -> {
         val m = context.resources.displayMetrics
         io.execute {
-          val album = RemoteAlbum.fetch(shareUrl, m.widthPixels, m.heightPixels)
+          val album = RemoteAlbum.fetch(source.url, m.widthPixels, m.heightPixels)
           val urls = album?.photoUrls.orEmpty()
           ui.post {
             if (urls.isNotEmpty()) {
-              remoteUrls = if (settings.shuffle) urls.shuffled() else urls
+              remoteUrls = if (source.shuffle) urls.shuffled() else urls
               remoteHeaders = emptyMap()
               remoteMode = true
               remoteIndex = -1
@@ -251,19 +241,13 @@ class PhotoFrameController(
           }
         }
       }
-      settings.usesImmich -> {
-        val base = settings.immichUrl
-        val key = settings.immichKey
-        if (base.isNullOrBlank() || key.isNullOrBlank()) {
-          startWeb()
-          return
-        }
+      is PhotoFrameSource.Immich -> {
         io.execute {
-          val urls = ImmichSource.listImageUrls(base, key, settings.immichAlbumId).orEmpty()
+          val urls = ImmichSource.listImageUrls(source.url, source.key, source.albumId).orEmpty()
           ui.post {
             if (urls.isNotEmpty()) {
-              remoteUrls = if (settings.shuffle) urls.shuffled() else urls
-              remoteHeaders = ImmichSource.authHeaders(key)
+              remoteUrls = if (source.shuffle) urls.shuffled() else urls
+              remoteHeaders = ImmichSource.authHeaders(source.key)
               remoteMode = true
               remoteIndex = -1
               remoteFailStreak = 0
@@ -275,18 +259,13 @@ class PhotoFrameController(
           }
         }
       }
-      settings.usesDav -> {
-        val url = settings.davUrl
-        if (url.isNullOrBlank()) {
-          startWeb()
-          return
-        }
+      is PhotoFrameSource.WebDav -> {
         io.execute {
-          val urls = DavSource.listImageUrls(url, settings.davUser, settings.davPass).orEmpty()
+          val urls = DavSource.listImageUrls(source.url, source.user, source.pass).orEmpty()
           ui.post {
             if (urls.isNotEmpty()) {
-              remoteUrls = if (settings.shuffle) urls.shuffled() else urls
-              remoteHeaders = DavSource.authHeaders(settings.davUser, settings.davPass)
+              remoteUrls = if (source.shuffle) urls.shuffled() else urls
+              remoteHeaders = DavSource.authHeaders(source.user, source.pass)
               remoteMode = true
               remoteIndex = -1
               remoteFailStreak = 0
@@ -297,21 +276,21 @@ class PhotoFrameController(
           }
         }
       }
-      settings.usesSmb -> {
+      is PhotoFrameSource.Smb -> {
         val src =
             SmbSource(
-                host = settings.smbHost.orEmpty(),
-                shareName = settings.smbShare.orEmpty(),
-                basePath = settings.smbPath.orEmpty(),
-                user = settings.smbUser.orEmpty(),
-                password = settings.smbPass.orEmpty(),
+                host = source.host,
+                shareName = source.share,
+                basePath = source.path,
+                user = source.user,
+                password = source.pass,
             )
         io.execute {
           val paths = if (src.connect()) src.listImages() else emptyList()
           ui.post {
             if (paths.isNotEmpty()) {
               smbSource = src
-              remoteUrls = if (settings.shuffle) paths.shuffled() else paths
+              remoteUrls = if (source.shuffle) paths.shuffled() else paths
               remoteFetch = { p -> src.openStream(p)?.use { BitmapFactory.decodeStream(it) } }
               remoteMode = true
               remoteIndex = -1
@@ -325,7 +304,7 @@ class PhotoFrameController(
           }
         }
       }
-      else -> startWeb()
+      PhotoFrameSource.DefaultFeed -> startWeb()
     }
   }
 

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -143,6 +143,8 @@ class PhotoFrameController(
 
   /** Hosts forward their touch events here. */
   fun onTouch(ev: MotionEvent) {
+    // While the timer alarm is showing, the slide-to-stop owns the touch stream.
+    if (faceRenderer.handleAlarmTouch(ev)) return
     when (ev.actionMasked) {
       MotionEvent.ACTION_DOWN -> {
         downX = ev.x

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameSource.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameSource.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+/** Source-selection Module for the photo-frame Screensaver. */
+sealed class PhotoFrameSource {
+  data object DefaultFeed : PhotoFrameSource()
+
+  data class Folder(
+      val path: String,
+      val includeVideo: Boolean,
+      val shuffle: Boolean,
+  ) : PhotoFrameSource()
+
+  data class SharedAlbum(
+      val url: String,
+      val shuffle: Boolean,
+  ) : PhotoFrameSource()
+
+  data class Immich(
+      val url: String,
+      val key: String,
+      val albumId: String?,
+      val shuffle: Boolean,
+  ) : PhotoFrameSource()
+
+  data class WebDav(
+      val url: String,
+      val user: String,
+      val pass: String,
+      val shuffle: Boolean,
+  ) : PhotoFrameSource()
+
+  data class Smb(
+      val host: String,
+      val share: String,
+      val path: String,
+      val user: String,
+      val pass: String,
+      val shuffle: Boolean,
+  ) : PhotoFrameSource()
+
+  data class WebPage(val url: String) : PhotoFrameSource()
+
+  val setupKey: String
+    get() =
+        when (this) {
+          DefaultFeed -> "default"
+          is Folder -> "folder"
+          is SharedAlbum -> "album"
+          is Immich -> "immich"
+          is WebDav -> "dav"
+          is Smb -> "smb"
+          is WebPage -> "web"
+        }
+
+  companion object {
+    /**
+     * Pick the active source from persisted Screensaver settings.
+     *
+     * Missing required fields deliberately fall back to [DefaultFeed], matching the product promise
+     * that the frame is never blank because of an unset or unreachable configured source.
+     */
+    fun from(settings: ScreensaverConfig.Settings, allowWebPage: Boolean = true): PhotoFrameSource =
+        when {
+          allowWebPage && settings.usesWebUrl -> WebPage(settings.webUrl!!)
+          settings.usesFolder ->
+              Folder(settings.folderPath!!, includeVideo = settings.includeVideo, shuffle = settings.shuffle)
+          settings.usesUrl -> SharedAlbum(settings.albumUrl!!, shuffle = settings.shuffle)
+          settings.usesImmich ->
+              Immich(
+                  url = settings.immichUrl!!,
+                  key = settings.immichKey!!,
+                  albumId = settings.immichAlbumId,
+                  shuffle = settings.shuffle,
+              )
+          settings.usesDav ->
+              WebDav(
+                  url = settings.davUrl!!,
+                  user = settings.davUser.orEmpty(),
+                  pass = settings.davPass.orEmpty(),
+                  shuffle = settings.shuffle,
+              )
+          settings.usesSmb ->
+              Smb(
+                  host = settings.smbHost!!,
+                  share = settings.smbShare!!,
+                  path = settings.smbPath.orEmpty(),
+                  user = settings.smbUser.orEmpty(),
+                  pass = settings.smbPass.orEmpty(),
+                  shuffle = settings.shuffle,
+              )
+          else -> DefaultFeed
+        }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/StoreCatalog.kt
+++ b/app/src/main/java/com/immortal/launcher/StoreCatalog.kt
@@ -7,11 +7,7 @@
 
 package com.immortal.launcher
 
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
-import android.content.pm.PackageInstaller
-import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -222,7 +218,9 @@ object StoreCatalog {
         } else {
           // Android-10 models — and Gen-1 once the overlay fix makes the stock
           // dialog visible — use the system installer dialog.
-          commit(context, app.packageName, apk)
+          PackageInstallSessions.commit(context, apk, STORE_INSTALL_ACTION) {
+            putExtra(STORE_EXTRA_PKG, app.packageName)
+          }
         }
       } catch (t: Throwable) {
         main.post { status(app.packageName, "Error: ${t.message ?: t.javaClass.simpleName}") }
@@ -240,26 +238,6 @@ object StoreCatalog {
             ?: JSONObject(httpGet("https://f-droid.org/api/v1/packages/$id"))
                 .getLong("suggestedVersionCode")
     return "https://f-droid.org/repo/${id}_$vc.apk"
-  }
-
-  private fun commit(context: Context, pkg: String, apk: File) {
-    val pi = context.packageManager.packageInstaller
-    val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
-    val sessionId = pi.createSession(params)
-    pi.openSession(sessionId).use { session ->
-      session.openWrite("base.apk", 0, apk.length()).use { out ->
-        apk.inputStream().use { it.copyTo(out) }
-        session.fsync(out)
-      }
-      val flags =
-          if (Build.VERSION.SDK_INT >= 31)
-              PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
-          else PendingIntent.FLAG_UPDATE_CURRENT
-      val intent =
-          Intent(STORE_INSTALL_ACTION).setPackage(context.packageName).putExtra(STORE_EXTRA_PKG, pkg)
-      val pending = PendingIntent.getBroadcast(context, sessionId, intent, flags)
-      session.commit(pending.intentSender)
-    }
   }
 
   // --- net helpers ------------------------------------------------------------

--- a/app/src/main/java/com/immortal/launcher/TimerAlarm.kt
+++ b/app/src/main/java/com/immortal/launcher/TimerAlarm.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioTrack
+import android.media.Ringtone
+import android.media.RingtoneManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.PowerManager
+import kotlin.math.PI
+import kotlin.math.exp
+import kotlin.math.sin
+
+/**
+ * Plays the timer's "time's up" sound. Rather than the harsh system alarm klaxon, it synthesizes a
+ * soft ascending three-note bell chime (A major) that loops gently with a pause between repeats —
+ * pleasant but still attention-getting. Holds a brief wake lock so it keeps sounding with the screen
+ * off, and auto-silences after [AUTO_SILENCE_MS] (1 min). The UI calls [stop] on a swipe.
+ */
+object TimerAlarm {
+
+  private const val AUTO_SILENCE_MS = 60_000L
+  private const val SAMPLE_RATE = 44_100
+
+  private val handler = Handler(Looper.getMainLooper())
+  private var track: AudioTrack? = null
+  private var fallback: Ringtone? = null
+  private var wakeLock: PowerManager.WakeLock? = null
+
+  val isRinging: Boolean
+    get() = track != null || fallback?.isPlaying == true
+
+  fun start(context: Context) {
+    val app = context.applicationContext
+    if (isRinging) return
+
+    runCatching {
+      val pm = app.getSystemService(Context.POWER_SERVICE) as PowerManager
+      wakeLock =
+          pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "immortal:timer-alarm").apply {
+            setReferenceCounted(false)
+            acquire(AUTO_SILENCE_MS + 5_000L)
+          }
+    }
+
+    val started = runCatching { startChime() }.getOrDefault(false)
+    if (!started) runCatching { startFallback(app) }
+
+    handler.postDelayed({ stop(app) }, AUTO_SILENCE_MS)
+  }
+
+  /** Soft synthesized bell chime, hardware-looped with a built-in pause between phrases. */
+  private fun startChime(): Boolean {
+    val samples = buildChime()
+    if (samples.isEmpty()) return false
+    val bytes = samples.size * 2
+
+    val attrs =
+        AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_ALARM)
+            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+            .build()
+    val format =
+        AudioFormat.Builder()
+            .setSampleRate(SAMPLE_RATE)
+            .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+            .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+            .build()
+
+    @Suppress("DEPRECATION")
+    val t =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            AudioTrack.Builder()
+                .setAudioAttributes(attrs)
+                .setAudioFormat(format)
+                .setBufferSizeInBytes(bytes)
+                .setTransferMode(AudioTrack.MODE_STATIC)
+                .build()
+        else
+            AudioTrack(
+                AudioManager.STREAM_ALARM,
+                SAMPLE_RATE,
+                AudioFormat.CHANNEL_OUT_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+                bytes,
+                AudioTrack.MODE_STATIC,
+            )
+
+    t.write(samples, 0, samples.size)
+    // Loop the whole buffer (chime + trailing silence) indefinitely.
+    t.setLoopPoints(0, samples.size, -1)
+    t.play()
+    track = t
+    return true
+  }
+
+  /** A gentle alarm ringtone, used only if PCM synthesis is unavailable on the device. */
+  private fun startFallback(app: Context) {
+    val uri =
+        RingtoneManager.getActualDefaultRingtoneUri(app, RingtoneManager.TYPE_NOTIFICATION)
+            ?: RingtoneManager.getActualDefaultRingtoneUri(app, RingtoneManager.TYPE_ALARM)
+            ?: return
+    fallback =
+        RingtoneManager.getRingtone(app, uri)?.apply {
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            audioAttributes =
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_ALARM)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                    .build()
+          }
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) isLooping = true
+          play()
+        }
+  }
+
+  /** Builds one phrase: three soft bell notes (A4 → C#5 → E5) then a short rest, as 16-bit PCM. */
+  private fun buildChime(): ShortArray {
+    val notes = doubleArrayOf(440.0, 554.37, 659.25)
+    val noteSeconds = 0.34
+    val restSeconds = 1.3
+    val noteLen = (SAMPLE_RATE * noteSeconds).toInt()
+    val restLen = (SAMPLE_RATE * restSeconds).toInt()
+    val buf = ShortArray(noteLen * notes.size + restLen)
+    var i = 0
+    for (freq in notes) {
+      for (n in 0 until noteLen) {
+        val t = n.toDouble() / SAMPLE_RATE
+        // Gentle pluck: fast soft attack, slow decay; a quiet 2nd harmonic adds bell shimmer.
+        val env = (1.0 - exp(-30.0 * t)) * exp(-3.2 * t)
+        val wave = sin(2 * PI * freq * t) * 0.62 + sin(2 * PI * 2 * freq * t) * 0.18
+        val v = (wave * env * 0.5 * Short.MAX_VALUE).toInt().coerceIn(-32768, 32767)
+        buf[i++] = v.toShort()
+      }
+    }
+    return buf
+  }
+
+  fun stop(context: Context) {
+    handler.removeCallbacksAndMessages(null)
+    runCatching {
+      track?.let {
+        it.pause()
+        it.flush()
+        it.stop()
+        it.release()
+      }
+    }
+    track = null
+    runCatching { fallback?.stop() }
+    fallback = null
+    runCatching { wakeLock?.let { if (it.isHeld) it.release() } }
+    wakeLock = null
+    TimerStore.stopRinging(context.applicationContext)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/TimerAlarmReceiver.kt
+++ b/app/src/main/java/com/immortal/launcher/TimerAlarmReceiver.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+/**
+ * Fires when a [TimerStore] timer reaches zero (scheduled via an exact [android.app.AlarmManager]
+ * alarm). Marks the timer as ringing and starts the audible alarm — this runs even if neither the
+ * home screen nor the screensaver is in the foreground, since AlarmManager wakes the process.
+ */
+class TimerAlarmReceiver : BroadcastReceiver() {
+  override fun onReceive(context: Context, intent: Intent) {
+    val app = context.applicationContext
+    TimerStore.markRinging(app)
+    TimerAlarm.start(app)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/TimerStore.kt
+++ b/app/src/main/java/com/immortal/launcher/TimerStore.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import java.util.concurrent.CopyOnWriteArraySet
+
+/**
+ * A single, shared countdown timer persisted across the app's surfaces. The home-screen Timers
+ * widget starts/pauses it; both that widget and the screensaver ([FaceRenderer]) read it back so a
+ * timer started on the home screen keeps counting down — and stays visible — once the photo frame
+ * takes over. Persistence (SharedPreferences) is the cross-component channel (home and screensaver
+ * are different components and rarely co-resident); [addListener] gives same-process surfaces a live
+ * nudge so a running timer's controls update immediately.
+ *
+ * Expiry is driven by an exact [AlarmManager] alarm (not just a UI loop), so the timer rings even if
+ * neither the home widget nor the screensaver is on screen. The alarm broadcasts to
+ * [TimerAlarmReceiver], which flips [State.ringing] on and starts [TimerAlarm].
+ */
+object TimerStore {
+
+  private const val PREFS = "immortal_timer"
+  private const val KEY_RUNNING = "running"
+  private const val KEY_ENDS_AT = "ends_at"
+  private const val KEY_REMAINING = "remaining_ms"
+  private const val KEY_RINGING = "ringing"
+  private const val ALARM_REQUEST = 0x71_4E_72 // "tNr"
+
+  /**
+   * The timer's persisted state. When [running], the countdown is anchored to [endsAt] (a wall
+   * clock epoch-ms) so it advances even while nothing is observing it; when paused, [remainingMs]
+   * holds what was left so it can be resumed exactly. [ringing] is set once it fires and stays on
+   * until silenced (by swipe, the widget Stop, or the 60s auto-silence in [TimerAlarm]).
+   */
+  data class State(
+      val running: Boolean = false,
+      val endsAt: Long = 0L,
+      val remainingMs: Long = 0L,
+      val ringing: Boolean = false,
+  ) {
+    /** Milliseconds left at [now] — derived from [endsAt] while running, else the frozen value. */
+    fun remaining(now: Long): Long =
+        if (running) (endsAt - now).coerceAtLeast(0L) else remainingMs.coerceAtLeast(0L)
+
+    /** Whether there's still a timer worth showing (running or paused with time left). */
+    fun active(now: Long): Boolean = remaining(now) > 0L
+  }
+
+  private val listeners = CopyOnWriteArraySet<() -> Unit>()
+
+  fun addListener(listener: () -> Unit) {
+    listeners.add(listener)
+  }
+
+  fun removeListener(listener: () -> Unit) {
+    listeners.remove(listener)
+  }
+
+  private fun notifyListeners() {
+    listeners.forEach { runCatching { it() } }
+  }
+
+  fun load(context: Context): State {
+    val p = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    return State(
+        running = p.getBoolean(KEY_RUNNING, false),
+        endsAt = p.getLong(KEY_ENDS_AT, 0L),
+        remainingMs = p.getLong(KEY_REMAINING, 0L),
+        ringing = p.getBoolean(KEY_RINGING, false),
+    )
+  }
+
+  private fun save(context: Context, state: State) {
+    context
+        .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        .edit()
+        .putBoolean(KEY_RUNNING, state.running)
+        .putLong(KEY_ENDS_AT, state.endsAt)
+        .putLong(KEY_REMAINING, state.remainingMs)
+        .putBoolean(KEY_RINGING, state.ringing)
+        .apply()
+    notifyListeners()
+  }
+
+  /** Start (or restart) the timer for [durationMs] from [now]. */
+  fun start(context: Context, durationMs: Long, now: Long = System.currentTimeMillis()) {
+    val endsAt = now + durationMs
+    save(context, State(running = true, endsAt = endsAt, remainingMs = durationMs, ringing = false))
+    scheduleAlarm(context, endsAt)
+  }
+
+  /** Freeze a running timer at its current remaining time. */
+  fun pause(context: Context, now: Long = System.currentTimeMillis()) {
+    val s = load(context)
+    if (!s.running) return
+    cancelAlarm(context)
+    save(context, State(running = false, endsAt = 0L, remainingMs = s.remaining(now)))
+  }
+
+  /** Re-anchor a paused timer to keep counting from where it stopped. */
+  fun resume(context: Context, now: Long = System.currentTimeMillis()) {
+    val s = load(context)
+    if (s.running || s.remainingMs <= 0L) return
+    val endsAt = now + s.remainingMs
+    save(context, State(running = true, endsAt = endsAt, remainingMs = s.remainingMs))
+    scheduleAlarm(context, endsAt)
+  }
+
+  /** Stop and forget the timer (also cancels a pending alarm). */
+  fun clear(context: Context) {
+    cancelAlarm(context)
+    save(context, State())
+  }
+
+  /** Called by [TimerAlarmReceiver] when the alarm fires: the timer is now ringing. */
+  fun markRinging(context: Context) {
+    save(context, State(running = false, endsAt = 0L, remainingMs = 0L, ringing = true))
+  }
+
+  /** Silence the ringing timer and reset to idle. */
+  fun stopRinging(context: Context) {
+    cancelAlarm(context)
+    save(context, State())
+  }
+
+  // --- exact-alarm scheduling -------------------------------------------------
+  private fun alarmPendingIntent(context: Context): PendingIntent {
+    val intent = Intent(context.applicationContext, TimerAlarmReceiver::class.java)
+    var flags = PendingIntent.FLAG_UPDATE_CURRENT
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) flags = flags or PendingIntent.FLAG_IMMUTABLE
+    return PendingIntent.getBroadcast(context.applicationContext, ALARM_REQUEST, intent, flags)
+  }
+
+  private fun scheduleAlarm(context: Context, triggerAtMillis: Long) {
+    val am = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager ?: return
+    val pi = alarmPendingIntent(context)
+    am.cancel(pi)
+    runCatching {
+      // Portals are Android 9/10 (< S), so exact alarms need no special permission.
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+          am.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pi)
+      else am.setExact(AlarmManager.RTC_WAKEUP, triggerAtMillis, pi)
+    }
+  }
+
+  private fun cancelAlarm(context: Context) {
+    val am = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager ?: return
+    am.cancel(alarmPendingIntent(context))
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/UpdateManager.kt
+++ b/app/src/main/java/com/immortal/launcher/UpdateManager.kt
@@ -7,10 +7,7 @@
 
 package com.immortal.launcher
 
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
-import android.content.pm.PackageInstaller
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -115,7 +112,7 @@ object UpdateManager {
           val ok = InstallDaemon.install(context, apk, "immortal-update")
           main.post { status(if (ok) "Updated" else "Update failed") }
         } else {
-          commit(context, apk)
+          PackageInstallSessions.commit(context, apk, UPDATE_INSTALL_ACTION)
         }
       } catch (t: Throwable) {
         main.post { status("Update failed: ${t.message ?: t.javaClass.simpleName}") }
@@ -137,30 +134,6 @@ object UpdateManager {
             else @Suppress("DEPRECATION") pi.versionCode.toLong()
           }
           .getOrDefault(0L)
-
-  private fun commit(context: Context, apk: File) {
-    val pi = context.packageManager.packageInstaller
-    val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
-    val sessionId = pi.createSession(params)
-    pi.openSession(sessionId).use { session ->
-      session.openWrite("base.apk", 0, apk.length()).use { out ->
-        apk.inputStream().use { it.copyTo(out) }
-        session.fsync(out)
-      }
-      val flags =
-          if (Build.VERSION.SDK_INT >= 31)
-              PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
-          else PendingIntent.FLAG_UPDATE_CURRENT
-      val pending =
-          PendingIntent.getBroadcast(
-              context,
-              sessionId,
-              Intent(UPDATE_INSTALL_ACTION).setPackage(context.packageName),
-              flags,
-          )
-      session.commit(pending.intentSender)
-    }
-  }
 
   private fun httpGet(spec: String): String = open(spec).inputStream.use {
     it.readBytes().toString(Charsets.UTF_8)

--- a/app/src/main/java/com/immortal/launcher/UserLayout.kt
+++ b/app/src/main/java/com/immortal/launcher/UserLayout.kt
@@ -23,6 +23,8 @@ object UserLayout {
   private const val PREFS = "immortal_layout"
   private const val KEY = "assignments"
   private const val KEY_ORDER = "home_order"
+  private const val KEY_GRID_ORDER = "grid_order"
+  private const val KEY_GRID_SLOTS = "grid_slots"
 
   /** package id -> folder name (user override). */
   fun load(context: Context): Map<String, String> {
@@ -55,6 +57,60 @@ object UserLayout {
         .putString(KEY_ORDER, serializeOrder(order))
         .apply()
   }
+
+  /**
+   * Unified top-level home-grid order: stable keys for every movable tile — built-ins
+   * ("builtin:calls" etc.), widgets ("widget-tile:…"), folders ("folder:…"), and ungrouped apps
+   * ("app:…"). Lets the user drag ANY tile, not just apps. Reuses the tolerant order codec.
+   */
+  fun loadGridOrder(context: Context): List<String> {
+    val raw =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getString(KEY_GRID_ORDER, null)
+            ?: return emptyList()
+    return deserializeOrder(raw)
+  }
+
+  fun saveGridOrder(context: Context, order: List<String>) {
+    context
+        .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        .edit()
+        .putString(KEY_GRID_ORDER, serializeOrder(order))
+        .apply()
+  }
+
+  /**
+   * Free-placement home grid: a flat list of slots where each entry is a tile key or `null` (a
+   * blank cell the user left). Stored as a JSON array with "" standing in for a blank.
+   */
+  fun loadGridSlots(context: Context): List<String?> {
+    val raw =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getString(KEY_GRID_SLOTS, null)
+            ?: return emptyList()
+    return deserializeSlots(raw)
+  }
+
+  fun saveGridSlots(context: Context, slots: List<String?>) {
+    context
+        .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        .edit()
+        .putString(KEY_GRID_SLOTS, serializeSlots(slots))
+        .apply()
+  }
+
+  internal fun serializeSlots(slots: List<String?>): String =
+      org.json.JSONArray(slots.map { it ?: "" }).toString()
+
+  internal fun deserializeSlots(raw: String): List<String?> =
+      runCatching {
+            val arr = org.json.JSONArray(raw)
+            buildList {
+              for (i in 0 until arr.length()) {
+                val s = arr.optString(i)
+                add(if (s.isNullOrBlank()) null else s)
+              }
+            }
+          }
+          .getOrDefault(emptyList())
 
   /** JSON encode of the assignment map (extracted for testing). */
   internal fun serialize(assignments: Map<String, String>): String {

--- a/app/src/main/java/com/immortal/launcher/UserLayout.kt
+++ b/app/src/main/java/com/immortal/launcher/UserLayout.kt
@@ -22,6 +22,7 @@ object UserLayout {
 
   private const val PREFS = "immortal_layout"
   private const val KEY = "assignments"
+  private const val KEY_ORDER = "home_order"
 
   /** package id -> folder name (user override). */
   fun load(context: Context): Map<String, String> {
@@ -39,6 +40,22 @@ object UserLayout {
         .apply()
   }
 
+  /** User-defined order of ungrouped home-screen app package IDs. */
+  fun loadOrder(context: Context): List<String> {
+    val raw =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getString(KEY_ORDER, null)
+            ?: return emptyList()
+    return deserializeOrder(raw)
+  }
+
+  fun saveOrder(context: Context, order: List<String>) {
+    context
+        .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        .edit()
+        .putString(KEY_ORDER, serializeOrder(order))
+        .apply()
+  }
+
   /** JSON encode of the assignment map (extracted for testing). */
   internal fun serialize(assignments: Map<String, String>): String {
     val obj = JSONObject()
@@ -53,6 +70,41 @@ object UserLayout {
             buildMap { obj.keys().forEach { k -> put(k, obj.getString(k)) } }
           }
           .getOrDefault(emptyMap())
+
+  internal fun serializeOrder(order: List<String>): String =
+      org.json.JSONArray(order.distinct()).toString()
+
+  internal fun deserializeOrder(raw: String): List<String> =
+      runCatching {
+            val arr = org.json.JSONArray(raw)
+            buildList {
+                  for (i in 0 until arr.length()) {
+                    val id = arr.optString(i)
+                    if (id.isNotBlank() && id !in this) add(id)
+                  }
+                }
+          }
+          .getOrDefault(emptyList())
+
+  fun <T> applyOrder(items: List<T>, order: List<String>, idOf: (T) -> String): List<T> {
+    if (order.isEmpty()) return items
+    val byId = items.associateBy(idOf)
+    val ordered = order.mapNotNull { byId[it] }
+    val orderedIds = order.toSet()
+    val remaining = items.filter { idOf(it) !in orderedIds }
+    return ordered + remaining
+  }
+
+  fun moveOrder(order: List<String>, source: String, target: String): List<String> {
+    if (source == target) return order
+    val mutable = order.toMutableList()
+    val from = mutable.indexOf(source)
+    val to = mutable.indexOf(target)
+    if (from < 0 || to < 0) return order
+    val item = mutable.removeAt(from)
+    mutable.add(to, item)
+    return mutable
+  }
 
   /** A folder name not already used by either the user map or the curated set. */
   fun nextFolderName(existing: Set<String>): String {

--- a/app/src/main/java/com/immortal/launcher/Wallpaper.kt
+++ b/app/src/main/java/com/immortal/launcher/Wallpaper.kt
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Home-screen wallpaper. The launcher background can be a flat dark fill, one of a few gradient
+ * presets (optionally with film grain), a bundled photo, or "sync with the screensaver" — which
+ * mirrors the screensaver's photo source as a blurred backdrop. Photo modes are always shown
+ * blurred + dimmed so app icons stay legible.
+ */
+object WallpaperConfig {
+
+  private const val PREFS = "immortal_wallpaper"
+  private const val KEY_MODE = "mode"
+  private const val KEY_GRAIN = "grain"
+
+  const val DARK = "dark"
+  const val SCREENSAVER = "screensaver"
+  const val PHOTO_PREFIX = "photo:"
+
+  data class Config(val mode: String = DARK, val grain: Boolean = false)
+
+  /** Gradient presets: id → top-to-bottom colour stops (ARGB longs). */
+  val GRADIENTS: List<Pair<String, List<Long>>> =
+      listOf(
+          "g_midnight" to listOf(0xFF0F2027, 0xFF203A43, 0xFF2C5364),
+          "g_dusk" to listOf(0xFF41295A, 0xFF2F0743),
+          "g_ocean" to listOf(0xFF1A2980, 0xFF26D0CE),
+          "g_ember" to listOf(0xFF6A2C70, 0xFFB83B5E, 0xFFF08A5D),
+          "g_aurora" to listOf(0xFF0B486B, 0xFF3B8686, 0xFF79BD9A),
+      )
+
+  /** Bundled photo presets (mode id → label). Files live in assets/photoframe_fallback. */
+  val PHOTOS: List<Pair<String, String>> =
+      listOf(
+          PHOTO_PREFIX + "01_wilderness.jpg" to "Wilderness",
+          PHOTO_PREFIX + "02_denali.jpg" to "Denali",
+          PHOTO_PREFIX + "03_yosemite.jpg" to "Yosemite",
+      )
+
+  fun gradientColors(mode: String): List<Long>? = GRADIENTS.firstOrNull { it.first == mode }?.second
+
+  fun isPhoto(mode: String): Boolean = mode == SCREENSAVER || mode.startsWith(PHOTO_PREFIX)
+
+  fun load(context: Context): Config {
+    val p = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    return Config(mode = p.getString(KEY_MODE, DARK) ?: DARK, grain = p.getBoolean(KEY_GRAIN, false))
+  }
+
+  fun setMode(context: Context, mode: String) =
+      context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit().putString(KEY_MODE, mode).apply()
+
+  fun setGrain(context: Context, on: Boolean) =
+      context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit().putBoolean(KEY_GRAIN, on).apply()
+
+  /**
+   * Loads + blurs the photo for a photo/screensaver wallpaper: a bundled asset for a `photo:` mode,
+   * or the screensaver's current source for [SCREENSAVER]. The blur is a real StackBlur on a
+   * moderate-resolution downscale (smooth "frosted glass", not the blocky look of a tiny upscale),
+   * and works on the Portal's Android 9/10 (no RenderScript / Modifier.blur needed).
+   */
+  fun loadPhoto(context: Context, mode: String): Bitmap? {
+    val src =
+        when {
+          mode.startsWith(PHOTO_PREFIX) -> bundled(context, mode.removePrefix(PHOTO_PREFIX))
+          else -> screensaverPhoto(context)
+        } ?: return null
+    // Downscale so the longest edge is ~moderate (keeps detail for a smooth blur, but cheap), then
+    // blur. Crop-upscaling a properly-blurred ~360px image reads as a clean frosted backdrop.
+    val maxDim = maxOf(src.width, src.height).coerceAtLeast(1)
+    val scale = (360f / maxDim).coerceAtMost(1f)
+    val tw = (src.width * scale).toInt().coerceAtLeast(1)
+    val th = (src.height * scale).toInt().coerceAtLeast(1)
+    val scaled = runCatching { Bitmap.createScaledBitmap(src, tw, th, true) }.getOrNull() ?: src
+    return runCatching { stackBlur(scaled, 24) }.getOrDefault(scaled)
+  }
+
+  private fun bundled(context: Context, name: String): Bitmap? =
+      runCatching {
+            context.assets.open("photoframe_fallback/$name").use { BitmapFactory.decodeStream(it) }
+          }
+          .getOrNull()
+
+  private fun anyBundled(context: Context): Bitmap? =
+      runCatching {
+            val names =
+                context.assets.list("photoframe_fallback")
+                    ?.filter { it.endsWith(".jpg", ignoreCase = true) }
+                    .orEmpty()
+            names.randomOrNull()?.let { bundled(context, it) }
+          }
+          .getOrNull()
+
+  private fun screensaverPhoto(context: Context): Bitmap? {
+    val cfg = ScreensaverConfig.load(context)
+    val folder = cfg.folderPath
+    if (cfg.usesFolder && folder != null && LocalMedia.isAccessible(folder)) {
+      val pick =
+          LocalMedia.enumerate(folder, includeVideo = false, max = 80)
+              .filterNot { it.isVideo }
+              .randomOrNull()
+      if (pick != null) {
+        runCatching { BitmapFactory.decodeFile(pick.path) }.getOrNull()?.let { return it }
+      }
+    }
+    return anyBundled(context)
+  }
+}
+
+/** The launcher's wallpaper layer, placed behind the home content. Re-reads its config on resume. */
+@Composable
+fun HomeBackground(modifier: Modifier = Modifier) {
+  val context = LocalContext.current
+  var cfg by remember { mutableStateOf(WallpaperConfig.load(context)) }
+  val lifecycleOwner = LocalLifecycleOwner.current
+  DisposableEffect(lifecycleOwner) {
+    val obs = LifecycleEventObserver { _, e ->
+      if (e == Lifecycle.Event.ON_RESUME) cfg = WallpaperConfig.load(context)
+    }
+    lifecycleOwner.lifecycle.addObserver(obs)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+  }
+
+  val mode = cfg.mode
+  val gradient = WallpaperConfig.gradientColors(mode)
+  androidx.compose.foundation.layout.Box(modifier) {
+    when {
+      gradient != null -> {
+        androidx.compose.foundation.layout.Box(
+            Modifier.fillMaxSize().background(Brush.verticalGradient(gradient.map { Color(it) })))
+      }
+      WallpaperConfig.isPhoto(mode) -> {
+        val bmp by
+            produceState<android.graphics.Bitmap?>(initialValue = null, mode) {
+              value = withContext(Dispatchers.IO) { WallpaperConfig.loadPhoto(context, mode) }
+            }
+        val b = bmp
+        if (b != null) {
+          Image(
+              bitmap = b.asImageBitmap(),
+              contentDescription = null,
+              contentScale = ContentScale.Crop,
+              modifier = Modifier.fillMaxSize(),
+          )
+          // Dim for icon legibility over the blurred photo.
+          androidx.compose.foundation.layout.Box(
+              Modifier.fillMaxSize().background(Color(0x73000000)))
+        } else {
+          androidx.compose.foundation.layout.Box(Modifier.fillMaxSize().background(Color(0xFF1A1A1A)))
+        }
+      }
+      else -> androidx.compose.foundation.layout.Box(Modifier.fillMaxSize().background(Color(0xFF1A1A1A)))
+    }
+    if (cfg.grain) GrainOverlay()
+  }
+}
+
+/** A subtle film-grain overlay (tiled random-noise bitmap at low alpha). */
+@Composable
+private fun GrainOverlay() {
+  val noise = remember { makeNoise(128) }
+  Canvas(Modifier.fillMaxSize()) {
+    drawIntoCanvas { c ->
+      val paint =
+          android.graphics.Paint().apply {
+            shader =
+                android.graphics.BitmapShader(
+                    noise,
+                    android.graphics.Shader.TileMode.REPEAT,
+                    android.graphics.Shader.TileMode.REPEAT,
+                )
+            alpha = 20
+          }
+      c.nativeCanvas.drawRect(0f, 0f, size.width, size.height, paint)
+    }
+  }
+}
+
+private fun makeNoise(n: Int): Bitmap {
+  val bmp = Bitmap.createBitmap(n, n, Bitmap.Config.ARGB_8888)
+  val rnd = java.util.Random(7)
+  val px = IntArray(n * n)
+  for (i in px.indices) {
+    val v = rnd.nextInt(256)
+    px[i] = (0xFF shl 24) or (v shl 16) or (v shl 8) or v
+  }
+  bmp.setPixels(px, 0, n, 0, 0, n, n)
+  return bmp
+}
+
+
+/**
+ * StackBlur (Mario Klingemann) — a fast Gaussian-like blur that runs on any API level (no
+ * RenderScript). Operates on a copy and returns the blurred bitmap.
+ */
+private fun stackBlur(sent: Bitmap, radius: Int): Bitmap {
+  val bitmap = sent.copy(sent.config ?: Bitmap.Config.ARGB_8888, true)
+  if (radius < 1) return bitmap
+  val w = bitmap.width
+  val h = bitmap.height
+  val pix = IntArray(w * h)
+  bitmap.getPixels(pix, 0, w, 0, 0, w, h)
+  val wm = w - 1
+  val hm = h - 1
+  val div = radius + radius + 1
+  val r = IntArray(w * h)
+  val g = IntArray(w * h)
+  val b = IntArray(w * h)
+  val vmin = IntArray(maxOf(w, h))
+  var divsum = (div + 1) shr 1
+  divsum *= divsum
+  val dv = IntArray(256 * divsum)
+  for (i in 0 until 256 * divsum) dv[i] = i / divsum
+  val stack = Array(div) { IntArray(3) }
+  val r1 = radius + 1
+
+  var yw = 0
+  var yi = 0
+  for (y in 0 until h) {
+    var rinsum = 0
+    var ginsum = 0
+    var binsum = 0
+    var routsum = 0
+    var goutsum = 0
+    var boutsum = 0
+    var rsum = 0
+    var gsum = 0
+    var bsum = 0
+    for (i in -radius..radius) {
+      val p = pix[yi + minOf(wm, maxOf(i, 0))]
+      val sir = stack[i + radius]
+      sir[0] = (p and 0xff0000) shr 16
+      sir[1] = (p and 0x00ff00) shr 8
+      sir[2] = (p and 0x0000ff)
+      val rbs = r1 - kotlin.math.abs(i)
+      rsum += sir[0] * rbs
+      gsum += sir[1] * rbs
+      bsum += sir[2] * rbs
+      if (i > 0) {
+        rinsum += sir[0]; ginsum += sir[1]; binsum += sir[2]
+      } else {
+        routsum += sir[0]; goutsum += sir[1]; boutsum += sir[2]
+      }
+    }
+    var stackpointer = radius
+    for (x in 0 until w) {
+      r[yi] = dv[rsum]
+      g[yi] = dv[gsum]
+      b[yi] = dv[bsum]
+      rsum -= routsum; gsum -= goutsum; bsum -= boutsum
+      var stackstart = stackpointer - radius + div
+      var sir = stack[stackstart % div]
+      routsum -= sir[0]; goutsum -= sir[1]; boutsum -= sir[2]
+      if (y == 0) vmin[x] = minOf(x + radius + 1, wm)
+      val p = pix[yw + vmin[x]]
+      sir[0] = (p and 0xff0000) shr 16
+      sir[1] = (p and 0x00ff00) shr 8
+      sir[2] = (p and 0x0000ff)
+      rinsum += sir[0]; ginsum += sir[1]; binsum += sir[2]
+      rsum += rinsum; gsum += ginsum; bsum += binsum
+      stackpointer = (stackpointer + 1) % div
+      sir = stack[stackpointer % div]
+      routsum += sir[0]; goutsum += sir[1]; boutsum += sir[2]
+      rinsum -= sir[0]; ginsum -= sir[1]; binsum -= sir[2]
+      yi++
+    }
+    yw += w
+  }
+  for (x in 0 until w) {
+    var rinsum = 0
+    var ginsum = 0
+    var binsum = 0
+    var routsum = 0
+    var goutsum = 0
+    var boutsum = 0
+    var rsum = 0
+    var gsum = 0
+    var bsum = 0
+    var yp = -radius * w
+    for (i in -radius..radius) {
+      yi = maxOf(0, yp) + x
+      val sir = stack[i + radius]
+      sir[0] = r[yi]; sir[1] = g[yi]; sir[2] = b[yi]
+      val rbs = r1 - kotlin.math.abs(i)
+      rsum += r[yi] * rbs
+      gsum += g[yi] * rbs
+      bsum += b[yi] * rbs
+      if (i > 0) {
+        rinsum += sir[0]; ginsum += sir[1]; binsum += sir[2]
+      } else {
+        routsum += sir[0]; goutsum += sir[1]; boutsum += sir[2]
+      }
+      if (i < hm) yp += w
+    }
+    yi = x
+    var stackpointer = radius
+    for (y in 0 until h) {
+      pix[yi] = (0xff shl 24) or (dv[rsum] shl 16) or (dv[gsum] shl 8) or dv[bsum]
+      rsum -= routsum; gsum -= goutsum; bsum -= boutsum
+      var stackstart = stackpointer - radius + div
+      var sir = stack[stackstart % div]
+      routsum -= sir[0]; goutsum -= sir[1]; boutsum -= sir[2]
+      if (x == 0) vmin[y] = minOf(y + r1, hm) * w
+      val p = x + vmin[y]
+      sir[0] = r[p]; sir[1] = g[p]; sir[2] = b[p]
+      rinsum += sir[0]; ginsum += sir[1]; binsum += sir[2]
+      rsum += rinsum; gsum += ginsum; bsum += binsum
+      stackpointer = (stackpointer + 1) % div
+      sir = stack[stackpointer]
+      routsum += sir[0]; goutsum += sir[1]; boutsum += sir[2]
+      rinsum -= sir[0]; ginsum -= sir[1]; binsum -= sir[2]
+      yi += w
+    }
+  }
+  bitmap.setPixels(pix, 0, w, 0, 0, w, h)
+  return bitmap
+}

--- a/app/src/main/java/com/immortal/launcher/Weather.kt
+++ b/app/src/main/java/com/immortal/launcher/Weather.kt
@@ -47,7 +47,7 @@ object Weather {
           }
           .getOrDefault("")
 
-  /** Cached lat/lon, or a fresh geolocation (cached on success). */
+  /** Cached lat/lon, or a fresh geolocation (cached on success). Also caches the city name. */
   private fun location(context: Context): Pair<Double, Double>? {
     val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
     prefs.getString("lat", null)?.toDoubleOrNull()?.let { la ->
@@ -59,7 +59,9 @@ object Weather {
                 val j = JSONObject(httpGet(url))
                 val la = j.optDouble("latitude", Double.NaN)
                 val lo = j.optDouble("longitude", Double.NaN)
-                if (!la.isNaN() && !lo.isNaN() && (la != 0.0 || lo != 0.0)) la to lo else null
+                val city = j.optString("city", "")
+                if (!la.isNaN() && !lo.isNaN() && (la != 0.0 || lo != 0.0)) Triple(la, lo, city)
+                else null
               }
               .getOrNull()
       if (coords != null) {
@@ -67,12 +69,38 @@ object Weather {
             .edit()
             .putString("lat", coords.first.toString())
             .putString("lon", coords.second.toString())
+            .putString("city", coords.third)
             .apply()
-        return coords
+        return coords.first to coords.second
       }
     }
     return null
   }
+
+  /** Last known city name (empty until geolocation has succeeded once). */
+  fun cachedCity(context: Context): String =
+      context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getString("city", "") ?: ""
+
+  /** Current conditions for the redesigned weather widget: city, rounded temp, and weather code. */
+  data class Current(val city: String, val temp: Int, val code: Int)
+
+  fun fetchCurrent(context: Context): Current? =
+      runCatching {
+            val (lat, lon) = location(context) ?: return null
+            val unit = if (ImmortalSettings.useFahrenheit(context)) "fahrenheit" else "celsius"
+            val w =
+                JSONObject(
+                    httpGet(
+                        "https://api.open-meteo.com/v1/forecast?latitude=$lat&longitude=$lon" +
+                            "&current=temperature_2m,weather_code&temperature_unit=$unit"))
+            val cur = w.getJSONObject("current")
+            Current(
+                city = cachedCity(context),
+                temp = cur.getDouble("temperature_2m").roundToInt(),
+                code = cur.getInt("weather_code"),
+            )
+          }
+          .getOrNull()
 
   /** One day of the multi-day forecast. [label] is "Today" then "Mon", "Tue", … */
   data class DayForecast(val label: String, val code: Int, val hi: Int, val lo: Int)

--- a/app/src/test/java/com/immortal/launcher/FleetScreensaverTest.kt
+++ b/app/src/test/java/com/immortal/launcher/FleetScreensaverTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.json.JSONObject
 
 /** Pure JSON-shaping + coercion for the fleet `/screensaver` endpoint (no Context). */
 class FleetScreensaverTest {
@@ -148,5 +149,156 @@ class FleetScreensaverTest {
         src(
             ScreensaverConfig.Settings(
                 source = ScreensaverConfig.SOURCE_DAV, davUrl = "https://dav.example/photos")))
+  }
+
+  @Test
+  fun apply_writesOnlyPresentDisplayKeys() {
+    val writer = RecordingWriter()
+    val applied =
+        FleetScreensaver.apply(
+            writer,
+            JSONObject()
+                .put("enabled", false)
+                .put("fit", ScreensaverConfig.FIT_FIT)
+                .put("intervalSec", 45)
+                .put("presenceMode", "presence"))
+
+    assertEquals(listOf("enabled", "fit", "intervalSec", "presenceMode"), applied)
+    assertEquals(
+        listOf("enabled=false", "fit=fit", "interval=45", "presence=PRESENCE"),
+        writer.calls,
+    )
+  }
+
+  @Test
+  fun apply_keepsCredentialSourcesAtomic() {
+    val partialWriter = RecordingWriter()
+    val partialApplied =
+        FleetScreensaver.apply(partialWriter, JSONObject().put("immichUrl", "https://immich.local"))
+
+    assertEquals(emptyList<String>(), partialApplied)
+    assertEquals(emptyList<String>(), partialWriter.calls)
+
+    val fullWriter = RecordingWriter()
+    val fullApplied =
+        FleetScreensaver.apply(
+            fullWriter,
+            JSONObject().put("immichUrl", "https://immich.local").put("immichKey", "secret"),
+        )
+
+    assertEquals(listOf("immich"), fullApplied)
+    assertEquals(listOf("immich=https://immich.local|secret"), fullWriter.calls)
+  }
+
+  @Test
+  fun apply_ignoresUnknownFitAndPresenceMode() {
+    val writer = RecordingWriter()
+    val applied =
+        FleetScreensaver.apply(
+            writer,
+            JSONObject().put("fit", "stretch").put("presenceMode", "sometimes"),
+        )
+
+    assertEquals(emptyList<String>(), applied)
+    assertEquals(emptyList<String>(), writer.calls)
+  }
+
+  @Test
+  fun apply_sourceResetAndFolderUseWriterSeam() {
+    val writer = RecordingWriter()
+    val applied =
+        FleetScreensaver.apply(
+            writer,
+            JSONObject()
+                .put("source", ScreensaverConfig.SOURCE_DEFAULT)
+                .put("folderPath", "/sdcard/Pictures"),
+        )
+
+    assertEquals(listOf("source", "folderPath"), applied)
+    assertEquals(listOf("default", "folder=/sdcard/Pictures"), writer.calls)
+  }
+
+  private class RecordingWriter : FleetScreensaver.Writer {
+    val calls = mutableListOf<String>()
+
+    override fun setEnabled(value: Boolean) {
+      calls += "enabled=$value"
+    }
+
+    override fun useDefault() {
+      calls += "default"
+    }
+
+    override fun setFolder(path: String) {
+      calls += "folder=$path"
+    }
+
+    override fun setAlbumUrl(url: String) {
+      calls += "album=$url"
+    }
+
+    override fun setImmich(url: String, key: String) {
+      calls += "immich=$url|$key"
+    }
+
+    override fun setSmb(host: String, share: String, path: String, user: String, pass: String) {
+      calls += "smb=$host|$share|$path|$user|$pass"
+    }
+
+    override fun setDav(url: String, user: String, pass: String) {
+      calls += "dav=$url|$user|$pass"
+    }
+
+    override fun setWebUrl(url: String) {
+      calls += "web=$url"
+    }
+
+    override fun setAlbumRefreshMin(value: Int) {
+      calls += "albumRefresh=$value"
+    }
+
+    override fun setFit(value: String) {
+      calls += "fit=$value"
+    }
+
+    override fun setInterval(value: Int) {
+      calls += "interval=$value"
+    }
+
+    override fun setShuffle(value: Boolean) {
+      calls += "shuffle=$value"
+    }
+
+    override fun setIncludeVideo(value: Boolean) {
+      calls += "includeVideo=$value"
+    }
+
+    override fun setBatterySaver(value: Boolean) {
+      calls += "batterySaver=$value"
+    }
+
+    override fun setShowNowPlaying(value: Boolean) {
+      calls += "showNowPlaying=$value"
+    }
+
+    override fun setPresenceMode(value: FrameMode) {
+      calls += "presence=${value.name}"
+    }
+
+    override fun setIdleSleepMin(value: Int) {
+      calls += "idleSleep=$value"
+    }
+
+    override fun setOvernightEnabled(value: Boolean) {
+      calls += "overnightEnabled=$value"
+    }
+
+    override fun setOvernightStartMin(value: Int) {
+      calls += "overnightStart=$value"
+    }
+
+    override fun setOvernightEndMin(value: Int) {
+      calls += "overnightEnd=$value"
+    }
   }
 }

--- a/app/src/test/java/com/immortal/launcher/HomeGridTest.kt
+++ b/app/src/test/java/com/immortal/launcher/HomeGridTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeGridTest {
+
+  @Test
+  fun normalize_keepsBlanksAndOrder_appendsNew_padsTrailingRow() {
+    // 2 columns; saved has a gap (null) between a and b; c is new.
+    val saved = listOf<String?>("a", null, "b")
+    val result = HomeGrid.normalizeSlots(saved, listOf("a", "b", "c"), cols = 2)
+    // The gap is preserved, c appended, then padded to fill the row + one spare row (2 cols).
+    assertEquals(listOf("a", null, "b", "c", null, null), result)
+  }
+
+  @Test
+  fun normalize_dropsStaleAndDuplicateKeysToBlanks() {
+    val saved = listOf<String?>("a", "gone", "a", "b")
+    val result = HomeGrid.normalizeSlots(saved, listOf("a", "b"), cols = 3)
+    // "gone" (stale) and the second "a" (dup) become blanks; nothing new to append.
+    // out before pad: [a, null, null, b] -> size 4, rem 1 -> +2 to fill row (6) -> +3 spare = 9
+    assertEquals(listOf("a", null, null, "b", null, null, null, null, null), result)
+  }
+
+  @Test
+  fun swap_exchangesTwoSlots_includingBlanks() {
+    val slots = listOf<String?>("a", null, "b")
+    assertEquals(listOf<String?>(null, "a", "b"), HomeGrid.swap(slots, 0, 1))
+    assertEquals(listOf<String?>("b", null, "a"), HomeGrid.swap(slots, 0, 2))
+    // No-op / out of range returns the input unchanged.
+    assertEquals(slots, HomeGrid.swap(slots, 1, 1))
+    assertEquals(slots, HomeGrid.swap(slots, 1, 9))
+  }
+
+  @Test
+  fun normalizeToPages_padsToWholePages_andKeepsSpareWhenArranging() {
+    // keepSpare=true (arranging): pad the page, then add a trailing spare page to drop into.
+    assertEquals(
+        listOf("a", "b", "c", null, null, null, null, null),
+        HomeGrid.normalizeToPages(listOf("a", "b", "c"), listOf("a", "b", "c"), 4, keepSpare = true),
+    )
+  }
+
+  @Test
+  fun normalizeToPages_compactsWhenNotArranging() {
+    // keepSpare=false: pad to one page, no spare, no extra empties.
+    assertEquals(
+        listOf("a", "b", null, null),
+        HomeGrid.normalizeToPages(listOf("a", "b"), listOf("a", "b"), 4, keepSpare = false),
+    )
+  }
+
+  @Test
+  fun normalizeToPages_autoDeletesEmptyInteriorPage() {
+    // Capacity 2: tiles on page 0 and page 2, page 1 entirely blank -> empty page removed.
+    val saved = listOf<String?>("a", "b", null, null, "c", "d")
+    assertEquals(
+        listOf("a", "b", "c", "d"),
+        HomeGrid.normalizeToPages(saved, listOf("a", "b", "c", "d"), 2, keepSpare = false),
+    )
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/HomeLayoutModelTest.kt
+++ b/app/src/test/java/com/immortal/launcher/HomeLayoutModelTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HomeLayoutModelTest {
+
+  @Test
+  fun effectiveApps_userAssignmentsOverrideCuratedFolders() {
+    val effective =
+        HomeLayoutModel.effectiveApps(
+            listOf(app("a", "Media"), app("b", "Games"), app("c", null)),
+            mapOf("a" to "", "c" to "Pinned"),
+        )
+    assertNull(effective[0].folder)
+    assertEquals("Games", effective[1].folder)
+    assertEquals("Pinned", effective[2].folder)
+  }
+
+  @Test
+  fun folderNamesAreDistinctAndSorted() {
+    assertEquals(
+        listOf("Games", "Media"),
+        HomeLayoutModel.folderNames(listOf(app("a", "Media"), app("b", "Games"), app("c", "Media"))),
+    )
+  }
+
+  @Test
+  fun createAndRenameFolderReturnUpdatedAssignments() {
+    val created = HomeLayoutModel.createFolder(emptyMap(), "a", "b", "  Photos  ")
+    assertEquals("Photos", created.folderName)
+    assertEquals(mapOf("a" to "Photos", "b" to "Photos"), created.assignments)
+
+    val renamed =
+        HomeLayoutModel.renameFolder(
+            effectiveApps = listOf(app("a", "Photos"), app("b", "Photos"), app("c", null)),
+            assignments = created.assignments,
+            oldName = "Photos",
+            rawName = "Family",
+        )
+    assertEquals("Family", renamed?.folderName)
+    assertEquals(mapOf("a" to "Family", "b" to "Family"), renamed?.assignments)
+  }
+
+  @Test
+  fun moveOutCollapsesSingleAppFolders() {
+    val result =
+        HomeLayoutModel.moveOut(
+            effectiveApps = listOf(app("a", "Folder"), app("b", "Folder"), app("c", null)),
+            assignments = mapOf("a" to "Folder", "b" to "Folder"),
+            packageName = "a",
+        )
+    assertEquals(mapOf("a" to "", "b" to ""), result?.assignments)
+    assertEquals(true, result?.closeFolder)
+  }
+
+  private fun app(packageName: String, folder: String?) = HomeLayoutModel.AppRef(packageName, folder)
+}

--- a/app/src/test/java/com/immortal/launcher/HomeWidgetStoreTest.kt
+++ b/app/src/test/java/com/immortal/launcher/HomeWidgetStoreTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeWidgetStoreTest {
+
+  @Test
+  fun serialize_deserialize_roundTripsWidgets() {
+    val widgets =
+        listOf(
+            HomeWidgetStore.HomeWidget(
+                appWidgetId = 42,
+                providerPackage = "io.homeassistant.companion.android",
+                providerClass = "io.homeassistant.companion.android.widgets.button.ButtonWidget",
+                spanX = 2,
+                spanY = 3,
+            ),
+            HomeWidgetStore.HomeWidget(
+                appWidgetId = 43,
+                providerPackage = "com.android.chrome",
+                providerClass = "org.chromium.chrome.browser.searchwidget.SearchWidgetProvider",
+                spanX = 4,
+                spanY = 1,
+            ),
+        )
+
+    assertEquals(widgets, HomeWidgetStore.deserialize(HomeWidgetStore.serialize(widgets)))
+  }
+
+  @Test
+  fun deserialize_ignoresInvalidEntriesAndDuplicates() {
+    val raw =
+        """
+        [
+          {"id": 7, "package": "a", "class": "A", "spanX": 99, "spanY": 0},
+          {"id": 7, "package": "b", "class": "B"},
+          {"id": -1, "package": "c", "class": "C"},
+          {"id": 8, "package": "", "class": "D"}
+        ]
+        """
+            .trimIndent()
+
+    val widgets = HomeWidgetStore.deserialize(raw)
+
+    assertEquals(1, widgets.size)
+    assertEquals(7, widgets[0].appWidgetId)
+    assertEquals(HomeWidgetStore.MAX_SPAN, widgets[0].spanX)
+    assertEquals(1, widgets[0].spanY)
+  }
+
+  @Test
+  fun deserialize_isEmptyOnGarbage() {
+    assertTrue(HomeWidgetStore.deserialize("not json").isEmpty())
+    assertTrue(HomeWidgetStore.deserialize("").isEmpty())
+  }
+
+  @Test
+  fun withAdded_replacesExistingId() {
+    val original =
+        listOf(HomeWidgetStore.HomeWidget(1, "old", "Old"), HomeWidgetStore.HomeWidget(2, "b", "B"))
+    val added = HomeWidgetStore.HomeWidget(1, "new", "New")
+
+    assertEquals(listOf(original[1], added), HomeWidgetStore.withAdded(original, added))
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/HomeWidgetStoreTest.kt
+++ b/app/src/test/java/com/immortal/launcher/HomeWidgetStoreTest.kt
@@ -77,17 +77,4 @@ class HomeWidgetStoreTest {
 
     assertEquals(listOf(original[1], added), HomeWidgetStore.withAdded(original, added))
   }
-
-  @Test
-  fun resized_updatesWidgetByStableKey() {
-    val custom =
-        HomeWidgetStore.HomeWidget(kind = HomeWidgetStore.KIND_TIMERS, customId = "timers:1")
-    val android = HomeWidgetStore.HomeWidget(2, "pkg", "Cls")
-
-    val resized = HomeWidgetStore.resized(listOf(custom, android), custom.key, 4, 3)
-
-    assertEquals(4, resized[0].spanX)
-    assertEquals(3, resized[0].spanY)
-    assertEquals(android, resized[1])
-  }
 }

--- a/app/src/test/java/com/immortal/launcher/HomeWidgetStoreTest.kt
+++ b/app/src/test/java/com/immortal/launcher/HomeWidgetStoreTest.kt
@@ -31,6 +31,12 @@ class HomeWidgetStoreTest {
                 spanX = 4,
                 spanY = 1,
             ),
+            HomeWidgetStore.HomeWidget(
+                kind = HomeWidgetStore.KIND_WEATHER,
+                customId = "weather:1",
+                spanX = 2,
+                spanY = 2,
+            ),
         )
 
     assertEquals(widgets, HomeWidgetStore.deserialize(HomeWidgetStore.serialize(widgets)))
@@ -70,5 +76,18 @@ class HomeWidgetStoreTest {
     val added = HomeWidgetStore.HomeWidget(1, "new", "New")
 
     assertEquals(listOf(original[1], added), HomeWidgetStore.withAdded(original, added))
+  }
+
+  @Test
+  fun resized_updatesWidgetByStableKey() {
+    val custom =
+        HomeWidgetStore.HomeWidget(kind = HomeWidgetStore.KIND_TIMERS, customId = "timers:1")
+    val android = HomeWidgetStore.HomeWidget(2, "pkg", "Cls")
+
+    val resized = HomeWidgetStore.resized(listOf(custom, android), custom.key, 4, 3)
+
+    assertEquals(4, resized[0].spanX)
+    assertEquals(3, resized[0].spanY)
+    assertEquals(android, resized[1])
   }
 }

--- a/app/src/test/java/com/immortal/launcher/InstallLifecycleTest.kt
+++ b/app/src/test/java/com/immortal/launcher/InstallLifecycleTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InstallLifecycleTest {
+
+  @Test
+  fun plan_prefersSilentWhenDaemonIsAvailable() {
+    val plan = InstallLifecycle.plan(legacy = true, daemonAvailable = true, dialogFixed = false)
+    assertEquals(InstallLifecycle.MODE_SILENT, plan.mode)
+    assertTrue(plan.daemonAvailable)
+    assertFalse(plan.paused)
+  }
+
+  @Test
+  fun plan_pausesOnlyUnfixedLegacyWithoutDaemon() {
+    val paused = InstallLifecycle.plan(legacy = true, daemonAvailable = false, dialogFixed = false)
+    assertEquals(InstallLifecycle.MODE_PAUSED, paused.mode)
+    assertTrue(paused.paused)
+
+    val fixed = InstallLifecycle.plan(legacy = true, daemonAvailable = false, dialogFixed = true)
+    assertEquals(InstallLifecycle.MODE_DIALOG, fixed.mode)
+    assertFalse(fixed.paused)
+
+    val modern = InstallLifecycle.plan(legacy = false, daemonAvailable = false, dialogFixed = false)
+    assertEquals(InstallLifecycle.MODE_DIALOG, modern.mode)
+    assertFalse(modern.paused)
+  }
+
+  @Test
+  fun terminalResult_classifiesStoreMessages() {
+    assertEquals(true, InstallLifecycle.terminalResult("Installed ✓"))
+    assertEquals(false, InstallLifecycle.terminalResult("Install failed"))
+    assertEquals(false, InstallLifecycle.terminalResult("Error: no network"))
+    assertEquals(false, InstallLifecycle.terminalResult("Paused — connect to your computer"))
+    assertNull(InstallLifecycle.terminalResult("Downloading…"))
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/MultiRoomNowPlayingTest.kt
+++ b/app/src/test/java/com/immortal/launcher/MultiRoomNowPlayingTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MultiRoomNowPlayingTest {
+
+  @Test
+  fun effective_prefersSnapcastWhenItHasTrackMetadata() {
+    val snapcast = track("Snapcast")
+    val musicAssistant = track("Music Assistant")
+
+    assertEquals(snapcast, MultiRoomNowPlaying.effective(snapcast, musicAssistant))
+  }
+
+  @Test
+  fun effective_fallsBackToMusicAssistantWhenSnapcastIsBare() {
+    val snapcast = NowPlayingState(PlaybackState.PLAYING)
+    val musicAssistant = track("AirPlay")
+
+    assertEquals(musicAssistant, MultiRoomNowPlaying.effective(snapcast, musicAssistant))
+  }
+
+  @Test
+  fun effective_treatsPausedTrackAsActive() {
+    val paused = track("Paused", PlaybackState.PAUSED)
+
+    assertEquals(paused, MultiRoomNowPlaying.effective(null, paused))
+    assertTrue(MultiRoomNowPlaying.hasTrack(paused))
+  }
+
+  @Test
+  fun effective_returnsIdleWhenNeitherSourceHasATrack() {
+    assertFalse(MultiRoomNowPlaying.hasTrack(NowPlayingState(PlaybackState.STOPPED, title = "Old")))
+
+    assertEquals(
+        NowPlayingState(PlaybackState.IDLE),
+        MultiRoomNowPlaying.effective(
+            NowPlayingState(PlaybackState.PLAYING),
+            NowPlayingState(PlaybackState.STOPPED, title = "Old"),
+        ),
+    )
+  }
+
+  private fun track(title: String, state: PlaybackState = PlaybackState.PLAYING) =
+      NowPlayingState(state = state, title = title, artist = "Artist")
+}

--- a/app/src/test/java/com/immortal/launcher/PhotoFrameSourceTest.kt
+++ b/app/src/test/java/com/immortal/launcher/PhotoFrameSourceTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PhotoFrameSourceTest {
+
+  @Test
+  fun from_defaultsWhenSourceIsUnsetOrIncomplete() {
+    assertEquals(PhotoFrameSource.DefaultFeed, PhotoFrameSource.from(ScreensaverConfig.Settings()))
+    assertEquals(
+        PhotoFrameSource.DefaultFeed,
+        PhotoFrameSource.from(ScreensaverConfig.Settings(source = ScreensaverConfig.SOURCE_FOLDER)))
+    assertEquals(
+        PhotoFrameSource.DefaultFeed,
+        PhotoFrameSource.from(ScreensaverConfig.Settings(source = ScreensaverConfig.SOURCE_IMMICH, immichUrl = "http://x")))
+  }
+
+  @Test
+  fun from_selectsConfiguredPhotoSources() {
+    assertEquals(
+        PhotoFrameSource.Folder("/photos", includeVideo = false, shuffle = true),
+        PhotoFrameSource.from(
+            ScreensaverConfig.Settings(
+                source = ScreensaverConfig.SOURCE_FOLDER,
+                folderPath = "/photos",
+                includeVideo = false,
+                shuffle = true,
+            )))
+    assertEquals(
+        PhotoFrameSource.SharedAlbum("https://photos.example/album", shuffle = true),
+        PhotoFrameSource.from(
+            ScreensaverConfig.Settings(
+                source = ScreensaverConfig.SOURCE_URL,
+                albumUrl = "https://photos.example/album",
+                shuffle = true,
+            )))
+    assertEquals(
+        PhotoFrameSource.Immich("http://immich", "key", albumId = "album", shuffle = false),
+        PhotoFrameSource.from(
+            ScreensaverConfig.Settings(
+                source = ScreensaverConfig.SOURCE_IMMICH,
+                immichUrl = "http://immich",
+                immichKey = "key",
+                immichAlbumId = "album",
+            )))
+  }
+
+  @Test
+  fun from_webPageCanBeDisabledForFacePreview() {
+    val settings =
+        ScreensaverConfig.Settings(
+            source = ScreensaverConfig.SOURCE_WEBURL,
+            webUrl = "https://dashboard.example",
+        )
+    assertTrue(PhotoFrameSource.from(settings) is PhotoFrameSource.WebPage)
+    assertEquals(PhotoFrameSource.DefaultFeed, PhotoFrameSource.from(settings, allowWebPage = false))
+  }
+
+  @Test
+  fun setupKey_matchesRemoteSetupVocabulary() {
+    assertEquals("default", PhotoFrameSource.DefaultFeed.setupKey)
+    assertEquals("album", PhotoFrameSource.SharedAlbum("u", shuffle = false).setupKey)
+    assertEquals("web", PhotoFrameSource.WebPage("u").setupKey)
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/TimerStoreTest.kt
+++ b/app/src/test/java/com/immortal/launcher/TimerStoreTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TimerStoreTest {
+
+  @Test
+  fun running_remainingCountsDownFromEndsAt() {
+    val now = 1_000_000L
+    val s = TimerStore.State(running = true, endsAt = now + 90_000L, remainingMs = 120_000L)
+
+    assertEquals(90_000L, s.remaining(now))
+    assertEquals(30_000L, s.remaining(now + 60_000L))
+    // Never reports negative time, and isn't considered active once it hits zero.
+    assertEquals(0L, s.remaining(now + 120_000L))
+    assertTrue(s.active(now))
+    assertFalse(s.active(now + 90_000L))
+  }
+
+  @Test
+  fun paused_remainingIsFrozenAndIndependentOfTime() {
+    val s = TimerStore.State(running = false, endsAt = 0L, remainingMs = 45_000L)
+
+    assertEquals(45_000L, s.remaining(0L))
+    assertEquals(45_000L, s.remaining(10_000_000L))
+    assertTrue(s.active(10_000_000L))
+  }
+
+  @Test
+  fun cleared_isInactive() {
+    val s = TimerStore.State()
+    assertEquals(0L, s.remaining(System.currentTimeMillis()))
+    assertFalse(s.active(System.currentTimeMillis()))
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/UserLayoutTest.kt
+++ b/app/src/test/java/com/immortal/launcher/UserLayoutTest.kt
@@ -47,4 +47,22 @@ class UserLayoutTest {
     assertTrue(UserLayout.deserialize("not json at all").isEmpty())
     assertTrue(UserLayout.deserialize("").isEmpty())
   }
+
+  @Test
+  fun order_serialize_deserialize_roundTripsDistinctIds() {
+    val order = listOf("com.a", "com.b", "com.a", "com.c")
+    assertEquals(listOf("com.a", "com.b", "com.c"), UserLayout.deserializeOrder(UserLayout.serializeOrder(order)))
+  }
+
+  @Test
+  fun applyOrder_keepsUnknownAndNewItemsStable() {
+    val apps = listOf("a", "b", "c")
+    assertEquals(listOf("c", "a", "b"), UserLayout.applyOrder(apps, listOf("c", "missing", "a")) { it })
+  }
+
+  @Test
+  fun moveOrder_movesSourceBeforeTarget() {
+    assertEquals(listOf("a", "c", "b"), UserLayout.moveOrder(listOf("a", "b", "c"), "c", "b"))
+    assertEquals(listOf("b", "a", "c"), UserLayout.moveOrder(listOf("a", "b", "c"), "a", "b"))
+  }
 }


### PR DESCRIPTION
Summary
- Add deep Modules for install lifecycle, photo-frame source selection, home layout decisions, fleet screensaver writes, and multi-room now-playing selection.
- Route Android adapters through those Modules to concentrate install/update, photo-frame, layout, route apply, and source-selection behavior.
- Add focused JVM tests for the new Interfaces and apply behavior.

Tests
- git diff --check
- ./gradlew :app:testDebugUnitTest