### PR TITLE
Settings hardening: apply tests, side-effect helper, secret redaction, drift guard

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,4 +117,8 @@ dependencies {
   // stub used in unit tests otherwise throws "not mocked").
   testImplementation(libs.junit)
   testImplementation("org.json:json:20240303")
+  // Pure-JVM mock of Context so the registry's apply/onApplied path is unit-testable without
+  // Robolectric (no instrumented android-all for compileSdk 36 / AGP 9 yet). The Context is only
+  // passed through to setters, so a mock that's never dereferenced is enough.
+  testImplementation("org.mockito:mockito-core:5.11.0")
 }

--- a/app/src/main/java/com/immortal/launcher/FleetRoutes.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetRoutes.kt
@@ -276,9 +276,7 @@ class FleetRoutes(private val context: Context) {
           if (body == null) resp(400, err("bad_json"))
           else {
             val applied = FleetScreensaver.apply(context, body)
-            SettingsGuard.reaffirmScreensaver(context)
-            // Overnight alarms are armed eagerly so a window change takes effect now.
-            if (applied.any { it.startsWith("overnight") }) SleepScheduler.applyOvernightNow(context)
+            SettingsGuard.afterScreensaverApply(context, applied)
             resp(
                 200,
                 ok()

--- a/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
@@ -449,7 +449,9 @@ object RemoteHtml {
     var t=document.createElement('div');t.className='t';t.textContent=ctl.title;
     if(ctl.type==='string'||(ctl.type==='int'&&ctl.asText)){
       row.className='setrow col';row.appendChild(t);
-      var inp=document.createElement('input');inp.value=(ctl.value!=null?ctl.value:'');if(ctl.help)inp.placeholder=ctl.help;
+      var inp=document.createElement('input');inp.value=(ctl.value!=null?ctl.value:'');
+      if(ctl.secret){inp.type='password';inp.placeholder=ctl.hasValue?'Set - leave blank to keep':(ctl.help||'');}
+      else if(ctl.help)inp.placeholder=ctl.help;
       if(ctl.type==='int')inp.inputMode='numeric';
       inp.onchange=function(){var v=ctl.type==='int'?parseInt(inp.value,10):inp.value;if(ctl.type==='int'&&isNaN(v))return;setPut(domId,ctl.key,v);};
       row.appendChild(inp);return row;

--- a/app/src/main/java/com/immortal/launcher/RemoteRoutes.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteRoutes.kt
@@ -234,7 +234,7 @@ class RemoteRoutes(private val context: Context) {
             if (body.has("calendarUrl")) {
               applied += FleetCalendar.apply(context, JSONObject().put("url", body.optString("calendarUrl")))
             }
-            SettingsGuard.reaffirmScreensaver(context)
+            SettingsGuard.afterScreensaverApply(context, applied)
             val s = ScreensaverConfig.load(context)
             json(
                 200,
@@ -326,8 +326,7 @@ class RemoteRoutes(private val context: Context) {
     when (target) {
       "screensaver" -> {
         val applied = FleetScreensaver.apply(context, b)
-        SettingsGuard.reaffirmScreensaver(context)
-        if (applied.any { it.startsWith("overnight") }) SleepScheduler.applyOvernightNow(context)
+        SettingsGuard.afterScreensaverApply(context, applied)
       }
       "calendar" -> FleetCalendar.apply(context, b)
     }

--- a/app/src/main/java/com/immortal/launcher/SettingsGuard.kt
+++ b/app/src/main/java/com/immortal/launcher/SettingsGuard.kt
@@ -78,6 +78,18 @@ object SettingsGuard {
   }
 
   /**
+   * The standard post-apply effects for a screensaver settings change: re-assert ownership and, if
+   * any overnight-window key changed, reschedule the sleep alarms. Centralised so every write path
+   * (the registry's `onApplied`, the fleet `/screensaver` route, `/remote/sources`, preset config)
+   * runs the identical thing — previously `/remote/sources` reaffirmed but skipped the overnight
+   * reschedule, so an overnight change pushed through it never re-armed the alarms.
+   */
+  fun afterScreensaverApply(context: Context, appliedKeys: Collection<String>) {
+    reaffirmScreensaver(context)
+    if (appliedKeys.any { it.startsWith("overnight") }) SleepScheduler.applyOvernightNow(context)
+  }
+
+  /**
    * Re-enables ADB after boot. The vendor init script
    * (`init.common.usb.rc`) kills adbd on every boot for omni_prod-user
    * builds when `ro.boot.force_enable_usb_adb=0`. Writing `adb_enabled=1`

--- a/app/src/main/java/com/immortal/launcher/settings/SettingSpec.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingSpec.kt
@@ -199,13 +199,19 @@ class StringSpec<S>(
           .put("type", "string")
           .put("title", title)
           .withHelp(help)
-          .put("value", get(s))
+          // Never expose a stored secret's cleartext in the schema — advertise only whether one is
+          // set (`hasValue`), so a client can show a masked field and leave it untouched unless the
+          // user types a new value.
+          .put("value", if (secret) "" else get(s))
           .put("secret", secret)
+          .apply { if (secret) put("hasValue", get(s).isNotBlank()) }
           .put("entry", entry.wire())
 
   override fun applyFrom(c: Context, body: JSONObject): Boolean {
     val k = firstPresent(key, aliases, body) ?: return false
     val v = body.optString(k)
+    // A blank submit for a secret means "leave it unchanged" (the field is masked, not cleared).
+    if (secret && v.isBlank()) return false
     if (!applyWhen(v)) return false
     set(c, v)
     return true

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -21,7 +21,6 @@ import com.immortal.launcher.QuickBar
 import com.immortal.launcher.QuickBarConfig
 import com.immortal.launcher.ScreensaverConfig
 import com.immortal.launcher.SettingsGuard
-import com.immortal.launcher.SleepScheduler
 import org.json.JSONArray
 
 /**
@@ -251,10 +250,7 @@ object SettingsDomains {
           // reaffirm + overnight reschedule that `RemoteRoutes.applyConfig` / `FleetRoutes` run).
           // Fires once per /remote/settings batch; the legacy /screensaver and /remote/sources
           // routes keep their own reaffirm, so there's no double-fire.
-          onApplied = { c, keys ->
-            SettingsGuard.reaffirmScreensaver(c)
-            if (keys.any { it.startsWith("overnight") }) SleepScheduler.applyOvernightNow(c)
-          },
+          onApplied = { c, keys -> SettingsGuard.afterScreensaverApply(c, keys) },
       )
 
   /**

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -1,0 +1,158 @@
+package com.immortal.launcher.settings
+
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.json.JSONObject
+import org.mockito.Mockito.mock
+
+/**
+ * Unit tests for the registry's WRITE path — `apply` (partial writes, alias resolution, coerce/skip,
+ * applyWhen guards), the per-batch `onApplied`, and `schemaJson` (sections / defaults / visibleWhen
+ * gating). The `Context` is only ever passed through to the setter lambdas, so a Mockito mock that's
+ * never dereferenced is enough — no Robolectric needed. Storage itself (the real `*Config` setters)
+ * is exercised on-device; here we lock the machinery with recording setters.
+ */
+class SettingsDomainTest {
+
+  private data class Snap(
+      val flag: Boolean = false,
+      val n: Int = 0,
+      val choice: String = "a",
+      val text: String = "",
+  )
+
+  private val ctx: Context = mock(Context::class.java)
+  private val writes = mutableListOf<Pair<String, Any?>>()
+  private val appliedBatches = mutableListOf<Set<String>>()
+
+  private fun domain(specs: List<SettingSpec<Snap>>) =
+      SettingsDomain(
+          id = "t",
+          title = "T",
+          load = { Snap() },
+          specs = specs,
+          onApplied = { _, keys -> appliedBatches.add(keys) },
+      )
+
+  @Test
+  fun apply_writesPresentKeys_firesOnAppliedOnce() {
+    val d =
+        domain(
+            listOf(
+                BoolSpec("flag", "F", get = { it.flag }, set = { _, v -> writes.add("flag" to v) }),
+                IntSpec("n", "N", get = { it.n }, set = { _, v -> writes.add("n" to v) }, min = 0, max = 10),
+                StringSpec("text", "T", get = { it.text }, set = { _, v -> writes.add("text" to v) }),
+            ))
+    val applied = d.apply(ctx, JSONObject().put("flag", true).put("n", 5))
+    assertEquals(setOf("flag", "n"), applied) // "text" absent → not applied
+    assertEquals(listOf<Pair<String, Any?>>("flag" to true, "n" to 5), writes)
+    assertEquals(1, appliedBatches.size) // onApplied fired exactly once for the batch
+    assertEquals(setOf("flag", "n"), appliedBatches[0])
+  }
+
+  @Test
+  fun apply_emptyBodyDoesNotFireOnApplied() {
+    domain(listOf(BoolSpec("flag", "F", get = { it.flag }, set = { _, _ -> }))).apply(ctx, JSONObject())
+    assertTrue(appliedBatches.isEmpty())
+  }
+
+  @Test
+  fun apply_resolvesAliasToCanonicalKey() {
+    val d =
+        domain(
+            listOf(
+                BoolSpec(
+                    "widgetOn",
+                    "W",
+                    get = { it.flag },
+                    set = { _, v -> writes.add("widgetOn" to v) },
+                    aliases = listOf("enabled"))))
+    val applied = d.apply(ctx, JSONObject().put("enabled", false)) // legacy alias
+    assertEquals(setOf("widgetOn"), applied) // reported under the canonical key, not the alias
+    assertEquals(listOf<Pair<String, Any?>>("widgetOn" to false), writes)
+  }
+
+  @Test
+  fun enum_skipsValueWhenCoerceReturnsNull() {
+    val d =
+        domain(
+            listOf(
+                EnumSpec(
+                    "choice",
+                    "C",
+                    get = { it.choice },
+                    set = { _, v -> writes.add("choice" to v) },
+                    options = listOf("a" to "A", "b" to "B"),
+                    coerce = { if (it == "a" || it == "b") it else null })))
+    assertTrue(d.apply(ctx, JSONObject().put("choice", "z")).isEmpty()) // unknown → skipped
+    assertTrue(writes.isEmpty())
+    assertEquals(setOf("choice"), d.apply(ctx, JSONObject().put("choice", "b"))) // valid → applied
+  }
+
+  @Test
+  fun string_applyWhenGuardSkipsBlank() {
+    val d =
+        domain(
+            listOf(
+                StringSpec(
+                    "text",
+                    "T",
+                    get = { it.text },
+                    set = { _, v -> writes.add("text" to v) },
+                    applyWhen = { it.isNotBlank() })))
+    assertTrue(d.apply(ctx, JSONObject().put("text", "")).isEmpty()) // blank guarded out
+    assertEquals(setOf("text"), d.apply(ctx, JSONObject().put("text", "hi")))
+  }
+
+  @Test
+  fun secretString_redactsInSchema_andBlankSubmitKeepsValue() {
+    var stored = "hunter2"
+    val spec = StringSpec<Snap>("pw", "Password", get = { stored }, set = { _, v -> stored = v }, secret = true)
+    val meta = spec.metaJson(ctx, Snap())
+    assertEquals("", meta.getString("value")) // cleartext never leaves the device
+    assertTrue(meta.getBoolean("secret"))
+    assertTrue(meta.getBoolean("hasValue")) // but the client knows one is set
+    assertFalse(spec.applyFrom(ctx, JSONObject().put("pw", ""))) // blank = leave unchanged
+    assertEquals("hunter2", stored)
+    assertTrue(spec.applyFrom(ctx, JSONObject().put("pw", "newpass"))) // a real value writes
+    assertEquals("newpass", stored)
+  }
+
+  @Test
+  fun schemaJson_tagsSections_injectsDefaults_gatesHidden() {
+    val d =
+        SettingsDomain(
+            id = "t",
+            title = "T",
+            load = { Snap(flag = true, n = 3) },
+            specs =
+                listOf(
+                    BoolSpec("flag", "F", get = { it.flag }, set = { _, _ -> }),
+                    IntSpec("n", "N", get = { it.n }, set = { _, _ -> }, min = 0, max = 10, visible = { _, s -> s.flag }),
+                    IntSpec("hid", "H", get = { 1 }, set = { _, _ -> }, min = 0, max = 10, visible = { _, s -> !s.flag }),
+                ),
+            sections = mapOf("n" to "Group"),
+            defaults = { Snap(flag = false, n = 7) },
+        )
+    val controls = d.schemaJson(ctx).getJSONArray("controls")
+    val byKey = (0 until controls.length()).associate { controls.getJSONObject(it).getString("key") to controls.getJSONObject(it) }
+    assertEquals(2, controls.length()) // "hid" gated out (flag=true → !flag=false)
+    assertFalse(byKey.getValue("flag").has("section")) // ungrouped
+    assertEquals("Group", byKey.getValue("n").getString("section"))
+    assertEquals(false, byKey.getValue("flag").getBoolean("default")) // from the defaults snapshot
+    assertEquals(7, byKey.getValue("n").getInt("default"))
+    assertEquals(3, byKey.getValue("n").getInt("value")) // current value, not default
+  }
+
+  @Test
+  fun allDomains_sectionKeysMatchRealSpecs() {
+    SettingsRegistry.domains.forEach { dom ->
+      val specKeys = dom.specs.map { it.key }.toSet()
+      val orphaned = dom.sections.keys - specKeys
+      assertTrue("domain '${dom.id}' has section keys with no matching spec: $orphaned", orphaned.isEmpty())
+    }
+  }
+}


### PR DESCRIPTION
Four fixes from the architecture review, before building features on the registry.

1. **Apply-path unit tests** — adds `mockito-core` (pure-JVM `Context` mock; no Robolectric) and `SettingsDomainTest`: partial apply, alias resolution, enum coerce/skip, applyWhen guards, per-batch `onApplied` firing once, and `schemaJson` section/default/visibleWhen. The central write path was untested.
2. **One side-effect helper** — `SettingsGuard.afterScreensaverApply(c, keys)` (reaffirm + overnight reschedule) called from all four write paths. Fixes a real miss: `/remote/sources` skipped the overnight reschedule, so overnight changes through it never re-armed the alarms.
3. **Secret redaction** — `StringSpec(secret=true)` stops emitting cleartext (advertises `value:""` + `hasValue`); blank submit leaves the secret unchanged; PWA masks the field. Verified on-device.
4. **Drift guard** — a test asserts every domain's `sections` keys match a real spec key.

Verified: full unit suite green (8 new tests); secret redaction confirmed on a Portal Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)