### PR TITLE
Settings registry completion: NavSpec + missing specs + completeness tripwire (Batch 2)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/settings/SettingSpec.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingSpec.kt
@@ -249,3 +249,29 @@ class DerivedSpec<S>(
 
   override fun applyFrom(c: Context, body: JSONObject): Boolean = false
 }
+
+/**
+ * A nav-out row for the on-device renderer: shows a current-value label and launches a bespoke
+ * Activity (the clock-face picker, the photo-source connect forms, the dismiss-target picker). It
+ * owns no stored value of its own — the target screen writes the underlying settings — so it adds
+ * nothing to the flat wire payload and is absent from the remote schema (`metaJson` is null; the
+ * remote has its own surfaces for these). Consumed by the on-device generic renderer only.
+ */
+class NavSpec<S>(
+    override val key: String,
+    val title: String,
+    /** Current-value label for the row. Takes Context too (some labels resolve a component name). */
+    val value: (Context, S) -> String,
+    /** The Activity the row launches. */
+    val activity: Class<*>,
+    val help: String? = null,
+    val visible: (Context, S) -> Boolean = { _, _ -> true },
+) : SettingSpec<S> {
+  override fun visibleWhen(c: Context, s: S) = visible(c, s)
+
+  override fun putValue(out: JSONObject, s: S) {} // navigates to a screen; no value of its own
+
+  override fun metaJson(c: Context, s: S): JSONObject? = null // on-device renderer only
+
+  override fun applyFrom(c: Context, body: JSONObject): Boolean = false
+}

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -184,6 +184,11 @@ object SettingsDomains {
                       "Show now playing",
                       get = { it.showNowPlaying },
                       set = ScreensaverConfig::setShowNowPlaying),
+                  BoolSpec(
+                      "antiBurnIn",
+                      "Reduce screen burn-in",
+                      get = { it.antiBurnIn },
+                      set = ScreensaverConfig::setAntiBurnIn),
                   EnumSpec(
                       "presenceMode",
                       "Power",
@@ -230,6 +235,12 @@ object SettingsDomains {
                       wrap = true,
                       format = ::hhmm,
                       visible = { _, s -> s.overnightEnabled }),
+                  BoolSpec(
+                      "overnightNightClock",
+                      "Show a dim night clock",
+                      get = { it.overnightNightClock },
+                      set = ScreensaverConfig::setOvernightNightClock,
+                      visible = { _, s -> s.overnightEnabled }),
               ),
           sections =
               mapOf(
@@ -239,12 +250,14 @@ object SettingsDomains {
                   "shuffle" to "Display",
                   "includeVideo" to "Display",
                   "showNowPlaying" to "Display",
+                  "antiBurnIn" to "Display",
                   "batterySaver" to "Power & sleep",
                   "presenceMode" to "Power & sleep",
                   "idleSleepMin" to "Power & sleep",
                   "overnightEnabled" to "Power & sleep",
                   "overnightStartMin" to "Power & sleep",
-                  "overnightEndMin" to "Power & sleep"),
+                  "overnightEndMin" to "Power & sleep",
+                  "overnightNightClock" to "Power & sleep"),
           defaults = { ScreensaverConfig.Settings() },
           // The screensaver's post-apply side effects, lifted from the route layer (the same
           // reaffirm + overnight reschedule that `RemoteRoutes.applyConfig` / `FleetRoutes` run).

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -148,6 +148,34 @@ class SettingsDomainTest {
   }
 
   @Test
+  fun screensaverRegistry_coversEveryPersistedField_orExplicitlyAccountsForIt() {
+    // Instance fields only — drops Compose's synthetic static `$stable` and any Companion.
+    val fields =
+        com.immortal.launcher.ScreensaverConfig.Settings::class.java.declaredFields
+            .filter { !java.lang.reflect.Modifier.isStatic(it.modifiers) }
+            .map { it.name }
+            .toSet()
+    val specKeys = (SettingsDomains.screensaver.specs + SettingsDomains.calendar.specs).map { it.key }.toSet()
+    // Fields not bound by a direct value spec, and why: photo-source credentials + the clock-face
+    // and dismiss-target pickers are managed by their own Activities (reached via a NavSpec); the
+    // calendar fields are owned by the calendar domain under different wire keys (widgetOn/url/
+    // range/size/side). New persisted settings must get a spec or be added here — a deliberate gate.
+    val managedElsewhere =
+        setOf(
+            "immichUrl", "immichKey", "immichAlbumId", "immichAlbumName",
+            "smbHost", "smbShare", "smbPath", "smbUser", "smbPass",
+            "davUrl", "davUser", "davPass", "webUrl",
+            "facesEnabled", "faceId", "faceSizeIndex",
+            "dismissAppComponent", "dismissHaDashboard",
+            "calendarUrl", "calendarEnabled", "calendarRange", "calendarSize", "calendarSide",
+        )
+    val uncovered = fields - specKeys - managedElsewhere
+    assertTrue(
+        "ScreensaverConfig.Settings has persisted fields neither in the registry nor accounted for: $uncovered",
+        uncovered.isEmpty())
+  }
+
+  @Test
   fun allDomains_sectionKeysMatchRealSpecs() {
     SettingsRegistry.domains.forEach { dom ->
       val specKeys = dom.specs.map { it.key }.toSet()


### PR DESCRIPTION
Groundwork + safety net before migrating the on-device screensaver screen to the registry.

- **NavSpec** — a nav-out row for the on-device renderer (label + launches a bespoke Activity: clock-face picker, source connect-forms, dismiss picker). Owns no value, absent from the remote schema, dormant until the renderer uses it.
- **Two missing value specs** — `antiBurnIn` and `overnightNightClock` (gated) were on-device only; now in the registry and remote-controllable. Verified in the schema + applied on a Portal Go.
- **Completeness tripwire** — a test asserts every persisted `ScreensaverConfig.Settings` field is bound by a spec or on an explicit 'managed elsewhere' list (source credentials, the clock-face/dismiss pickers, the calendar fields the calendar domain owns under different keys). A new setting fails the build until it's wired in — catching exactly the registry/on-device drift the review flagged.

This is the safety net for Batch 3 (the on-device renderer + screen migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)