### PR TITLE
Settings: render the on-device Screensaver screen from the registry (Batch 3)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/ScreensaverSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverSettingsActivity.kt
@@ -13,12 +13,8 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.focusGroup
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,7 +24,6 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -38,33 +33,34 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.immortal.launcher.settings.SettingsDomain
+import com.immortal.launcher.settings.SettingsDomains
 import com.immortal.launcher.ui.theme.SampleAppTheme
+import org.json.JSONObject
 
 /**
- * Settings screen for the photo-frame screensaver. Reached from a "Screensaver"
- * tile in the launcher's Settings folder. Lets the user keep Immortal's built-in
- * photos or point the frame at a local folder of photos/videos — including one on a
- * USB-C drive plugged into the Portal.
+ * Settings screen for the photo-frame screensaver. Reached from a "Screensaver" tile in the
+ * launcher's Settings folder. The controls are now rendered generically from the `screensaver` and
+ * `calendar` settings domains (the same registry that drives the phone remote) via [SettingsList];
+ * the rich sub-screens (clock-face picker, photo-source setup, calendar/dismiss entry) stay bespoke
+ * and are reached through the registry's `NavSpec`s.
  */
 class ScreensaverSettingsActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -78,7 +74,7 @@ private fun ScreensaverSettingsScreen() {
   val context = LocalContext.current
   var settings by remember { mutableStateOf(ScreensaverConfig.load(context)) }
 
-  // Re-read config when we come back from a subpage (source picker, dismiss target).
+  // Re-read config when we come back from a sub-screen (source picker, face picker, dismiss target).
   val lifecycleOwner = LocalLifecycleOwner.current
   DisposableEffect(lifecycleOwner) {
     val obs = LifecycleEventObserver { _, e ->
@@ -88,10 +84,16 @@ private fun ScreensaverSettingsScreen() {
     onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
   }
 
-  // Remote support: focus the first control on open; Back exits the screen.
   val activity = context as? Activity
   val firstFocus = remember { FocusRequester() }
   LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
+
+  // Every change routes through the registry's apply (which fires the domain's onApplied side
+  // effects — reaffirm + overnight reschedule), then we re-read for the next recomposition.
+  fun apply(domain: SettingsDomain<ScreensaverConfig.Settings>, key: String, value: Any) {
+    domain.apply(context, JSONObject().put(key, value))
+    settings = ScreensaverConfig.load(context)
+  }
 
   Column(
       modifier =
@@ -116,523 +118,49 @@ private fun ScreensaverSettingsScreen() {
       )
       Spacer(Modifier.size(26.dp))
 
+      // Master toggle gates everything below (kept here rather than in the list so the rest only
+      // renders when the frame is on, matching the original screen).
       Card {
         ToggleRow("Show the photo-frame screensaver", settings.enabled) {
-          ScreensaverConfig.setEnabled(context, it)
-          SettingsGuard.reaffirmScreensaver(context)
-          settings = settings.copy(enabled = it)
+          apply(SettingsDomains.screensaver, "enabled", it)
         }
       }
       Text(
-          "Turn this off to let your Portal's screen turn off on its own timer (or to use " +
-              "your own screensaver). Immortal won't switch it back on.",
+          "Turn this off to let your Portal's screen sleep on its own timer (or run your own " +
+              "screensaver). Immortal won't switch it back on.",
           color = Color(0xFF7C7C7C),
           fontSize = 13.sp,
           modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
       )
 
       if (settings.enabled) {
-        Spacer(Modifier.size(26.dp))
-
-        SectionLabel("Clock face")
-        Card {
-          NavRow(title = "Clock face", value = FaceCatalog.entryFor(settings.faceId).name) {
-            context.startActivity(Intent(context, FacePickerActivity::class.java))
-          }
+        Spacer(Modifier.size(20.dp))
+        SettingsList(SettingsDomains.screensaver, settings, exclude = setOf("enabled")) { k, v ->
+          apply(SettingsDomains.screensaver, k, v)
         }
-        Text(
-            "Choose how the time looks — the classic corner clock, a big centred clock, or the " +
-                "full-screen flip clock.",
-            color = Color(0xFF7C7C7C),
-            fontSize = 13.sp,
-            modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
-        )
-
-        Spacer(Modifier.size(26.dp))
-
-        SectionLabel("Photos")
-        Card {
-          NavRow(title = "Photo source", value = currentSourceLabel(settings)) {
-            context.startActivity(Intent(context, ScreensaverSourcesActivity::class.java))
-          }
+        SectionLabel("Calendar")
+        SettingsList(SettingsDomains.calendar, settings) { k, v ->
+          apply(SettingsDomains.calendar, k, v)
         }
-        Text(
-            "Pick where your photos come from — the built-in feed, your own folder or a shared " +
-                "album, or a self-hosted source like Immich or a NAS.",
-            color = Color(0xFF7C7C7C),
-            fontSize = 13.sp,
-            modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
-        )
-
-      Spacer(Modifier.size(26.dp))
-
-      SectionLabel("Display")
-      Card {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(18.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-          Text("Image fit", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
-          Segmented(
-              options =
-                  listOf(
-                      "Fill" to ScreensaverConfig.FIT_FILL,
-                      "Fit" to ScreensaverConfig.FIT_FIT,
-                  ),
-              selected = settings.fit,
-              onSelect = {
-                ScreensaverConfig.setFit(context, it)
-                settings = settings.copy(fit = it)
-              },
-          )
-        }
-        Divider()
-        IntervalStepper(
-            seconds = settings.intervalSec,
-            onChange = { v ->
-              val clamped = ScreensaverConfig.clampInterval(v)
-              ScreensaverConfig.setInterval(context, clamped)
-              settings = settings.copy(intervalSec = clamped)
-            },
-        )
-        Divider()
-        ToggleRow("Shuffle order", settings.shuffle) {
-          ScreensaverConfig.setShuffle(context, it)
-          settings = settings.copy(shuffle = it)
-        }
-        Divider()
-        ToggleRow("Include videos", settings.includeVideo) {
-          ScreensaverConfig.setIncludeVideo(context, it)
-          settings = settings.copy(includeVideo = it)
-        }
-        Divider()
-        ToggleRow("Reduce screen burn-in", settings.antiBurnIn) {
-          ScreensaverConfig.setAntiBurnIn(context, it)
-          settings = settings.copy(antiBurnIn = it)
-        }
-      }
-      Text(
-          "Gently drifts the clock and widgets by a few pixels to protect always-on screens from " +
-              "burn-in. Subtle by design — turn it off if you notice the motion.",
-          color = Color(0xFF7C7C7C),
-          fontSize = 13.sp,
-          modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
-      )
-
-      // When dismissed — where a tap on the frame takes you. Default is the launcher;
-      // Home Assistant users typically point this at their dashboard app instead.
-      Spacer(Modifier.size(26.dp))
-      SectionLabel("When dismissed")
-      val dismissLabel =
-          remember(settings.dismissAppComponent, settings.dismissHaDashboard) {
-            ScreensaverDismiss.chosenLabel(context)
-          }
-      Card {
-        NavRow(
-            title = "Open when you tap to exit",
-            value =
-                if (dismissLabel != null) "Opens $dismissLabel"
-                else "Immortal launcher",
-        ) {
-          context.startActivity(Intent(context, ScreensaverDismissAppActivity::class.java))
-        }
-      }
-      Text(
-          "Tap the screensaver to wake your Portal. By default that brings you home to " +
-              "Immortal — or pick an app (like Home Assistant) to drop straight into it.",
-          color = Color(0xFF7C7C7C),
-          fontSize = 13.sp,
-          modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
-      )
-
-      // Music — sourced from the device's own media session, so it works with any
-      // app (Spotify, podcasts, the Music Assistant player…); shown for everyone.
-      Spacer(Modifier.size(26.dp))
-      SectionLabel("Music")
-      Card {
-        ToggleRow("Show what's playing", settings.showNowPlaying) {
-          ScreensaverConfig.setShowNowPlaying(context, it)
-          settings = settings.copy(showNowPlaying = it)
-        }
-      }
-      Text(
-          "Show the current track and album art on the screensaver while anything is " +
-              "playing music on your Portal.",
-          color = Color(0xFF7C7C7C),
-          fontSize = 13.sp,
-          modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
-      )
-
-      // Calendar — a clean upcoming-events panel, fed by a public iCalendar (.ics)
-      // link from Google Calendar or Apple iCloud (no account sign-in).
-      Spacer(Modifier.size(26.dp))
-      SectionLabel("Calendar")
-      Card {
-        NavRow(
-            title = "Calendar link",
-            value = calendarValue(settings),
-        ) {
-          context.startActivity(Intent(context, CalendarUrlEntryActivity::class.java))
-        }
-        if (settings.hasCalendarLink) {
-          Divider()
-          // Show/hide the widget without forgetting the link, so it's a quick toggle.
-          ToggleRow("Show calendar widget", settings.calendarEnabled) {
-            ScreensaverConfig.setCalendarEnabled(context, it)
-            settings = settings.copy(calendarEnabled = it)
-          }
-        }
-        if (settings.usesCalendar) {
-          Divider()
-          Row(
-              modifier = Modifier.fillMaxWidth().padding(18.dp),
-              verticalAlignment = Alignment.CenterVertically,
-          ) {
-            Text("Show", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
-            Segmented(
-                options =
-                    listOf(
-                        "1 day" to CalendarFeed.RANGE_DAY,
-                        "3 days" to CalendarFeed.RANGE_3DAY,
-                        "Week" to CalendarFeed.RANGE_WEEK,
-                        "Events" to CalendarFeed.RANGE_AGENDA,
-                    ),
-                selected = settings.calendarRange,
-                onSelect = {
-                  ScreensaverConfig.setCalendarRange(context, it)
-                  settings = settings.copy(calendarRange = it)
+        Spacer(Modifier.size(6.dp))
+        Surface(
+            color = Color(0xFF2E6BE6),
+            shape = RoundedCornerShape(16.dp),
+            modifier =
+                Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                  context.startActivity(Intent(context, PhotoFramePreviewActivity::class.java))
                 },
-            )
-          }
-          Divider()
-          Row(
-              modifier = Modifier.fillMaxWidth().padding(18.dp),
-              verticalAlignment = Alignment.CenterVertically,
-          ) {
-            Text("Size", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
-            Segmented(
-                options = listOf("Small" to "0", "Medium" to "1", "Large" to "2"),
-                selected = settings.calendarSize.toString(),
-                onSelect = {
-                  val i = it.toIntOrNull() ?: 1
-                  ScreensaverConfig.setCalendarSize(context, i)
-                  settings = settings.copy(calendarSize = i)
-                },
-            )
-          }
-          Divider()
-          Row(
-              modifier = Modifier.fillMaxWidth().padding(18.dp),
-              verticalAlignment = Alignment.CenterVertically,
-          ) {
-            Text("Position", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
-            Segmented(
-                options =
-                    listOf(
-                        "Left" to ScreensaverConfig.CAL_SIDE_LEFT,
-                        "Right" to ScreensaverConfig.CAL_SIDE_RIGHT,
-                    ),
-                selected = settings.calendarSide,
-                onSelect = {
-                  ScreensaverConfig.setCalendarSide(context, it)
-                  settings = settings.copy(calendarSide = it)
-                },
-            )
-          }
-        }
-      }
-      Text(
-          "Shows your upcoming events on the frame. \"Events\" lists the next " +
-              "few whenever they are; the others show a day, three days, or the week ahead. " +
-              "Use a Google \"secret iCal\" address or an Apple iCloud public-calendar link.",
-          color = Color(0xFF7C7C7C),
-          fontSize = 13.sp,
-          modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
-      )
-
-      Spacer(Modifier.size(26.dp))
-
-      val hasBattery = remember { DreamPolicy.hasBattery(context) }
-      SectionLabel("Power")
-      Surface(color = Color(0xFF1C1C1E), shape = RoundedCornerShape(18.dp)) {
-        Column {
-          // Presence-driven baseline (all models): let the Portal sleep the screen when the
-          // room empties and re-show photos when someone returns — the same signal the
-          // multi-room music follows. ALWAYS_ON is the original permanent-frame behaviour.
-          ToggleRow(
-              "Follow presence (sleep when the room's empty)",
-              settings.presenceMode == FrameMode.PRESENCE) {
-                val mode = if (it) FrameMode.PRESENCE else FrameMode.ALWAYS_ON
-                ScreensaverConfig.setPresenceMode(context, mode)
-                settings = settings.copy(presenceMode = mode)
-              }
+        ) {
           Text(
-              "On: the frame follows the Portal's own presence — photos while someone's " +
-                  "around, screen off (and multi-room music paused) when the room empties, on " +
-                  "every model. Off: a permanent photo frame on mains power. Newer behaviour — " +
-                  "confirm a wall-powered Portal actually sleeps when you leave before relying " +
-                  "on it.",
-              fontSize = 13.sp,
-              color = Color(0xFF9A9A9A),
-              modifier = Modifier.padding(start = 18.dp, end = 18.dp, bottom = 14.dp),
-          )
-          Divider()
-
-          if (hasBattery) {
-            // Battery models (Portal Go): battery life vs always-on frame unplugged.
-            ToggleRow("Sleep on battery when nobody's around", settings.batterySaver) {
-              ScreensaverConfig.setBatterySaver(context, it)
-              settings = settings.copy(batterySaver = it)
-            }
-            Text(
-                "On: unplugged, the Portal keeps showing photos while someone is nearby " +
-                    "and goes to sleep when the room is empty (saves the battery). " +
-                    "Off: the photo frame stays on battery too.",
-                fontSize = 13.sp,
-                color = Color(0xFF9A9A9A),
-                modifier = Modifier.padding(start = 18.dp, end = 18.dp, bottom = 14.dp),
-            )
-            Divider()
-          }
-
-          // Idle screen-off (all models). Off by default.
-          ToggleRow("Turn the screen off after a while", settings.idleSleepOn) {
-            val v = if (it) 30 else 0
-            ScreensaverConfig.setIdleSleepMin(context, v)
-            settings = settings.copy(idleSleepMin = v)
-          }
-          if (settings.idleSleepOn) {
-            Divider()
-            MinuteStepper(settings.idleSleepMin) { v ->
-              val c = ScreensaverConfig.clampIdle(v)
-              ScreensaverConfig.setIdleSleepMin(context, c)
-              settings = settings.copy(idleSleepMin = c)
-            }
-          }
-          Text(
-              "After the screensaver has shown this long with no touch, the screen turns " +
-                  "off; tap to wake it. This is a simple timer — the Portal can't tell us " +
-                  "whether someone's in the room.",
-              fontSize = 13.sp,
-              color = Color(0xFF9A9A9A),
-              modifier = Modifier.padding(start = 18.dp, end = 18.dp, top = 4.dp, bottom = 14.dp),
-          )
-
-          Divider()
-
-          // Overnight window (all models). Off by default.
-          ToggleRow("Overnight sleep", settings.overnightEnabled) {
-            ScreensaverConfig.setOvernightEnabled(context, it)
-            settings = settings.copy(overnightEnabled = it)
-            SleepScheduler.applyOvernightNow(context)
-          }
-          if (settings.overnightEnabled) {
-            Divider()
-            TimeStepper("From", settings.overnightStartMin) { v ->
-              ScreensaverConfig.setOvernightStartMin(context, v)
-              settings = settings.copy(overnightStartMin = ScreensaverConfig.wrapMinuteOfDay(v))
-              SleepScheduler.applyOvernightNow(context)
-            }
-            Divider()
-            TimeStepper("Until", settings.overnightEndMin) { v ->
-              ScreensaverConfig.setOvernightEndMin(context, v)
-              settings = settings.copy(overnightEndMin = ScreensaverConfig.wrapMinuteOfDay(v))
-              SleepScheduler.applyOvernightNow(context)
-            }
-            Divider()
-            ToggleRow("Show a night clock instead of going dark", settings.overnightNightClock) {
-              ScreensaverConfig.setOvernightNightClock(context, it)
-              settings = settings.copy(overnightNightClock = it)
-              SleepScheduler.applyOvernightNow(context)
-            }
-          }
-          Text(
-              if (settings.overnightEnabled && settings.overnightNightClock)
-                  "Shows a dimmed flip clock between these times every night — a bedside clock. " +
-                      "Tap it any time to use the device."
-              else "Keeps the screen off between these times every night.",
-              fontSize = 13.sp,
-              color = Color(0xFF9A9A9A),
-              modifier = Modifier.padding(start = 18.dp, end = 18.dp, top = 4.dp, bottom = 14.dp),
+              "Preview screensaver",
+              color = Color.White,
+              fontSize = 18.sp,
+              fontWeight = FontWeight.SemiBold,
+              textAlign = TextAlign.Center,
+              modifier = Modifier.padding(vertical = 16.dp).fillMaxWidth(),
           )
         }
       }
-
-      Spacer(Modifier.size(28.dp))
-      Surface(
-          color = Color(0xFF2E6BE6),
-          shape = RoundedCornerShape(16.dp),
-          modifier =
-              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
-                context.startActivity(Intent(context, PhotoFramePreviewActivity::class.java))
-              },
-      ) {
-        Text(
-            "Preview screensaver",
-            color = Color.White,
-            fontSize = 18.sp,
-            fontWeight = FontWeight.SemiBold,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(vertical = 16.dp).fillMaxWidth(),
-        )
-      }
-      } // end if (settings.enabled)
     }
   }
-}
-
-/** Short summary of the active source, shown on the "Photo source" nav row. */
-private fun currentSourceLabel(s: ScreensaverConfig.Settings): String =
-    when {
-      s.usesFolder -> "My photos & videos"
-      s.usesUrl -> "Shared album link"
-      s.usesImmich ->
-          if (s.immichAlbumName.isNullOrBlank()) "Immich — whole library"
-          else "Immich — ${s.immichAlbumName}"
-      s.usesSmb -> "Network share"
-      s.usesDav -> "WebDAV folder"
-      s.usesWebUrl -> "Web page"
-      else -> "Immortal photos"
-    }
-
-private fun calendarValue(s: ScreensaverConfig.Settings): String =
-    when {
-      s.calendarUrl.isNullOrBlank() -> "Off"
-      !s.calendarEnabled -> "${CalendarFeed.providerName(s.calendarUrl)} - hidden"
-      else -> "${CalendarFeed.providerName(s.calendarUrl)} - ${calendarRangeLabel(s.calendarRange)}"
-    }
-
-private fun calendarRangeLabel(range: String): String =
-    when (CalendarFeed.clampRange(range)) {
-      CalendarFeed.RANGE_DAY -> "1 day"
-      CalendarFeed.RANGE_3DAY -> "3 days"
-      CalendarFeed.RANGE_WEEK -> "Week"
-      CalendarFeed.RANGE_AGENDA -> "Events"
-      else -> "1 day"
-    }
-
-/**
- * Remote-friendly replacement for a slider: focusable, with LEFT/RIGHT adjusting the
- * value and UP/DOWN passing through so the remote can move off it (a focused Slider
- * traps all four directions). On touch it's still adjustable via the on-screen arrows.
- */
-@Composable
-private fun IntervalStepper(seconds: Int, onChange: (Int) -> Unit) {
-  val src = remember { MutableInteractionSource() }
-  val focused by src.collectIsFocusedAsState()
-  Row(
-      modifier =
-          Modifier.fillMaxWidth()
-              .onKeyEvent { e ->
-                if (e.type == KeyEventType.KeyDown) {
-                  when (e.key) {
-                    Key.DirectionLeft -> {
-                      onChange(seconds - 5)
-                      true
-                    }
-                    Key.DirectionRight -> {
-                      onChange(seconds + 5)
-                      true
-                    }
-                    else -> false // let UP/DOWN/CENTER move focus away
-                  }
-                } else false
-              }
-              .focusable(interactionSource = src)
-              .background(if (focused) Color(0x402E6BE6) else Color.Transparent)
-              .padding(start = 18.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
-      verticalAlignment = Alignment.CenterVertically,
-  ) {
-    Text("Time per item", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
-    // Tappable arrows for touchscreens. They're excluded from D-pad focus
-    // traversal (focusProperties canFocus=false) so on the remote the row itself
-    // keeps handling left/right — the value adjusts the same way with either input.
-    ArrowButton("◀", focused) { onChange(seconds - 5) }
-    Text(
-        "${seconds}s",
-        color = if (focused) Color.White else Color(0xFFDDDDDD),
-        fontSize = 17.sp,
-        fontWeight = FontWeight.SemiBold,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.widthIn(min = 52.dp),
-    )
-    ArrowButton("▶", focused) { onChange(seconds + 5) }
-  }
-}
-
-/** Remote-friendly minute stepper for the idle screen-off timeout (5-min steps). */
-@Composable
-private fun MinuteStepper(minutes: Int, onChange: (Int) -> Unit) {
-  val src = remember { MutableInteractionSource() }
-  val focused by src.collectIsFocusedAsState()
-  Row(
-      modifier =
-          Modifier.fillMaxWidth()
-              .onKeyEvent { e ->
-                if (e.type == KeyEventType.KeyDown) {
-                  when (e.key) {
-                    Key.DirectionLeft -> { onChange(minutes - 5); true }
-                    Key.DirectionRight -> { onChange(minutes + 5); true }
-                    else -> false
-                  }
-                } else false
-              }
-              .focusable(interactionSource = src)
-              .background(if (focused) Color(0x402E6BE6) else Color.Transparent)
-              .padding(start = 18.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
-      verticalAlignment = Alignment.CenterVertically,
-  ) {
-    Text("Turn off after", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
-    ArrowButton("◀", focused) { onChange(minutes - 5) }
-    Text(
-        "${minutes}m",
-        color = if (focused) Color.White else Color(0xFFDDDDDD),
-        fontSize = 17.sp,
-        fontWeight = FontWeight.SemiBold,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.widthIn(min = 64.dp),
-    )
-    ArrowButton("▶", focused) { onChange(minutes + 5) }
-  }
-}
-
-/** Remote-friendly time-of-day stepper for the overnight window (15-min steps). */
-@Composable
-private fun TimeStepper(label: String, minuteOfDay: Int, onChange: (Int) -> Unit) {
-  val src = remember { MutableInteractionSource() }
-  val focused by src.collectIsFocusedAsState()
-  Row(
-      modifier =
-          Modifier.fillMaxWidth()
-              .onKeyEvent { e ->
-                if (e.type == KeyEventType.KeyDown) {
-                  when (e.key) {
-                    Key.DirectionLeft -> { onChange(minuteOfDay - 15); true }
-                    Key.DirectionRight -> { onChange(minuteOfDay + 15); true }
-                    else -> false
-                  }
-                } else false
-              }
-              .focusable(interactionSource = src)
-              .background(if (focused) Color(0x402E6BE6) else Color.Transparent)
-              .padding(start = 18.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
-      verticalAlignment = Alignment.CenterVertically,
-  ) {
-    Text(label, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
-    ArrowButton("◀", focused) { onChange(minuteOfDay - 15) }
-    Text(
-        formatMinuteOfDay(minuteOfDay),
-        color = if (focused) Color.White else Color(0xFFDDDDDD),
-        fontSize = 17.sp,
-        fontWeight = FontWeight.SemiBold,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.widthIn(min = 80.dp),
-    )
-    ArrowButton("▶", focused) { onChange(minuteOfDay + 15) }
-  }
-}
-
-private fun formatMinuteOfDay(min: Int): String {
-  val m = ((min % 1440) + 1440) % 1440
-  return "%02d:%02d".format(m / 60, m % 60)
 }

--- a/app/src/main/java/com/immortal/launcher/SettingsComponents.kt
+++ b/app/src/main/java/com/immortal/launcher/SettingsComponents.kt
@@ -9,6 +9,9 @@ package com.immortal.launcher
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,18 +21,28 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -170,5 +183,51 @@ internal fun Segmented(
         )
       }
     }
+  }
+}
+
+/**
+ * Remote-friendly stepper (replaces the per-screen IntervalStepper/MinuteStepper/TimeStepper):
+ * focusable, LEFT/RIGHT adjust the value and UP/DOWN pass through so the remote can move off it (a
+ * focused Slider traps all four directions). On touch it's still adjustable via the on-screen arrows.
+ */
+@Composable
+internal fun Stepper(label: String, valueText: String, widthMin: Dp = 64.dp, onMinus: () -> Unit, onPlus: () -> Unit) {
+  val src = remember { MutableInteractionSource() }
+  val focused by src.collectIsFocusedAsState()
+  Row(
+      modifier =
+          Modifier.fillMaxWidth()
+              .onKeyEvent { e ->
+                if (e.type == KeyEventType.KeyDown)
+                    when (e.key) {
+                      Key.DirectionLeft -> {
+                        onMinus()
+                        true
+                      }
+                      Key.DirectionRight -> {
+                        onPlus()
+                        true
+                      }
+                      else -> false
+                    }
+                else false
+              }
+              .focusable(interactionSource = src)
+              .background(if (focused) Color(0x402E6BE6) else Color.Transparent)
+              .padding(start = 18.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(label, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+    ArrowButton("◀", focused) { onMinus() } // left-pointing triangle
+    Text(
+        valueText,
+        color = if (focused) Color.White else Color(0xFFDDDDDD),
+        fontSize = 17.sp,
+        fontWeight = FontWeight.SemiBold,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.widthIn(min = widthMin),
+    )
+    ArrowButton("▶", focused) { onPlus() } // right-pointing triangle
   }
 }

--- a/app/src/main/java/com/immortal/launcher/SettingsRenderer.kt
+++ b/app/src/main/java/com/immortal/launcher/SettingsRenderer.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.settings.BoolSpec
+import com.immortal.launcher.settings.DerivedSpec
+import com.immortal.launcher.settings.EnumSpec
+import com.immortal.launcher.settings.Entry
+import com.immortal.launcher.settings.IntSpec
+import com.immortal.launcher.settings.NavSpec
+import com.immortal.launcher.settings.SettingSpec
+import com.immortal.launcher.settings.SettingsDomain
+import com.immortal.launcher.settings.StringSpec
+import org.json.JSONObject
+
+/**
+ * The on-device counterpart to the phone-remote's generic settings renderer: turns a
+ * [SettingsDomain] into Compose rows built on the shared [SettingsComponents], so the on-device
+ * screens render from the SAME registry that drives the remote and persistence. Stateless — the
+ * caller owns the snapshot and reloads it after each [onApply] (which routes through the registry's
+ * `apply`, so the domain's `onApplied` side effects fire on the on-device path too).
+ *
+ * Specs render by type: bool→toggle, enum→segmented, int→stepper, string(nav)/NavSpec→nav row into
+ * a bespoke Activity, derived→skipped. Controls are grouped into the domain's `sections`, each in a
+ * card, with the spec's `help` shown beneath it.
+ */
+@Composable
+fun <S> SettingsList(
+    domain: SettingsDomain<S>,
+    snapshot: S,
+    exclude: Set<String> = emptySet(),
+    onApply: (key: String, value: Any) -> Unit,
+) {
+  val context = LocalContext.current
+  val visible = domain.specs.filter { it.key !in exclude && it.visibleWhen(context, snapshot) }
+  val groups = LinkedHashMap<String?, MutableList<SettingSpec<S>>>()
+  visible.forEach { groups.getOrPut(domain.sections[it.key]) { mutableListOf() }.add(it) }
+  groups.forEach { (section, specs) ->
+    if (section != null) SectionLabel(section)
+    Card {
+      specs.forEachIndexed { i, spec ->
+        if (i > 0) Divider()
+        SettingControl(spec, snapshot, onApply)
+      }
+    }
+    Spacer(Modifier.size(22.dp))
+  }
+}
+
+@Composable
+private fun <S> SettingControl(spec: SettingSpec<S>, snapshot: S, onApply: (String, Any) -> Unit) {
+  val context = LocalContext.current
+  @Suppress("UNCHECKED_CAST")
+  when (spec) {
+    is BoolSpec<*> -> {
+      val s = spec as BoolSpec<S>
+      Column {
+        ToggleRow(s.title, s.get(snapshot)) { onApply(s.key, it) }
+        HelpText(s.help)
+      }
+    }
+    is EnumSpec<*> -> {
+      val s = spec as EnumSpec<S>
+      Column {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(18.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+          Text(s.title, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+          // EnumSpec.options is value→label; Segmented wants label→value.
+          Segmented(s.options.map { (v, l) -> l to v }, s.get(snapshot)) { onApply(s.key, it) }
+        }
+        HelpText(s.help)
+      }
+    }
+    is IntSpec<*> -> {
+      val s = spec as IntSpec<S>
+      val v = s.get(snapshot)
+      Column {
+        Stepper(
+            label = s.title,
+            valueText = s.format(v),
+            widthMin = 72.dp,
+            onMinus = { onApply(s.key, v - s.step) },
+            onPlus = { onApply(s.key, v + s.step) },
+        )
+        HelpText(s.help)
+      }
+    }
+    is StringSpec<*> -> {
+      val s = spec as StringSpec<S>
+      val entry = s.entry
+      if (entry is Entry.Nav) {
+        Column {
+          NavRow(s.title, s.get(snapshot).ifBlank { "Not set" }) {
+            context.startActivity(Intent(context, entry.activity))
+          }
+          HelpText(s.help)
+        }
+      }
+      // An inline string on a D-pad screen is rare; the on-device screens that need free text use a
+      // dedicated entry Activity (Entry.Nav). An Inline string here renders nothing for now.
+    }
+    is NavSpec<*> -> {
+      val s = spec as NavSpec<S>
+      Column {
+        NavRow(s.title, s.value(context, snapshot)) {
+          context.startActivity(Intent(context, s.activity))
+        }
+        HelpText(s.help)
+      }
+    }
+    is DerivedSpec<*> -> {} // read-only/flat-only — not rendered on-device
+  }
+}
+
+/** The grey description shown beneath a control (the spec's `help`), matching the screens' style. */
+@Composable
+private fun HelpText(help: String?) {
+  if (help.isNullOrBlank()) return
+  Text(
+      help,
+      color = Color(0xFF9A9A9A),
+      fontSize = 13.sp,
+      modifier = Modifier.padding(start = 18.dp, end = 18.dp, bottom = 14.dp),
+  )
+}

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -10,9 +10,16 @@ package com.immortal.launcher.settings
 import android.content.Context
 import com.immortal.launcher.CalendarFeed
 import com.immortal.launcher.CalendarUrlEntryActivity
+import com.immortal.launcher.DreamPolicy
+import com.immortal.launcher.FaceCatalog
+import com.immortal.launcher.FacePickerActivity
 import com.immortal.launcher.FleetCalendar
 import com.immortal.launcher.FleetScreensaver
 import com.immortal.launcher.FrameMode
+import com.immortal.launcher.PhotoFramePreviewActivity
+import com.immortal.launcher.ScreensaverDismiss
+import com.immortal.launcher.ScreensaverDismissAppActivity
+import com.immortal.launcher.ScreensaverSourcesActivity
 import com.immortal.launcher.ImmortalSettings
 import com.immortal.launcher.MqttConfig
 import com.immortal.launcher.MqttService
@@ -62,13 +69,17 @@ object SettingsDomains {
                       get = { it.calendarEnabled },
                       set = ScreensaverConfig::setCalendarEnabled,
                       aliases = listOf("enabled"),
+                      visible = { _, s -> s.hasCalendarLink },
                   ),
                   StringSpec(
                       key = "url",
-                      title = "Calendar feed (.ics)",
+                      title = "Calendar feed",
                       get = { it.calendarUrl ?: "" },
                       set = ScreensaverConfig::setCalendarUrl,
                       entry = Entry.Nav(CalendarUrlEntryActivity::class.java),
+                      help =
+                          "A public iCalendar (.ics) link - a Google \"secret iCal\" address or an Apple " +
+                              "iCloud public-calendar link. Shows your upcoming events on the frame.",
                   ),
                   EnumSpec(
                       key = "range",
@@ -76,6 +87,7 @@ object SettingsDomains {
                       get = { it.calendarRange },
                       set = ScreensaverConfig::setCalendarRange,
                       options = FleetCalendar.RANGES.map { it to rangeLabel(it) },
+                      visible = { _, s -> s.usesCalendar },
                   ),
                   IntSpec(
                       key = "size",
@@ -86,6 +98,7 @@ object SettingsDomains {
                       max = 2,
                       step = 1,
                       format = { CAL_SIZE_LABELS.getOrElse(it) { _ -> it.toString() } },
+                      visible = { _, s -> s.usesCalendar },
                   ),
                   EnumSpec(
                       key = "side",
@@ -96,6 +109,7 @@ object SettingsDomains {
                           listOf(
                               ScreensaverConfig.CAL_SIDE_LEFT to "Left",
                               ScreensaverConfig.CAL_SIDE_RIGHT to "Right"),
+                      visible = { _, s -> s.usesCalendar },
                   ),
                   // Read-only derived views (flat-payload-only — they round-trip the legacy format).
                   DerivedSpec(key = "enabled", get = { it.usesCalendar }),
@@ -119,6 +133,18 @@ object SettingsDomains {
 
   private fun hhmm(min: Int): String = "%02d:%02d".format(min / 60, min % 60)
 
+  /** Short label for the active photo source, shown on the "Photo source" nav row. */
+  private fun sourceLabel(s: ScreensaverConfig.Settings): String =
+      when {
+        s.usesImmich -> "Immich"
+        s.usesSmb -> "Network share"
+        s.usesDav -> "WebDAV"
+        s.usesWebUrl -> "Web page"
+        s.usesUrl -> "Shared album"
+        s.usesFolder -> "Local folder"
+        else -> "Immortal photos"
+      }
+
   /**
    * The photo-frame display settings — the slice the legacy `FleetScreensaver.toJson` reports.
    * Mirrors that flat wire format exactly (16 keys). The 13 plain display controls are writable
@@ -138,7 +164,41 @@ object SettingsDomains {
           load = ScreensaverConfig::load,
           specs =
               listOf(
-                  BoolSpec("enabled", "Photo frame", get = { it.enabled }, set = ScreensaverConfig::setEnabled),
+                  BoolSpec(
+                      "enabled",
+                      "Show the photo-frame screensaver",
+                      get = { it.enabled },
+                      set = ScreensaverConfig::setEnabled,
+                      help =
+                          "Turn this off to let your Portal's screen sleep on its own timer (or run " +
+                              "your own screensaver). Immortal won't switch it back on."),
+                  NavSpec(
+                      "clockFace",
+                      "Clock face",
+                      value = { _, s -> FaceCatalog.entryFor(s.faceId).name },
+                      activity = FacePickerActivity::class.java,
+                      help =
+                          "Choose how the time looks - the classic corner clock, a big centred clock, " +
+                              "or the full-screen flip clock.",
+                      visible = { _, s -> s.enabled }),
+                  NavSpec(
+                      "photoSource",
+                      "Photo source",
+                      value = { _, s -> sourceLabel(s) },
+                      activity = ScreensaverSourcesActivity::class.java,
+                      help =
+                          "Where your photos come from - the built-in feed, your own folder or a shared " +
+                              "album, or a self-hosted source like Immich or a NAS.",
+                      visible = { _, s -> s.enabled }),
+                  NavSpec(
+                      "dismissTarget",
+                      "Open when you tap to exit",
+                      value = { c, _ -> ScreensaverDismiss.chosenLabel(c)?.let { "Opens $it" } ?: "Immortal launcher" },
+                      activity = ScreensaverDismissAppActivity::class.java,
+                      help =
+                          "Tapping the screensaver wakes the Portal. By default that brings you home to " +
+                              "Immortal - or pick an app (like Home Assistant) to drop straight into.",
+                      visible = { _, s -> s.enabled }),
                   DerivedSpec("source", get = { it.source }),
                   DerivedSpec("folderPath", get = { it.folderPath ?: "" }),
                   DerivedSpec("albumUrl", get = { it.albumUrl ?: "" }),
@@ -176,9 +236,13 @@ object SettingsDomains {
                       set = ScreensaverConfig::setIncludeVideo),
                   BoolSpec(
                       "batterySaver",
-                      "Battery saver",
+                      "Sleep on battery when nobody's around",
                       get = { it.batterySaver },
-                      set = ScreensaverConfig::setBatterySaver),
+                      set = ScreensaverConfig::setBatterySaver,
+                      help =
+                          "Unplugged, keep showing photos while someone's nearby and sleep when the room " +
+                              "empties (saves the battery). Off: the frame stays on, on battery too.",
+                      visible = { c, _ -> DreamPolicy.hasBattery(c) }),
                   BoolSpec(
                       "showNowPlaying",
                       "Show now playing",
@@ -198,7 +262,10 @@ object SettingsDomains {
                           listOf(
                               FrameMode.ALWAYS_ON.name to "Always on",
                               FrameMode.PRESENCE.name to "Follow presence"),
-                      coerce = { FleetScreensaver.coercePresenceMode(it)?.name }),
+                      coerce = { FleetScreensaver.coercePresenceMode(it)?.name },
+                      help =
+                          "Follow presence: photos while someone's around, screen off (and multi-room " +
+                              "music paused) when the room empties. Always on: a permanent frame on mains power."),
                   IntSpec(
                       "idleSleepMin",
                       "Idle screen-off",
@@ -207,12 +274,16 @@ object SettingsDomains {
                       min = 0,
                       max = 120,
                       step = 5,
-                      format = { if (it <= 0) "Off" else "$it min" }),
+                      format = { if (it <= 0) "Off" else "$it min" },
+                      help =
+                          "After the screensaver shows this long with no touch, the screen turns off; " +
+                              "tap to wake. A simple timer - it can't tell whether someone's in the room."),
                   BoolSpec(
                       "overnightEnabled",
                       "Overnight screen-off",
                       get = { it.overnightEnabled },
-                      set = ScreensaverConfig::setOvernightEnabled),
+                      set = ScreensaverConfig::setOvernightEnabled,
+                      help = "Keep the screen off (or show a dim night clock) between two times every night."),
                   IntSpec(
                       "overnightStartMin",
                       "Off from",


### PR DESCRIPTION
Makes the on-device Screensaver screen render from the **same registry** that drives the phone remote and persistence — so a new setting is defined once, not twice. This closes the biggest gap from the architecture review (the on-device UI was a parallel hand-coded impl that had already drifted).

## What
- **`SettingsList(domain, snapshot, onApply)`** — the on-device counterpart to the PWA renderer. Pattern-matches spec types onto the shared `SettingsComponents`: bool→ToggleRow, enum→Segmented, int→Stepper, string(nav)/NavSpec→NavRow launching the bespoke Activity, derived→skipped; grouped by section with each control's `help` beneath it. Stateless — apply routes through the registry's `apply`, so the domain's `onApplied` side-effects fire on-device too (the single apply path the review wanted).
- Generic **`Stepper`** added to `SettingsComponents` (replaces the per-screen Interval/Minute/Time steppers).
- Screensaver domain enriched to cover the whole screen: NavSpecs for clock-face / photo-source / dismiss (launching the **unchanged** bespoke screens), battery-saver gated on battery hardware, calendar gated on the feed, help text.
- `ScreensaverSettingsActivity` rewritten — **~350 lines of hand-rolled controls deleted** (net −195).

## Verified end-to-end on a Portal Go (A10)
Every control / section / help line renders; nav rows show value labels and launch their Activities (FacePicker confirmed); battery gating shows on the battery device; **toggling Overnight applies through the registry, fires the reschedule, and reveals the gated time-steppers + night-clock**; calendar content gates on the feed. Unit suite (incl. the completeness tripwire) green.

The bespoke sub-screens (FacePicker, source connect-forms, etc.) are untouched — they're nav targets, not rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)