### PR TITLE
Settings: Immortal sub-screens become Activities — collapse the two nav models (Batch 4a)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -162,6 +162,12 @@
             android:exported="false"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- Immortal-settings sub-screens (reached via a NavSpec from the registry-driven screen). -->
+        <activity android:name=".MultiRoomActivity" android:exported="false" android:theme="@style/Theme.SampleApp" />
+        <activity android:name=".MqttActivity" android:exported="false" android:theme="@style/Theme.SampleApp" />
+        <activity android:name=".DeviceHealthActivity" android:exported="false" android:theme="@style/Theme.SampleApp" />
+        <activity android:name=".BootAppsActivity" android:exported="false" android:theme="@style/Theme.SampleApp" />
+
         <!-- Connect a self-hosted Immich server as the screensaver source. -->
         <activity
             android:name=".ImmichConnectActivity"

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -34,7 +34,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -80,56 +84,20 @@ class ImmortalSettingsActivity : ComponentActivity() {
 
 @Composable
 private fun ImmortalSettingsScreen() {
-  val context = LocalContext.current
-  var showBootApps by remember { mutableStateOf(false) }
-  var showMultiRoom by remember { mutableStateOf(false) }
-  var showMqtt by remember { mutableStateOf(false) }
-  var showHealth by remember { mutableStateOf(false) }
-  var bootSelected by remember { mutableStateOf(BootLaunch.packages(context).toSet()) }
-
-  if (showBootApps) {
-    BootAppsScreen(
-        selected = bootSelected,
-        onToggle = { pkg ->
-          bootSelected = if (pkg in bootSelected) bootSelected - pkg else bootSelected + pkg
-          BootLaunch.setPackages(context, bootSelected.toList())
-        },
-        onBack = { showBootApps = false },
-    )
-    return
-  }
-  if (showMultiRoom) {
-    MultiRoomScreen(onBack = { showMultiRoom = false })
-    return
-  }
-  if (showMqtt) {
-    MqttScreen(onBack = { showMqtt = false })
-    return
-  }
-  if (showHealth) {
-    DeviceHealthScreen(onBack = { showHealth = false })
-    return
-  }
-
-  SettingsMain(
-      bootCount = bootSelected.size,
-      onOpenBootApps = { showBootApps = true },
-      onOpenMultiRoom = { showMultiRoom = true },
-      onOpenMqtt = { showMqtt = true },
-      onOpenHealth = { showHealth = true },
-  )
-}
-
-@Composable
-private fun SettingsMain(
-    bootCount: Int,
-    onOpenBootApps: () -> Unit,
-    onOpenMultiRoom: () -> Unit,
-    onOpenMqtt: () -> Unit,
-    onOpenHealth: () -> Unit,
-) {
+  // The sub-screens (multi-room, MQTT, device health, boot apps) are now their own Activities,
+  // reached by launching them from the nav rows below — one nav model, like the Screensaver screen.
   val context = LocalContext.current
   var settings by remember { mutableStateOf(ImmortalSettings.load(context)) }
+
+  // Re-read on resume so values changed in a sub-screen Activity reflect when we come back.
+  val resumeOwner = LocalLifecycleOwner.current
+  DisposableEffect(resumeOwner) {
+    val obs = LifecycleEventObserver { _, e ->
+      if (e == Lifecycle.Event.ON_RESUME) settings = ImmortalSettings.load(context)
+    }
+    resumeOwner.lifecycle.addObserver(obs)
+    onDispose { resumeOwner.lifecycle.removeObserver(obs) }
+  }
 
   // Remote support: focus the first control on open; Back exits the screen.
   val activity = context as? Activity
@@ -334,18 +302,20 @@ private fun SettingsMain(
         }
       }
 
-      MultiRoomNavRow(onOpen = onOpenMultiRoom)
+      MultiRoomNavRow(onOpen = { context.startActivity(Intent(context, MultiRoomActivity::class.java)) })
 
-      MqttNavRow(onOpen = onOpenMqtt)
+      MqttNavRow(onOpen = { context.startActivity(Intent(context, MqttActivity::class.java)) })
 
       RemoteNavRow()
 
       QuickButtonsSection()
 
       Spacer(Modifier.size(26.dp))
-      BootAppsNavRow(count = bootCount, onOpen = onOpenBootApps)
+      BootAppsNavRow(
+          count = BootLaunch.packages(context).size,
+          onOpen = { context.startActivity(Intent(context, BootAppsActivity::class.java)) })
 
-      DeviceHealthNavRow(onOpen = onOpenHealth)
+      DeviceHealthNavRow(onOpen = { context.startActivity(Intent(context, DeviceHealthActivity::class.java)) })
 
       Text(
           "Changes apply as soon as you go back to the home screen.",
@@ -412,7 +382,7 @@ private fun MultiRoomStep(n: String, text: String) {
 }
 
 @Composable
-private fun MultiRoomScreen(onBack: () -> Unit) {
+internal fun MultiRoomScreen(onBack: () -> Unit) {
   val context = LocalContext.current
   var enabled by remember { mutableStateOf(ImmortalSettings.multiRoomEnabled(context)) }
   var host by remember { mutableStateOf(ImmortalSettings.snapcastHost(context)) }
@@ -787,7 +757,7 @@ private fun RemoteNavRow() {
  * MQTT broker. Off by default; Back returns to the main settings page.
  */
 @Composable
-private fun MqttScreen(onBack: () -> Unit) {
+internal fun MqttScreen(onBack: () -> Unit) {
   val context = LocalContext.current
   var enabled by remember { mutableStateOf(MqttConfig.isEnabled(context)) }
   var host by remember { mutableStateOf(MqttConfig.host(context)) }
@@ -1117,7 +1087,7 @@ private fun DeviceHealthNavRow(onOpen: () -> Unit) {
  * the uninstall path it served is kept as a clearly-warned advanced action at the bottom.
  */
 @Composable
-private fun DeviceHealthScreen(onBack: () -> Unit) {
+internal fun DeviceHealthScreen(onBack: () -> Unit) {
   val context = LocalContext.current
   val checks = remember { DevicePermissions.all(context) }
   val issues = checks.count { !it.granted }
@@ -1317,7 +1287,7 @@ private fun BootAppsNavRow(count: Int, onOpen: () -> Unit) {
  * main settings page (handled by the parent via [onBack]).
  */
 @Composable
-private fun BootAppsScreen(
+internal fun BootAppsScreen(
     selected: Set<String>,
     onToggle: (String) -> Unit,
     onBack: () -> Unit,

--- a/app/src/main/java/com/immortal/launcher/ImmortalSubScreens.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSubScreens.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import com.immortal.launcher.ui.theme.SampleAppTheme
+
+/**
+ * Activity wrappers for the Immortal settings sub-screens, so each is reached by a `NavSpec`
+ * (launching an Activity) like every other settings sub-screen — collapsing the old in-file
+ * `mutableStateOf` navigation onto the one nav model the Screensaver screen already uses. The screen
+ * composables themselves live in [ImmortalSettingsActivity]; these are thin hosts (`onBack` = finish).
+ */
+class MultiRoomActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { MultiRoomScreen(onBack = { finish() }) } }
+  }
+}
+
+class MqttActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { MqttScreen(onBack = { finish() }) } }
+  }
+}
+
+class DeviceHealthActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { DeviceHealthScreen(onBack = { finish() }) } }
+  }
+}
+
+class BootAppsActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent {
+      SampleAppTheme(darkTheme = true) {
+        // The selection state lived in the parent screen before; the Activity owns it now.
+        val context = LocalContext.current
+        var selected by remember { mutableStateOf(BootLaunch.packages(context).toSet()) }
+        BootAppsScreen(
+            selected = selected,
+            onToggle = { pkg ->
+              selected = if (pkg in selected) selected - pkg else selected + pkg
+              BootLaunch.setPackages(context, selected.toList())
+            },
+            onBack = { finish() },
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
The Immortal settings screen drove its four sub-screens (multi-room, MQTT, device health, boot apps) with in-file `mutableStateOf` toggles — a second nav model vs the Screensaver screen's Activity-per-subscreen. This collapses them onto **one** model (the review flagged the two-nav-model inconsistency).

- The four sub-screen composables are now `internal`, hosted by thin Activities (`MultiRoomActivity`, `MqttActivity`, `DeviceHealthActivity`, `BootAppsActivity`); `BootAppsActivity` owns the boot-selection state the parent used to hold.
- `ImmortalSettingsScreen` drops the `showX` plumbing; nav rows launch the Activities, and it re-reads on resume.
- Manifest updated.

**Verified on a Portal Go:** the screen renders; Device health + Boot apps open as their own Activities and Back returns. Unit suite green.

**Next (Batch 4b):** render the Immortal top-level controls from the registry via `SettingsList` (as Screensaver now does). That needs the rich per-control help prose relocated onto the `immortal` specs to avoid a UX regression, so it's a focused follow-up rather than rushed at the tail of this work. The bespoke sub-screens (live MQTT/multi-room status) stay bespoke as nav targets regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)