### PR TITLE
Settings: Immortal top-level controls render from the registry (Batch 4b)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -65,10 +65,12 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.drawable.toBitmap
+import com.immortal.launcher.settings.SettingsDomains
 import com.immortal.launcher.ui.theme.SampleAppTheme
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.json.JSONObject
 
 /**
  * Immortal's own settings (weather unit, home-screen tile size), reached from the
@@ -104,6 +106,13 @@ private fun ImmortalSettingsScreen() {
   val firstFocus = remember { FocusRequester() }
   LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
 
+  // Every change routes through the registry's apply (so the domain's onApplied side effects —
+  // status-bar re-apply, multi-room resync — fire on the on-device path too), then we re-read.
+  fun apply(key: String, value: Any) {
+    SettingsDomains.immortal.apply(context, JSONObject().put(key, value))
+    settings = ImmortalSettings.load(context)
+  }
+
   Column(
       modifier =
           Modifier.fillMaxSize()
@@ -127,179 +136,14 @@ private fun ImmortalSettingsScreen() {
       )
       Spacer(Modifier.size(26.dp))
 
-      SectionLabel("Weather")
-      Card {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(18.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-          Column(modifier = Modifier.weight(1f)) {
-            Text("Temperature", color = Color.White, fontSize = 17.sp)
-            Text(
-                "Auto follows your Portal's language & region setting.",
-                color = Color(0xFF9A9A9A),
-                fontSize = 13.sp,
-                modifier = Modifier.padding(top = 2.dp),
-            )
-          }
-          Segmented(
-              options =
-                  listOf(
-                      "Auto" to ImmortalSettings.UNIT_AUTO,
-                      "°F" to ImmortalSettings.UNIT_F,
-                      "°C" to ImmortalSettings.UNIT_C,
-                  ),
-              selected = settings.weatherUnit,
-              onSelect = {
-                ImmortalSettings.setWeatherUnit(context, it)
-                settings = settings.copy(weatherUnit = it)
-              },
-          )
-        }
-        Divider()
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(18.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-          Column(modifier = Modifier.weight(1f)) {
-            Text("Home-screen forecast", color = Color.White, fontSize = 17.sp)
-            Text(
-                "Show a forecast below your apps. Off by default.",
-                color = Color(0xFF9A9A9A),
-                fontSize = 13.sp,
-                modifier = Modifier.padding(top = 2.dp),
-            )
-          }
-          Segmented(
-              options =
-                  listOf(
-                      "Off" to ImmortalSettings.WIDGET_OFF,
-                      "Hourly" to ImmortalSettings.WIDGET_HOURLY,
-                      "7-day" to ImmortalSettings.WIDGET_DAILY,
-                  ),
-              selected = settings.weatherWidget,
-              onSelect = {
-                ImmortalSettings.setWeatherWidget(context, it)
-                settings = settings.copy(weatherWidget = it)
-              },
-          )
-        }
-      }
-
-      Spacer(Modifier.size(26.dp))
-
-      SectionLabel("Home screen")
-      Card {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(18.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-          Column(modifier = Modifier.weight(1f)) {
-            Text("App icon size", color = Color.White, fontSize = 17.sp)
-            Text(
-                "Large is closer to the stock Portal launcher.",
-                color = Color(0xFF9A9A9A),
-                fontSize = 13.sp,
-                modifier = Modifier.padding(top = 2.dp),
-            )
-          }
-          Segmented(
-              options =
-                  listOf(
-                      "Standard" to ImmortalSettings.SIZE_STANDARD,
-                      "Large" to ImmortalSettings.SIZE_LARGE,
-                      "Extra large" to ImmortalSettings.SIZE_XL,
-                  ),
-              selected = settings.tileSize,
-              onSelect = {
-                ImmortalSettings.setTileSize(context, it)
-                settings = settings.copy(tileSize = it)
-              },
-          )
-        }
-        Divider()
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(18.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-          Column(modifier = Modifier.weight(1f)) {
-            Text("Now-playing mini-player", color = Color.White, fontSize = 17.sp)
-            Text(
-                "Show the current track, cover art and controls in the header while music is playing.",
-                color = Color(0xFF9A9A9A),
-                fontSize = 13.sp,
-                modifier = Modifier.padding(top = 2.dp),
-            )
-          }
-          Segmented(
-              options = listOf("Off" to "off", "On" to "on"),
-              selected = if (settings.showMiniPlayer) "on" else "off",
-              onSelect = {
-                val on = it == "on"
-                ImmortalSettings.setShowMiniPlayer(context, on)
-                settings = settings.copy(showMiniPlayer = on)
-              },
-          )
-        }
-        Divider()
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(18.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-          Column(modifier = Modifier.weight(1f)) {
-            Text("Status bar", color = Color.White, fontSize = 17.sp)
-            Text(
-                "Hidden by default for a cleaner full-screen look. Swipe down from the top " +
-                    "to reveal it briefly.",
-                color = Color(0xFF9A9A9A),
-                fontSize = 13.sp,
-                modifier = Modifier.padding(top = 2.dp),
-            )
-          }
-          Segmented(
-              options = listOf("Show" to "show", "Hide" to "hide"),
-              selected = if (settings.hideStatusBar) "hide" else "show",
-              onSelect = {
-                val hide = it == "hide"
-                ImmortalSettings.setHideStatusBar(context, hide)
-                settings = settings.copy(hideStatusBar = hide)
-                SettingsGuard.applyStatusBar(context)
-              },
-          )
-        }
-      }
-
-      Spacer(Modifier.size(26.dp))
-
-      SectionLabel("Clock")
-      Card {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(18.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-          Column(modifier = Modifier.weight(1f)) {
-            Text("Time format", color = Color.White, fontSize = 17.sp)
-            Text(
-                "Applies to the home screen, screensaver, and forecast. Auto follows your Portal's system setting.",
-                color = Color(0xFF9A9A9A),
-                fontSize = 13.sp,
-                modifier = Modifier.padding(top = 2.dp),
-            )
-          }
-          Segmented(
-              options =
-                  listOf(
-                      "Auto" to ImmortalSettings.CLOCK_AUTO,
-                      "12h" to ImmortalSettings.CLOCK_12,
-                      "24h" to ImmortalSettings.CLOCK_24,
-                  ),
-              selected = settings.clockFormat,
-              onSelect = {
-                ImmortalSettings.setClockFormat(context, it)
-                settings = settings.copy(clockFormat = it)
-              },
-          )
-        }
+      // Top-level controls render from the `immortal` domain (the same registry that drives the
+      // remote). The multi-room fields are excluded here — they live behind the Multi-room sub-screen.
+      SettingsList(
+          SettingsDomains.immortal,
+          settings,
+          exclude = setOf("multiRoomEnabled", "snapcastHost", "maUsername", "maPassword"),
+      ) { k, v ->
+        apply(k, v)
       }
 
       MultiRoomNavRow(onOpen = { context.startActivity(Intent(context, MultiRoomActivity::class.java)) })

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -358,7 +358,8 @@ object SettingsDomains {
                           listOf(
                               ImmortalSettings.UNIT_AUTO to "Auto",
                               ImmortalSettings.UNIT_F to "Fahrenheit",
-                              ImmortalSettings.UNIT_C to "Celsius")),
+                              ImmortalSettings.UNIT_C to "Celsius"),
+                      help = "Auto follows your Portal's language & region setting."),
                   EnumSpec(
                       "tileSize",
                       "App tile size",
@@ -368,7 +369,8 @@ object SettingsDomains {
                           listOf(
                               ImmortalSettings.SIZE_STANDARD to "Standard",
                               ImmortalSettings.SIZE_LARGE to "Large",
-                              ImmortalSettings.SIZE_XL to "XL")),
+                              ImmortalSettings.SIZE_XL to "XL"),
+                      help = "Large is closer to the stock Portal launcher."),
                   EnumSpec(
                       "weatherWidget",
                       "Weather widget",
@@ -378,7 +380,8 @@ object SettingsDomains {
                           listOf(
                               ImmortalSettings.WIDGET_OFF to "Off",
                               ImmortalSettings.WIDGET_HOURLY to "Hourly",
-                              ImmortalSettings.WIDGET_DAILY to "Daily")),
+                              ImmortalSettings.WIDGET_DAILY to "Daily"),
+                      help = "Show a forecast below your apps. Off by default."),
                   EnumSpec(
                       "clockFormat",
                       "Clock",
@@ -388,17 +391,23 @@ object SettingsDomains {
                           listOf(
                               ImmortalSettings.CLOCK_AUTO to "Auto",
                               ImmortalSettings.CLOCK_12 to "12-hour",
-                              ImmortalSettings.CLOCK_24 to "24-hour")),
+                              ImmortalSettings.CLOCK_24 to "24-hour"),
+                      help =
+                          "Applies to the home screen, screensaver and forecast. Auto follows your Portal's system setting."),
                   BoolSpec(
                       "showMiniPlayer",
-                      "Mini player",
+                      "Now-playing mini-player",
                       get = { it.showMiniPlayer },
-                      set = ImmortalSettings::setShowMiniPlayer),
+                      set = ImmortalSettings::setShowMiniPlayer,
+                      help =
+                          "Show the current track, cover art and controls in the header while music is playing."),
                   BoolSpec(
                       "hideStatusBar",
                       "Hide status bar",
                       get = { it.hideStatusBar },
-                      set = ImmortalSettings::setHideStatusBar),
+                      set = ImmortalSettings::setHideStatusBar,
+                      help =
+                          "Hidden by default for a cleaner full-screen look. Swipe down from the top to reveal it briefly."),
                   BoolSpec(
                       "multiRoomEnabled",
                       "Multi-room audio",
@@ -426,12 +435,12 @@ object SettingsDomains {
               ),
           sections =
               mapOf(
-                  "weatherUnit" to "Display",
-                  "tileSize" to "Display",
-                  "weatherWidget" to "Display",
-                  "clockFormat" to "Display",
-                  "showMiniPlayer" to "Display",
-                  "hideStatusBar" to "Display",
+                  "weatherUnit" to "Weather",
+                  "weatherWidget" to "Weather",
+                  "tileSize" to "Home screen",
+                  "showMiniPlayer" to "Home screen",
+                  "hideStatusBar" to "Home screen",
+                  "clockFormat" to "Clock",
                   "multiRoomEnabled" to "Audio",
                   "snapcastHost" to "Audio",
                   "maUsername" to "Audio",

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -176,6 +176,25 @@ class SettingsDomainTest {
   }
 
   @Test
+  fun immortalRegistry_coversEveryPersistedField_orExplicitlyAccountsForIt() {
+    // The on-device Immortal screen now renders its top-level controls from this domain, so a new
+    // ImmortalSettings.Settings field that nobody adds a spec for would silently never appear. Every
+    // field is currently bound by a value spec (the multi-room ones gate on the master toggle), so
+    // managedElsewhere is empty — a new field must get a spec or be listed here, a deliberate gate.
+    val fields =
+        com.immortal.launcher.ImmortalSettings.Settings::class.java.declaredFields
+            .filter { !java.lang.reflect.Modifier.isStatic(it.modifiers) }
+            .map { it.name }
+            .toSet()
+    val specKeys = SettingsDomains.immortal.specs.map { it.key }.toSet()
+    val managedElsewhere = emptySet<String>()
+    val uncovered = fields - specKeys - managedElsewhere
+    assertTrue(
+        "ImmortalSettings.Settings has persisted fields neither in the registry nor accounted for: $uncovered",
+        uncovered.isEmpty())
+  }
+
+  @Test
   fun allDomains_sectionKeysMatchRealSpecs() {
     SettingsRegistry.domains.forEach { dom ->
       val specKeys = dom.specs.map { it.key }.toSet()


### PR DESCRIPTION
Completes the on-device migration. The Immortal screen's Weather / Home screen / Clock controls were a parallel hand-coded definition (~170 lines of `Segmented` rows) that could drift from the registry that drives the remote. They now render via `SettingsList(immortal)` — the same generic renderer the Screensaver screen uses — so the controls, their help, grouping and apply path are **defined once**.

- Enriched the `immortal` domain: per-control help lifted onto the specs, re-sectioned into Weather / Home screen / Clock (was a single "Display").
- `ImmortalSettingsScreen` drops the three hand-coded control cards for one `SettingsList` call (multi-room fields excluded — they live behind the Multi-room sub-screen Activity); changes route through the registry `apply` so `onApplied` (status-bar re-apply, multi-room resync) fires here too.
- Added `immortalRegistry_coversEveryPersistedField` — a new `ImmortalSettings` field with no spec now fails the build (drift tripwire, mirroring the screensaver one).
- mini-player + status-bar move from Off/On segments to plain toggles.

**Verified on a Portal Go:** renders Weather/Home screen/Clock from the registry with help intact; changing Temperature unit applies + re-reads + recomposes; nav rows still launch the sub-screen Activities. Unit suite green.

With this, **both on-device settings screens render from the same registry that drives the phone remote and persistence** — the divergence problem is closed end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)