### PR TITLE
Settings backend: honest validation at the apply boundary + per-domain apply lock

### DIFF
--- a/app/src/main/java/com/immortal/launcher/settings/SettingSpec.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingSpec.kt
@@ -60,6 +60,30 @@ private fun firstPresent(key: String, aliases: List<String>, body: JSONObject): 
 
 private fun JSONObject.withHelp(help: String?): JSONObject = apply { help?.let { put("help", it) } }
 
+/**
+ * Strict scalar parsing at the HTTP boundary. `JSONObject.optInt`/`optBoolean` quietly coerce a
+ * wrong-typed value to `0`/`false` (so a non-numeric port or a garbage toggle would be written and
+ * reported as "applied"). These return null instead, so [SettingSpec.applyFrom] can reject the write
+ * and leave it out of the applied-key set — making that set a truthful record of what took effect.
+ */
+private fun Any?.asIntOrNull(): Int? =
+    when (this) {
+      is Number -> toInt()
+      is String -> trim().toIntOrNull()
+      else -> null
+    }
+
+private fun Any?.asBooleanOrNull(): Boolean? =
+    when (this) {
+      is Boolean -> this
+      is String -> when (trim().lowercase()) {
+        "true" -> true
+        "false" -> false
+        else -> null
+      }
+      else -> null
+    }
+
 class BoolSpec<S>(
     override val key: String,
     val title: String,
@@ -81,7 +105,8 @@ class BoolSpec<S>(
 
   override fun applyFrom(c: Context, body: JSONObject): Boolean {
     val k = firstPresent(key, aliases, body) ?: return false
-    set(c, body.optBoolean(k))
+    val v = body.opt(k).asBooleanOrNull() ?: return false // reject a non-boolean rather than coerce
+    set(c, v)
     return true
   }
 }
@@ -125,7 +150,13 @@ class IntSpec<S>(
 
   override fun applyFrom(c: Context, body: JSONObject): Boolean {
     val k = firstPresent(key, aliases, body) ?: return false
-    set(c, body.optInt(k)) // the underlying setter clamps/wraps
+    val n = body.opt(k).asIntOrNull() ?: return false // reject a non-integer rather than coerce to 0
+    // Reject an out-of-range value (so the schema's advertised min/max is actually enforced, and the
+    // applied set stays truthful) instead of letting the setter silently clamp it. Wrap fields
+    // (time-of-day) legitimately arrive outside [min,max] from the stepper's -step at 0, so they skip
+    // the range check; the setter still wraps/clamps as the final guard either way.
+    if (!wrap && n !in min..max) return false
+    set(c, n)
     return true
   }
 }

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomain.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomain.kt
@@ -61,12 +61,17 @@ class SettingsDomain<S>(
     return JSONObject().put("id", id).put("title", title).put("controls", controls)
   }
 
-  /** Apply every present key, then fire [onApplied] once. Returns the set of applied keys. */
-  fun apply(c: Context, body: JSONObject): Set<String> {
-    val applied = applyValues(c, body)
-    if (applied.isNotEmpty()) onApplied(c, applied)
-    return applied
-  }
+  /**
+   * Apply every present key, then fire [onApplied] once. Returns the set of applied keys. Serialized
+   * per-domain so two concurrent applies (two remote clients, or remote + on-device) can't interleave
+   * their writes or have the post-apply read-back reflect a different writer's half-applied state.
+   */
+  fun apply(c: Context, body: JSONObject): Set<String> =
+      synchronized(this) {
+        val applied = applyValues(c, body)
+        if (applied.isNotEmpty()) onApplied(c, applied)
+        applied
+      }
 
   /**
    * Apply every present key WITHOUT firing [onApplied]. For callers that already run their own
@@ -74,11 +79,12 @@ class SettingsDomain<S>(
    * themselves) — delegating their value writes here unifies the spec definitions without
    * double-firing the domain's hook. Most callers want [apply].
    */
-  fun applyValues(c: Context, body: JSONObject): Set<String> {
-    val applied = LinkedHashSet<String>()
-    specs.forEach { if (it.applyFrom(c, body)) applied.add(it.key) }
-    return applied
-  }
+  fun applyValues(c: Context, body: JSONObject): Set<String> =
+      synchronized(this) {
+        val applied = LinkedHashSet<String>()
+        specs.forEach { if (it.applyFrom(c, body)) applied.add(it.key) }
+        applied
+      }
 }
 
 /**

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -94,6 +94,46 @@ class SettingsDomainTest {
   }
 
   @Test
+  fun int_rejectsNonNumericAndOutOfRange_soAppliedSetIsTruthful() {
+    val d =
+        domain(
+            listOf(IntSpec("n", "N", get = { it.n }, set = { _, v -> writes.add("n" to v) }, min = 0, max = 10)))
+    // Wrong type and out-of-range are REJECTED (not coerced to 0 / silently clamped + reported applied).
+    assertTrue("non-numeric rejected", d.apply(ctx, JSONObject().put("n", "abc")).isEmpty())
+    assertTrue("above max rejected", d.apply(ctx, JSONObject().put("n", 99)).isEmpty())
+    assertTrue("below min rejected", d.apply(ctx, JSONObject().put("n", -1)).isEmpty())
+    assertTrue("no write happened for any rejected value", writes.isEmpty())
+    // In-range applies; a numeric string coerces.
+    assertEquals(setOf("n"), d.apply(ctx, JSONObject().put("n", 7)))
+    assertEquals(setOf("n"), d.apply(ctx, JSONObject().put("n", "3")))
+    assertEquals(listOf<Pair<String, Any?>>("n" to 7, "n" to 3), writes)
+  }
+
+  @Test
+  fun int_wrapField_acceptsOutOfRange_forTheStepperWrap() {
+    val seen = mutableListOf<Int>()
+    val d =
+        domain(
+            listOf(
+                IntSpec(
+                    "t", "T", get = { it.n }, set = { _, v -> seen.add(v) }, min = 0, max = 1439, wrap = true)))
+    // A time-of-day (wrap) field legitimately receives the stepper's -step at 0; range check is skipped
+    // and the setter wraps it. (Non-wrap fields would reject this — see the test above.)
+    assertEquals(setOf("t"), d.apply(ctx, JSONObject().put("t", -15)))
+    assertEquals(listOf(-15), seen)
+  }
+
+  @Test
+  fun bool_rejectsNonBoolean() {
+    val d = domain(listOf(BoolSpec("flag", "F", get = { it.flag }, set = { _, v -> writes.add("flag" to v) })))
+    assertTrue(d.apply(ctx, JSONObject().put("flag", "maybe")).isEmpty()) // garbage string → skipped
+    assertTrue(d.apply(ctx, JSONObject().put("flag", 3)).isEmpty()) // number → skipped
+    assertTrue(writes.isEmpty())
+    assertEquals(setOf("flag"), d.apply(ctx, JSONObject().put("flag", true)))
+    assertEquals(setOf("flag"), d.apply(ctx, JSONObject().put("flag", "false"))) // "true"/"false" accepted
+  }
+
+  @Test
   fun string_applyWhenGuardSkipsBlank() {
     val d =
         domain(


### PR DESCRIPTION
Second multi-perspective review (device / remote / backend / integrity). The backend reviewers converged on one real class of bug, fixed here.

**The bug:** `IntSpec`/`BoolSpec.applyFrom` used `JSONObject.optInt`/`optBoolean`, which silently coerce a wrong-typed value to `0`/`false`, and `IntSpec` never enforced its own advertised `min`/`max` — it trusted the setter to clamp. So a remote `POST {"port":"abc"}` or `{"port":70000}` was written as a default **and reported in the applied-key set as if the user's value took effect**. The set the client renders as confirmation wasn't truthful.

**Fixes**
- `IntSpec.applyFrom` parses strictly (Number or numeric String, else reject) and rejects out-of-range values for non-wrap fields (wrap/time-of-day still pass through to the wrapping setter). The schema's `min`/`max` is now enforced server-side.
- `BoolSpec.applyFrom` rejects a non-boolean.
- Rejected writes are **not** added to the applied set — it faithfully reports what changed.
- `SettingsDomain.apply`/`applyValues` are `synchronized` per-domain — two concurrent applies can't interleave writes or make the post-apply read-back reflect another writer's half-applied state.

**Tests:** int rejects non-numeric + out-of-range (wrap field still accepts the stepper's −step at 0); bool rejects non-boolean. Full suite green; no existing apply behaviour changed.

This is the first slice of acting on the second review — the "completely solid backend" pillar. Device-UX and remote-PWA findings (and the structural mqtt/quickbar collapse) are summarized for prioritization, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)