### PR TITLE
Settings device polish: connect-screen initial focus + confirm the destructive admin disable

### DIFF
--- a/app/src/main/java/com/immortal/launcher/AlbumUrlEntryActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/AlbumUrlEntryActivity.kt
@@ -55,6 +55,7 @@ private fun AlbumUrlEntryScreen(onSave: (String) -> Unit, onCancel: () -> Unit) 
   val context = LocalContext.current
   val existing = remember { ScreensaverConfig.load(context).albumUrl.orEmpty() }
   var url by remember { mutableStateOf(existing) }
+  val (_, initialFocus) = rememberInitialFocus()
 
   val trimmed = url.trim()
   val supported = trimmed.isNotEmpty() && RemoteAlbum.isSupported(trimmed)
@@ -114,7 +115,7 @@ private fun AlbumUrlEntryScreen(onSave: (String) -> Unit, onCancel: () -> Unit) 
           color = if (supported) Color(0xFF2E6BE6) else Color(0xFF2A2A2C),
           shape = RoundedCornerShape(16.dp),
           modifier =
-              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+              Modifier.fillMaxWidth().then(initialFocus).tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
                 if (supported) onSave(trimmed)
               },
       ) {

--- a/app/src/main/java/com/immortal/launcher/CalendarUrlEntryActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/CalendarUrlEntryActivity.kt
@@ -70,6 +70,7 @@ private fun CalendarUrlEntryScreen(
   val context = LocalContext.current
   val existing = remember { ScreensaverConfig.load(context).calendarUrl.orEmpty() }
   var url by remember { mutableStateOf(existing) }
+  val (_, initialFocus) = rememberInitialFocus()
 
   val trimmed = url.trim()
   val supported = trimmed.isNotEmpty() && CalendarFeed.isSupported(trimmed)
@@ -129,7 +130,7 @@ private fun CalendarUrlEntryScreen(
           color = if (supported) Color(0xFF2E6BE6) else Color(0xFF2A2A2C),
           shape = RoundedCornerShape(16.dp),
           modifier =
-              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+              Modifier.fillMaxWidth().then(initialFocus).tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
                 if (supported) onSave(trimmed)
               },
       ) {

--- a/app/src/main/java/com/immortal/launcher/DavConnectActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/DavConnectActivity.kt
@@ -68,6 +68,7 @@ private fun DavConnectScreen(onDone: () -> Unit) {
   var testing by remember { mutableStateOf(false) }
   var status by remember { mutableStateOf<String?>(null) }
   var connectedCount by remember { mutableStateOf<Int?>(null) }
+  val (_, initialFocus) = rememberInitialFocus()
 
   BackHandler { onDone() }
 
@@ -127,7 +128,7 @@ private fun DavConnectScreen(onDone: () -> Unit) {
       )
       Spacer(Modifier.heightIn(min = 22.dp))
 
-      Field(url, { url = it }, "http://nas:30035/share/photos/")
+      Field(url, { url = it }, "http://nas:30035/share/photos/", modifier = initialFocus)
       Spacer(Modifier.heightIn(min = 12.dp))
       Field(user, { user = it }, "Username (optional)")
       Spacer(Modifier.heightIn(min = 12.dp))
@@ -173,6 +174,7 @@ private fun Field(
     onChange: (String) -> Unit,
     placeholder: String,
     password: Boolean = false,
+    modifier: Modifier = Modifier,
 ) {
   OutlinedTextField(
       value = value,
@@ -180,7 +182,7 @@ private fun Field(
       placeholder = { Text(placeholder, color = Color(0xFF777777)) },
       singleLine = true,
       visualTransformation = if (password) PasswordVisualTransformation() else VisualTransformation.None,
-      modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
+      modifier = modifier.fillMaxWidth().heightIn(min = 56.dp),
       shape = RoundedCornerShape(14.dp),
   )
 }

--- a/app/src/main/java/com/immortal/launcher/ImmichConnectActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmichConnectActivity.kt
@@ -69,6 +69,7 @@ private fun ImmichConnectScreen(onDone: () -> Unit) {
   // null = not connected yet (show the form); non-null = connected, show the album picker.
   var albums by remember { mutableStateOf<List<ImmichSource.Album>?>(null) }
   var selectedAlbumId by remember { mutableStateOf(existing.immichAlbumId) }
+  val (_, initialFocus) = rememberInitialFocus()
 
   BackHandler { onDone() }
 
@@ -128,7 +129,7 @@ private fun ImmichConnectScreen(onDone: () -> Unit) {
             onValueChange = { url = it },
             placeholder = { Text("http://192.168.1.50:2283", color = Color(0xFF777777)) },
             singleLine = true,
-            modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
+            modifier = initialFocus.fillMaxWidth().heightIn(min = 56.dp),
             shape = RoundedCornerShape(14.dp),
         )
         Spacer(Modifier.heightIn(min = 12.dp))

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -936,6 +936,7 @@ internal fun DeviceHealthScreen(onBack: () -> Unit) {
   val checks = remember { DevicePermissions.all(context) }
   val issues = checks.count { !it.granted }
   var adminActive by remember { mutableStateOf(ScreenControl.isAdminActive(context)) }
+  var confirmingDisable by remember { mutableStateOf(false) }
 
   Column(
       modifier =
@@ -1032,13 +1033,22 @@ internal fun DeviceHealthScreen(onBack: () -> Unit) {
             modifier = Modifier.padding(start = 4.dp, end = 4.dp, bottom = 10.dp),
         )
         Text(
-            "Disable screen-off admin",
+            if (confirmingDisable) "Tap again to confirm — this stops automatic screen-off"
+            else "Disable screen-off admin",
             color = Color(0xFFE0908A),
             fontSize = 15.sp,
+            fontWeight = if (confirmingDisable) FontWeight.SemiBold else FontWeight.Normal,
             modifier =
                 Modifier.tvFocusable(RoundedCornerShape(8.dp)) {
-                      ScreenControl.deactivateAdmin(context)
-                      adminActive = ScreenControl.isAdminActive(context)
+                      // Two-tap arm: a single stray remote press shouldn't tear down device admin
+                      // (which silently breaks screensaver sleep + the HA screen-off control).
+                      if (confirmingDisable) {
+                        ScreenControl.deactivateAdmin(context)
+                        adminActive = ScreenControl.isAdminActive(context)
+                        confirmingDisable = false
+                      } else {
+                        confirmingDisable = true
+                      }
                     }
                     .padding(start = 4.dp, top = 2.dp, bottom = 4.dp),
         )

--- a/app/src/main/java/com/immortal/launcher/SmbConnectActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/SmbConnectActivity.kt
@@ -69,6 +69,7 @@ private fun SmbConnectScreen(onDone: () -> Unit) {
   var testing by remember { mutableStateOf(false) }
   var status by remember { mutableStateOf<String?>(null) }
   var connectedCount by remember { mutableStateOf<Int?>(null) }
+  val (_, initialFocus) = rememberInitialFocus()
 
   BackHandler { onDone() }
 
@@ -130,7 +131,7 @@ private fun SmbConnectScreen(onDone: () -> Unit) {
       )
       Spacer(Modifier.heightIn(min = 22.dp))
 
-      Field(host, { host = it }, "Server (e.g. 192.168.1.50)")
+      Field(host, { host = it }, "Server (e.g. 192.168.1.50)", modifier = initialFocus)
       Spacer(Modifier.heightIn(min = 12.dp))
       Field(share, { share = it }, "Share name (e.g. media)")
       Spacer(Modifier.heightIn(min = 12.dp))
@@ -180,6 +181,7 @@ private fun Field(
     onChange: (String) -> Unit,
     placeholder: String,
     password: Boolean = false,
+    modifier: Modifier = Modifier,
 ) {
   OutlinedTextField(
       value = value,
@@ -188,7 +190,7 @@ private fun Field(
       singleLine = true,
       visualTransformation =
           if (password) PasswordVisualTransformation() else androidx.compose.ui.text.input.VisualTransformation.None,
-      modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
+      modifier = modifier.fillMaxWidth().heightIn(min = 56.dp),
       shape = RoundedCornerShape(14.dp),
   )
 }

--- a/app/src/main/java/com/immortal/launcher/WebUrlEntryActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/WebUrlEntryActivity.kt
@@ -65,6 +65,7 @@ class WebUrlEntryActivity : ComponentActivity() {
 private fun WebUrlEntryScreen(onSave: (String) -> Unit, onCancel: () -> Unit) {
   val context = LocalContext.current
   var url by remember { mutableStateOf(ScreensaverConfig.load(context).webUrl.orEmpty()) }
+  val (_, initialFocus) = rememberInitialFocus()
 
   val trimmed = url.trim()
   val valid = trimmed.startsWith("http://", true) || trimmed.startsWith("https://", true)
@@ -115,7 +116,7 @@ private fun WebUrlEntryScreen(onSave: (String) -> Unit, onCancel: () -> Unit) {
           color = if (valid) Color(0xFF2E6BE6) else Color(0xFF2A2A2C),
           shape = RoundedCornerShape(16.dp),
           modifier =
-              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+              Modifier.fillMaxWidth().then(initialFocus).tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
                 if (valid) onSave(trimmed)
               },
       ) {


### PR DESCRIPTION
From the second review's on-device UX pass.

- **Initial focus on the six entry screens.** The Album/Web/Calendar URL and SMB/WebDAV/Immich connect screens never requested focus, so a remote user landed on nothing and the first D-pad press was wasted. Each now uses the existing `rememberInitialFocus()`: single-field screens focus the primary button (no scroll); multi-field forms focus the first field (so it doesn't scroll past the inputs — the `Field` helper gained an optional `modifier`).
- **Two-tap confirm on "Disable screen-off admin."** It deactivated device admin on a single tap — which silently breaks screensaver sleep + the HA screen-off control. Now arms first ("Tap again to confirm…"), lighter than a dialog and keeps D-pad focus on the row.

Compiles clean; the focus helper is the same one the face picker already uses on-device. (Connect screens are 3–4 levels deep and not exported, so not scripted-tap reachable for a screenshot.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)