### PR TITLE
Settings: collapse quickbar onto the registry + retire the MQTT TLS-port drift

### DIFF
--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -465,66 +465,16 @@ internal fun MultiRoomScreen(onBack: () -> Unit) {
 @Composable
 private fun QuickButtonsSection() {
   val context = LocalContext.current
-  var enabled by remember { mutableStateOf(QuickBarConfig.isEnabled(context)) }
-  var always by remember { mutableStateOf(QuickBarConfig.alwaysShow(context)) }
+  var settings by remember { mutableStateOf(QuickBarConfig.load(context)) }
 
   Spacer(Modifier.size(26.dp))
   SectionLabel("Quick buttons")
-  Card {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(18.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-      Column(modifier = Modifier.weight(1f)) {
-        Text("Top-bar app switcher", color = Color.White, fontSize = 17.sp)
-        Text(
-            "A centered button at the top that opens your recent apps to switch between them.",
-            color = Color(0xFF9A9A9A),
-            fontSize = 13.sp,
-            modifier = Modifier.padding(top = 2.dp),
-        )
-      }
-      Segmented(
-          options = listOf("Off" to "off", "On" to "on"),
-          selected = if (enabled) "on" else "off",
-          onSelect = {
-            val on = it == "on"
-            enabled = on
-            QuickBarConfig.setEnabled(context, on)
-            // The accessibility service is baseline-enabled (reconcile is a no-op here); the
-            // cluster's visibility is gated on this setting, so just refresh the overlay.
-            SettingsGuard.reconcileBarWatch(context)
-            QuickBar.applyConfig()
-          },
-      )
-    }
-    if (enabled) {
-      Divider()
-      Row(
-          modifier = Modifier.fillMaxWidth().padding(18.dp),
-          verticalAlignment = Alignment.CenterVertically,
-      ) {
-        Column(modifier = Modifier.weight(1f)) {
-          Text("When to show", color = Color.White, fontSize = 17.sp)
-          Text(
-              "Swipe down from the top to reveal the bar (and the buttons), or keep them always on.",
-              color = Color(0xFF9A9A9A),
-              fontSize = 13.sp,
-              modifier = Modifier.padding(top = 2.dp),
-          )
-        }
-        Segmented(
-            options = listOf("With bar" to "bar", "Always" to "always"),
-            selected = if (always) "always" else "bar",
-            onSelect = {
-              val a = it == "always"
-              always = a
-              QuickBarConfig.setAlwaysShow(context, a)
-              QuickBar.applyConfig()
-            },
-        )
-      }
-    }
+  // Rendered from the `quickbar` registry domain (the same specs the phone remote uses), so the
+  // toggle and its gated "Always show" can't drift from the remote's version. Apply routes through
+  // the domain so its onApplied (reconcile + overlay refresh) fires here too.
+  SettingsList(SettingsDomains.quickbar, settings) { k, v ->
+    SettingsDomains.quickbar.apply(context, JSONObject().put(k, v))
+    settings = QuickBarConfig.load(context)
   }
   Text(
       "Needs the accessibility-based top-bar watch enabled during setup. The switcher shows your " +

--- a/app/src/main/java/com/immortal/launcher/QuickBarConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/QuickBarConfig.kt
@@ -27,4 +27,9 @@ object QuickBarConfig {
 
   fun setAlwaysShow(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("always_show", on).apply()
+
+  /** Immutable snapshot, so the settings domain renders through the generic on-device list. */
+  data class Settings(val enabled: Boolean = false, val alwaysShow: Boolean = false)
+
+  fun load(c: Context): Settings = Settings(enabled = isEnabled(c), alwaysShow = alwaysShow(c))
 }

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -543,34 +543,47 @@ object SettingsDomains {
                   "password" to "Broker",
                   "useTls" to "Security",
                   "validateCert" to "Security"),
-          onApplied = { c, _ -> MqttService.sync(c) },
+          onApplied = { c, keys ->
+            // TLS<->port convenience hop, lifted out of the bespoke on-device screen so the phone
+            // remote gets it too (it didn't before — a real drift): flipping TLS moves the port to
+            // the conventional default IF the user left it on the other mode's default.
+            if ("useTls" in keys) {
+              val tls = MqttConfig.useTls(c)
+              val port = MqttConfig.port(c)
+              if (tls && port == MqttConfig.DEFAULT_PORT) MqttConfig.setPort(c, MqttConfig.DEFAULT_TLS_PORT)
+              else if (!tls && port == MqttConfig.DEFAULT_TLS_PORT) MqttConfig.setPort(c, MqttConfig.DEFAULT_PORT)
+            }
+            MqttService.sync(c)
+          },
       )
 
   /**
-   * The floating quick-button cluster ([QuickBarConfig]); Context as snapshot. Same Context-snapshot
-   * caveat as [mqtt]: served on-device by the bespoke `QuickButtonsSection` (own `mutableStateOf`),
-   * not the generic [SettingsList], which wouldn't recompose after a toggle here. The remote renders
-   * it generically (a POST returns a fresh schema, so no live recompose is needed there).
+   * The floating quick-button cluster ([QuickBarConfig]). Backed by an immutable
+   * [QuickBarConfig.Settings] snapshot, so both the phone remote AND the on-device `QuickButtonsSection`
+   * render it through the generic pipeline ([SettingsList]) — one definition, no bespoke duplicate.
    */
-  val quickbar: SettingsDomain<Context> =
+  val quickbar: SettingsDomain<QuickBarConfig.Settings> =
       SettingsDomain(
           id = "quickbar",
           title = "Quick buttons",
-          load = { it },
+          load = QuickBarConfig::load,
           specs =
               listOf(
                   BoolSpec(
                       "enabled",
                       "App-switcher button",
-                      get = { QuickBarConfig.isEnabled(it) },
-                      set = QuickBarConfig::setEnabled),
+                      get = { it.enabled },
+                      set = QuickBarConfig::setEnabled,
+                      help = "A centered button at the top that opens your recent apps to switch between them."),
                   BoolSpec(
                       "alwaysShow",
                       "Always show",
-                      get = { QuickBarConfig.alwaysShow(it) },
+                      get = { it.alwaysShow },
                       set = QuickBarConfig::setAlwaysShow,
-                      visible = { c, _ -> QuickBarConfig.isEnabled(c) }),
+                      help = "On: always visible. Off: only while the system top bar is revealed.",
+                      visible = { _, s -> s.enabled }),
               ),
+          defaults = { QuickBarConfig.Settings() },
           onApplied = { c, _ ->
             SettingsGuard.reconcileBarWatch(c)
             QuickBar.applyConfig()

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -271,15 +271,26 @@ class SettingsDomainTest {
   }
 
   @Test
-  fun contextSnapshotDomains_specKeysArePinned() {
-    // mqtt & quickbar use Context as the snapshot — they have no aggregate `Settings` data class, so
-    // the reflection completeness tripwires above can't enumerate their fields. Pin the spec-key set
-    // instead: adding a new MqttConfig/QuickBarConfig setting now forces a conscious update here (and
-    // a spec), rather than the field silently shipping with no remote/registry exposure.
+  fun mqttRegistry_specKeysArePinned() {
+    // mqtt still uses Context as the snapshot — no aggregate `Settings` data class for the reflection
+    // tripwire to enumerate. Pin the spec-key set: a new MqttConfig setting forces a conscious update
+    // here (and a spec) rather than silently shipping with no remote/registry exposure.
     assertEquals(
         setOf("enabled", "host", "port", "username", "password", "useTls", "validateCert"),
         SettingsDomains.mqtt.specs.map { it.key }.toSet())
-    assertEquals(setOf("enabled", "alwaysShow"), SettingsDomains.quickbar.specs.map { it.key }.toSet())
+  }
+
+  @Test
+  fun quickbarRegistry_coversEveryPersistedField() {
+    // quickbar now has a real QuickBarConfig.Settings snapshot (so it renders through SettingsList on
+    // both surfaces) — give it the same reflection tripwire as screensaver/immortal.
+    val fields =
+        com.immortal.launcher.QuickBarConfig.Settings::class.java.declaredFields
+            .filter { !java.lang.reflect.Modifier.isStatic(it.modifiers) }
+            .map { it.name }
+            .toSet()
+    val specKeys = SettingsDomains.quickbar.specs.map { it.key }.toSet()
+    assertEquals(fields, specKeys)
   }
 
   @Test


### PR DESCRIPTION
From the second review's "single source of truth breaks at the bespoke screens" finding.

**quickbar — fully collapsed.** `QuickBarConfig` gains an immutable `Settings` snapshot + `load()`, so the quickbar domain is a normal data-class domain (not Context-as-snapshot). The on-device `QuickButtonsSection`'s ~70 hand-coded lines are replaced by `SettingsList(quickbar)` — the same specs the remote renders. **Verified on a Portal Go:** toggling the App-switcher button recomposes and reveals the gated "Always show" (the Context-snapshot dead-toggle problem is gone), and apply routes through the domain so `onApplied` fires.

**mqtt — TLS↔port drift retired.** The hop lived only in the bespoke `MqttScreen`, so a remote that toggled TLS left the port stale. It's lifted into the mqtt domain's `onApplied`, so the remote gets it too.

**Why MqttScreen isn't fully collapsed yet:** its host/user/password are `Entry.Inline` strings the generic list renders nothing for, and it batches behind an Apply button (`explicitApply`). A proper collapse needs the renderer to grow inline-text-field + explicit-apply support — a follow-up — but the *drift* is retired now.

Tests: quickbar gains a reflection completeness tripwire; the mqtt spec-key pin stays. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)