### PR TITLE
Added a simple, mqtt configurable notification overlay

### DIFF
--- a/app/src/main/java/com/immortal/launcher/BarWatchService.kt
+++ b/app/src/main/java/com/immortal/launcher/BarWatchService.kt
@@ -30,6 +30,7 @@ class BarWatchService : AccessibilityService() {
     QuickBar.attach(this) // host the cluster as a TYPE_ACCESSIBILITY_OVERLAY (renders on the bar)
     RemoteInput.register(this) // let the phone-remote routes drive input through us
     RemoteCursor.attach(this) // host the remote touchpad's on-TV pointer overlay
+    NotificationOverlay.attach(this) // host MQTT-notify toasts (see MqttPublisher.handleNotify)
     updateBar()
   }
 
@@ -41,6 +42,7 @@ class BarWatchService : AccessibilityService() {
     QuickBar.detach()
     RemoteInput.unregister()
     RemoteCursor.detach()
+    NotificationOverlay.detach()
     return super.onUnbind(intent)
   }
 

--- a/app/src/main/java/com/immortal/launcher/MqttNotifyPayload.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttNotifyPayload.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.json.JSONObject
+
+/**
+ * Schema and parser for the MQTT notify payload (see `docs/design/mqtt-notifications.md`).
+ *
+ * Payload arrives on `immortal/<id>/notify/set` as a JSON document; all fields are
+ * optional and the parser is forgiving — malformed JSON, out-of-range numbers, and
+ * unknown enums fall back to defaults rather than rejecting the whole message. An
+ * empty payload (`{}` / `""`) returns null so the caller can no-op cleanly.
+ *
+ * Two production paths arrive here: Track 1 (HA `notify.send_message`) ships
+ * `{"message": "..."}` via the entity's `command_template`; Track 2 (raw
+ * `mqtt.publish`) ships the full schema. Same parsing path for both.
+ */
+data class NotifyPayload(
+    val title: String,
+    val message: String,
+    val image: String?,
+    val sound: String?,
+    val position: Position,
+    val durationSec: Int,
+    val volume: Float,
+    val wakeScreen: Boolean,
+    val onTap: String?,
+) {
+  enum class Position {
+    TOP,
+    BOTTOM
+  }
+
+  /** True when the payload would render a toast (has any visible text). */
+  val hasVisual: Boolean
+    get() = title.isNotEmpty() || message.isNotEmpty()
+
+  /** True when there's nothing to do — neither visual nor audio. */
+  val isEmpty: Boolean
+    get() = !hasVisual && sound.isNullOrBlank()
+
+  companion object {
+    const val DEFAULT_DURATION_SEC = 6
+    const val DEFAULT_VOLUME = 1.0f
+
+    /**
+     * Parse a payload string. Returns null for empty/malformed/no-op payloads — the
+     * caller treats both "couldn't parse" and "parsed to no-op" the same way. Out-of-range
+     * `duration` / `volume` are clamped, unknown `position` falls back to BOTTOM.
+     */
+    fun parse(raw: String): NotifyPayload? {
+      val trimmed = raw.trim()
+      if (trimmed.isEmpty()) return null
+      val obj = runCatching { JSONObject(trimmed) }.getOrNull() ?: return null
+      val payload =
+          NotifyPayload(
+              title = obj.optString("title", ""),
+              message = obj.optString("message", ""),
+              image = obj.optString("image", "").ifBlank { null },
+              sound = obj.optString("sound", "").ifBlank { null },
+              position =
+                  when (obj.optString("position", "bottom").lowercase()) {
+                    "top" -> Position.TOP
+                    else -> Position.BOTTOM
+                  },
+              // `duration` is seconds. Negative → 0 (no auto-dismiss). HA may publish it
+              // as a string via templated automations — accept either via optInt's coercion.
+              durationSec = obj.optInt("duration", DEFAULT_DURATION_SEC).coerceAtLeast(0),
+              // `volume` clamps to [0.0, 1.0]; the cap is also bounded by the user's
+              // notification-stream slider at playback time (see SoundPlayer).
+              volume =
+                  obj.optDouble("volume", DEFAULT_VOLUME.toDouble())
+                      .toFloat()
+                      .coerceIn(0f, 1f),
+              wakeScreen = obj.optBoolean("wake_screen", true),
+              onTap = obj.optString("on_tap", "").ifBlank { null },
+          )
+      return if (payload.isEmpty) null else payload
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -169,7 +169,16 @@ class MqttPublisher(private val appContext: Context) {
               val pkt = c.readPacket() ?: break
               if (pkt.type == 0x30) {
                 val (t, p) = c.parsePublish(pkt)
-                handleCommand(t, String(p, Charsets.UTF_8))
+                // Drop retained set-topic deliveries — both the broker's protocol-mandated
+                // replay on (re)subscribe AND any future producer publish with retain=true.
+                // Command topics should never be retained; if one is, dropping it avoids
+                // replaying stale doorbells on every reconnect.
+                val retained = (pkt.flags and 0x01) != 0
+                if (retained) {
+                  Log.i(TAG, "ignoring retained set-topic message: $t")
+                } else {
+                  handleCommand(t, String(p, Charsets.UTF_8))
+                }
               }
             }
           }
@@ -252,6 +261,7 @@ class MqttPublisher(private val appContext: Context) {
           "media_play_pause" -> NowPlayingHub.playPause()
           "media_next" -> NowPlayingHub.next()
           "media_previous" -> NowPlayingHub.previous()
+          "notify" -> handleNotify(payload)
           else -> Log.w(TAG, "unknown command $obj")
         }
       }
@@ -284,6 +294,36 @@ class MqttPublisher(private val appContext: Context) {
     }
     // Echo the last target so the text entity shows what it was set to.
     client?.publish("$base/open/state", t, retain = true)
+  }
+
+  /**
+   * Render a notify payload (toast + optional sound). Schema: [NotifyPayload]; behavior
+   * rules: `docs/design/mqtt-notifications.md`. The handler is forgiving — malformed JSON
+   * is a silent no-op; partial payloads use defaults.
+   */
+  private fun handleNotify(raw: String) {
+    val spec = NotifyPayload.parse(raw) ?: return // empty/malformed/no-op
+    if (spec.hasVisual) {
+      // wake_screen defaults to true. Always call wake when requested — idempotent if the
+      // device is already interactive, dismisses the photo dream if it's in front (PowerManager
+      // reports isInteractive=true while dreaming, so a screen-on check alone misses it; and
+      // PresenceHub.current.screen only reflects THIS process's dream service, which doesn't
+      // help if a sibling package owns the active dream). 3s auto-release wake lock, no harm.
+      if (spec.wakeScreen) ScreenControl.wake(appContext)
+      val tap: (() -> Unit)? = spec.onTap?.let { target -> { openTarget(target) } }
+      NotificationOverlay.show(spec, tap)
+    }
+    if (!spec.sound.isNullOrBlank()) {
+      val nm =
+          appContext.getSystemService(Context.NOTIFICATION_SERVICE)
+              as? android.app.NotificationManager
+      val dndOff =
+          nm == null ||
+              nm.currentInterruptionFilter ==
+                  android.app.NotificationManager.INTERRUPTION_FILTER_ALL
+      if (dndOff) SoundPlayer.play(appContext, spec.sound, spec.volume)
+      else Log.i(TAG, "DND active; suppressing notify sound")
+    }
   }
 
   // --- state (device → broker) ------------------------------------------------
@@ -396,6 +436,7 @@ class MqttPublisher(private val appContext: Context) {
 
     button(c, "go_home", "Home", icon = "mdi:home")
     textEntity(c, "open", "Open", icon = "mdi:open-in-app")
+    notifyEntity(c, "notify", "Notify")
     button(c, "identify", "Identify", icon = "mdi:bullhorn")
     sensor(c, "ip", "IP address", icon = "mdi:ip-network", diagnostic = true)
   }
@@ -416,6 +457,7 @@ class MqttPublisher(private val appContext: Context) {
           "button" to "media_previous",
           "button" to "go_home",
           "text" to "open",
+          "notify" to "notify",
           "button" to "identify",
           "sensor" to "ip",
           "button" to "screen_off", // legacy (pre-1.41)
@@ -521,6 +563,22 @@ class MqttPublisher(private val appContext: Context) {
             .put("entity_category", "config")
             .put("icon", icon)
     publishConfig(c, "text", obj, cfg)
+  }
+
+  /**
+   * The MQTT `notify` discovery component (HA 2024.7+ `NotifyEntity`). HA exposes the
+   * entity as a target for the `notify.send_message` action; only `message` reaches the
+   * `command_template`, so Track 1 ships `{"message": "..."}` to the device. Rich payloads
+   * use Track 2 (raw `mqtt.publish` to `<base>/notify/set`). See
+   * `docs/design/mqtt-notifications.md` § *Home Assistant integration*.
+   */
+  private fun notifyEntity(c: MqttClient, obj: String, name: String) {
+    val cfg =
+        base(obj, name)
+            .put("command_topic", "$base/$obj/set")
+            .put("command_template", "{\"message\": {{ value|tojson }}}")
+            .put("availability_topic", "$base/availability")
+    publishConfig(c, "notify", obj, cfg)
   }
 
   /** Publish (or, when [cfg] is null, clear) a retained discovery config. */

--- a/app/src/main/java/com/immortal/launcher/NotificationOverlay.kt
+++ b/app/src/main/java/com/immortal/launcher/NotificationOverlay.kt
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.accessibilityservice.AccessibilityService
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.graphics.drawable.GradientDrawable
+import android.os.Handler
+import android.os.Looper
+import android.util.Base64
+import android.util.Log
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * The MQTT-notify toast. A bottom- or top-anchored card with optional image + title +
+ * message, hosted by [BarWatchService] as a third `wm.addView` peer alongside [QuickBar]
+ * and [RemoteCursor].
+ *
+ * Why an accessibility-service overlay instead of a regular window: `TYPE_ACCESSIBILITY_OVERLAY`
+ * renders above the system bar and doesn't require `SYSTEM_ALERT_WINDOW`, matching how
+ * [QuickBar] already pins its row to the bar.
+ *
+ * Replace-don't-stack: a new [show] takes over the slot, cancels the previous auto-dismiss
+ * timer, and re-arms a new one. Tap dismisses early and fires the payload's `on_tap` action
+ * (the host passes the dispatcher in — the overlay doesn't know about HA routing).
+ *
+ * See `docs/design/mqtt-notifications.md` for the full schema and behavior contract.
+ */
+object NotificationOverlay {
+  private const val TAG = "ImmortalNotifyOverlay"
+  private const val IMAGE_MAX_EDGE_PX = 512
+  private const val IMAGE_TIMEOUT_MS = 3000
+  private val main = Handler(Looper.getMainLooper())
+
+  private var host: AccessibilityService? = null
+  private var wm: WindowManager? = null
+  private var view: View? = null
+  private var dismissAt: Long = 0
+  private var onTapCallback: (() -> Unit)? = null
+
+  // --- lifecycle (called by BarWatchService) ----------------------------------
+
+  fun attach(service: AccessibilityService) {
+    main.post {
+      host = service
+      wm = service.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
+    }
+  }
+
+  fun detach() {
+    main.post { hideInternal() }
+    main.post {
+      host = null
+      wm = null
+    }
+  }
+
+  // --- public API (called by MqttPublisher.handleNotify) ----------------------
+
+  /**
+   * Display [spec]. Replaces any current toast. Image fetch and decode happen on a worker
+   * thread; the toast renders text immediately and the image fills in when it lands (or
+   * never, if the fetch fails — the toast still shows). [onTap] is invoked when the toast
+   * is tapped before auto-dismiss; the overlay itself doesn't know about HA routing.
+   */
+  fun show(spec: NotifyPayload, onTap: (() -> Unit)? = null) {
+    main.post { showInternal(spec, onTap) }
+  }
+
+  private fun showInternal(spec: NotifyPayload, onTap: (() -> Unit)?) {
+    val ctx = host ?: run {
+      // Boot race: MqttPublisher may receive a notify before BarWatchService.onServiceConnected
+      // has fired. Drop with a log so it's visible in logcat — producers can retry.
+      Log.w(TAG, "show() before attach(); dropping payload (title='${spec.title}')")
+      return
+    }
+    val wmgr = wm ?: return
+
+    // Cancel any in-flight auto-dismiss before we replace.
+    main.removeCallbacks(dismissRunnable)
+    onTapCallback = onTap
+    removeView(wmgr)
+
+    val card = buildCard(ctx, spec)
+    // Explicit pixel width (display width minus side insets) — MATCH_PARENT plus
+    // CENTER_HORIZONTAL collapses to content-width on TYPE_ACCESSIBILITY_OVERLAY in some
+    // configurations, leaving the toast pinned narrow and left-aligned. Pixel width is
+    // unambiguous. Standoff from the gravity edge goes on the window via `y`, not on the
+    // root view (addView overwrites the root view's layoutParams with the WindowManager
+    // params we pass).
+    val dm = ctx.resources.displayMetrics
+    val sideInsetPx = (24 * dm.density).toInt()
+    val standoffPx = (48 * dm.density).toInt()
+    val lp =
+        WindowManager.LayoutParams(
+                dm.widthPixels - 2 * sideInsetPx,
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+                PixelFormat.TRANSLUCENT,
+            )
+            .apply {
+              gravity =
+                  Gravity.CENTER_HORIZONTAL or
+                      when (spec.position) {
+                        NotifyPayload.Position.TOP -> Gravity.TOP
+                        NotifyPayload.Position.BOTTOM -> Gravity.BOTTOM
+                      }
+              y = standoffPx
+            }
+
+    runCatching { wmgr.addView(card, lp); view = card }
+        .onFailure { Log.w(TAG, "addView failed", it) }
+
+    // Wire taps (whole-card click).
+    card.setOnClickListener {
+      val cb = onTapCallback
+      hideInternal()
+      runCatching { cb?.invoke() }
+    }
+
+    // Schedule auto-dismiss unless duration is 0 (acknowledgement-required).
+    if (spec.durationSec > 0) {
+      dismissAt = System.currentTimeMillis() + spec.durationSec * 1000L
+      main.postDelayed(dismissRunnable, spec.durationSec * 1000L)
+    } else {
+      dismissAt = 0
+    }
+
+    // Image (if any) fetches in the background and sets when ready.
+    spec.image?.let { src ->
+      val imageView = card.findViewWithTag<ImageView>(IMAGE_TAG) ?: return@let
+      loadImage(src, imageView)
+    }
+  }
+
+  /** Hide and free the current toast without firing on-tap. Safe to call repeatedly. */
+  fun dismiss() {
+    main.post { hideInternal() }
+  }
+
+  // --- internals --------------------------------------------------------------
+
+  private val dismissRunnable = Runnable { hideInternal() }
+
+  private fun hideInternal() {
+    main.removeCallbacks(dismissRunnable)
+    onTapCallback = null
+    val wmgr = wm
+    if (wmgr != null) removeView(wmgr)
+  }
+
+  private fun removeView(wmgr: WindowManager) {
+    view?.let { v -> runCatching { wmgr.removeView(v) } }
+    view = null
+  }
+
+  // --- view building ----------------------------------------------------------
+
+  private const val IMAGE_TAG = "notify_image"
+
+  private fun buildCard(ctx: Context, spec: NotifyPayload): View {
+    val d = ctx.resources.displayMetrics.density
+    fun dp(v: Int) = (v * d).toInt()
+
+    // Root view's layoutParams are overwritten by the WindowManager.LayoutParams passed to
+    // addView, so don't bother setting margins or width here — the window's pixel width and
+    // y-standoff (set in showInternal) are the source of truth for size and position.
+    val card =
+        LinearLayout(ctx).apply {
+          orientation = LinearLayout.HORIZONTAL
+          gravity = Gravity.CENTER_VERTICAL
+          setPadding(dp(16), dp(12), dp(16), dp(12))
+          background =
+              GradientDrawable().apply {
+                shape = GradientDrawable.RECTANGLE
+                cornerRadius = dp(16).toFloat()
+                setColor(0xE6101010.toInt()) // ~90% opaque near-black, matches launcher overlays
+              }
+        }
+
+    if (spec.image != null) {
+      val img =
+          ImageView(ctx).apply {
+            tag = IMAGE_TAG
+            scaleType = ImageView.ScaleType.CENTER_CROP
+            background =
+                GradientDrawable().apply {
+                  shape = GradientDrawable.RECTANGLE
+                  cornerRadius = dp(8).toFloat()
+                  setColor(0x33FFFFFF) // placeholder until the bitmap loads
+                }
+            clipToOutline = true
+          }
+      val imgLp = LinearLayout.LayoutParams(dp(80), dp(80))
+      imgLp.setMargins(0, 0, dp(12), 0)
+      card.addView(img, imgLp)
+    }
+
+    val textColumn =
+        LinearLayout(ctx).apply {
+          orientation = LinearLayout.VERTICAL
+          val lp =
+              LinearLayout.LayoutParams(
+                  0,
+                  LinearLayout.LayoutParams.WRAP_CONTENT,
+                  1f,
+              )
+          layoutParams = lp
+        }
+
+    if (spec.title.isNotEmpty()) {
+      textColumn.addView(
+          TextView(ctx).apply {
+            text = spec.title
+            setTextColor(Color.WHITE)
+            textSize = 16f
+            typeface = android.graphics.Typeface.DEFAULT_BOLD
+            maxLines = 1
+            ellipsize = android.text.TextUtils.TruncateAt.END
+          })
+    }
+    if (spec.message.isNotEmpty()) {
+      textColumn.addView(
+          TextView(ctx).apply {
+            text = spec.message
+            setTextColor(0xFFCCCCCC.toInt())
+            textSize = 14f
+            maxLines = 2
+            ellipsize = android.text.TextUtils.TruncateAt.END
+            if (spec.title.isNotEmpty()) {
+              val lp = layoutParams as? LinearLayout.LayoutParams ?: LinearLayout.LayoutParams(
+                  LinearLayout.LayoutParams.MATCH_PARENT,
+                  LinearLayout.LayoutParams.WRAP_CONTENT,
+              )
+              lp.topMargin = dp(2)
+              layoutParams = lp
+            }
+          })
+    }
+    card.addView(textColumn)
+    return card
+  }
+
+  // --- image loading ----------------------------------------------------------
+
+  private fun loadImage(source: String, target: ImageView) {
+    Thread {
+          val bitmap = if (source.startsWith("data:")) decodeInline(source) else fetchAndDecode(source)
+          if (bitmap != null) main.post { runCatching { target.setImageBitmap(bitmap) } }
+        }
+        .apply {
+          isDaemon = true
+          name = "notify-image-fetch"
+        }
+        .start()
+  }
+
+  /** Decode a `data:image/...;base64,...` URI. Falls back to null on any malformed input. */
+  private fun decodeInline(uri: String): Bitmap? =
+      runCatching {
+            val comma = uri.indexOf(',')
+            if (comma <= 0) return@runCatching null
+            val bytes = Base64.decode(uri.substring(comma + 1), Base64.DEFAULT)
+            decodeSampled(bytes)
+          }
+          .onFailure { Log.w(TAG, "inline image decode failed", it) }
+          .getOrNull()
+
+  /** Fetch [url] with a short timeout and decode with `inSampleSize` to cap memory. */
+  private fun fetchAndDecode(url: String): Bitmap? =
+      runCatching {
+            val conn = URL(url).openConnection() as HttpURLConnection
+            conn.connectTimeout = IMAGE_TIMEOUT_MS
+            conn.readTimeout = IMAGE_TIMEOUT_MS
+            conn.instanceFollowRedirects = true
+            conn.inputStream.use { it.readBytes() }.also { conn.disconnect() }
+          }
+          .onFailure { Log.w(TAG, "image fetch failed: $url", it) }
+          .getOrNull()
+          ?.let { decodeSampled(it) }
+
+  /**
+   * Decode [bytes] with `inSampleSize` chosen so the long edge lands at ≤ [IMAGE_MAX_EDGE_PX].
+   * Two-pass: header-only first to read dimensions, then full decode at the sampled size.
+   * Non-optional on Gen-1 Portal+ — full-res decode of a 4K snapshot will OOM.
+   */
+  private fun decodeSampled(bytes: ByteArray): Bitmap? {
+    val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeByteArray(bytes, 0, bytes.size, opts)
+    val long = maxOf(opts.outWidth, opts.outHeight)
+    var sample = 1
+    while (long / sample > IMAGE_MAX_EDGE_PX) sample *= 2
+    val full = BitmapFactory.Options().apply { inSampleSize = sample }
+    return BitmapFactory.decodeByteArray(bytes, 0, bytes.size, full)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/SoundPlayer.kt
+++ b/app/src/main/java/com/immortal/launcher/SoundPlayer.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.media.MediaPlayer
+import android.net.Uri
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+
+/**
+ * One-shot `MediaPlayer` wrapper for MQTT-notify chimes (see `MqttPublisher.handleNotify`).
+ *
+ * Routes to the notification stream — `USAGE_NOTIFICATION` + `CONTENT_TYPE_SONIFICATION`
+ * via [AudioAttributes], **not** `STREAM_MUSIC` — so a doorbell isn't capped by Spotify's
+ * current volume and we don't duck our own chime. Requests transient-may-duck focus so any
+ * `STREAM_MUSIC` playback (Snapcast, cast, Spotify) ducks for the chime's duration and
+ * restores after.
+ *
+ * Single in-flight player; a new [play] releases the previous one. [release] is idempotent.
+ * Failures (bad URL, codec mismatch, network) surface as a single `Log.w` and never throw —
+ * the visual toast still renders. See `docs/design/mqtt-notifications.md` § *Sound*.
+ */
+object SoundPlayer {
+  private const val TAG = "ImmortalSoundPlayer"
+  private val main = Handler(Looper.getMainLooper())
+
+  @Volatile private var current: MediaPlayer? = null
+  @Volatile private var focusRequest: AudioFocusRequest? = null
+  @Volatile private var stashedContext: Context? = null
+
+  /**
+   * Play [source] (http(s) URL or local URI) at [volume] (0.0–1.0 of the notification-stream
+   * max, bounded by the user's system slider). Releases any in-flight player first. Returns
+   * immediately; preparation and playback happen on `MediaPlayer`'s own thread.
+   */
+  fun play(context: Context, source: String, volume: Float) {
+    if (source.isBlank()) return
+    Log.i(TAG, "play(volume=$volume) source=$source")
+    main.post { startInternal(context.applicationContext, source, volume.coerceIn(0f, 1f)) }
+  }
+
+  /** Stop and free any active player. Safe to call from any thread; safe to call repeatedly. */
+  fun release() {
+    main.post { releaseInternal() }
+  }
+
+  private fun startInternal(appContext: Context, source: String, volume: Float) {
+    stashedContext = appContext
+    // Release a previous player, but on a worker so a slow `stop()` doesn't ANR if we're
+    // already on the main thread. The new player gets installed immediately below.
+    val previous = current
+    current = null
+    if (previous != null) {
+      Thread { runCatching { previous.release() } }.apply { isDaemon = true }.start()
+    }
+
+    val am = appContext.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+    // STREAM_ALARM, not STREAM_NOTIFICATION: on Portal, the "media volume" slider drives a
+    // single linked group (SYSTEM/RING/MUSIC/NOTIFICATION/SYSTEM_ENFORCED/DTMF/TTS), so
+    // STREAM_NOTIFICATION isn't actually separable from music volume on this hardware. Only
+    // STREAM_ALARM and STREAM_VOICE_CALL are independent. Alarm is loud-by-default and the
+    // semantic match for "audible alert that needs attention." DND suppression is still
+    // enforced upstream in MqttPublisher.handleNotify (we gate the call to play() on the
+    // interruption filter), so this routing change doesn't break the polite-in-DND rule.
+    val attrs =
+        AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_ALARM)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+            .build()
+
+    // Transient-may-duck on STREAM_NOTIFICATION: STREAM_MUSIC ducks for our chime and
+    // resumes when we abandon focus. If a call holds STREAM_VOICE_CALL focus, this request
+    // is denied — we silently don't play, which is the documented in-call behavior.
+    val granted = requestFocus(am, attrs)
+    if (!granted) {
+      // Common when a Messenger/WhatsApp call is active; documented behavior.
+      Log.i(TAG, "audio focus denied; skipping chime")
+      return
+    }
+
+    val player =
+        runCatching {
+              MediaPlayer().apply {
+                setAudioAttributes(attrs)
+                setVolume(volume, volume)
+                setDataSource(appContext, Uri.parse(source))
+                setOnPreparedListener { it.start() }
+                setOnCompletionListener { mp ->
+                  if (current === mp) current = null
+                  runCatching { mp.release() }
+                  abandonFocus(am)
+                }
+                setOnErrorListener { mp, what, extra ->
+                  Log.w(TAG, "playback error what=$what extra=$extra src=$source")
+                  if (current === mp) current = null
+                  runCatching { mp.release() }
+                  abandonFocus(am)
+                  true // we've handled it
+                }
+                prepareAsync()
+              }
+            }
+            .onFailure {
+              Log.w(TAG, "setDataSource failed for $source", it)
+              abandonFocus(am)
+            }
+            .getOrNull()
+
+    current = player
+  }
+
+  private fun releaseInternal() {
+    val mp = current
+    current = null
+    if (mp != null) runCatching { mp.release() }
+    val am = stashedContext?.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+    abandonFocus(am)
+  }
+
+  private fun requestFocus(am: AudioManager?, attrs: AudioAttributes): Boolean {
+    if (am == null) return false
+    return if (Build.VERSION.SDK_INT >= 26) {
+      val req =
+          AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+              .setAudioAttributes(attrs)
+              .build()
+      focusRequest = req
+      am.requestAudioFocus(req) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+    } else {
+      @Suppress("DEPRECATION")
+      am.requestAudioFocus(
+          null,
+          AudioManager.STREAM_ALARM,
+          AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK,
+      ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+    }
+  }
+
+  private fun abandonFocus(am: AudioManager?) {
+    am ?: return
+    if (Build.VERSION.SDK_INT >= 26) {
+      focusRequest?.let { runCatching { am.abandonAudioFocusRequest(it) } }
+    } else {
+      @Suppress("DEPRECATION") runCatching { am.abandonAudioFocus(null) }
+    }
+    focusRequest = null
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/MqttClientTest.kt
+++ b/app/src/test/java/com/immortal/launcher/MqttClientTest.kt
@@ -8,10 +8,13 @@
 package com.immortal.launcher
 
 import java.io.DataInputStream
+import java.io.OutputStream
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.ServerSocket
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -84,6 +87,86 @@ class MqttClientTest {
       val c = clientTo(server)
       try {
         assertFalse(c.connect(keepAliveSec = 30, connectTimeoutMs = 2000))
+      } finally {
+        c.close()
+      }
+    }
+  }
+
+  /**
+   * Drive a CONNACK + a single QoS-0 PUBLISH whose first-byte [publishFirstByte] carries
+   * the bits we want to verify (in particular bit 0, the retain flag). The body is a small
+   * fixed topic + payload — enough for [MqttClient.readPacket] to consume cleanly.
+   */
+  private fun fakeBrokerWithPublish(publishFirstByte: Int): ServerSocket {
+    val server = ServerSocket()
+    server.bind(InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0))
+    Thread {
+          runCatching {
+            server.accept().use { sock ->
+              val inp = DataInputStream(sock.getInputStream())
+              // Consume the CONNECT.
+              inp.readByte()
+              var len = 0
+              var shift = 0
+              while (true) {
+                val b = inp.readByte().toInt() and 0xff
+                len = len or ((b and 0x7f) shl shift)
+                if (b and 0x80 == 0) break
+                shift += 7
+              }
+              repeat(len) { inp.readByte() }
+              val out: OutputStream = sock.getOutputStream()
+              // CONNACK.
+              out.write(byteArrayOf(0x20, 0x02, 0x00, 0x00))
+              // PUBLISH: first-byte = type | flags; remaining length = topic_len_be (2) +
+              // topic bytes (2: "ab") + payload ("xy", 2) = 6.
+              out.write(byteArrayOf(publishFirstByte.toByte(), 6, 0, 2, 'a'.code.toByte(), 'b'.code.toByte(), 'x'.code.toByte(), 'y'.code.toByte()))
+              out.flush()
+              // Hold the socket open briefly so the client can read before EOF.
+              Thread.sleep(200)
+            }
+          }
+        }
+        .apply { isDaemon = true }
+        .start()
+    return server
+  }
+
+  @Test
+  fun readPacket_extractsRetainBit_set() {
+    // 0x31 = PUBLISH (0x30) | retain (0x01).
+    fakeBrokerWithPublish(publishFirstByte = 0x31).use { server ->
+      val c = clientTo(server)
+      try {
+        assertTrue(c.connect(keepAliveSec = 30, connectTimeoutMs = 2000))
+        val pkt = c.readPacket()
+        assertNotNull(pkt)
+        assertEquals(0x30, pkt!!.type)
+        // Retain bit lives at flags & 0x01 — exactly what MqttPublisher's connect loop
+        // inspects to drop retained set-topic messages.
+        assertEquals(1, pkt.flags and 0x01)
+      } finally {
+        c.close()
+      }
+    }
+  }
+
+  @Test
+  fun readPacket_extractsRetainBit_unset() {
+    // 0x30 = PUBLISH with retain=0.
+    fakeBrokerWithPublish(publishFirstByte = 0x30).use { server ->
+      val c = clientTo(server)
+      try {
+        assertTrue(c.connect(keepAliveSec = 30, connectTimeoutMs = 2000))
+        val pkt = c.readPacket()
+        assertNotNull(pkt)
+        assertEquals(0x30, pkt!!.type)
+        assertEquals(0, pkt.flags and 0x01)
+        // Topic + payload should still parse correctly.
+        val (topic, payload) = c.parsePublish(pkt)
+        assertEquals("ab", topic)
+        assertEquals("xy", String(payload, Charsets.UTF_8))
       } finally {
         c.close()
       }

--- a/app/src/test/java/com/immortal/launcher/MqttNotifyPayloadTest.kt
+++ b/app/src/test/java/com/immortal/launcher/MqttNotifyPayloadTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Drives [NotifyPayload.parse] across the inputs the publisher will see in practice — the
+ * two production paths (HA notify entity message-only / raw `mqtt.publish` rich) and the
+ * forgiving fallbacks (out-of-range numbers, unknown enums, malformed JSON).
+ */
+class MqttNotifyPayloadTest {
+
+  @Test
+  fun emptyString_returnsNull() {
+    assertNull(NotifyPayload.parse(""))
+    assertNull(NotifyPayload.parse("   "))
+  }
+
+  @Test
+  fun emptyJson_returnsNull() {
+    // {} has no visible text and no sound — caller no-ops, parser returns null.
+    assertNull(NotifyPayload.parse("{}"))
+  }
+
+  @Test
+  fun malformedJson_returnsNull() {
+    assertNull(NotifyPayload.parse("not json"))
+    assertNull(NotifyPayload.parse("{\"title\":"))
+    assertNull(NotifyPayload.parse("[\"array\"]")) // JSONObject rejects non-object roots
+  }
+
+  @Test
+  fun messageOnly_parsesWithDefaults() {
+    val p = NotifyPayload.parse("""{"message":"Door unlocked"}""")!!
+    assertEquals("", p.title)
+    assertEquals("Door unlocked", p.message)
+    assertNull(p.image)
+    assertNull(p.sound)
+    assertEquals(NotifyPayload.Position.BOTTOM, p.position)
+    assertEquals(6, p.durationSec)
+    assertEquals(1.0f, p.volume, 0.0001f)
+    assertTrue(p.wakeScreen)
+    assertNull(p.onTap)
+    assertTrue(p.hasVisual)
+    assertFalse(p.isEmpty)
+  }
+
+  @Test
+  fun titleOnly_isVisual() {
+    val p = NotifyPayload.parse("""{"title":"Alarm"}""")!!
+    assertTrue(p.hasVisual)
+    assertFalse(p.isEmpty)
+  }
+
+  @Test
+  fun soundOnly_isNotEmpty_butNotVisual() {
+    val p = NotifyPayload.parse("""{"sound":"http://nas/chime.mp3"}""")!!
+    assertFalse(p.hasVisual)
+    assertFalse(p.isEmpty)
+    assertEquals("http://nas/chime.mp3", p.sound)
+  }
+
+  @Test
+  fun emptyStringFields_treatedAsBlank() {
+    // Track 1 templates can render empty strings for missing data dict entries — make sure
+    // we don't treat ""-valued image/sound/on_tap as present.
+    val p = NotifyPayload.parse("""{"message":"hi","image":"","sound":"","on_tap":""}""")!!
+    assertNull(p.image)
+    assertNull(p.sound)
+    assertNull(p.onTap)
+  }
+
+  @Test
+  fun fullPayload_parses() {
+    val raw =
+        """
+        {
+          "title": "Front door",
+          "message": "Motion at 6:42pm",
+          "image": "http://homeassistant.local:8123/local/snapshot.jpg",
+          "sound": "http://nas.local/doorbell.mp3",
+          "position": "top",
+          "duration": 8,
+          "volume": 0.6,
+          "wake_screen": false,
+          "on_tap": "lovelace/security"
+        }
+        """
+            .trimIndent()
+    val p = NotifyPayload.parse(raw)!!
+    assertEquals("Front door", p.title)
+    assertEquals("Motion at 6:42pm", p.message)
+    assertEquals("http://homeassistant.local:8123/local/snapshot.jpg", p.image)
+    assertEquals("http://nas.local/doorbell.mp3", p.sound)
+    assertEquals(NotifyPayload.Position.TOP, p.position)
+    assertEquals(8, p.durationSec)
+    assertEquals(0.6f, p.volume, 0.0001f)
+    assertFalse(p.wakeScreen)
+    assertEquals("lovelace/security", p.onTap)
+  }
+
+  @Test
+  fun position_mixedCase_falls_back_predictably() {
+    assertEquals(NotifyPayload.Position.TOP, NotifyPayload.parse("""{"title":"x","position":"TOP"}""")!!.position)
+    assertEquals(NotifyPayload.Position.TOP, NotifyPayload.parse("""{"title":"x","position":"Top"}""")!!.position)
+    assertEquals(NotifyPayload.Position.BOTTOM, NotifyPayload.parse("""{"title":"x","position":"BOTTOM"}""")!!.position)
+    // Unknown values default to BOTTOM rather than failing the whole payload.
+    assertEquals(NotifyPayload.Position.BOTTOM, NotifyPayload.parse("""{"title":"x","position":"side"}""")!!.position)
+  }
+
+  @Test
+  fun durationZero_meansNoAutoDismiss() {
+    val p = NotifyPayload.parse("""{"title":"Smoke","duration":0}""")!!
+    assertEquals(0, p.durationSec)
+  }
+
+  @Test
+  fun durationNegative_clampedToZero() {
+    val p = NotifyPayload.parse("""{"title":"x","duration":-5}""")!!
+    assertEquals(0, p.durationSec)
+  }
+
+  @Test
+  fun volumeOutOfRange_clamps() {
+    val low = NotifyPayload.parse("""{"title":"x","volume":-0.5}""")!!
+    assertEquals(0f, low.volume, 0.0001f)
+    val high = NotifyPayload.parse("""{"title":"x","volume":2.5}""")!!
+    assertEquals(1f, high.volume, 0.0001f)
+  }
+
+  @Test
+  fun volumeNonNumeric_fallsBackToDefault() {
+    // optDouble returns the default when the string can't be parsed.
+    val p = NotifyPayload.parse("""{"title":"x","volume":"loud"}""")!!
+    assertEquals(NotifyPayload.DEFAULT_VOLUME, p.volume, 0.0001f)
+  }
+
+  @Test
+  fun unknownFields_areIgnored() {
+    val p = NotifyPayload.parse("""{"message":"hi","priority":"high","color":"red"}""")!!
+    assertEquals("hi", p.message)
+    // Forward-compat: ignored, not rejected.
+  }
+
+  @Test
+  fun inlineImageDataUri_passesThroughAsString() {
+    val raw = """{"message":"x","image":"data:image/png;base64,iVBOR"}"""
+    val p = NotifyPayload.parse(raw)!!
+    assertEquals("data:image/png;base64,iVBOR", p.image)
+  }
+}

--- a/docs/design/mqtt-notifications.md
+++ b/docs/design/mqtt-notifications.md
@@ -1,0 +1,490 @@
+# MQTT notifications for Portals — design
+
+An MQTT-driven notification surface that lets Home Assistant push a transient toast
+(with optional image, sound, and a tap target) to any Portal running Immortal, plus
+a way to fire a sound on its own. Two HA entry points: a discoverable
+`notify.send_message` action for trivial one-line alerts, and a raw
+`mqtt.publish` to the device's notify topic for rich doorbell-shaped payloads.
+Either way the Portal renders a Portal-native bottom toast.
+
+**Status:** designed, not yet implemented. This document records the schema we'll
+ship, the behavior rules, and the implementation surface.
+
+## Goal
+
+- A doorbell event in HA reaches the kitchen Portal as a toast with the camera
+  image; tapping the toast opens the security dashboard.
+- A "package delivered" event chimes the bedroom Portal without changing what's on
+  screen.
+- The integration shows up in HA's notify picker for trivial alerts (a one-line
+  `notify.send_message` action targets the Portal entity); rich doorbell-shaped
+  payloads fall back to a single `mqtt.publish` against a documented topic.
+- The broker is assumed to be trusted-LAN-only; the design does not defend
+  against an attacker with publish credentials. See *Trust assumptions* below.
+- Nothing about this requires the user to grant `SYSTEM_ALERT_WINDOW` or any other
+  permission beyond what Immortal already has — the toast piggybacks on infra the
+  launcher already owns.
+
+## What it is not (kept narrow on purpose)
+
+- **Not** a full-screen takeover. If you want a doorbell-shaped "drop everything,
+  show me the camera" experience, fire the existing `open` text entity in the same
+  automation — that already deep-links to any HA dashboard path. Notify is the
+  ephemeral surface; `open` is the destination surface; HA automations compose them.
+- **Not** a notification tray / shade. Portal didn't have one, and stacking past
+  alerts on a 1–10" smart display is the wrong shape. A new toast replaces the
+  current one.
+- **Not** a multi-button action menu. One `on_tap`, applied to the toast as a
+  whole. If you need [Unlock] [Talk] [Dismiss], wire HA buttons in the destination
+  dashboard.
+- **Not** a fleet broadcast. Each Portal subscribes only to its own
+  `immortal/<id>/notify/set` topic; there is no "all Portals" address.
+  HA automations that want to ring every Portal name them individually
+  (`target: entity_id: [notify.kitchen, notify.bedroom]` on Track 1, or N
+  `mqtt.publish` actions on Track 2). HA's editor handles this natively.
+
+## Payload schema
+
+The canonical interface is a JSON document published to
+`immortal/<device_id>/notify/set`. All fields are optional.
+
+```json
+{
+  "title": "Front door",
+  "message": "Motion at 6:42pm",
+  "image": "http://homeassistant.local:8123/api/camera_proxy/camera.front_door",
+  "sound": "http://nas.local/doorbell.mp3",
+  "position": "bottom",
+  "duration": 8,
+  "volume": 1.0,
+  "wake_screen": true,
+  "on_tap": "lovelace/security"
+}
+```
+
+Field semantics:
+
+| Field         | Type   | Default    | Notes                                                                                          |
+|---------------|--------|------------|------------------------------------------------------------------------------------------------|
+| `title`       | string | `""`       | Bolded line at the top of the toast.                                                           |
+| `message`     | string | `""`       | Body text. Long messages wrap to two lines, then ellipsize.                                    |
+| `image`       | string | `null`     | `http(s)://` URL → fetched, or `data:image/...;base64,...` → decoded inline. See *Image* below. |
+| `sound`       | string | `null`     | `http(s)://` URL or local URI fed to `MediaPlayer`. See *Sound* below.                          |
+| `position`    | enum   | `"bottom"` | `"top"` or `"bottom"` — bottom matches Portal's own ephemeral-UI gravity (Quick Controls, "Hey Portal" listener). |
+| `duration`    | int    | `6`        | Auto-dismiss timeout for the visual toast, in **seconds**. `0` = no auto-dismiss; the toast stays until the user taps it. Sound has its own lifecycle. |
+| `volume`      | float  | `1.0`      | Sound volume `0.0`–`1.0` of the alarm-stream max. Bounded by the user's system alarm-volume slider (so `1.0` ≠ "loudest possible," it's "loudest the alarm slider is set to"). On Portal, alarm is the only stream independent from the "media volume" group — see *Sound → Portal volume quirk*. |
+| `wake_screen` | bool   | `true`     | If the screen is off when the notify arrives, call `ScreenControl.wake` so the toast is visible. Set `false` for low-priority chimes that shouldn't wake a sleeping room. |
+| `on_tap`      | string | `null`     | Same string grammar as the existing `open` entity: full URL, installed package name, or bare HA dashboard path. |
+
+### Special cases
+
+- **Empty payload** (`{}` or empty string): no-op. Safe so an HA automation can't
+  silently produce a "ghost" toast by forgetting a template field.
+- **Sound-only**: `sound` present, both `title` and `message` empty → no visual,
+  just audio. Covers "chime when the package arrives, don't touch the screen."
+- **No `on_tap`**: tap dismisses the toast early. Auto-dismiss still fires
+  after `duration`.
+- **Acknowledgement-required (`duration: 0`)**: the toast renders and stays.
+  No timer; only a tap dismisses it. Combine with `on_tap` to make the tap
+  also navigate (smoke alarm: tap to acknowledge → opens the alarm dashboard).
+- **Image load failure**: image times out, 404s, or fails to decode → render the
+  toast without the image, keep text and sound. Don't suppress the whole toast for
+  one missing asset — a doorbell event with text-but-no-camera-frame is still
+  useful.
+- **Replace, don't stack**: a new toast arriving while one is showing replaces it
+  immediately. The new sound starts; the old sound is cut off only if the new
+  payload has its own `sound` field (otherwise an in-flight chime keeps playing).
+- **Wake the screen (unless opted out)**: if the screen is off when the notify
+  arrives and `wake_screen` is `true` (the default), call `ScreenControl.wake`
+  before showing the toast so the user actually sees it. `wake_screen: false`
+  on a low-priority chime keeps a sleeping bedroom dark.
+- **Respect Do Not Disturb (audio only)**: before playing sound, check
+  `NotificationManager.getCurrentInterruptionFilter()`. If it's anything other
+  than `INTERRUPTION_FILTER_ALL`, suppress the sound — the toast still
+  renders. DND silences audible interruptions; the visual stays because the
+  screen is the screen, and a silent on-screen alert is also the feedback
+  signal that the payload reached the device (no separate state echo needed
+  for debugging).
+
+### Image: URL vs. inline
+
+Two paths, detected by prefix:
+
+- `data:image/<mime>;base64,<payload>` — decoded synchronously via
+  `Base64.decode` + `BitmapFactory.decodeByteArray`. Use this when the producer
+  already has the bytes (HA template using `state_attr('camera.foo', 'snapshot')`).
+- Anything else starting with `http://` or `https://` — fetched on a background
+  thread with a short timeout (~3s), `BitmapFactory.decodeStream`. Use this for
+  the common case of HA camera-proxy URLs on the LAN.
+
+Decoding uses `BitmapFactory.Options.inSampleSize` to downscale **during**
+decode, sized so the long edge lands at ≤512px. Decoding full-resolution and
+then `Bitmap.createScaledBitmap`-ing OOMs the Gen-1 Portal+ on anything 4K —
+the in-decode subsample is non-optional, not an optimization.
+
+**Producer note — HA camera URLs need auth.** A URL like
+`http://homeassistant.local:8123/api/camera_proxy/camera.front_door` requires
+a bearer token; the Portal fetches it anonymously and gets `401`. The working
+patterns are:
+
+- Save a snapshot in HA to `/config/www/snapshot.jpg` (the `camera.snapshot`
+  service writes there), then reference it as
+  `http://homeassistant.local:8123/local/snapshot.jpg` — `/local/` is served
+  without auth.
+- Embed a long-lived access token in the URL:
+  `http://homeassistant.local:8123/api/camera_proxy/camera.front_door?token=<long-lived>`.
+- For Track 1 senders inside HA, template the bytes inline as `data:image/...;base64,...`
+  — HA fetches the snapshot itself (auth in scope) and the Portal never has to.
+
+This is producer-side; the Portal can't help. Worth surfacing in the user-facing
+HA setup guide too.
+
+### Sound
+
+`MediaPlayer.setDataSource(url)` for both HTTP and local URIs. Lifecycle is
+independent of the toast:
+
+- Routed to `STREAM_ALARM` via `AudioAttributes` (`USAGE_ALARM` +
+  `CONTENT_TYPE_SONIFICATION`) — **not** `STREAM_NOTIFICATION` or `STREAM_MUSIC`.
+  See *Portal volume quirk* below for the on-hardware reason.
+- `MediaPlayer.setVolume(volume, volume)` from the payload's `volume` field
+  (`0.0`–`1.0`), defaulting to `1.0`. The multiplier is bounded by the user's
+  system alarm-volume slider — `volume: 1.0` means "as loud as the user set the
+  Alarm slider," not "as loud as the hardware can go."
+
+#### Portal volume quirk
+
+On Portal hardware (verified on Portal+ / Android 10), the "media volume"
+slider drives a single linked group of seven streams: `STREAM_SYSTEM`,
+`STREAM_RING`, `STREAM_MUSIC`, `STREAM_NOTIFICATION`, `STREAM_SYSTEM_ENFORCED`,
+`STREAM_DTMF`, `STREAM_TTS`. Only `STREAM_VOICE_CALL` and `STREAM_ALARM` are
+independent. So `USAGE_NOTIFICATION → STREAM_NOTIFICATION`, which sounds like
+the "right" semantic match on regular Android, in practice routes to the same
+slider as Spotify — meaning every chime is at music volume and "doorbell at 5%
+because Spotify was quiet earlier" is the default failure mode.
+
+`STREAM_ALARM` is the only stream that's both **independent** (one persistent
+slider position, doesn't drift) and **loud-by-default** on Portal. It's also
+the semantic match for "audible alert that needs attention." So we route there.
+
+**DND interaction:** Android's "alarm bypasses DND" behavior only applies to
+system-generated notifications, not to raw `MediaPlayer` audio. Our DND
+suppression happens upstream in `MqttPublisher.handleNotify` (we gate the call
+to `SoundPlayer.play` on `INTERRUPTION_FILTER_ALL`), so routing through alarm
+doesn't break the polite-in-DND rule.
+- **In-call behavior**: if the Portal is in an active Messenger/WhatsApp call,
+  the call holds `STREAM_VOICE_CALL` focus and our `STREAM_NOTIFICATION` focus
+  request is denied — sound silently doesn't play. Visual toast still renders
+  (bottom-anchored, doesn't obscure the call UI much). This falls out of
+  Android's focus model; documented so it's expected behavior, not a bug.
+- Audio focus requested as `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK` — music
+  currently playing on `STREAM_MUSIC` (Snapcast / Music Assistant / cast)
+  ducks for the chime's duration instead of stopping. Doorbell-during-Spotify
+  behaves the way a phone would.
+- The sound plays to completion (or until the file ends); it is **not**
+  truncated by `duration` and **not** killed by tap-to-dismiss.
+- If a second `notify` arrives with its own `sound`, the in-flight player is
+  released and the new one starts. If the second `notify` has no `sound`, the
+  in-flight player keeps going.
+- A `MediaPlayer` that fails to prepare (bad URL, codec mismatch, transient
+  network) is released silently. The visual toast (if any) still renders — we
+  treat sound the same way we treat image: best-effort, never blocks the rest.
+
+## Home Assistant integration
+
+Two paths to fire a notify, by design: discoverable for the common case,
+honest about its limits, and a raw escape hatch for rich payloads.
+
+### Track 1: `notify.send_message` — simple, discoverable
+
+An MQTT `notify` entity is published via discovery, so the Portal appears in
+HA's notify picker (`notify.kitchen_portal`, `notify.bedroom_portal`, etc.)
+and slots into the standard `send_message` action:
+
+```yaml
+action: notify.send_message
+target:
+  entity_id: notify.kitchen_portal
+data:
+  message: "Door unlocked"
+```
+
+This produces a plain-text toast at the device's default position (bottom)
+with the default duration (6s). **Only `message` reaches the wire** — HA's
+`NotifyEntity` platform (2024.7+) intentionally passes only the message
+string to `command_template`; `title`, `data:`, `target` are accepted by the
+service but not template-exposed and will be silently dropped. The entity is
+for trivial alerts ("garage door closed", "package detected") where a one-line
+toast is the whole story.
+
+### Track 2: `mqtt.publish` — the full schema
+
+For doorbell-shaped flows that want title, image, sound, tap-action, position,
+or non-default duration, automations publish the full JSON payload directly:
+
+```yaml
+action: mqtt.publish
+data:
+  topic: immortal/kitchen-portal/notify/set
+  payload: |
+    {
+      "title": "Front door",
+      "message": "Motion at 6:42pm",
+      "image": "http://homeassistant.local:8123/api/camera_proxy/camera.front_door",
+      "sound": "http://nas.local/doorbell.mp3",
+      "on_tap": "lovelace/security",
+      "duration": 8000
+    }
+```
+
+Same wire contract as Track 1 — the on-device handler is identical. The
+only difference is that Track 1 hides everything but `message` behind HA's
+notify abstraction.
+
+### Why two tracks?
+
+HA's `NotifyEntity` is a deliberate narrowing of the old
+`BaseNotificationService` (which did pass `data:` through). The replacement
+architecture exposes only `message` to the template; richer payloads now
+belong to per-integration custom services (`notify.mobile_app_*` ships its
+own websocket protocol to the phone, bypassing the MQTT abstraction
+entirely). MQTT has no analogue of that path short of shipping our own HA
+custom component — out of scope for v1, sketched in *Future hooks*. So we
+accept the split: discoverable simple, raw-but-honest rich.
+
+### Topic layout
+
+Reusing `MqttPublisher`'s base path (`immortal/<device_id>/...`):
+
+```
+immortal/<id>/notify/set        ← JSON payload, full schema (Track 2)
+                                  Track 1 publishes the same topic with just
+                                  {"message": "..."} via command_template.
+homeassistant/notify/immortal_<id>/notify/config  ← discovery for Track 1
+```
+
+Fire-and-forget: no state topic. HA's logbook records every `send_message`
+call on Track 1; Track 2 callers can log their own `mqtt.publish` events.
+
+**Producers MUST NOT retain notify payloads.** A retained `set` topic would
+re-fire the alert on every MQTT reconnect — a 3am doorbell every time the
+device's WiFi flaps. The on-device PUBLISH loop defends against this by
+inspecting the retain bit in the packet header (`pkt.flags and 0x01`) and
+dropping any retained delivery on a `<base>/+/set` topic, with a log line
+for visibility.
+
+Per MQTT v3.1.1 §3.3.1.3, the broker sets the retain bit on delivery **only
+when the message is sent as a result of a new subscription being made**, not
+on subsequent live publishes. So this check catches the exact failure mode
+that matters (the broker's protocol-mandated retained replay on subscribe /
+reconnect) and is silent on mid-session `mqtt.publish ... retain: true` —
+which arrives at existing subscribers with retain bit cleared, indistinguishable
+from a normal publish, and which fires once as the producer intended.
+
+The retained value in the broker still persists across restarts and is re-fired
+on each new subscription, so producers who set `retain: true` will see the
+phantom-on-reconnect behavior the next time the device cycles. Track 1
+(`notify.send_message`) doesn't retain by default; the risk is purely Track 2
+callers who set `retain: true` in their `mqtt.publish` action.
+
+### Discovery config
+
+```json
+{
+  "name": "Notify",
+  "unique_id": "immortal_<id>_notify",
+  "command_topic": "immortal/<id>/notify/set",
+  "command_template": "{\"message\": {{ value|tojson }}}",
+  "availability_topic": "immortal/<id>/availability",
+  "device": { ... shared device block, same as every other entity ... }
+}
+```
+
+The template wraps the bare `message` string into the same JSON envelope the
+device parses for Track 2 — so the on-device handler has one parsing path
+regardless of which track produced the payload.
+
+## Implementation
+
+Four new pieces; everything else extends existing code.
+
+### 1. `NotificationOverlay` (new)
+
+A bottom- or top-aligned toast view attached to `BarWatchService` as a third
+`wm.addView` peer alongside `QuickBar` and `RemoteCursor`. Each existing
+tenant hand-rolls its own `TYPE_ACCESSIBILITY_OVERLAY` window via the
+accessibility service's `WindowManager` (see `QuickBar.kt:46–72` for the
+pattern); `NotificationOverlay` mirrors it as a singleton `object` with
+`attach(service)` / `detach()` / `show(spec)`. No new permission required,
+no `SYSTEM_ALERT_WINDOW`, no manifest change.
+
+**Boot-race:** `MqttService` and `BarWatchService` come up independently —
+there's a window where `MqttPublisher` may receive a notify before
+`BarWatchService.onServiceConnected` has fired and attached the overlay. In
+that case `NotificationOverlay.show(spec)` finds `host == null` and drops the
+payload with a single `Log.w`. Acceptable: the producer can retry, and the
+window is on the order of a second at startup.
+
+**Lifecycle:** `BarWatchService` is baseline-enabled on every provisioned
+Portal — `SettingsGuard.reconcileBarWatch` is now unconditional
+(`setBarWatchEnabled(context, true)`) because the service also backs the
+Calls→stock-home bridge and the phone remote, so it's always on regardless
+of which feature is the caller. That means `NotificationOverlay.attach(this)`
+just slots into `BarWatchService.onServiceConnected` alongside the existing
+three lines (`QuickBar.attach`, `RemoteInput.register`, `RemoteCursor.attach`),
+and `detach()` matches in `onUnbind`. No reconciler change. On unprovisioned
+devices the accessibility service silently can't self-enable (it requires
+`WRITE_SECURE_SETTINGS`, granted by the provisioning kit), but MQTT wouldn't
+be configured on an unprovisioned Portal either — both are baseline-launcher
+concerns gated on the same setup step.
+
+Layout:
+
+```
+ ┌──────────────────────────────────────────────┐
+ │ ┌────┐  Front door                           │
+ │ │img │  Motion at 6:42pm                     │
+ │ └────┘                                       │
+ └──────────────────────────────────────────────┘
+```
+
+- Width: `match_parent` minus 24dp side margins.
+- Height: hugs content; image is 80dp square when present.
+- Background: same dark scrim Immortal uses for its other overlays (consistent
+  with `FolderOverlay` / `NameOverlay` in `HomeActivity.kt`).
+- Vertical anchor: gravity flip based on `position`.
+- Slide-in / slide-out animation: ~180ms, from the edge it's anchored to.
+- Tap target: the whole card. Tap → fire `on_tap` (if set) and dismiss.
+
+A single instance of the overlay lives in the accessibility service; `show(spec)`
+replaces whatever's currently displayed. The auto-dismiss timer is held by the
+overlay and reset on each `show`.
+
+### 2. `SoundPlayer` (new)
+
+```kotlin
+object SoundPlayer {
+  fun play(context: Context, source: String): Unit
+  fun stop(): Unit
+}
+```
+
+- Holds a single `MediaPlayer`. `play()` releases any in-flight player and
+  starts a new one.
+- Requests transient-duck audio focus before `start()`, abandons it in
+  `onCompletion` / `onError`.
+- Surfaces failure as a single-line `Log.w`, never throws.
+
+### 3. `MqttPublisher.handleCommand` — new branch
+
+```kotlin
+"notify" -> handleNotify(payload)
+```
+
+Retained set-topic messages are dropped upstream of `handleNotify` in the
+PUBLISH-handling loop (`MqttPublisher.loop`): the retain bit in the MQTT
+packet flags (`pkt.flags and 0x01`) is checked, and any retained delivery on
+`<base>/<obj>/set` is logged-and-dropped before dispatching to a command
+branch. Per MQTT spec this catches the broker's retained replay on
+subscribe/reconnect (the bug that matters); see *Topic layout* for the
+spec-nuance on mid-session retained publishes. The check covers every command
+(notify, open, screen_power, etc.), not just notify — none of the command
+topics should ever be retained.
+
+`handleNotify(json)`:
+
+1. Parses the JSON (gracefully — malformed → log + drop).
+2. If `title` or `message` non-empty:
+   a. If the screen is off and `wake_screen != false`, call `ScreenControl.wake`.
+   b. `NotificationOverlay.show(spec)` regardless of DND (visual is always
+      allowed; DND silences audio only).
+3. If `sound` non-empty: check DND — if `getCurrentInterruptionFilter()` is
+   `INTERRUPTION_FILTER_ALL`, `SoundPlayer.play(context, sound, volume)`;
+   otherwise skip the sound. (`STREAM_VOICE_CALL` focus from an active call
+   naturally denies our focus request — sound is then a silent no-op.)
+
+The empty-payload no-op falls out naturally — neither branch fires.
+
+### 4. `MqttPublisher.publishDiscovery` — register the entity
+
+Add one entry to the `allEntities` list:
+
+```kotlin
+"notify" to "notify"   // (component, object)
+```
+
+And a `notifyEntity()` helper that emits the discovery config shown above.
+Mirrors `textEntity()` in shape; the only difference is the `notify` component
+slot and the `command_template`.
+
+## Trust assumptions
+
+The notify payload accepts arbitrary URLs and feeds them to `MediaPlayer`
+(sound) and `BitmapFactory.decodeStream` (image). A compromised or untrusted
+broker with publish access to `immortal/+/notify/set` can therefore trigger
+image and sound fetches against attacker-controlled hosts — or against
+private-network addresses (`localhost`, `192.168.x.x`) — on every Portal in
+the fleet, with whatever side effects those endpoints expose.
+
+This is not a new threat class. `MqttPublisher` already trusts the broker for
+`open` (deep-link to any URL/package/HA path) and `screen_power` (wake/sleep)
+commands; notify widens the URL-loading surface but does not introduce a new
+privilege. The deployment assumption is the same as every Home Assistant
+MQTT install: **the broker runs on a trusted LAN with publish-restricted
+credentials.** We do not add scheme/host allow-listing in v1; producers who
+want it can run their own filtering bridge between HA and the device topic.
+
+## Future hooks (out of scope for v1)
+
+The user has flagged eventual interest in HA-driven on-device timers and a
+local wake-word path. Both fit cleanly on the same pipeline:
+
+- `MqttPublisher.handleCommand "timer"` — start/cancel a named timer on the
+  device; ring on completion via the same `SoundPlayer`.
+- `MqttPublisher.handleCommand "speak"` — local TTS via Android's built-in
+  engine.
+- A `wake_active` binary sensor — exposes the device's mic-listening state to
+  HA so the Assist conversation agent can be gated on it.
+
+Keep the JSON-payload shape consistent across these so HA automations feel
+uniform; bundle new fields under the same `data:` dict that `notify` already uses.
+
+## Validation plan
+
+- **Unit**: payload parser — empty, partial, malformed, mixed-case position,
+  bad `duration` (negative / non-numeric), bad `volume` (out-of-range,
+  non-numeric → clamp to `[0.0, 1.0]`).
+- **On-device**: doorbell-style flow on a real Portal+ (Gen-1, Android 9) and
+  a Portal Go (Android 10) — toast appears, image renders, sound plays at
+  `volume` over Spotify (which ducks), tap navigates to the configured HA
+  dashboard, screensaver doesn't swallow the toast.
+- **Concurrency**: two `notify` events 200ms apart — the second replaces the
+  first visually; sound behaves per the rules above.
+- **MediaPlayer race**: two `notify` events with `sound` 50ms apart — verify
+  no crash. `MediaPlayer.release()` racing `prepareAsync()` is a known
+  Android-9 crasher and Portal+ Gen-1 is exactly that target.
+- **Audio focus return**: notify with sound arrives while Snapcast is playing
+  via `NowPlayingHub` — verify Snapcast resumes (un-ducks) after the chime
+  ends, doesn't stay paused.
+- **Image timeout**: notify with an image URL pointing at an unreachable host
+  — verify the toast renders within ~5s (connect/read timeout plus render
+  budget), worker thread isn't blocked beyond that. Explicit `connectTimeout`
+  / `readTimeout` on the fetch.
+- **Retained-replay**: publish a `notify` payload with `retain: true` (the
+  misconfigured Track 2 case), bounce the device — verify the retained
+  payload is dropped on reconnect (logged as `"ignoring retained set-topic
+  message"`), no phantom doorbell. Mid-session retained publishes will fire
+  once per the MQTT spec (broker strips the retain bit on delivery to existing
+  subscribers), which is correct.
+- **DND audio-only**: notify with sound arrives while DND is on — verify
+  toast renders, sound suppressed; turn DND off, fire again — sound plays.
+  Also verify an in-flight sound is not killed by DND toggling on mid-render
+  (sound has its own lifecycle).
+- **Failure modes**: bad image URL (toast still renders), bad sound URL (toast
+  still renders, no audio), bad `on_tap` (toast dismisses, no navigation,
+  log warning).
+- **Baseline accessibility-service host**: enable MQTT/HA only, with QuickBar
+  and phone-remote disabled, on a provisioned Portal — verify the toast still
+  renders (the service is baseline-enabled, so its tenants attach regardless
+  of which UI feature is on).
+

--- a/docs/features/smart-home.md
+++ b/docs/features/smart-home.md
@@ -63,8 +63,66 @@ data:
     }
 ```
 
-All fields are optional. Schema and behavior rules in
+All fields are optional. Full behavior rules in
 [`docs/design/mqtt-notifications.md`](../design/mqtt-notifications.md).
+
+### Payload fields
+
+| Field         | Type   | Default    | Notes                                                                                                                          |
+|---------------|--------|------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `title`       | string | `""`       | Bold line at the top of the toast. One line, ellipsizes if too long.                                                            |
+| `message`     | string | `""`       | Body text below the title. Wraps to two lines, then ellipsizes.                                                                |
+| `image`       | string | `null`     | `http(s)://` URL → fetched, or `data:image/...;base64,...` → decoded inline. Decode is downsampled to ≤512px to stay safe on Portal heap. |
+| `sound`       | string | `null`     | `http(s)://` URL or local URI fed to `MediaPlayer`. Plays through `STREAM_ALARM` — see *Portal volume quirk* below.              |
+| `position`    | enum   | `"bottom"` | `"top"` or `"bottom"`. Bottom matches Portal's own ephemeral-UI gravity. See note on top-overlap below.                          |
+| `duration`    | int    | `6`        | Auto-dismiss timeout for the visual toast, in **seconds**. `0` = no auto-dismiss; toast stays until tapped. Sound has its own lifecycle. |
+| `volume`      | float  | `1.0`      | Sound volume `0.0`–`1.0` of the alarm-stream max. Bounded by the user's system alarm-volume slider.                              |
+| `wake_screen` | bool   | `true`     | If the screen is off when the notify arrives, wake it so the toast is visible. Set `false` for low-priority chimes that shouldn't wake a sleeping room. |
+| `on_tap`      | string | `null`     | Tap target. URL, installed package name, or HA dashboard path. See *Tap targets* below.                                          |
+
+### Special cases
+
+- **Empty payload** (`{}` or empty string): no-op. An automation that drops all
+  template fields can't accidentally produce a "ghost" toast.
+- **Sound-only**: `sound` present, both `title` and `message` empty → no visual,
+  just audio. Useful for chimes that shouldn't change what's on screen.
+- **Replace, don't stack**: a new toast arriving while one is showing replaces
+  it. The previous sound keeps playing unless the new payload has its own `sound`.
+- **DND audio gate**: when the system is in Do Not Disturb, sound is suppressed
+  but the toast still renders. The visual is the polite signal that the device
+  received the alert.
+- **Acknowledgement-required**: `duration: 0` means the toast stays until the
+  user taps it. Combine with `on_tap` so the tap also navigates.
+
+### Tap targets (`on_tap`)
+
+The `on_tap` field is what the toast does when tapped (in addition to
+dismissing). The Portal's router accepts four forms by prefix:
+
+| You write                                | Behavior                                                                                                  |
+|------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `http://...` / `https://...`             | Opens in the default browser via `ACTION_VIEW`.                                                            |
+| `homeassistant://...`                    | Opens directly in the HA companion app (HA's custom URI scheme).                                           |
+| An installed package name, e.g. `com.android.chrome` | Launches that app's main activity.                                                                |
+| Anything else (bare path)                | Treated as an HA dashboard path. Routed via `homeassistant://navigate/<path>` to the installed HA app.     |
+
+For HA dashboards, all of these mean the same thing:
+
+| Input                                                 | Goes to                                            |
+|--------------------------------------------------------|----------------------------------------------------|
+| `lovelace`                                             | Main HA dashboard.                                 |
+| `lovelace/security`                                    | The *security* view inside the main dashboard.     |
+| `lovelace-doorbell/0`                                  | First view of the custom `lovelace-doorbell` dashboard. |
+| `/lovelace/security`                                   | Leading slash trimmed → same as above.             |
+| `http://homeassistant.local:8123/lovelace/security`    | Host stripped → same as above.                     |
+| `homeassistant://navigate/lovelace/security`           | Passed through verbatim.                           |
+
+You can find a dashboard's slug at **Settings → Dashboards** (the *URL* column), and view slugs inside each dashboard's URL bar.
+
+Requirements: the HA companion app must be installed (either
+`io.homeassistant.companion.android` or the minimal F-Droid flavor, which is
+what no-GMS Portals use), and the user must be logged in. If neither is true,
+the tap is a no-op with a logcat warning.
 
 !!! note "Position `top` overlaps the launcher header"
     The default `position: "bottom"` lands the toast safely below Immortal's home
@@ -87,6 +145,81 @@ session cookie. The simplest place to host them on Home Assistant is the auth-le
 **Camera snapshots** with `/api/camera_proxy/...` URLs **won't work directly** — that path
 needs a bearer token the Portal doesn't have. Either save the snapshot to `www/` first (use the
 `camera.snapshot` service in your automation) or embed a long-lived access token in the URL.
+
+#### Using HA media-source URIs
+
+If you'd rather keep media in HA's structured media library (`/media/`, surfaced
+under *Media* in the HA UI) than copy into `/config/www/`, resolve a signed URL
+at automation time and pass that to the notify payload. Signed URLs expire
+(default ~30 minutes), so the resolve must happen as part of the firing
+automation — caching the URL won't work.
+
+Wrap the resolve + publish into a reusable script so each automation is a single
+call:
+
+```yaml
+# scripts.yaml
+portal_notify:
+  alias: "Portal: send rich notification"
+  fields:
+    topic:           { description: "MQTT notify topic, e.g. immortal/<device-id>/notify/set" }
+    title:           { description: "Bold line" }
+    message:         { description: "Body text" }
+    sound_media:     { description: "media-source:// URI for the chime" }
+    image_media:     { description: "media-source:// URI for the image (optional)" }
+    on_tap:          { description: "HA dashboard path, URL, or package name (optional)" }
+    duration:        { description: "Auto-dismiss seconds; 0 = stays until tapped", default: 6 }
+  sequence:
+    - variables:
+        base_url: "http://homeassistant.local:8123"
+        sound_url: ""
+        image_url: ""
+    - if: "{{ sound_media is defined and sound_media }}"
+      then:
+        - action: media_source.resolve_media
+          data:
+            media_content_id: "{{ sound_media }}"
+          response_variable: sound_r
+        - variables:
+            sound_url: "{{ base_url }}{{ sound_r.url }}"
+    - if: "{{ image_media is defined and image_media }}"
+      then:
+        - action: media_source.resolve_media
+          data:
+            media_content_id: "{{ image_media }}"
+          response_variable: image_r
+        - variables:
+            image_url: "{{ base_url }}{{ image_r.url }}"
+    - action: mqtt.publish
+      data:
+        topic: "{{ topic }}"
+        payload: >-
+          {
+            "title": {{ (title | default('')) | tojson }},
+            "message": {{ (message | default('')) | tojson }},
+            "sound": {{ sound_url | tojson }},
+            "image": {{ image_url | tojson }},
+            {% if on_tap is defined and on_tap %}"on_tap": {{ on_tap | tojson }},{% endif %}
+            "duration": {{ duration | default(6) }}
+          }
+```
+
+Then automations call it with media-source URIs directly:
+
+```yaml
+action: script.portal_notify
+data:
+  topic: immortal/<device-id>/notify/set
+  title: "Front door"
+  message: "Motion at 6:42pm"
+  sound_media: media-source://media_source/local/sounds/doorbell.mp3
+  image_media: media-source://media_source/local/snapshots/front-door.jpg
+  on_tap: lovelace/security
+```
+
+Edit `base_url` if your HA instance is reached at a different hostname. If you
+only have one Portal, hardcode the `topic` inside the script and drop it from
+the field list.
 
 ### Portal volume quirk
 

--- a/docs/features/smart-home.md
+++ b/docs/features/smart-home.md
@@ -14,10 +14,89 @@ The publisher reuses the state Immortal already holds and surfaces it to Home As
 
 ## What it can control
 
-The one command Immortal can honour on this hardware is **screen on/off** (`ScreenControl`,
-which uses the screen-off device-admin granted during [provisioning](../provisioning.md)). So
-from Home Assistant you can, for example, wake or sleep a Portal's display as part of an
-automation.
+- **Screen on/off** (`ScreenControl`, which uses the screen-off device-admin granted during
+  [provisioning](../provisioning.md)) — wake or sleep a Portal's display as part of an automation.
+- **Open** a URL, an installed package, or a Home Assistant dashboard path on the Portal — the
+  same string grammar the screensaver picker accepts.
+- **Notifications** — push a toast (with optional image, sound, and a tap target) from any
+  Home Assistant automation. See below.
+
+## Notifications
+
+Immortal renders a Portal-native bottom toast in response to MQTT-driven notify messages from
+Home Assistant. Two ways to fire one — pick whichever fits the automation:
+
+### Simple alerts: `notify.send_message`
+
+Each configured Portal shows up in HA's notify picker. For a plain text alert, use the
+standard `send_message` action:
+
+```yaml
+action: notify.send_message
+target:
+  entity_id: notify.kitchen_portal
+data:
+  message: "Door unlocked"
+```
+
+This produces a bottom toast at the default duration (6s). Only the `message` reaches the
+device — Home Assistant's MQTT notify entity (2024.7+) doesn't pass `title` or `data:` through
+the `command_template`, so use the raw-topic path below for anything richer.
+
+### Rich alerts: `mqtt.publish`
+
+For doorbells, motion events, or anything wanting an image / sound / tap-action, publish the
+full JSON payload directly to the device's notify topic:
+
+```yaml
+action: mqtt.publish
+data:
+  topic: immortal/<device-id>/notify/set
+  payload: |
+    {
+      "title": "Front door",
+      "message": "Motion at 6:42pm",
+      "image": "http://homeassistant.local:8123/local/snapshot.jpg",
+      "sound": "http://homeassistant.local:8123/local/sounds/doorbell.mp3",
+      "on_tap": "lovelace/security",
+      "duration": 8
+    }
+```
+
+All fields are optional. Schema and behavior rules in
+[`docs/design/mqtt-notifications.md`](../design/mqtt-notifications.md).
+
+!!! note "Position `top` overlaps the launcher header"
+    The default `position: "bottom"` lands the toast safely below Immortal's home
+    grid. `position: "top"` renders the toast in the same vertical band as the
+    launcher's clock / photos / weather row and partially obscures it — fine
+    when something needs the user's attention right where their eyes already
+    are, but worth knowing if you're tempted to use top by default.
+
+### Media hosting
+
+The Portal fetches images and sounds anonymously over HTTP — no bearer token, no
+session cookie. The simplest place to host them on Home Assistant is the auth-less
+`/config/www/` directory, which serves at `http://homeassistant.local:8123/local/...`:
+
+```
+/config/www/sounds/doorbell.mp3       →  /local/sounds/doorbell.mp3
+/config/www/snapshots/front-door.jpg  →  /local/snapshots/front-door.jpg
+```
+
+**Camera snapshots** with `/api/camera_proxy/...` URLs **won't work directly** — that path
+needs a bearer token the Portal doesn't have. Either save the snapshot to `www/` first (use the
+`camera.snapshot` service in your automation) or embed a long-lived access token in the URL.
+
+### Portal volume quirk
+
+The Portal has a *single* "media volume" slider that drives almost every audio stream: music,
+ring, notification, system. The only streams that are independent on Portal are **call** and
+**alarm**. So notify sounds route through `STREAM_ALARM` — that's the only way to get a chime
+that's loud-by-default and doesn't drift when you change Spotify's volume. The alarm slider
+becomes your "notification volume" on this hardware; set it once to a level that's audible
+from across the room and forget it. Do Not Disturb still silences notify sounds (Immortal
+gates the audio on the system DND state before playback) — the visual toast still renders.
 
 ## Setup
 


### PR DESCRIPTION
Tested on a Portal+ (2nd gen)
Adds the ability to pop up a notification, from mqtt, that can display a photo, play a sound, and perform an intent navigation. 
Additionally, you can play just a sound in isolation without a notification pop up.
<img width="2160" height="1440" alt="F1" src="https://github.com/user-attachments/assets/8e730eb8-1ca4-4654-829c-cfc0c1a13fcf" />
<img width="2160" height="1440" alt="F2" src="https://github.com/user-attachments/assets/eef5036f-b694-4588-bcc5-083c9c623b7d" />
<img width="2160" height="1440" alt="F3" src="https://github.com/user-attachments/assets/16322f90-a513-4e8f-ba14-3a75cd73571f" />

Example use case: User has a doorbell camera that is wired for talk back in Home Assistant. Instead of overriding current user action on screen, a notification appears that plays a sound and contains a photo and description of the interruption. User can decide to select the notification and be navigated to a target dashboard to interact as needed. 

Example use case for just sound notification: User has a driveway sensor but no camera/image. Sensor fires and informs portal to play an audible notification.

The notification sound was validated against DND and is attached to the STREAM_ALARM volume control which is not linked to the standard user volume control/buttons.

2 available notification submittal paths. Path 1 uses home assistants default notification capabilities which is limited in what it can send; it can only send a message. Path 2 is direct mqtt message submittal and allows for more configuration, such as notification position, media to play, etc.