### PR TITLE
Fix launcher losing default-home role after photo-frame crash

### DIFF
--- a/app/src/main/java/com/immortal/launcher/CrashGuard.kt
+++ b/app/src/main/java/com/immortal/launcher/CrashGuard.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.AlarmManager
+import android.app.Application
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import kotlin.system.exitProcess
+
+/**
+ * Last line of defence for the device's home experience: if anything crashes our process with an
+ * uncaught exception, bounce straight back into [HomeActivity] instead of leaving the Portal
+ * stranded.
+ *
+ * Why a launcher needs this. When the home app's process dies on a crash, Android **clears its
+ * preferred-activity (HOME) association** (`ActivityTaskManager: Clearing package preferred
+ * activities`), so the next Home press pops the "Select Home app" chooser. We can't silently
+ * re-assert the home role from inside the app (it isn't a secure setting — see [SettingsGuard]),
+ * so instead we relaunch our Home component *explicitly by class*, which bypasses the chooser
+ * entirely: the user lands back in Immortal and never sees it. The crash is still recorded
+ * (we chain to the platform handler) — we recover, we don't swallow.
+ *
+ * The known trigger for this was an oversized photo-frame bitmap (fixed at the source in
+ * [PhotoFrameController]); this guard is the belt-and-suspenders for any *future* uncaught crash.
+ *
+ * Loop safety: a relaunch that immediately re-crashes would hot-loop (battery drain, alarm spam).
+ * [decide] gives up after [MAX_RAPID] crashes inside [WINDOW_MS] of each other; crashes spaced
+ * further apart always relaunch (the window resets), so an occasional fault still self-heals while
+ * a genuine boot-loop is allowed to settle.
+ */
+object CrashGuard {
+  private const val TAG = "ImmortalCrashGuard"
+  private const val PREFS = "crash_guard"
+  private const val KEY_LAST = "last_crash_ms"
+  private const val KEY_COUNT = "rapid_count"
+
+  // Two crashes closer than this count as "rapid" (same fault re-firing on relaunch).
+  internal const val WINDOW_MS = 10_000L
+  // Relaunch up to this many rapid crashes, then stop until the next well-spaced crash / reboot.
+  internal const val MAX_RAPID = 3
+  // Fire the relaunch after the dying process is gone, so the fresh task starts clean.
+  private const val RELAUNCH_DELAY_MS = 1_000L
+  private const val RELAUNCH_REQ = 0x1A0A
+
+  fun install(app: Application) {
+    val previous = Thread.getDefaultUncaughtExceptionHandler()
+    Thread.setDefaultUncaughtExceptionHandler { thread, error ->
+      runCatching {
+        Log.e(TAG, "uncaught exception on '${thread.name}' — recovering launcher", error)
+        if (registerCrashAndDecide(app, System.currentTimeMillis())) scheduleRelaunch(app)
+        else Log.e(TAG, "crash loop detected (>$MAX_RAPID in ${WINDOW_MS}ms) — not relaunching")
+      }
+      // Chain to the platform handler so the crash still reaches logcat / DropBox and the process
+      // dies the normal way; our relaunch is scheduled out-of-process via AlarmManager.
+      if (previous != null) previous.uncaughtException(thread, error)
+      else {
+        android.os.Process.killProcess(android.os.Process.myPid())
+        exitProcess(10)
+      }
+    }
+  }
+
+  /**
+   * Record this crash against the recent history and decide whether to relaunch. Persisted with
+   * `commit()` (not `apply()`) because the process is about to die and an async write would be lost.
+   */
+  private fun registerCrashAndDecide(ctx: Context, nowMs: Long): Boolean {
+    val p = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    val (relaunch, count) = decide(nowMs, p.getLong(KEY_LAST, 0L), p.getInt(KEY_COUNT, 0))
+    p.edit().putLong(KEY_LAST, nowMs).putInt(KEY_COUNT, count).commit()
+    return relaunch
+  }
+
+  /**
+   * Pure loop-breaker decision (no Android deps, so it's unit-tested directly). Crashes within
+   * [WINDOW_MS] of the previous one accumulate; spacing them out resets the streak to 1.
+   */
+  internal fun decide(nowMs: Long, lastCrashMs: Long, prevCount: Int): Pair<Boolean, Int> {
+    val count = if (nowMs - lastCrashMs < WINDOW_MS) prevCount + 1 else 1
+    return (count <= MAX_RAPID) to count
+  }
+
+  private fun scheduleRelaunch(ctx: Context) {
+    val intent =
+        Intent(ctx, HomeActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+    val pi =
+        PendingIntent.getActivity(
+            ctx,
+            RELAUNCH_REQ,
+            intent,
+            PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE)
+    val am = ctx.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    am.set(AlarmManager.RTC, System.currentTimeMillis() + RELAUNCH_DELAY_MS, pi)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/ImmortalApp.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalApp.kt
@@ -22,6 +22,10 @@ import android.content.IntentFilter
 class ImmortalApp : Application() {
   override fun onCreate() {
     super.onCreate()
+    // Arm first, before any other init: as the home app, an uncaught crash makes Android drop our
+    // default-home role (→ "Select Home app" chooser). This relaunches us straight back so the
+    // user never sees it. Installed up front so a crash during the rest of onCreate is covered too.
+    CrashGuard.install(this)
     // The shared presence source of truth: owns DREAMING_STARTED / SCREEN_OFF / POWER and
     // exposes one PresenceState for the screensaver (in-process) and the Snapcast companion
     // (broadcast). DREAMING_STOPPED stays here because it also drives the frame relaunch, and

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -291,7 +291,7 @@ class PhotoFrameController(
             if (paths.isNotEmpty()) {
               smbSource = src
               remoteUrls = if (source.shuffle) paths.shuffled() else paths
-              remoteFetch = { p -> src.openStream(p)?.use { BitmapFactory.decodeStream(it) } }
+              remoteFetch = { p -> src.openStream(p)?.use { decodeBoundedStream(it) } }
               remoteMode = true
               remoteIndex = -1
               remoteFailStreak = 0
@@ -673,6 +673,43 @@ class PhotoFrameController(
   }
 
   /**
+   * Downsample any photo to a safe size before it ever reaches the [ImageView].
+   *
+   * A full-resolution camera original is enormous once decoded: a ~39MP shot becomes a ~157MB
+   * ARGB_8888 bitmap, which is larger than the hardware Canvas can draw (~100MB). The draw then
+   * throws "trying to draw too large bitmap" on the main thread and crashes the whole launcher —
+   * and because Android responds to a *home app* crashing by clearing its preferred-activity (HOME)
+   * association, the very next Home press pops the "Select Home app" chooser. Bounding the longest
+   * edge to [MAX_EDGE] here (the same two-pass trick used by [Thumbnails]/[MediaArt]) keeps every
+   * source — folder, SMB, Immich, WebDAV, bundled — well under the cap, so it can't happen.
+   *
+   * The bound never upscales (small images decode untouched) and uses a power-of-two
+   * [BitmapFactory.Options.inSampleSize], the only value the decoder honours efficiently.
+   */
+  private fun sampleSizeFor(w: Int, h: Int): Int {
+    val longest = maxOf(w, h)
+    return if (longest > MAX_EDGE) Integer.highestOneBit(longest / MAX_EDGE) else 1
+  }
+
+  private fun decodeBoundedFile(path: String): Bitmap? {
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeFile(path, bounds)
+    val opts =
+        BitmapFactory.Options().apply { inSampleSize = sampleSizeFor(bounds.outWidth, bounds.outHeight) }
+    return BitmapFactory.decodeFile(path, opts)
+  }
+
+  /** Stream variant: buffers to bytes so the bounds pass can run before the real decode. */
+  private fun decodeBoundedStream(input: java.io.InputStream): Bitmap? {
+    val bytes = input.readBytes()
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+    val opts =
+        BitmapFactory.Options().apply { inSampleSize = sampleSizeFor(bounds.outWidth, bounds.outHeight) }
+    return BitmapFactory.decodeByteArray(bytes, 0, bytes.size, opts)
+  }
+
+  /**
    * Decode a local image and apply its EXIF orientation. Phone cameras save the
    * raw sensor buffer and record the intended rotation in an EXIF tag rather than
    * baking it into the pixels, so [BitmapFactory.decodeFile] alone shows portrait
@@ -684,7 +721,7 @@ class PhotoFrameController(
    * being skipped.
    */
   private fun decodeCorrected(path: String): Bitmap? {
-    val bmp = BitmapFactory.decodeFile(path) ?: return null
+    val bmp = decodeBoundedFile(path) ?: return null
     val orientation =
         runCatching {
               ExifInterface(path)
@@ -1091,7 +1128,7 @@ class PhotoFrameController(
     val name = bundledNames[bundledIdx % bundledNames.size]
     bundledIdx++
     return runCatching {
-          context.assets.open("$FALLBACK_DIR/$name").use { BitmapFactory.decodeStream(it) }
+          context.assets.open("$FALLBACK_DIR/$name").use { decodeBoundedStream(it) }
         }
         .getOrNull()
   }
@@ -1112,7 +1149,7 @@ class PhotoFrameController(
     c.instanceFollowRedirects = true
     c.setRequestProperty("User-Agent", USER_AGENT)
     headers.forEach { (k, v) -> c.setRequestProperty(k, v) }
-    return c.inputStream.use { BitmapFactory.decodeStream(it) }
+    return c.inputStream.use { decodeBoundedStream(it) }
   }
 
   private val MATCH = FrameLayout.LayoutParams.MATCH_PARENT
@@ -1127,6 +1164,12 @@ class PhotoFrameController(
 
   private companion object {
     const val TAG = "ImmortalPhotoFrame"
+    // Cap on the longest edge of any decoded photo. Full-res camera originals (tens of MP) decode
+    // to bitmaps larger than the hardware Canvas can draw (~100MB), which crashes the launcher and
+    // makes Android drop its default-home role. The largest Portal panel is 1920px; 2560 leaves
+    // Ken-Burns overscan headroom (2560²·4 ≈ 26MB) while staying far under the cap. See
+    // [decodeBoundedFile]/[decodeBoundedStream].
+    const val MAX_EDGE = 2560
     // Bundled fallback photos live under app/src/main/assets/<FALLBACK_DIR>/.
     const val FALLBACK_DIR = "photoframe_fallback"
     // How long to skip a web source after it fails, so a dead host (e.g. a Picsum

--- a/app/src/test/java/com/immortal/launcher/CrashGuardTest.kt
+++ b/app/src/test/java/com/immortal/launcher/CrashGuardTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The pure crash-loop breaker behind [CrashGuard]: relaunch unless crashes are hot-looping. */
+class CrashGuardTest {
+
+  @Test
+  fun firstCrashEverRelaunches() {
+    val (relaunch, count) = CrashGuard.decide(nowMs = 1_000_000L, lastCrashMs = 0L, prevCount = 0)
+    assertTrue(relaunch)
+    assertEquals(1, count)
+  }
+
+  @Test
+  fun crashesSpacedApartAlwaysRelaunchAndResetTheStreak() {
+    // Each crash is more than the window after the last → streak never climbs, always relaunch.
+    var last = 0L
+    repeat(10) {
+      val now = last + CrashGuard.WINDOW_MS + 1
+      val (relaunch, count) = CrashGuard.decide(now, last, prevCount = CrashGuard.MAX_RAPID)
+      assertTrue(relaunch)
+      assertEquals(1, count)
+      last = now
+    }
+  }
+
+  @Test
+  fun rapidCrashesRelaunchUpToTheCapThenGiveUp() {
+    val base = 5_000_000L
+    // Crashes 1..MAX_RAPID, each within the window of the previous → relaunch.
+    var count = 0
+    for (i in 1..CrashGuard.MAX_RAPID) {
+      val (relaunch, c) = CrashGuard.decide(base + i, base + i - 1, count)
+      assertTrue("rapid crash #$i should still relaunch", relaunch)
+      count = c
+    }
+    // The next rapid crash exceeds the cap → give up (no relaunch).
+    val (relaunch, _) = CrashGuard.decide(base + CrashGuard.MAX_RAPID + 1, base + CrashGuard.MAX_RAPID, count)
+    assertFalse("crash past the cap should not relaunch", relaunch)
+  }
+
+  @Test
+  fun recoveringAfterTheWindowReenablesRelaunch() {
+    // Hit the cap...
+    var count = 0
+    val base = 9_000_000L
+    for (i in 1..(CrashGuard.MAX_RAPID + 1)) {
+      count = CrashGuard.decide(base + i, base + i - 1, count).second
+    }
+    // ...then a well-spaced crash resets the streak and relaunches again.
+    val later = base + CrashGuard.MAX_RAPID + 1 + CrashGuard.WINDOW_MS + 1
+    val (relaunch, c) = CrashGuard.decide(later, base + CrashGuard.MAX_RAPID + 1, count)
+    assertTrue(relaunch)
+    assertEquals(1, c)
+  }
+}


### PR DESCRIPTION
## Problem

Reported on Reddit: the launcher *"randomly keeps asking to select it as the default home app"* when exiting the screensaver. Device Health green, all permissions granted, reinstalled via provisioning — so it looked like a provisioning fault, but the user's logcat showed the real cause:

```
FATAL EXCEPTION: main   (Process: com.immortal.launcher)
java.lang.RuntimeException: Canvas: trying to draw too large(157163520bytes) bitmap.
    at android.widget.ImageView.onDraw
ActivityTaskManager: Force finishing activity com.immortal.launcher/.PhotoFramePreviewActivity
ActivityTaskManager: Clearing package preferred activities from com.immortal.launcher
```

On screensaver exit the continuation frame (`PhotoFramePreviewActivity`) shows a photo. `PhotoFrameController` decoded folder / SMB / Immich / WebDAV / bundled images at **full native resolution**, so a high-megapixel original (~39 MP = 157 MB as ARGB_8888) exceeded the hardware Canvas max draw size and threw on the main thread. Android responds to the **home app** crashing by clearing its preferred-activity (HOME) association → the next Home press shows the chooser.

Matches every symptom: intermittent (only oversized photos), tied to screensaver exit, "fixed" by a factory reset (reverts to the bounded web feed) until a full-res source is reselected, Device Health all green.

## Fix (two layers)

1. **Source fix** — bound every photo-frame decode to `MAX_EDGE` (2560px) using the two-pass `inJustDecodeBounds` + `inSampleSize` pattern already used by `MediaArt` / `Thumbnails` / `StoreIcons`. No source can produce an oversized bitmap. Covers the folder, SMB, bundled-asset, and HTTP-download (Immich/WebDAV/iCloud/Google) decode paths.

2. **Defense in depth** — `CrashGuard` installs a default uncaught-exception handler that relaunches `HomeActivity` by explicit component (bypassing the chooser), so any *future* uncaught crash can't strand the device on the home picker. A pure, unit-tested loop-breaker (`CrashGuard.decide`) stops it hot-looping on a repeating fault. (The home role itself can't be re-asserted in-app — not a secure setting; see `SettingsGuard` — so explicit relaunch is the correct recovery.)

## Verification

- `./gradlew :app:assembleDebug` — BUILD SUCCESSFUL
- `./gradlew :app:testDebugUnitTest` — green, incl. new `CrashGuardTest` (4 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)