### PR TITLE
Follow-ups to MQTT notify overlay (#72)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,11 @@ jobs:
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
+        with:
+          # Pin to platform-tools only. The action's default package set includes the
+          # obsolete `tools` package, whose archive now fails to download ("Error on
+          # ZipFile unknown archive") and breaks setup. `tools` isn't needed for unit tests.
+          packages: platform-tools
 
       - name: Install compile SDK
         run: yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" >/dev/null || true

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -275,8 +275,21 @@ class MqttPublisher(private val appContext: Context) {
    * Reuses [ScreensaverDismiss]'s HA helpers so the behaviour matches the screensaver picker.
    */
   private fun openTarget(payload: String) {
+    if (!routeTarget(payload)) return
+    // Echo the last target so the text entity shows what it was set to. Only the "Open"
+    // entity echoes; notify taps route via routeTarget() directly so a doorbell tap doesn't
+    // rewrite this entity's retained state.
+    client?.publish("$base/open/state", payload.trim(), retain = true)
+  }
+
+  /**
+   * Dispatch a target string without touching any entity state. Same grammar as [openTarget]
+   * (full URL, installed package name, or bare HA dashboard path). Returns true when a target
+   * was launched, false for a blank or unroutable input (e.g. no HA app installed for a path).
+   */
+  private fun routeTarget(payload: String): Boolean {
     val t = payload.trim()
-    if (t.isBlank()) return
+    if (t.isBlank()) return false
     val pm = appContext.packageManager
     when {
       t.startsWith("http://") || t.startsWith("https://") || t.startsWith("homeassistant://") ->
@@ -285,15 +298,14 @@ class MqttPublisher(private val appContext: Context) {
       pm.getLaunchIntentForPackage(t) != null ->
           appContext.startActivity(pm.getLaunchIntentForPackage(t)!!.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
       else -> {
-        val pkg = ScreensaverDismiss.installedHaPackage(appContext) ?: return
+        val pkg = ScreensaverDismiss.installedHaPackage(appContext) ?: return false
         appContext.startActivity(
             Intent(Intent.ACTION_VIEW, Uri.parse(ScreensaverDismiss.haDeepLink(t)))
                 .setPackage(pkg)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
       }
     }
-    // Echo the last target so the text entity shows what it was set to.
-    client?.publish("$base/open/state", t, retain = true)
+    return true
   }
 
   /**
@@ -310,7 +322,7 @@ class MqttPublisher(private val appContext: Context) {
       // PresenceHub.current.screen only reflects THIS process's dream service, which doesn't
       // help if a sibling package owns the active dream). 3s auto-release wake lock, no harm.
       if (spec.wakeScreen) ScreenControl.wake(appContext)
-      val tap: (() -> Unit)? = spec.onTap?.let { target -> { openTarget(target) } }
+      val tap: (() -> Unit)? = spec.onTap?.let { target -> { routeTarget(target) } }
       NotificationOverlay.show(spec, tap)
     }
     if (!spec.sound.isNullOrBlank()) {

--- a/app/src/main/java/com/immortal/launcher/SoundPlayer.kt
+++ b/app/src/main/java/com/immortal/launcher/SoundPlayer.kt
@@ -21,9 +21,10 @@ import android.util.Log
 /**
  * One-shot `MediaPlayer` wrapper for MQTT-notify chimes (see `MqttPublisher.handleNotify`).
  *
- * Routes to the notification stream — `USAGE_NOTIFICATION` + `CONTENT_TYPE_SONIFICATION`
- * via [AudioAttributes], **not** `STREAM_MUSIC` — so a doorbell isn't capped by Spotify's
- * current volume and we don't duck our own chime. Requests transient-may-duck focus so any
+ * Routes to the alarm stream — `USAGE_ALARM` + `CONTENT_TYPE_SONIFICATION` via
+ * [AudioAttributes], **not** `STREAM_MUSIC` or `STREAM_NOTIFICATION` — so a doorbell isn't
+ * capped by Spotify's current volume (on Portal, notification and music share one slider;
+ * only alarm is independent — see [startInternal]). Requests transient-may-duck focus so any
  * `STREAM_MUSIC` playback (Snapcast, cast, Spotify) ducks for the chime's duration and
  * restores after.
  *
@@ -40,7 +41,7 @@ object SoundPlayer {
   @Volatile private var stashedContext: Context? = null
 
   /**
-   * Play [source] (http(s) URL or local URI) at [volume] (0.0–1.0 of the notification-stream
+   * Play [source] (http(s) URL or local URI) at [volume] (0.0–1.0 of the alarm-stream
    * max, bounded by the user's system slider). Releases any in-flight player first. Returns
    * immediately; preparation and playback happen on `MediaPlayer`'s own thread.
    */
@@ -79,9 +80,14 @@ object SoundPlayer {
             .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
             .build()
 
-    // Transient-may-duck on STREAM_NOTIFICATION: STREAM_MUSIC ducks for our chime and
-    // resumes when we abandon focus. If a call holds STREAM_VOICE_CALL focus, this request
-    // is denied — we silently don't play, which is the documented in-call behavior.
+    // Abandon any focus held by a just-replaced chime before requesting again. Without this,
+    // a second notify overwrites `focusRequest` with the new request and leaks the old one —
+    // it's never abandoned, so STREAM_MUSIC stays ducked after the chime ends.
+    abandonFocus(am)
+
+    // Transient-may-duck: STREAM_MUSIC ducks for our (alarm-stream) chime and resumes when we
+    // abandon focus. If a call holds STREAM_VOICE_CALL focus, this request is denied — we
+    // silently don't play, which is the documented in-call behavior.
     val granted = requestFocus(am, attrs)
     if (!granted) {
       // Common when a Messenger/WhatsApp call is active; documented behavior.

--- a/docs/design/mqtt-notifications.md
+++ b/docs/design/mqtt-notifications.md
@@ -233,7 +233,7 @@ data:
       "image": "http://homeassistant.local:8123/api/camera_proxy/camera.front_door",
       "sound": "http://nas.local/doorbell.mp3",
       "on_tap": "lovelace/security",
-      "duration": 8000
+      "duration": 8
     }
 ```
 


### PR DESCRIPTION
Post-merge finishing touches to the MQTT notification overlay from [#72](https://github.com/starbrightlab/immortal/pull/72), plus a CI repair that's currently breaking `main`.

## Fixes

1. **`on_tap` no longer pollutes the Open entity.** `openTarget` is split into a pure `routeTarget()` (dispatch only) and the `open/state` echo. Notify taps now call `routeTarget()` directly, so tapping a doorbell toast no longer rewrites the "Open" text entity's retained HA state. The Open entity behaves exactly as before.
2. **Audio-focus leak fixed.** `SoundPlayer.startInternal` now abandons any held focus before requesting again, so a second chime arriving close behind the first can't orphan the previous `AudioFocusRequest` and leave `STREAM_MUSIC` ducked after the chime ends.
3. **Stale comments scrubbed.** `SoundPlayer` KDoc and inline comments now say alarm stream / `USAGE_ALARM` instead of `STREAM_NOTIFICATION`/`USAGE_NOTIFICATION`, matching the actual routing.
4. **Doc typo.** `"duration": 8000` -> `8` in the design doc (duration is parsed as seconds).

## CI repair

`main` is currently red because `android-actions/setup-android@v3`'s default package set includes the obsolete `tools` package, whose archive now fails to download (`Error on ZipFile unknown archive`). Pinned `packages: platform-tools`, which is all the unit-test job needs.

## Not included
Image-fetch body-size cap (review item #5) is deferred as a separate follow-up under the documented trusted-LAN model.

Unit suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)