### PR TITLE
Add MQTT screensaver command (#54)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -262,6 +262,16 @@ class MqttPublisher(private val appContext: Context) {
           "media_next" -> NowPlayingHub.next()
           "media_previous" -> NowPlayingHub.previous()
           "notify" -> handleNotify(payload)
+          // Show the photo frame on demand — the same surface the launcher's header
+          // screensaver button launches (HomeActivity.onStartScreensaver). This is the
+          // in-app photo frame as a foreground Activity, not the system dream, so it stays
+          // consistent with the header button: screen/state remains "interactive", and the
+          // go_home command dismisses it. We don't try to start the system dream (no public
+          // API; Somnambulator/IDreamManager reflection is device-fragile on Portal).
+          "screensaver" ->
+              appContext.startActivity(
+                  Intent(appContext, PhotoFramePreviewActivity::class.java)
+                      .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
           else -> Log.w(TAG, "unknown command $obj")
         }
       }
@@ -447,6 +457,7 @@ class MqttPublisher(private val appContext: Context) {
     button(c, "media_previous", "Previous track", icon = "mdi:skip-previous")
 
     button(c, "go_home", "Home", icon = "mdi:home")
+    button(c, "screensaver", "Screensaver", icon = "mdi:image-multiple")
     textEntity(c, "open", "Open", icon = "mdi:open-in-app")
     notifyEntity(c, "notify", "Notify")
     button(c, "identify", "Identify", icon = "mdi:bullhorn")
@@ -468,6 +479,7 @@ class MqttPublisher(private val appContext: Context) {
           "button" to "media_next",
           "button" to "media_previous",
           "button" to "go_home",
+          "button" to "screensaver",
           "text" to "open",
           "notify" to "notify",
           "button" to "identify",

--- a/docs/features/smart-home.md
+++ b/docs/features/smart-home.md
@@ -18,6 +18,10 @@ The publisher reuses the state Immortal already holds and surfaces it to Home As
   [provisioning](../provisioning.md)) — wake or sleep a Portal's display as part of an automation.
 - **Open** a URL, an installed package, or a Home Assistant dashboard path on the Portal — the
   same string grammar the screensaver picker accepts.
+- **Screensaver** — show the photo frame on demand (a `Screensaver` button entity). This is the
+  same photo-frame surface the launcher's header button opens; `Home` dismisses it. Note it's the
+  in-app photo frame, not the system dream, so the `Screen state` sensor stays `interactive` while
+  it's showing.
 - **Notifications** — push a toast (with optional image, sound, and a tap target) from any
   Home Assistant automation. See below.
 


### PR DESCRIPTION
Closes #54.

Home Assistant could already watch `immortal/<id>/screen/state` (`off` / `interactive` / `dreaming`) and wake/sleep via `screen_power`, but there was no way to *command* the screensaver to start. This adds a `Screensaver` button entity at `immortal/<id>/screensaver/set` that shows the photo frame on demand.

## What it does
On press, the handler launches `PhotoFramePreviewActivity` — the exact same photo-frame surface the launcher's header screensaver button opens ([HomeActivity.onStartScreensaver](https://github.com/starbrightlab/immortal/blob/main/app/src/main/java/com/immortal/launcher/HomeActivity.kt#L216)). It mirrors the existing `go_home` command branch and the `button()` discovery pattern.

## Design notes
- This shows the **in-app photo frame as a foreground Activity, not the system dream** — the same thing the header button does. So it's consistent with existing in-app behaviour: `screen/state` stays `interactive` while the frame is showing, and the existing `go_home` command dismisses it.
- We deliberately **don't** try to start the literal system dream. There's no public API; the only routes are SystemUI's Somnambulator activity or `IDreamManager.dream()` via reflection, both device-fragile on the Portal's Android 9/10. The author of #54 anticipated this ("no DreamManager/Somnambulator workaround needed") — reusing the photo-frame activity is exactly that clean internal path.

## Scope
Start-only button (matches the issue's "ON starts the dream now"); stop is already covered by `go_home`. Image-fetch hardening and any "report dreaming state" wiring are out of scope here.

Builds clean; unit suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)