### PR TITLE
Fix app uninstall from launcher edit mode

### DIFF
--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -989,6 +989,7 @@ private fun LauncherScreen(
                           dimmed = isDragged,
                           modifier = boundsMod.alpha(if (isDragged) 0f else 1f),
                           onClick = { onLaunch(app.component) },
+                          onDelete = { onUninstall(app.component.packageName) },
                       )
                     }
                   }


### PR DESCRIPTION
## Problem
Since the widgets grid refactor, tapping the red X on an app tile in launcher edit mode (pencil button) did nothing — apps could not be uninstalled from the home screen. Widget removal still worked. Multiple user reports.

## Root cause
`AppTile` was instantiated in the home grid without an `onDelete` handler, so the red X badge called `AppTile`'s empty default lambda. The `onUninstall` callback (backed by an `ACTION_DELETE` intent) was already plumbed through `LauncherScreen` but never connected to the badge. The widget path (`WidgetCell` / `onRemove`) was wired correctly, which is why widget removal kept working.

## Fix
One line — wire the app tile's badge to the existing `onUninstall` callback, mirroring `WidgetCell`'s `onRemove`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)