### PR TITLE
Stop overnight dark-window screen flicker (#73)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/DreamPolicy.kt
+++ b/app/src/main/java/com/immortal/launcher/DreamPolicy.kt
@@ -127,6 +127,10 @@ object DreamPolicy {
     // companion). SUPPRESSED (a Calls handoff) leaves presence untouched.
     PresenceHub.onDreamStopped(context, verdict)
     if (verdict != DreamStopVerdict.REDREAM) return
+    // Inside the overnight window the SleepScheduler owns the screen. In dark mode, relaunching the
+    // frame would wake the screen just to blank it again — a flash every time a stray sibling/system
+    // dream cycles overnight (issue #73). Let the scheduler re-blank in place instead.
+    if (SleepScheduler.handleRedreamDuringOvernight(context)) return
     runCatching {
       context.startActivity(
           Intent(context, PhotoFramePreviewActivity::class.java)

--- a/app/src/main/java/com/immortal/launcher/SleepScheduler.kt
+++ b/app/src/main/java/com/immortal/launcher/SleepScheduler.kt
@@ -165,6 +165,61 @@ object SleepScheduler {
       else if (start < end) now in start until end
       else now >= start || now < end // wraps midnight
 
+  /** What a would-be photo-frame redream should do when it happens inside the overnight window. */
+  internal enum class OvernightRedream {
+    /** Not in the window (or night-clock mode): let the normal frame relaunch proceed. */
+    RELAUNCH,
+    /** The user deliberately woke the device (a session is live): leave the screen alone. */
+    LEAVE,
+    /** Dark window, no live session: re-blank directly, without launching an Activity. */
+    REBLANK,
+  }
+
+  /**
+   * Pure (unit-tested) decision for [handleRedreamDuringOvernight]. A stray dream stop inside the
+   * dark window must not relaunch [PhotoFramePreviewActivity]: launching an Activity wakes the
+   * screen, and the activity then immediately blanks it again — a brief flash every time a
+   * sibling/system dream cycles overnight (issue #73). Night-clock mode still relaunches, because
+   * there the frame *is* the dimmed clock the window is meant to show.
+   */
+  internal fun classifyOvernightRedream(
+      inWindow: Boolean,
+      nightSessionActive: Boolean,
+      nightClock: Boolean,
+  ): OvernightRedream =
+      when {
+        !inWindow -> OvernightRedream.RELAUNCH
+        nightSessionActive -> OvernightRedream.LEAVE
+        nightClock -> OvernightRedream.RELAUNCH
+        else -> OvernightRedream.REBLANK
+      }
+
+  /**
+   * Called from [DreamPolicy.onDreamingStopped] before it would relaunch the photo frame. Returns
+   * true if the overnight window owns the screen and the caller must NOT relaunch (we either left a
+   * live session alone, or re-blanked the dark window in place). Returns false to allow the normal
+   * relaunch (outside the window, or night-clock mode where the relaunch renders the clock).
+   */
+  fun handleRedreamDuringOvernight(context: Context): Boolean {
+    val decision =
+        classifyOvernightRedream(
+            inWindow = isOvernightNow(context),
+            nightSessionActive = nightSessionActive,
+            nightClock = ScreensaverConfig.load(context).overnightNightClock,
+        )
+    return when (decision) {
+      OvernightRedream.RELAUNCH -> false
+      OvernightRedream.LEAVE -> true
+      OvernightRedream.REBLANK -> {
+        // Keep the system Dream suppressed for the window, then blank without an Activity launch
+        // (no flash). Mirrors enterOvernightRest's dark path minus the screen-on round-trip.
+        SettingsGuard.setSystemScreensaverEnabled(context, false)
+        ScreenControl.sleep(context)
+        true
+      }
+    }
+  }
+
   /** (Re)schedule the daily start/end alarms, or clear them if disabled. */
   fun scheduleOvernight(context: Context) {
     val cfg = ScreensaverConfig.load(context)

--- a/app/src/test/java/com/immortal/launcher/SleepSchedulerTest.kt
+++ b/app/src/test/java/com/immortal/launcher/SleepSchedulerTest.kt
@@ -7,12 +7,55 @@
 
 package com.immortal.launcher
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /** The overnight-window membership test, including the wrap past midnight. */
 class SleepSchedulerTest {
+
+  // ----- overnight redream classification (issue #73 dark-window flicker) -----
+
+  @Test
+  fun redream_outsideWindow_relaunchesNormally() {
+    assertEquals(
+        SleepScheduler.OvernightRedream.RELAUNCH,
+        SleepScheduler.classifyOvernightRedream(
+            inWindow = false, nightSessionActive = false, nightClock = false))
+  }
+
+  @Test
+  fun redream_darkWindow_reblanksInPlace() {
+    // The flicker fix: in the dark window with no live session, never relaunch the Activity.
+    assertEquals(
+        SleepScheduler.OvernightRedream.REBLANK,
+        SleepScheduler.classifyOvernightRedream(
+            inWindow = true, nightSessionActive = false, nightClock = false))
+  }
+
+  @Test
+  fun redream_liveSession_leavesScreenAlone() {
+    // A deliberate overnight wake (renewable session): don't slam the screen off under the user.
+    assertEquals(
+        SleepScheduler.OvernightRedream.LEAVE,
+        SleepScheduler.classifyOvernightRedream(
+            inWindow = true, nightSessionActive = true, nightClock = false))
+    // Session wins even in night-clock mode.
+    assertEquals(
+        SleepScheduler.OvernightRedream.LEAVE,
+        SleepScheduler.classifyOvernightRedream(
+            inWindow = true, nightSessionActive = true, nightClock = true))
+  }
+
+  @Test
+  fun redream_nightClockWindow_relaunchesTheClock() {
+    // Night-clock mode wants the relaunch — that Activity renders the dimmed clock.
+    assertEquals(
+        SleepScheduler.OvernightRedream.RELAUNCH,
+        SleepScheduler.classifyOvernightRedream(
+            inWindow = true, nightSessionActive = false, nightClock = true))
+  }
 
   @Test
   fun window_wrappingMidnight_includesLateNightAndEarlyMorning() {


### PR DESCRIPTION
Addresses #73.

## Symptom
With the overnight window set to **dark** (screen off overnight, e.g. 9:30pm-8am) on a gen-1 Portal, the screen flickers briefly every few minutes, and the device is hard to interrupt without a power cycle.

## Root cause
[`DreamPolicy.onDreamingStopped`](https://github.com/starbrightlab/immortal/blob/main/app/src/main/java/com/immortal/launcher/DreamPolicy.kt#L111) relaunches `PhotoFramePreviewActivity` on a `REDREAM` verdict **without checking the overnight window**. Inside the dark window that Activity wakes the screen and then immediately blanks it ([`PhotoFramePreviewActivity.onCreate`](https://github.com/starbrightlab/immortal/blob/main/app/src/main/java/com/immortal/launcher/PhotoFramePreviewActivity.kt#L67) calls `ScreenControl.sleep` + `finish`). So every time a sibling/system dream cycles overnight, we get a brief flash. The same involuntary relaunch can also slam over a deliberate wake, which is why the device is hard to interrupt.

## Fix
Before relaunching, `DreamPolicy` now defers to `SleepScheduler.handleRedreamDuringOvernight`:
- **Dark window, no live session** -> re-blank in place via `ScreenControl.sleep`, with no Activity launch, so no flash.
- **Live overnight session** (a deliberate, touch-renewable wake) -> leave the screen alone, so we don't trap the user.
- **Night-clock mode** -> relaunch as before, since there the frame *is* the dimmed clock the window is meant to show.
- **Outside the window** -> unchanged.

The decision is a pure function (`classifyOvernightRedream`) with unit tests.

## Caveat
If part of the flicker is the Portal's hardware presence lighting the panel directly (not via a dream relaunch), this reduces but may not fully eliminate it; that residual would need a `SCREEN_ON` re-blank, which risks trapping the user, so it's intentionally out of scope here pending confirmation from the reporter.

Builds clean; unit suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)