### PR TITLE
Phone remote: view and rename a device's name

### DIFF
--- a/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
@@ -121,6 +121,9 @@ object RemoteHtml {
   .tile img{width:48px;height:48px;border-radius:12px;background:#1c1c1e}
   .tile span{font-size:12px;max-width:80px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
   .devrow{display:flex;gap:16px;margin-bottom:8px}
+  .renamerow{display:flex;gap:10px;align-items:center;margin-bottom:8px}
+  .renamerow input{flex:1;min-width:0;padding:13px;font-size:16px;background:#0e0e10;border:1px solid #3a3a3c;border-radius:12px;color:#fff}
+  .renamerow .primary{width:auto;padding:13px 18px;font-size:15px;white-space:nowrap}
   .addpanel{background:#161618;border:1px solid #2a2a2c;border-radius:14px;padding:14px;margin-bottom:18px}
   .discovered{display:flex;flex-wrap:wrap;gap:8px;margin:8px 0}
   .discovered button{padding:10px 14px;font-size:14px;background:#1c1c1e;color:#fff;border-radius:10px}
@@ -226,6 +229,11 @@ object RemoteHtml {
 
     <div id=tabSetup class="panel scroll hide">
       <div class=label>Devices</div>
+      <div class=renamerow>
+        <input id=devname maxlength=48 placeholder="Device name" autocomplete=off>
+        <button class=primary onclick=saveRename()>Save name</button>
+      </div>
+      <div id=renameMsg class=sub></div>
       <div class=devrow>
         <button class=link onclick=toggleAdd()>+ Add device</button>
         <button class=link onclick=forgetDevice()>Forget this device</button>
@@ -386,7 +394,28 @@ object RemoteHtml {
     });
     if(name==='apps'){loadApps();loadPresets();}
     if(name==='settings'){closeSrcPanel();loadSettings();}
+    if(name==='setup')loadRename();
     if(name==='media')startNowPlaying();else stopNowPlaying();
+  }
+  // Prefill the rename field with the active Portal's current name (the source of truth on-device).
+  function loadRename(){
+    var inp=document.getElementById('devname');var msg=document.getElementById('renameMsg');msg.textContent='';
+    api('/remote/devices').then(function(d){inp.value=d.self||'';}).catch(function(){});
+  }
+  // Save the active Portal's name via the declarative fleet settings domain, then refresh the
+  // local roster label so the switcher isn't stale. Server re-validates (trim, 1..48).
+  function saveRename(){
+    var inp=document.getElementById('devname');var msg=document.getElementById('renameMsg');
+    var v=(inp.value||'').trim();
+    if(v.length<1||v.length>48){msg.textContent='Name must be 1 to 48 characters.';return;}
+    msg.textContent='Saving…';
+    api('/remote/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({domain:'fleet',values:{name:v}})})
+      .then(function(d){
+        if(!(d&&d.ok&&(d.applied||[]).indexOf('name')>=0)){msg.textContent='Couldn\'t save the name.';return;}
+        var l=devicesList(),i=activeIdx();if(l[i]){l[i].name=v;saveDevices(l);}
+        renderDevSel();inp.value=v;msg.textContent='Saved.';
+      })
+      .catch(function(){msg.textContent='Couldn\'t reach that device.';});
   }
   // --- generic settings (rendered from the declarative /remote/settings schema) ---
   // Apply scope: 'this' = the active Portal only; 'all' = every paired Portal (fleet broadcast).
@@ -522,7 +551,8 @@ object RemoteHtml {
   function setPut(domId,key,value){
     var vals={};vals[key]=value;
     var body=JSON.stringify({domain:domId,values:vals});
-    if(setScope==='all')broadcast(body);
+    // The device name is per-device — never broadcast it, or every Portal ends up identically named.
+    if(setScope==='all'&&domId!=='fleet')broadcast(body);
     api('/remote/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:body})
       .then(function(d){if(d&&d.domain)applyDomainUpdate(domId,d.domain);})
       .catch(function(){flash('Couldn’t apply — is the Portal reachable?',true);});
@@ -531,7 +561,7 @@ object RemoteHtml {
     var vals={};
     (dom.controls||[]).forEach(function(c){if(c['default']!==undefined)vals[c.key]=c['default'];});
     var body=JSON.stringify({domain:dom.id,values:vals});
-    if(setScope==='all')broadcast(body);
+    if(setScope==='all'&&dom.id!=='fleet')broadcast(body);
     api('/remote/settings',{method:'POST',headers:{'Content-Type':'application/json'},body:body})
       .then(function(d){if(d&&d.domain){applyDomainUpdate(dom.id,d.domain);flash('Reset to defaults',false);}})
       .catch(function(){flash('Couldn’t reset — is the Portal reachable?',true);});

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -14,6 +14,7 @@ import com.immortal.launcher.DreamPolicy
 import com.immortal.launcher.FaceCatalog
 import com.immortal.launcher.FacePickerActivity
 import com.immortal.launcher.FleetCalendar
+import com.immortal.launcher.FleetConfig
 import com.immortal.launcher.FleetScreensaver
 import com.immortal.launcher.FrameMode
 import com.immortal.launcher.PhotoFramePreviewActivity
@@ -601,6 +602,34 @@ object SettingsDomains {
           },
       )
 
+  /**
+   * Device identity. One control: the Portal's display name, shown in the phone remote's device
+   * switcher and used as the Home Assistant device name. HA `unique_id` and the MQTT topic path key
+   * off a separate stable device id ([MqttConfig.deviceId]), so renaming is cosmetic and safe.
+   * Bound to [FleetConfig], whose setter also rewrites the shell-readable fleet manifest.
+   */
+  val fleet: SettingsDomain<Context> =
+      SettingsDomain(
+          id = "fleet",
+          title = "Device",
+          load = { it },
+          specs =
+              listOf(
+                  StringSpec(
+                      "name",
+                      "Device name",
+                      get = { FleetConfig.name(it) },
+                      // Trim surrounding whitespace before storing. Any printable characters are
+                      // allowed (HA device name and the mDNS service name tolerate them).
+                      set = { c, v -> FleetConfig.setName(c, v.trim()) },
+                      // Reject blank or over-long names; the trimmed form must be 1..48 chars.
+                      applyWhen = { it.trim().length in 1..48 },
+                      help = "Shown in the phone remote and in Home Assistant.",
+                  ),
+              ),
+      )
+
   /** Every registered domain. */
-  val all: List<SettingsDomain<*>> = listOf(screensaver, calendar, immortal, mqtt, quickbar)
+  val all: List<SettingsDomain<*>> =
+      listOf(screensaver, calendar, immortal, mqtt, quickbar, fleet)
 }

--- a/app/src/test/java/com/immortal/launcher/settings/FleetSettingsTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/FleetSettingsTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher.settings
+
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Locks the device-name validation contract on the real registered `fleet` domain (the one the
+ * phone-remote rename uses). The `applyWhen` guard is a pure predicate, so it's exercised directly;
+ * the actual storage round-trip (FleetConfig get/set → SharedPreferences) is on-device.
+ */
+class FleetSettingsTest {
+
+  private val nameSpec: StringSpec<Context> =
+      SettingsDomains.fleet.specs.first { it.key == "name" } as StringSpec<Context>
+
+  @Test
+  fun fleetDomain_isRegistered_withNameSpec() {
+    assertTrue(SettingsDomains.all.any { it.id == "fleet" })
+    assertEquals("name", nameSpec.key)
+  }
+
+  @Test
+  fun name_acceptsReasonableValues() {
+    assertTrue(nameSpec.applyWhen("Kitchen"))
+    assertTrue(nameSpec.applyWhen("Bedroom Portal 2"))
+    assertTrue(nameSpec.applyWhen("x".repeat(48))) // exactly the cap
+  }
+
+  @Test
+  fun name_rejectsBlankAndWhitespaceOnly() {
+    assertFalse(nameSpec.applyWhen(""))
+    assertFalse(nameSpec.applyWhen("   "))
+    assertFalse(nameSpec.applyWhen("\t\n"))
+  }
+
+  @Test
+  fun name_rejectsOverLength_afterTrim() {
+    assertFalse(nameSpec.applyWhen("x".repeat(49)))
+    // Surrounding whitespace doesn't count: trims to 48, which is allowed.
+    assertTrue(nameSpec.applyWhen("  " + "x".repeat(48) + "  "))
+  }
+}


### PR DESCRIPTION
Adds the ability to view and change a Portal's name from the phone-remote UI, which makes managing many Portals from one phone much easier. Requested as a follow-up to the phone-remote work.

## How it works
The remote already has a generic, registry-backed settings pipeline (declarative domains -> `/remote/settings` -> auto-rendered PWA). The device name already had storage (`FleetConfig.name`/`setName`); it just wasn't registered. So this is mostly declarative:

- **Register a `fleet` settings domain** with one `StringSpec` for the name, bound to `FleetConfig`. It appears in the remote's Settings tab with no route or schema changes. Validation: trim, non-blank, 48-char cap, any printable characters; the server re-validates via `applyWhen`.
- **Inline rename in the Devices tab** (where you switch between paired Portals): prefilled from `/remote/devices`, saved through the fleet domain, and the local device-roster label is refreshed so the switcher isn't stale. This is the piece that makes it useful across many Portals: switch device -> rename -> switch -> rename.
- **Never broadcast the name** under the "All Portals" scope, so a fleet-wide apply can't make every Portal identically named.

## Safety / scoping notes
- Renaming is cosmetic and safe: HA `unique_id` and the MQTT topic path key off the stable `MqttConfig.deviceId`, not the name. The name is only the HA device label and the mDNS service name.
- The on-device settings UI references specific domains, so the new `fleet` domain surfaces **only** in the phone remote, not on-device (no duplicate field).
- HA's device label updates on the next MQTT reconnect/republish (a live-refresh hook was scoped as an optional Tier 3 and deliberately left out).

## Tests
New `FleetSettingsTest` locks the validation contract (accept reasonable names, reject blank/whitespace-only/over-length, trim before the length check) against the real registered domain. Full unit suite + debug build pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)