### PR TITLE
Add server-synced roster so the phone remote reconnects across sessions

### DIFF
--- a/app/src/main/java/com/immortal/launcher/RemoteDiscovery.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteDiscovery.kt
@@ -20,7 +20,9 @@ import org.json.JSONObject
  * advertises itself as `_immortal-remote._tcp` (friendly name + agent port) and simultaneously
  * browses for its peers, keeping a resolved list. The phone can't do mDNS itself, so [RemoteRoutes]
  * exposes the discovered peers at `/remote/devices`; the phone then pairs each (with its on-screen
- * PIN) and keeps the tokens locally — no token ever crosses between Portals.
+ * PIN) and keeps the tokens locally. A Portal never mints or shares another's token itself; the
+ * phone is the only courier — it may back its own roster up to each Portal ([RemoteRoster]) so
+ * pairing one restores the rest, but that backup is auth-gated by the same on-screen PIN.
  *
  * Best-effort: registration/resolve hiccups are logged and skipped, never fatal to the agent.
  */

--- a/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
@@ -13,6 +13,8 @@ package com.immortal.launcher
  * keyboard + a lower-half touchpad with scroll buttons), **Apps** (presets + app grid), **Setup**
  * (device add/switch + the screensaver/calendar source form that replaced the old standalone LAN
  * form). A per-device session token lives in localStorage; every API call sends it as a Bearer.
+ * The whole roster is also backed up to each paired Portal ([RemoteRoster]) so a fresh browser can
+ * pair one device and get them all back, instead of re-pairing the fleet after storage is evicted.
  *
  * Touchpad scrolling is discrete `▲ ▼` buttons (one big swipe each via `/remote/scroll`): the
  * Portal ignores a stream of tiny per-frame swipes, so a two-finger drag can't drive it.
@@ -313,6 +315,12 @@ object RemoteHtml {
   function activeIdx(){var i=parseInt(localStorage.getItem(AKEY)||'0',10),l=devicesList();return (i>=0&&i<l.length)?i:0;}
   function setActive(i){localStorage.setItem(AKEY,String(i));}
   function active(){return devicesList()[activeIdx()]||null;}
+  // Server-synced roster: each paired Portal keeps a backup of this phone's whole roster, so a fresh
+  // browser (storage evicted, different origin, changed IP) can pair ONE Portal and get them all
+  // back. We push on every roster change and pull-and-merge whenever we pair a device.
+  function syncRoster(){var l=devicesList(),body=JSON.stringify({roster:l});l.forEach(function(dv){fetch(dv.base+'/remote/roster',{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+dv.token},body:body}).catch(function(){});});}
+  function mergeRoster(server){var l=devicesList(),have={},added=0;l.forEach(function(x){have[x.base]=1;});(server||[]).forEach(function(s){if(s&&s.base&&s.token&&!have[s.base]){l.push({name:s.name||'Portal',base:s.base,token:s.token});have[s.base]=1;added++;}});if(added)saveDevices(l);return added;}
+  function pullRoster(base,token){return fetch(base+'/remote/roster',{headers:{'Authorization':'Bearer '+token}}).then(function(r){return r.json();}).then(function(d){return mergeRoster(d&&d.roster);}).catch(function(){return 0;});}
   function show(view){
     document.getElementById('pairView').classList.toggle('hide',view!=='pair');
     document.getElementById('remoteView').classList.toggle('hide',view!=='remote');
@@ -345,7 +353,9 @@ object RemoteHtml {
         if(d.ok&&d.token){
           var l=devicesList().filter(function(x){return x.base!==location.origin;});
           l.unshift({name:d.name||'Portal',base:location.origin,token:d.token});
-          saveDevices(l);setActive(0);startActive();
+          saveDevices(l);setActive(0);
+          // Rehydrate the rest of the fleet this Portal remembers, then re-push the merged roster.
+          pullRoster(location.origin,d.token).then(function(){syncRoster();startActive();});
         } else document.getElementById('pairErr').textContent='That code didn\'t work. Check the Portal and try again.';
       })
       .catch(function(){document.getElementById('pairErr').textContent='Couldn\'t reach the Portal.';});
@@ -356,7 +366,7 @@ object RemoteHtml {
     sel.value=activeIdx();
   }
   function switchDevice(){setActive(parseInt(document.getElementById('devsel').value,10));document.getElementById('addPanel').classList.add('hide');loadApps();loadPresets();loadSources();}
-  function forgetDevice(){var l=devicesList();if(!l.length)return;l.splice(activeIdx(),1);saveDevices(l);setActive(0);if(l.length){renderDevSel();showTab('remote');}else{location.hash='';show('pair');}}
+  function forgetDevice(){var l=devicesList();if(!l.length)return;l.splice(activeIdx(),1);saveDevices(l);setActive(0);syncRoster();if(l.length){renderDevSel();showTab('remote');}else{location.hash='';show('pair');}}
   function toggleAdd(){var p=document.getElementById('addPanel');p.classList.toggle('hide');document.getElementById('addPair').classList.add('hide');if(!p.classList.contains('hide'))loadDiscovered();}
   function loadDiscovered(){
     api('/remote/devices').then(function(d){
@@ -382,6 +392,8 @@ object RemoteHtml {
         if(d.ok&&d.token){
           var l=devicesList();l.push({name:d.name||pendingPeer.name,base:pendingPeer.base,token:d.token});
           saveDevices(l);setActive(l.length-1);renderDevSel();
+          // Pull anything this peer already knows, then back the merged roster up to every Portal.
+          pullRoster(pendingPeer.base,d.token).then(function(){syncRoster();renderDevSel();});
           document.getElementById('addPanel').classList.add('hide');pendingPeer=null;showTab('remote');
         } else document.getElementById('addErr').textContent='That code didn\'t work.';
       })
@@ -413,7 +425,7 @@ object RemoteHtml {
       .then(function(d){
         if(!(d&&d.ok&&(d.applied||[]).indexOf('name')>=0)){msg.textContent='Couldn\'t save the name.';return;}
         var l=devicesList(),i=activeIdx();if(l[i]){l[i].name=v;saveDevices(l);}
-        renderDevSel();inp.value=v;msg.textContent='Saved.';
+        renderDevSel();inp.value=v;msg.textContent='Saved.';syncRoster();
       })
       .catch(function(){msg.textContent='Couldn\'t reach that device.';});
   }
@@ -827,7 +839,7 @@ object RemoteHtml {
   (function(){
     var m=location.hash.match(/pin=(\d{6})/);
     if(m){document.getElementById('pin').value=m[1];pair();}
-    else if(active())startActive();
+    else if(active()){startActive();pullRoster(active().base,active().token).then(function(n){if(n)renderDevSel();});}
     else show('pair');
   })();
 </script>

--- a/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
@@ -29,6 +29,12 @@ object RemoteHtml {
 <meta charset=utf-8>
 <meta name=viewport content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
 <meta name=apple-mobile-web-app-capable content=yes>
+<meta name=mobile-web-app-capable content=yes>
+<meta name=theme-color content="#0e0e10">
+<meta name=apple-mobile-web-app-title content="Immortal">
+<meta name=apple-mobile-web-app-status-bar-style content=black>
+<link rel=manifest href="/remote/manifest.webmanifest">
+<link rel=apple-touch-icon href="/remote/app-icon?size=180">
 <title>Immortal remote</title>
 <style>
   *{box-sizing:border-box;-webkit-tap-highlight-color:transparent}
@@ -230,6 +236,10 @@ object RemoteHtml {
     </div>
 
     <div id=tabSetup class="panel scroll hide">
+      <div id=installTip class="addpanel hide">
+        <p class=sub style="margin:0 0 8px">Add this remote to your home screen for an app that stays paired between sessions — an installed app's storage isn't cleared like a browser tab's. Use your browser's <b>Share</b>/menu &rsaquo; <b>Add to Home Screen</b>.</p>
+        <button class=link onclick=dismissInstallTip()>Got it</button>
+      </div>
       <div class=label>Devices</div>
       <div class=renamerow>
         <input id=devname maxlength=48 placeholder="Device name" autocomplete=off>
@@ -308,6 +318,10 @@ object RemoteHtml {
   </div>
 
 <script>
+  // Ask the browser to keep our storage durable (Chrome/Android honours this for engaged/installed
+  // sites) so the paired roster survives — complements the per-Portal roster backup and home-screen
+  // install. Best-effort: unsupported or denied is fine, the synced roster still recovers us.
+  if(navigator.storage&&navigator.storage.persist)navigator.storage.persist().catch(function(){});
   // Multi-device: a roster of paired Portals {name, base, token} kept on the phone; one is active.
   var DKEY='immortal_remote_devices', AKEY='immortal_remote_active', pendingPeer=null;
   function devicesList(){try{return JSON.parse(localStorage.getItem(DKEY)||'[]');}catch(e){return [];}}
@@ -321,6 +335,10 @@ object RemoteHtml {
   function syncRoster(){var l=devicesList(),body=JSON.stringify({roster:l});l.forEach(function(dv){fetch(dv.base+'/remote/roster',{method:'POST',headers:{'Content-Type':'application/json','Authorization':'Bearer '+dv.token},body:body}).catch(function(){});});}
   function mergeRoster(server){var l=devicesList(),have={},added=0;l.forEach(function(x){have[x.base]=1;});(server||[]).forEach(function(s){if(s&&s.base&&s.token&&!have[s.base]){l.push({name:s.name||'Portal',base:s.base,token:s.token});have[s.base]=1;added++;}});if(added)saveDevices(l);return added;}
   function pullRoster(base,token){return fetch(base+'/remote/roster',{headers:{'Authorization':'Bearer '+token}}).then(function(r){return r.json();}).then(function(d){return mergeRoster(d&&d.roster);}).catch(function(){return 0;});}
+  // "Add to Home Screen" tip — the durable-storage path. Hidden once installed (standalone) or dismissed.
+  function isStandalone(){return !!((window.matchMedia&&window.matchMedia('(display-mode:standalone)').matches)||window.navigator.standalone);}
+  function maybeInstallTip(){var t=document.getElementById('installTip');if(!t)return;var done=localStorage.getItem('immortal_remote_a2hs')==='1';t.classList.toggle('hide',isStandalone()||done);}
+  function dismissInstallTip(){localStorage.setItem('immortal_remote_a2hs','1');var t=document.getElementById('installTip');if(t)t.classList.add('hide');}
   function show(view){
     document.getElementById('pairView').classList.toggle('hide',view!=='pair');
     document.getElementById('remoteView').classList.toggle('hide',view!=='remote');
@@ -406,7 +424,7 @@ object RemoteHtml {
     });
     if(name==='apps'){loadApps();loadPresets();}
     if(name==='settings'){closeSrcPanel();loadSettings();}
-    if(name==='setup')loadRename();
+    if(name==='setup'){loadRename();maybeInstallTip();}
     if(name==='media')startNowPlaying();else stopNowPlaying();
   }
   // Prefill the rename field with the active Portal's current name (the source of truth on-device).

--- a/app/src/main/java/com/immortal/launcher/RemoteRoster.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteRoster.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Server-side backup of the phone's **device roster** (the `{name, base, token}` list the remote
+ * keeps in `localStorage`). Each paired Portal stores the latest roster the phone pushed to it, so
+ * a fresh browser — storage wiped by Safari's 7-day eviction, a different origin, a changed
+ * DHCP IP — can **pair one Portal and get the whole fleet back** instead of re-pairing every device.
+ *
+ * The phone is the source of truth; the Portal is a dumb store. Retrieval is auth-gated exactly like
+ * input ([RemoteRoutes.roster]) — the on-screen PIN that mints a session is the same gate that
+ * releases the roster, so only someone who paired in person can pull it. A Portal still never mints
+ * or shares another Portal's token itself; the phone is the only courier, carrying its own tokens.
+ *
+ * Stored blobs are run through [sanitize] on the way in and out so a malformed or oversized upload
+ * can't wedge the store or balloon SharedPreferences.
+ */
+object RemoteRoster {
+  private const val PREFS = "remote_roster"
+  private const val KEY_ROSTER = "roster" // JSON array of {name, base, token}
+
+  internal const val MAX_ENTRIES = 64
+  internal const val MAX_FIELD = 512
+
+  private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+  /** The stored roster (sanitized), or an empty array if none has been pushed yet. */
+  fun load(c: Context): JSONArray = sanitize(prefs(c).getString(KEY_ROSTER, null))
+
+  /** Replace the stored roster with [blob] (a JSON array string), sanitizing first. */
+  fun save(c: Context, blob: String) {
+    prefs(c).edit().putString(KEY_ROSTER, sanitize(blob).toString()).apply()
+  }
+
+  fun clear(c: Context) {
+    prefs(c).edit().remove(KEY_ROSTER).apply()
+  }
+
+  // --- pure helper (unit-tested) ----------------------------------------------
+
+  /**
+   * Parse [raw] into a clean roster array: keep only objects with a non-blank `base` **and** `token`,
+   * dedupe by `base` (first wins), default/clamp `name`, clamp field lengths, and cap the count.
+   * Anything that isn't a JSON array — or any junk entry — is dropped rather than stored.
+   */
+  internal fun sanitize(raw: String?): JSONArray {
+    val out = JSONArray()
+    val arr = runCatching { JSONArray(raw ?: "[]") }.getOrNull() ?: return out
+    val seen = HashSet<String>()
+    for (i in 0 until arr.length()) {
+      if (out.length() >= MAX_ENTRIES) break
+      val o = arr.optJSONObject(i) ?: continue
+      val base = o.optString("base").trim().take(MAX_FIELD)
+      val token = o.optString("token").trim().take(MAX_FIELD)
+      if (base.isEmpty() || token.isEmpty()) continue
+      if (!seen.add(base)) continue
+      val name = o.optString("name").trim().ifEmpty { "Portal" }.take(48)
+      out.put(JSONObject().put("name", name).put("base", base).put("token", token))
+    }
+    return out
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/RemoteRoutes.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteRoutes.kt
@@ -54,6 +54,7 @@ class RemoteRoutes(private val context: Context) {
         "/remote/presets" -> authed(req) { presets(req) }
         "/remote/preset" -> authed(req) { runPreset(req) }
         "/remote/devices" -> authed(req) { devices() }
+        "/remote/roster" -> authed(req) { roster(req) }
         "/remote/sources" -> authed(req) { sources(req) }
         "/remote/settings" -> authed(req) { settings(req) }
         else -> json(404, err("not_found"))
@@ -276,6 +277,29 @@ class RemoteRoutes(private val context: Context) {
                           .put("applied", JSONArray(applied.toList()))
                           .put("domain", SettingsRegistry.domain(domainId)!!.schemaJson(context)))
             }
+          }
+        }
+        else -> json(405, err("method_not_allowed"))
+      }
+
+  /**
+   * The phone's device roster, backed up here so any paired Portal's page can rehydrate the whole
+   * fleet — pair one device and the rest come back, instead of re-pairing all of them after a
+   * browser wipes its storage. GET returns the stored roster; POST replaces it with the phone's
+   * current `[{name, base, token}]`. Auth-gated like every input route: the on-screen PIN that
+   * mints a session is the same gate that releases the roster, so only someone who paired in
+   * person can read it. See [RemoteRoster] for the storage + sanitisation.
+   */
+  private fun roster(req: FleetHttpServer.Request): FleetHttpServer.Response =
+      when (req.method) {
+        "GET" -> json(200, ok().put("roster", RemoteRoster.load(context)))
+        "POST" -> {
+          val body = parseJson(req.bodyText())
+          val arr = body?.optJSONArray("roster")
+          if (arr == null) json(400, err("roster_required"))
+          else {
+            RemoteRoster.save(context, arr.toString())
+            json(200, ok().put("roster", RemoteRoster.load(context)))
           }
         }
         else -> json(405, err("method_not_allowed"))

--- a/app/src/main/java/com/immortal/launcher/RemoteRoutes.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteRoutes.kt
@@ -32,6 +32,11 @@ class RemoteRoutes(private val context: Context) {
         // Public (LAN-guarded only): the page itself carries no secrets, and pairing
         // is gated by the PIN shown on the Portal's screen.
         "/remote/ui" -> requireMethod("GET", req) { html(RemoteHtml.PAGE) }
+        // PWA install surface: the manifest + app icon let the remote be added to the phone's
+        // home screen as a standalone app, whose storage isn't evicted like a browser tab's —
+        // the durable home for the synced roster. Public (no secrets), like the page itself.
+        "/remote/manifest.webmanifest" -> requireMethod("GET", req) { manifest() }
+        "/remote/app-icon" -> requireMethod("GET", req) { appIcon(req) }
         "/remote/pair" -> requireMethod("POST", req) { pair(req) }
         // App icons aren't sensitive; serving them unauthenticated keeps the token out
         // of <img> URLs. Still behind the server's LAN-only peer guard.
@@ -74,6 +79,55 @@ class RemoteRoutes(private val context: Context) {
   private fun icon(req: FleetHttpServer.Request): FleetHttpServer.Response {
     val pkg = req.queryParam("pkg") ?: return json(400, err("pkg_required"))
     val png = RemoteApps.iconPng(context, pkg) ?: return json(404, err("no_icon"))
+    return FleetHttpServer.Response.stream(200, "image/png", png.size.toLong()) { it.write(png) }
+  }
+
+  /**
+   * The PWA web app manifest. Installing the remote to the home screen makes it a standalone app
+   * and — crucially for "stay connected between sessions" — gives its storage the durable lifetime
+   * an installed app gets, instead of the ~7-day eviction a plain browser tab faces. Served as
+   * `application/manifest+json`; icons point at [appIcon] (Immortal's own launcher icon).
+   */
+  private fun manifest(): FleetHttpServer.Response {
+    val obj =
+        JSONObject()
+            .put("name", "Immortal Remote")
+            .put("short_name", "Immortal")
+            .put("description", "Control your Immortal Portal from your phone.")
+            .put("start_url", "/remote/ui")
+            .put("scope", "/remote/")
+            .put("display", "standalone")
+            .put("orientation", "portrait")
+            .put("background_color", "#0e0e10")
+            .put("theme_color", "#0e0e10")
+            .put(
+                "icons",
+                JSONArray()
+                    .put(iconEntry(192, "any"))
+                    .put(iconEntry(512, "any"))
+                    .put(iconEntry(512, "maskable")))
+    val bytes = obj.toString().toByteArray(Charsets.UTF_8)
+    return FleetHttpServer.Response.stream(
+        200, "application/manifest+json; charset=utf-8", bytes.size.toLong()) {
+          it.write(bytes)
+        }
+  }
+
+  private fun iconEntry(size: Int, purpose: String) =
+      JSONObject()
+          .put("src", "/remote/app-icon?size=$size")
+          .put("sizes", "${size}x${size}")
+          .put("type", "image/png")
+          .put("purpose", purpose)
+
+  /**
+   * Immortal's own launcher icon as PNG, for the manifest icons and the iOS apple-touch-icon.
+   * Public like [icon] (an app icon isn't a secret), and rendered at the requested (clamped) size
+   * from our adaptive launcher icon — so the installed remote wears the same face as the app.
+   */
+  private fun appIcon(req: FleetHttpServer.Request): FleetHttpServer.Response {
+    val size = (req.queryParam("size")?.toIntOrNull() ?: 192).coerceIn(48, 1024)
+    val png = RemoteApps.iconPng(context, context.packageName, size) ?: return json(404, err("no_icon"))
     return FleetHttpServer.Response.stream(200, "image/png", png.size.toLong()) { it.write(png) }
   }
 

--- a/app/src/test/java/com/immortal/launcher/RemoteRosterTest.kt
+++ b/app/src/test/java/com/immortal/launcher/RemoteRosterTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.json.JSONArray
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** The pure roster sanitiser behind the server-synced backup (no Context / prefs needed). */
+class RemoteRosterTest {
+
+  private fun entry(name: String?, base: String?, token: String?): String {
+    val sb = StringBuilder("{")
+    val parts = mutableListOf<String>()
+    if (name != null) parts += "\"name\":\"$name\""
+    if (base != null) parts += "\"base\":\"$base\""
+    if (token != null) parts += "\"token\":\"$token\""
+    sb.append(parts.joinToString(",")).append("}")
+    return sb.toString()
+  }
+
+  @Test
+  fun keepsWellFormedEntries() {
+    val raw = "[${entry("Kitchen", "http://10.0.0.5:8723", "tok1")}]"
+    val out = RemoteRoster.sanitize(raw)
+    assertEquals(1, out.length())
+    val o = out.getJSONObject(0)
+    assertEquals("Kitchen", o.getString("name"))
+    assertEquals("http://10.0.0.5:8723", o.getString("base"))
+    assertEquals("tok1", o.getString("token"))
+  }
+
+  @Test
+  fun dropsEntriesMissingBaseOrToken() {
+    val raw =
+        "[" +
+            entry("A", "http://a:1", "tok") + "," +
+            entry("B", null, "tok") + "," + // no base
+            entry("C", "http://c:1", null) + // no token
+            "]"
+    val out = RemoteRoster.sanitize(raw)
+    assertEquals(1, out.length())
+    assertEquals("http://a:1", out.getJSONObject(0).getString("base"))
+  }
+
+  @Test
+  fun dedupesByBaseFirstWins() {
+    val raw =
+        "[" + entry("First", "http://x:1", "tokA") + "," + entry("Second", "http://x:1", "tokB") + "]"
+    val out = RemoteRoster.sanitize(raw)
+    assertEquals(1, out.length())
+    assertEquals("tokA", out.getJSONObject(0).getString("token"))
+  }
+
+  @Test
+  fun defaultsBlankName() {
+    val raw = "[${entry("", "http://x:1", "tok")}]"
+    assertEquals("Portal", RemoteRoster.sanitize(raw).getJSONObject(0).getString("name"))
+  }
+
+  @Test
+  fun garbageAndNonArrayBecomeEmpty() {
+    assertEquals(0, RemoteRoster.sanitize(null).length())
+    assertEquals(0, RemoteRoster.sanitize("").length())
+    assertEquals(0, RemoteRoster.sanitize("not json").length())
+    assertEquals(0, RemoteRoster.sanitize("{\"base\":\"x\"}").length()) // object, not array
+  }
+
+  @Test
+  fun capsEntryCount() {
+    val many = JSONArray()
+    for (i in 0 until RemoteRoster.MAX_ENTRIES + 25) {
+      many.put(org.json.JSONObject().put("name", "P$i").put("base", "http://h$i:1").put("token", "t$i"))
+    }
+    assertEquals(RemoteRoster.MAX_ENTRIES, RemoteRoster.sanitize(many.toString()).length())
+  }
+}

--- a/docs/features/remote.md
+++ b/docs/features/remote.md
@@ -51,6 +51,17 @@ To control more Portals, tap **+ Device** on the remote: it lists the others fou
 (mDNS); pick one and enter the PIN from *its* Settings › Remote screen. Switch between paired
 devices from the dropdown; **Forget** drops the current one.
 
+### Reconnecting (pair one, restore all)
+
+The phone keeps its device roster in the browser's local storage and reconnects silently on its
+own. But that storage isn't forever — Safari evicts an un-installed site's storage after about a
+week, a new phone or a private tab starts empty, and a changed Portal IP looks like a brand-new
+site. To avoid re-pairing the whole fleet in those cases, each paired Portal keeps a **backup of
+your roster**: when storage is lost, just pair **one** Portal again with its PIN and the rest come
+back automatically. The phone re-uploads the merged roster to every Portal whenever it changes, so
+the backups stay current (and a device you **Forget** is dropped from them too). Tip: add the page
+to your home screen — an installed web app's storage isn't evicted, so you rarely hit this at all.
+
 ## Security
 
 - The remote is served by the fleet agent, which only accepts **LAN/loopback** peers.
@@ -59,10 +70,16 @@ devices from the dropdown; **Forget** drops the current one.
   the room can pair. (The fleet bearer token also works, so the laptop CLI can drive it.)
 - App icons are served unauthenticated (they aren't secrets), which keeps the token out of image
   URLs. Everything that reads the app list or sends input is authenticated.
-- **Multi-device** keeps each Portal's token on the phone (paired per-device) — tokens are never
-  shared between Portals, so one compromised device can't drive the others. The agent sends
+- **Multi-device** keeps each Portal's token on the phone (paired per-device). A Portal never mints
+  or shares another Portal's token itself — the phone is the only courier. The agent sends
   permissive CORS headers so one Portal's page can call the others, but the LAN peer guard and the
   per-device token remain the real gates (CORS is only a browser read-policy).
+- **Roster backup** (reconnecting, above) stores the phone's token list on each paired Portal so the
+  fleet survives a storage wipe. This is gated by the same PIN that pairing uses — reading the backup
+  is no more powerful than walking up to each Portal and pairing it in person — but it does mean a
+  Portal's app storage now holds the other Portals' session tokens, so it's a deliberate trade of a
+  little blast radius for not re-pairing a wall of devices every week. Revoking (Settings › Remote)
+  still drops a device's own sessions, and a stale restored token is forgotten on its first 401.
 
 ## How input works (and its limits)
 
@@ -117,4 +134,5 @@ All under the agent's port (default `8723`). `/remote/ui`, `/remote/pair`, `/rem
 | `GET`/`POST` | `/remote/presets` | list, or replace with `{"presets":[{id,name,steps[]}]}` |
 | `POST` | `/remote/preset` | `{"id":"…"}` → run a saved preset's steps in order |
 | `GET` | `/remote/devices` | this device's name + mDNS-discovered peers `[{name,host,port}]` |
+| `GET`/`POST` | `/remote/roster` | read or replace the phone's backed-up device roster `[{name,base,token}]` |
 | `GET`/`POST` | `/remote/sources` | read or set the screensaver photo source + calendar feed |

--- a/docs/features/remote.md
+++ b/docs/features/remote.md
@@ -59,8 +59,13 @@ week, a new phone or a private tab starts empty, and a changed Portal IP looks l
 site. To avoid re-pairing the whole fleet in those cases, each paired Portal keeps a **backup of
 your roster**: when storage is lost, just pair **one** Portal again with its PIN and the rest come
 back automatically. The phone re-uploads the merged roster to every Portal whenever it changes, so
-the backups stay current (and a device you **Forget** is dropped from them too). Tip: add the page
-to your home screen — an installed web app's storage isn't evicted, so you rarely hit this at all.
+the backups stay current (and a device you **Forget** is dropped from them too).
+
+Best of all, the remote is an **installable web app** (PWA): from your browser's Share/menu choose
+**Add to Home Screen** and it installs as a standalone "Immortal" app, with the app's own icon. An
+installed app's storage isn't evicted the way a browser tab's is, so once installed you rarely lose
+the roster at all — the per-Portal backup is just the safety net. The remote also asks the browser
+for persistent storage on load (honoured on Chrome/Android), and a *Devices* tab tip points the way.
 
 ## Security
 
@@ -111,13 +116,15 @@ automatically (via `WRITE_SECURE_SETTINGS`) and which comes back on its own afte
 
 ## API
 
-All under the agent's port (default `8723`). `/remote/ui`, `/remote/pair`, `/remote/icon` and
-`/remote/art` are open on the LAN (no secrets); the rest require
-`Authorization: Bearer <session-or-fleet-token>`.
+All under the agent's port (default `8723`). `/remote/ui`, `/remote/manifest.webmanifest`,
+`/remote/app-icon`, `/remote/pair`, `/remote/icon` and `/remote/art` are open on the LAN (no
+secrets); the rest require `Authorization: Bearer <session-or-fleet-token>`.
 
 | Method | Path | Purpose |
 |---|---|---|
 | `GET` | `/remote/ui` | The remote web page |
+| `GET` | `/remote/manifest.webmanifest` | PWA manifest (installable home-screen app) |
+| `GET` | `/remote/app-icon?size=…` | Immortal's launcher icon (PNG) for install/apple-touch-icon |
 | `POST` | `/remote/pair` | `{"pin":"123456"}` → `{ok, token}` |
 | `GET` | `/remote/apps` | Launchable apps `[{label, packageName}]` |
 | `GET` | `/remote/icon?pkg=…` | App icon (PNG) |


### PR DESCRIPTION
The phone keeps its paired-device roster ({name, base, token}) only in the
browser's localStorage. That gets evicted (Safari's ~7-day cap on an
un-installed site), starts empty in a new browser/origin, and looks brand-new
after a DHCP IP change -- so a multi-device setup has to be re-paired from
scratch every time, which is poor UX.

Back the roster up on each paired Portal: the phone pushes its full roster to
every device whenever it changes, and pulls-and-merges when it pairs one. After
a storage wipe you pair a single Portal with its PIN and the rest come back
automatically ("pair one, restore all"), instead of re-pairing the fleet.

- RemoteRoster: SharedPreferences-backed store + a pure, unit-tested sanitiser
  (validate/dedupe-by-base/clamp/cap) so a malformed upload can't wedge it.
- RemoteRoutes: auth-gated GET/POST /remote/roster. The on-screen PIN that mints
  a session is the same gate that releases the roster -- reading it is no more
  powerful than pairing each Portal in person.
- RemoteHtml: push on pair/add/forget/rename; pull-and-merge on pair and on
  startup; local token always wins on conflict so a fresh session isn't clobbered.
- Docs: reconnecting + security trade-off (tokens now also live on each Portal),
  with the home-screen-install tip as the durable-storage path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0163p2xPMLPceBaiNLHk2soK