### PR TITLE
Add an optional home-screen page-width cap (off by default)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -396,6 +396,8 @@ private fun LauncherScreen(
   // widget's mode/unit), re-read on resume so a change applies the moment the user
   // comes back to the home screen.
   var tileSize by remember { mutableStateOf(ImmortalSettings.load(context).tileSize) }
+  var constrainPageWidth by
+      remember { mutableStateOf(ImmortalSettings.load(context).constrainPageWidth) }
   var weatherWidget by remember { mutableStateOf(ImmortalSettings.load(context).weatherWidget) }
   var weatherFahrenheit by remember { mutableStateOf(ImmortalSettings.useFahrenheit(context)) }
   val lifecycleOwner = LocalLifecycleOwner.current
@@ -412,6 +414,7 @@ private fun LauncherScreen(
       if (e == Lifecycle.Event.ON_RESUME) {
         val s = ImmortalSettings.load(context)
         tileSize = s.tileSize
+        constrainPageWidth = s.constrainPageWidth
         weatherWidget = s.weatherWidget
         weatherFahrenheit = ImmortalSettings.useFahrenheit(context)
         widgets = loadLiveWidgets()
@@ -806,14 +809,15 @@ private fun LauncherScreen(
     Column(
         modifier =
             Modifier.fillMaxHeight()
-                // Cap the content width and center it so the grid stays
-                // comfortably sized on large displays (e.g. Portal+ 1920px)
-                // instead of stretching 6 columns across the whole panel. On the
-                // smaller models this is effectively full-width (unchanged).
-                // (widthIn must precede fillMaxWidth so the cap wins, then align
-                // centers the capped content.)
+                // Optionally cap the content width and center it so the grid stays
+                // comfortably sized on large displays (e.g. Portal+ 1920px) instead
+                // of stretching 6 columns across the whole panel. Off by default —
+                // most users want the full screen — and gated on the user's
+                // "Constrain page width" preference; uncapped, fillMaxWidth takes the
+                // whole panel. (widthIn must precede fillMaxWidth so the cap wins,
+                // then align centers the capped content.)
                 .align(Alignment.TopCenter)
-                .widthIn(max = 1264.dp)
+                .widthIn(max = if (constrainPageWidth) 1264.dp else Dp.Infinity)
                 .fillMaxWidth()
                 // Top is padded clear of the 60dp systemui status-bar window,
                 // which silently eats touches even while hidden in immersive —

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
@@ -55,6 +55,10 @@ object ImmortalSettings {
       // Hide the system status bar (immersive). Default on — the clean wall-frame look,
       // and what provisioning seeds; swipe from the top still reveals it transiently.
       val hideStatusBar: Boolean = true,
+      // Cap the home-screen content width on large landscape displays (Portal+) instead of
+      // using the whole panel. Off by default — most users want the full screen; turning it
+      // on restores the centred, constrained grid.
+      val constrainPageWidth: Boolean = false,
       // Multi-room audio: when this Portal is a Snapcast speaker, surface what the
       // group is playing on the now-playing card (read from the Music Assistant /
       // snapserver at [snapcastHost]). Off until configured.
@@ -81,6 +85,7 @@ object ImmortalSettings {
         clockFormat = p.getString("clock_format", CLOCK_AUTO) ?: CLOCK_AUTO,
         showMiniPlayer = p.getBoolean("show_mini_player", true),
         hideStatusBar = p.getBoolean("hide_status_bar", true),
+        constrainPageWidth = p.getBoolean("constrain_page_width", false),
         multiRoomEnabled = p.getBoolean("multiroom_enabled", false),
         snapcastHost = p.getString("snapcast_host", "") ?: "",
         maPort = p.getInt("ma_port", DEFAULT_MA_PORT),
@@ -144,6 +149,9 @@ object ImmortalSettings {
 
   fun setHideStatusBar(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("hide_status_bar", on).apply()
+
+  fun setConstrainPageWidth(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("constrain_page_width", on).apply()
 
   /**
    * Whether the clock should render in 24-hour form. AUTO follows the device's

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -429,6 +429,13 @@ object SettingsDomains {
                       help =
                           "Hidden by default for a cleaner full-screen look. Swipe down from the top to reveal it briefly."),
                   BoolSpec(
+                      "constrainPageWidth",
+                      "Constrain page width",
+                      get = { it.constrainPageWidth },
+                      set = ImmortalSettings::setConstrainPageWidth,
+                      help =
+                          "Cap the home screen width on large landscape displays instead of filling the whole panel. Off by default."),
+                  BoolSpec(
                       "multiRoomEnabled",
                       "Multi-room audio",
                       get = { it.multiRoomEnabled },
@@ -470,6 +477,7 @@ object SettingsDomains {
                   "tileSize" to "Home screen",
                   "showMiniPlayer" to "Home screen",
                   "hideStatusBar" to "Home screen",
+                  "constrainPageWidth" to "Home screen",
                   "clockFormat" to "Clock",
                   "multiRoomEnabled" to "Audio",
                   "snapcastHost" to "Audio",


### PR DESCRIPTION
## What

The launcher pages had a hardcoded **1264dp** width cap (`HomeActivity.kt`) to keep the 6-column grid comfortably sized. On the larger Portal+ models in landscape this looked restrictive.

This makes the cap **opt-in**: full-width by default (what most users want), with a new **"Constrain page width"** toggle to restore the previous centred, capped layout.

## How

Added through the standard `SettingSpec` registry so it needs no bespoke UI:

- **`ImmortalSettings`** — new `constrainPageWidth: Boolean = false` field + load/setter (`constrain_page_width` pref).
- **`SettingsDomains.immortal`** — `BoolSpec` + `"Home screen"` section. Auto-renders on-device and over the phone remote.
- **`HomeActivity`** — reactive state reloaded on `ON_RESUME` (applies on return, like tile size); cap becomes `widthIn(max = if (constrainPageWidth) 1264.dp else Dp.Infinity)`.

## Behavior

Off by default → `fillMaxWidth()` uses the whole panel, so Portal+ landscape gets the full screen. Existing installs go full-width on upgrade (negligible change on small/portrait models, where 1264dp was already ≈ full-width). Toggle on → original layout returns.

## Tests

`./gradlew :app:testDebugUnitTest` passes. The existing `immortalRegistry_coversEveryPersistedField` reflection tripwire validates the new field↔spec binding — no new test required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)