### PR TITLE
Preserve custom home grid across Calls handoff

### DIFF
--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -375,10 +375,12 @@ private fun LauncherScreen(
     else @Suppress("UnspecifiedRegisterReceiverFlag") context.registerReceiver(receiver, filter)
     onDispose { runCatching { context.unregisterReceiver(receiver) } }
   }
-  val apps by
-      produceState(initialValue = emptyList<AppEntry>(), reload) {
+  val loadedApps by
+      produceState<List<AppEntry>?>(initialValue = null, reload) {
         value = withContext(Dispatchers.IO) { loadApps(context) }
       }
+  val appsLoaded = loadedApps != null
+  val apps = loadedApps.orEmpty()
   var editMode by remember { mutableStateOf(false) }
   var openFolder by remember { mutableStateOf<String?>(null) }
   var showWidgetPicker by remember { mutableStateOf(false) }
@@ -580,8 +582,8 @@ private fun LauncherScreen(
   // curated defaults: a user override wins over Curation.folderFor(). An empty
   // string is an explicit "ungrouped" override (used when dragging out of a
   // folder), so it beats a curated default too.
-  val assignments = remember { mutableStateMapOf<String, String>() }
-  LaunchedEffect(Unit) { assignments.putAll(UserLayout.load(context)) }
+  val assignments =
+      remember { mutableStateMapOf<String, String>().apply { putAll(UserLayout.load(context)) } }
   val appsEff =
       remember(apps, assignments.toMap()) {
         val effective = HomeLayoutModel.effectiveApps(apps.toLayoutRefs(), assignments)
@@ -608,8 +610,10 @@ private fun LauncherScreen(
   var gridSlots by remember { mutableStateOf(UserLayout.loadGridSlots(context)) }
   val gridColumns = gridColumnsFor(tileSize)
   // Keep the saved slot list in step with what's actually present, preserving the user's blanks.
-  LaunchedEffect(allTileKeys, gridColumns) {
-    val normalized = HomeGrid.normalizeSlots(gridSlots, allTileKeys, gridColumns)
+  LaunchedEffect(allTileKeys, gridColumns, appsLoaded) {
+    val normalized =
+        HomeGrid.normalizeSlotsWhenReady(
+            gridSlots, allTileKeys, gridColumns, dynamicTilesLoaded = appsLoaded)
     if (normalized != gridSlots) {
       gridSlots = normalized
       UserLayout.saveGridSlots(context, normalized)
@@ -887,10 +891,16 @@ private fun LauncherScreen(
           val rows = ((avail.value + 20f) / (rowH.value + 20f)).toInt().coerceAtLeast(1)
           val cap = (gridColumns * rows).coerceAtLeast(1)
           LaunchedEffect(cap) { pageCapacity = cap }
-          LaunchedEffect(allTileKeys, cap, dragKey != null) {
+          LaunchedEffect(allTileKeys, cap, dragKey != null, appsLoaded) {
             // Keep a spare empty page only while arranging; otherwise empty pages are removed.
             val normalized =
-                HomeGrid.normalizeToPages(gridSlots, allTileKeys, cap, keepSpare = dragKey != null)
+                HomeGrid.normalizeToPagesWhenReady(
+                    gridSlots,
+                    allTileKeys,
+                    cap,
+                    keepSpare = dragKey != null,
+                    dynamicTilesLoaded = appsLoaded,
+                )
             if (normalized != gridSlots) {
               gridSlots = normalized
               UserLayout.saveGridSlots(context, normalized)

--- a/app/src/main/java/com/immortal/launcher/HomeGrid.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeGrid.kt
@@ -49,6 +49,18 @@ object HomeGrid {
   }
 
   /**
+   * Normalize only once the caller has loaded dynamic launcher tiles. Before that, [keys] contains
+   * only built-ins/widgets, so reconciling would treat persisted app/folder slots as stale and
+   * overwrite the user's custom layout.
+   */
+  fun normalizeSlotsWhenReady(
+      saved: List<String?>,
+      keys: List<String>,
+      cols: Int,
+      dynamicTilesLoaded: Boolean,
+  ): List<String?> = if (dynamicTilesLoaded) normalizeSlots(saved, keys, cols) else saved
+
+  /**
    * Like [normalizeSlots] but page-aware: pads to whole [pageCapacity] pages, **auto-deletes any
    * fully-empty page**, and (when [keepSpare]) appends one trailing empty page so the user can drag
    * onto a fresh page. In-page blanks (gaps inside a page that still has tiles) are preserved.
@@ -73,6 +85,19 @@ object HomeGrid {
     if (keepSpare || out.isEmpty()) repeat(pageCapacity) { out.add(null) }
     return out
   }
+
+  /**
+   * Page-aware variant of [normalizeSlotsWhenReady]. Used by the launcher once page capacity is
+   * known; it must obey the same dynamic-load gate before persisting reconciled slots.
+   */
+  fun normalizeToPagesWhenReady(
+      saved: List<String?>,
+      keys: List<String>,
+      pageCapacity: Int,
+      keepSpare: Boolean = true,
+      dynamicTilesLoaded: Boolean,
+  ): List<String?> =
+      if (dynamicTilesLoaded) normalizeToPages(saved, keys, pageCapacity, keepSpare) else saved
 
   /** Swap the contents of two slots (either may be blank). Out-of-range/no-op returns the input. */
   fun swap(slots: List<String?>, a: Int, b: Int): List<String?> {

--- a/app/src/test/java/com/immortal/launcher/HomeGridTest.kt
+++ b/app/src/test/java/com/immortal/launcher/HomeGridTest.kt
@@ -31,6 +31,23 @@ class HomeGridTest {
   }
 
   @Test
+  fun normalizeWhenReady_keepsSavedSlotsUntilDynamicTilesLoad() {
+    val saved = listOf<String?>("builtin:calls", "app:custom", "folder:Family")
+    val partialKeys = listOf("builtin:calls", "builtin:store")
+
+    assertEquals(
+        saved,
+        HomeGrid.normalizeSlotsWhenReady(
+            saved, partialKeys, cols = 3, dynamicTilesLoaded = false),
+    )
+    assertEquals(
+        listOf("builtin:calls", null, null, "builtin:store", null, null, null, null, null),
+        HomeGrid.normalizeSlotsWhenReady(
+            saved, partialKeys, cols = 3, dynamicTilesLoaded = true),
+    )
+  }
+
+  @Test
   fun swap_exchangesTwoSlots_includingBlanks() {
     val slots = listOf<String?>("a", null, "b")
     assertEquals(listOf<String?>(null, "a", "b"), HomeGrid.swap(slots, 0, 1))
@@ -65,6 +82,32 @@ class HomeGridTest {
     assertEquals(
         listOf("a", "b", "c", "d"),
         HomeGrid.normalizeToPages(saved, listOf("a", "b", "c", "d"), 2, keepSpare = false),
+    )
+  }
+
+  @Test
+  fun normalizeToPagesWhenReady_keepsSavedSlotsUntilDynamicTilesLoad() {
+    val saved = listOf<String?>("app:a", "app:b", null, "folder:Media")
+
+    assertEquals(
+        saved,
+        HomeGrid.normalizeToPagesWhenReady(
+            saved,
+            keys = listOf("builtin:calls"),
+            pageCapacity = 4,
+            keepSpare = false,
+            dynamicTilesLoaded = false,
+        ),
+    )
+    assertEquals(
+        listOf(null, null, null, "folder:Media"),
+        HomeGrid.normalizeToPagesWhenReady(
+            saved,
+            keys = listOf("folder:Media"),
+            pageCapacity = 4,
+            keepSpare = false,
+            dynamicTilesLoaded = true,
+        ),
     )
   }
 }


### PR DESCRIPTION
## Summary
- keep saved home-grid slots untouched until the launcher app scan has completed
- load user folder assignments before deriving top-level tile keys
- add regression coverage for avoiding destructive pre-load grid reconciliation

Fixes #84.

## Tests
- `git diff --check`
- `ANDROID_HOME=/Users/simonrotzer/Library/Android/sdk ANDROID_SDK_ROOT=/Users/simonrotzer/Library/Android/sdk ./gradlew :app:testDebugUnitTest --tests com.immortal.launcher.HomeGridTest --tests com.immortal.launcher.UserLayoutTest --no-daemon`
- `ANDROID_HOME=/Users/simonrotzer/Library/Android/sdk ANDROID_SDK_ROOT=/Users/simonrotzer/Library/Android/sdk ./gradlew :app:testDebugUnitTest --no-daemon`