### PR TITLE
Make Alexa wake word opt-in

### DIFF
--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -25,8 +25,8 @@ and is fully navigable by remote on the [Portal TV](portal-tv.md).
 - **App switcher** — a top-bar control (`AppSwitcherActivity`) that lists your recently-used
   apps so you can hop between them without returning to the grid.
 - **"hey" voice button** — an optional mic button for push-to-talk to your voice assistant. It
-  appears when the companion wake-word app is installed and is supported on **first-gen Portals
-  only** — see [Alexa & voice](../guides/voice-alexa.md).
+  appears only when the companion wake-word app is explicitly enabled and installed, and is
+  supported on **first-gen Portals only** — see [Alexa & voice](../guides/voice-alexa.md).
 
 ## Tiles
 

--- a/docs/guides/voice-alexa.md
+++ b/docs/guides/voice-alexa.md
@@ -1,8 +1,8 @@
 # Alexa & voice (first-gen Portals)
 
-Immortal can revive the Portal's original on-device **Amazon Alexa** client so it does hands-free
-**"Hey Alexa"** again — text, voice, and visual answers — and adds a **"hey" button** in the home
-header for push-to-talk.
+Immortal can revive the Portal's original on-device **Amazon Alexa** client for text, voice, and
+visual answers. The always-listening **"Hey Alexa"** wake-word helper is available as a separate
+opt-in because it can keep the microphone busy during Messenger calls on some Gen-1 hardware.
 
 !!! danger "First-gen (Android 9) Portals only"
     Alexa revival and the wake word are supported on **first-gen Portals (Android 9)** — the
@@ -16,11 +16,12 @@ header for push-to-talk.
 
 ## How it works (and why it's allowed)
 
-Two pieces work together:
+Alexa support has two pieces:
 
 - **falcon** — the Portal's original Amazon Alexa client (`com.amazon.alexa.multimodal.falcon`),
   revived so it runs again on the locked, unrooted device.
-- **"hey" (Millennium)** — a small wake-word app that drives falcon hands-free.
+- **"hey" (Millennium)** — an optional wake-word app that drives falcon hands-free and adds the
+  launcher mic button.
 
 Immortal **never hosts Amazon's binary.** The provisioning kit either downloads a
 **patched-and-signed** falcon build, or reconstructs it on your machine from the **public Portal
@@ -45,11 +46,18 @@ The kit then:
 2. **Opens Alexa to link your Amazon account.** A sign-in code appears on the Portal — go to
    [amazon.com/code](https://www.amazon.com/code) and enter it. You can do this while the rest of
    setup runs.
-3. **Installs the "hey" (Millennium) wake-word app** and grants it the microphone.
-4. **Waits for Alexa to connect** (it watches for the device reaching its ready state). When it's
-   done, try: *"Hey Alexa, what's the weather?"*
+3. **Skips the "hey" (Millennium) wake-word app by default** so Messenger calls keep exclusive
+   access to clean microphone audio.
+4. **Waits for Alexa to connect** (it watches for the device reaching its ready state).
 
 Once linked, you can hide falcon's icon from the launcher — it runs headless.
+
+!!! warning "Wake word is explicit opt-in"
+    Set `INSTALL_ALEXA_WAKE_WORD=true` in `provisioning/config.env`, then re-run
+    `./provision.sh --alexa`, to install the Millennium wake-word app and show the launcher mic
+    button. This restores hands-free "Hey Alexa", but on at least one Gen-1 Portal+ it caused
+    Facebook Messenger call microphone audio to cut in and out. Leave it off if Messenger calling
+    matters on that device.
 
 !!! warning "Windows: the reconstruct path needs bspatch"
     macOS and Linux ship (or can install) `bspatch`. Windows doesn't, so on Windows use the hosted
@@ -57,7 +65,8 @@ Once linked, you can hide falcon's icon from the launcher — it runs headless.
 
 ## Using the "hey" button
 
-When the Millennium app is installed, a **"hey" mic button** appears in the home header:
+When `INSTALL_ALEXA_WAKE_WORD=true` and the Millennium app is installed, a **"hey" mic button**
+appears in the home header:
 
 - **Tap** — push-to-talk: wakes your assistant without saying the wake word.
 - **Long-press** — pick *which* assistant to talk to (the chooser is provided by Millennium;
@@ -67,7 +76,9 @@ The trigger is guarded so only the launcher itself can fire it, not other apps o
 
 ## Removing it
 
-`./provision.sh --restore` removes **only** the "hey" wake-word app.
+`./provision.sh --restore` removes **only** the "hey" wake-word app. Running
+`./provision.sh --alexa` with the default `INSTALL_ALEXA_WAKE_WORD=false` also removes Millennium
+if an older setup installed it.
 
 !!! warning "falcon is left installed on purpose"
     Uninstalling falcon drops its Amazon registration and would mint a **new ghost device** with
@@ -82,5 +93,8 @@ The trigger is guarded so only the launcher itself can fire it, not other apps o
   linking at [amazon.com/code](https://www.amazon.com/code), then re-run `./provision.sh --alexa`.
 - **Duplicate-permission conflict with `com.amazon.dee.app`** — the standalone Amazon Alexa app
   conflicts with falcon's permissions; a coexistence build is needed, so remove that app or skip it.
-- **Wake word never triggers** — the "hey" (Millennium) app must be installed and hold the
-  microphone permission; re-run the Alexa step to reinstall it.
+- **Wake word never triggers** — set `INSTALL_ALEXA_WAKE_WORD=true` in `config.env`, then re-run
+  the Alexa step so the "hey" (Millennium) app is installed and holds the microphone permission.
+- **Messenger calls sound broken after enabling wake word** — turn the wake word back off by
+  setting `INSTALL_ALEXA_WAKE_WORD=false` and re-running `./provision.sh --alexa`, or run
+  `./provision.sh --restore`.

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -122,7 +122,7 @@ Enter):
 | Prompt | What it means | Suggested answer |
 | --- | --- | --- |
 | **Block Meta OS updates?** | Stops a future Meta update from silently undoing your setup. The Portal is discontinued, so you give up only unlikely future patches. | **Yes** (default) |
-| **Restore Amazon Alexa?** *(first-gen only)* | Revives hands-free "Hey Alexa." See the [Alexa & voice guide](guides/voice-alexa.md). | Your call — `y` to set it up |
+| **Restore Amazon Alexa?** *(first-gen only)* | Revives the original Alexa client. The always-on "Hey Alexa" wake word is a separate opt-in because it can interfere with Messenger call audio on some Gen-1 hardware. See the [Alexa & voice guide](guides/voice-alexa.md). | Your call — `y` to set up Alexa |
 | **Device name** *(only with `--fleet`)* | A friendly name for [fleet management](features/fleet.md), e.g. "Living Room". | Whatever you like |
 
 If you don't want to be asked at all, you can preset these in `config.env` (see

--- a/provisioning/README.md
+++ b/provisioning/README.md
@@ -48,6 +48,7 @@ installs → freeze OS updates → set launcher → set screensaver. Each step i
 | `PREINSTALL_FDROID`, `PREINSTALL_APKS` | Apps to pre-install during setup (see below) |
 | `APK_GLOB` | Which APK to install (drop yours in `apks/`) |
 | `ASSET_DIR` | Photos pushed to the frame (first becomes `frame.jpg`) |
+| `RESTORE_ALEXA`, `INSTALL_ALEXA_WAKE_WORD` | First-gen Alexa restore and the separate opt-in wake-word helper |
 
 To ship your own app instead of the sample, replace `apks/app-debug.apk`, drop photos in
 `assets/`, and update `PKG`/`HOME_ACTIVITY`/`DREAM_SERVICE` in `config.env`.

--- a/provisioning/config.env
+++ b/provisioning/config.env
@@ -136,13 +136,13 @@ RELEASE_APK_URL=
 SHIZUKU_APK_URL="https://github.com/RikkaApps/Shizuku/releases/download/v13.6.0/shizuku-v13.6.0.r1086.2650830c-release.apk"
 
 # ---- Restore the original Amazon Alexa app (the "hey" free tier) -------------
-# Optional. Revives the discontinued on-device Alexa client ("falcon") so the
-# Portal does hands-free "Hey Alexa" again (text + voice + visual). We never host
-# Amazon's binary: the user downloads the PUBLIC stock APK from a firmware dump,
-# and we ship only a BINARY DIFF that reconstructs our patched+signed build
-# byte-for-byte. Run inline (you're asked y/N during provisioning) or standalone
-# with `./provision.sh --alexa`. NEVER uninstalls falcon (that would register a
-# new ghost device with Amazon); --restore removes only the wake-word app.
+# Optional. Revives the discontinued on-device Alexa client ("falcon") for text,
+# voice, and visual answers. We never host Amazon's binary: the user downloads
+# the PUBLIC stock APK from a firmware dump, and we ship only a BINARY DIFF that
+# reconstructs our patched+signed build byte-for-byte. Run inline (you're asked
+# y/N during provisioning) or standalone with `./provision.sh --alexa`. NEVER
+# uninstalls falcon (that would register a new ghost device with Amazon);
+# --restore removes only the wake-word app.
 #
 # RESTORE_ALEXA: blank = ask when interactive (skip in CI); true/false = force.
 RESTORE_ALEXA=
@@ -161,7 +161,11 @@ FALCON_BSDIFF_URL="https://github.com/starbrightlab/hey-dist/releases/download/v
 # hosted falcon.bsdiff actually reconstructs. (drop-7 added EXTENSION/SKILL drops for the A10
 # Portal Go's newer dee.app, but A10 isn't supported yet + drop-7 was never re-validated on A9.)
 FALCON_RESULT_SHA256=76133f807e492e46aaf58e6ae503e623a93af840eaa3eccfb8630f1ecab3268d
-# The "hey" wake-word app (free build).
+# The "hey" wake-word app (free build). This app keeps a background microphone
+# listener so the wake word can work. On at least one Gen-1 Portal+ it appears to
+# starve Facebook Messenger calls of clean mic audio; restore fixes calls by
+# removing only this package. Keep it opt-in until that interaction is understood.
+INSTALL_ALEXA_WAKE_WORD=false
 MILLENNIUM_PKG=com.millennium
 MILLENNIUM_APK_URL="https://github.com/starbrightlab/hey-dist/releases/download/v0.1.0/millennium.apk"
 # Local-path overrides for testing before the hosted URLs exist (any that are set

--- a/provisioning/provision.ps1
+++ b/provisioning/provision.ps1
@@ -367,12 +367,14 @@ function Set-Screensaver {
 # ----- Alexa restore (the "hey" free tier) -----------------------------------
 # Mirrors provision.sh's restore_alexa: reconstruct our patched+signed falcon from
 # the PUBLIC stock APK via our binary diff, install it, apply the privileged grants,
-# then install the wake-word app. Optional, opt-in, NON-FATAL (a failure here never
-# aborts the rest of the provision - we Warn + return, never Die).
+# then optionally install the wake-word app. Optional, opt-in, NON-FATAL (a failure
+# here never aborts the rest of the provision - we Warn + return, never Die).
 #
 # WINDOWS CAVEAT: unlike macOS, Windows ships no `bspatch`. So either install one
 # and point BSPATCH_EXE at it, or set FALCON_PATCHED_LOCAL to a prebuilt APK. With
-# neither, the falcon step is skipped with guidance (the rest still runs).
+# neither, the falcon step is skipped with guidance (the rest still runs). The
+# wake-word app is separate and explicit opt-in because it keeps a background mic
+# listener that can interfere with Messenger calls on Gen-1 Portal+.
 function Get-Sha256($path) { (Get-FileHash -Algorithm SHA256 -Path $path).Hash.ToLower() }
 
 function Restore-Alexa {
@@ -475,19 +477,31 @@ function Restore-Alexa {
   Warn "If this Portal isn't linked yet, an Amazon sign-in is now on screen - go to amazon.com/code and enter the code shown (you can do this while the rest of setup runs)."
 
   # 4. millennium = the "hey" wake-word app (drives falcon hands-free).
+  # It keeps a background mic listener. Because that can interfere with Messenger
+  # calls on at least one Gen-1 Portal+, make it explicit opt-in and remove our
+  # previously installed copy when the option is off.
   $mp = if ($cfg["MILLENNIUM_PKG"]) { $cfg["MILLENNIUM_PKG"] } else { "com.millennium" }
-  $mapk = $null
-  if ($cfg["MILLENNIUM_APK_LOCAL"] -and (Test-Path $cfg["MILLENNIUM_APK_LOCAL"])) { $mapk = $cfg["MILLENNIUM_APK_LOCAL"] }
-  elseif ($cfg["MILLENNIUM_APK_URL"]) {
-    Step "Downloading the hey (millennium) app"
-    try { Invoke-WebRequest $cfg["MILLENNIUM_APK_URL"] -OutFile (Join-Path $work "millennium.apk"); $mapk = Join-Path $work "millennium.apk" }
-    catch { Warn "millennium download failed (Alexa text/voice still works; wake word needs it)" }
+  $installWake = $cfg["INSTALL_ALEXA_WAKE_WORD"] -eq "true"
+  if ($installWake) {
+    $mapk = $null
+    if ($cfg["MILLENNIUM_APK_LOCAL"] -and (Test-Path $cfg["MILLENNIUM_APK_LOCAL"])) { $mapk = $cfg["MILLENNIUM_APK_LOCAL"] }
+    elseif ($cfg["MILLENNIUM_APK_URL"]) {
+      Step "Downloading the hey (millennium) app"
+      try { Invoke-WebRequest $cfg["MILLENNIUM_APK_URL"] -OutFile (Join-Path $work "millennium.apk"); $mapk = Join-Path $work "millennium.apk" }
+      catch { Warn "millennium download failed (Alexa text/voice still works; wake word needs it)" }
+    }
+    if ($mapk -and (Test-Path $mapk)) {
+      Step "Installing hey (millennium)"
+      A install -r $mapk | Out-Null; Ok "millennium installed"
+    }
+    if ("$(A shell pm path $mp)".Trim()) { A shell pm grant $mp android.permission.RECORD_AUDIO | Out-Null }
+  } else {
+    Step "Skipping the hey (millennium) wake-word app"
+    if ("$(A shell pm path $mp)".Trim()) {
+      A uninstall $mp | Out-Null; Ok "millennium removed"
+    }
+    Warn "Wake word is off by default because its always-on mic can break Messenger call audio on Gen-1 Portal+ (#86). Set INSTALL_ALEXA_WAKE_WORD=true in config.env to opt in."
   }
-  if ($mapk -and (Test-Path $mapk)) {
-    Step "Installing hey (millennium)"
-    A install -r $mapk | Out-Null; Ok "millennium installed"
-  }
-  if ("$(A shell pm path $mp)".Trim()) { A shell pm grant $mp android.permission.RECORD_AUDIO | Out-Null }
 
   # 5. Wait for ReadyState - EVENT-DRIVEN, not on a timer. falcon logs `AccountRegisteredCondition:
   # isMet` the instant the Amazon account is linked, and never before, so it's a precise "sign-in just
@@ -513,8 +527,12 @@ function Restore-Alexa {
     Start-Sleep -Seconds 5
   }
   if ($ready) {
-    if ("$(A shell pm path $mp)".Trim()) { A shell am start -n "$mp/com.millennium.ui.HeyActivity" | Out-Null }
-    Ok "Alexa connected (ReadyState) - say 'Hey Alexa, what's the weather?'"
+    if ($installWake) {
+      if ("$(A shell pm path $mp)".Trim()) { A shell am start -n "$mp/com.millennium.ui.HeyActivity" | Out-Null }
+      Ok "Alexa connected (ReadyState) - say 'Hey Alexa, what's the weather?'"
+    } else {
+      Ok "Alexa connected (ReadyState); wake word left off for Messenger call compatibility"
+    }
     Write-Host "  Once linked, you can hide falcon's icon from the launcher - it runs headless." -ForegroundColor DarkGray
   } else {
     Warn "Alexa didn't connect within ~6 min. Check Wi-Fi + that the Amazon account is linked, then re-run with -Alexa."
@@ -534,7 +552,7 @@ function Maybe-Restore-Alexa {
     if ([Environment]::UserInteractive) {
       Write-Host ""
       Write-Host "Restore Amazon Alexa on this Portal?" -ForegroundColor White
-      Write-Host "  Revives the original Alexa app - hands-free 'Hey Alexa', with text, voice and visual answers."
+      Write-Host "  Revives the original Alexa app for text, voice and visual answers. Wake word is a separate opt-in."
       $ans = Read-Host "  [y/N]"
       $want = if ($ans -match '^[Yy]') { "true" } else { "false" }
     } else { $want = "false" }

--- a/provisioning/provision.sh
+++ b/provisioning/provision.sh
@@ -19,8 +19,8 @@
 #                             for the laptop fleet tool (the persistent channel)
 #   ./provision.sh --wifi-adb on-demand raw adb-over-WiFi for shell/scrcpy (temp;
 #                             pauses Shizuku, resets on reboot)
-#   ./provision.sh --alexa    restore the original Amazon Alexa app (the "hey"
-#                             free tier): revive falcon + install the wake word
+#   ./provision.sh --alexa    restore the original Amazon Alexa app; the "hey"
+#                             wake word is a separate config opt-in
 
 set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -499,10 +499,10 @@ set_screensaver() {
 # Revives the original Amazon Alexa client ("falcon") on this locked, unrooted
 # Portal: reconstruct our patched+signed APK from the PUBLIC stock dump via our
 # binary diff (we never host Amazon's binary), install it, apply the privileged
-# grants, then install the "hey" wake-word app. Optional, opt-in, and NON-FATAL:
-# a failure here never aborts an otherwise-successful provision. Config in
-# config.env (ALEXA_* / FALCON_* / MILLENNIUM_*); local-path overrides let us
-# test against built artifacts before the hosted URLs exist.
+# grants, then optionally install the "hey" wake-word app. Optional, opt-in, and
+# NON-FATAL: a failure here never aborts an otherwise-successful provision.
+# Config in config.env (ALEXA_* / FALCON_* / MILLENNIUM_*); local-path overrides
+# let us test against built artifacts before the hosted URLs exist.
 sha256() {
   if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | awk '{print $1}'
   elif command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'
@@ -597,7 +597,7 @@ restore_alexa() {
   ok "falcon provisioned"
 
   # 3b. Surface the Amazon sign-in NOW, right after install, so a fresh Portal shows the linking
-  #     code immediately and the user can complete registration WHILE we install the wake app and
+  #     code immediately and the user can complete registration while we finish the Alexa step and
   #     wait to connect — turning a fresh setup into a single pass. (Already-linked Portals just
   #     reconnect; this launch is harmless for them.) We clear logcat here so the ReadyState we
   #     watch for below is from this launch onward, not a stale entry from a prior run.
@@ -608,17 +608,29 @@ restore_alexa() {
   printf "  %sIf this Portal isn't linked yet, an Amazon sign-in is now on screen — go to amazon.com/code\n  and enter the code shown. You can do this while the rest of setup runs.%s\n" "$Y" "$N"
 
   # 4. millennium = the "hey" wake-word app (drives falcon hands-free).
+  # It keeps a background mic listener. Because that can interfere with Messenger
+  # calls on at least one Gen-1 Portal+, make it explicit opt-in and remove our
+  # previously installed copy when the option is off.
   local MP="${MILLENNIUM_PKG:-com.millennium}"
-  local mapk="${MILLENNIUM_APK_LOCAL:-}"
-  if [ -z "$mapk" ] && [ -n "${MILLENNIUM_APK_URL:-}" ]; then
-    step "Downloading the hey (millennium) app"
-    if curl -fSL --retry 2 -o "$work/millennium.apk" "$MILLENNIUM_APK_URL" 2>/dev/null; then mapk="$work/millennium.apk"; else warn "millennium download failed (Alexa text/voice still works; wake word needs it)"; fi
+  local install_wake="${INSTALL_ALEXA_WAKE_WORD:-false}"
+  if [ "$install_wake" = true ]; then
+    local mapk="${MILLENNIUM_APK_LOCAL:-}"
+    if [ -z "$mapk" ] && [ -n "${MILLENNIUM_APK_URL:-}" ]; then
+      step "Downloading the hey (millennium) app"
+      if curl -fSL --retry 2 -o "$work/millennium.apk" "$MILLENNIUM_APK_URL" 2>/dev/null; then mapk="$work/millennium.apk"; else warn "millennium download failed (Alexa text/voice still works; wake word needs it)"; fi
+    fi
+    if [ -n "$mapk" ] && [ -f "$mapk" ]; then
+      step "Installing hey (millennium)"
+      a install -r "$mapk" >/dev/null 2>&1 && ok "millennium installed" || warn "millennium install failed"
+    fi
+    a shell pm path "$MP" >/dev/null 2>&1 && a shell pm grant "$MP" android.permission.RECORD_AUDIO >/dev/null 2>&1
+  else
+    step "Skipping the hey (millennium) wake-word app"
+    if a shell pm path "$MP" >/dev/null 2>&1; then
+      a uninstall "$MP" >/dev/null 2>&1 && ok "millennium removed" || warn "Couldn't remove millennium"
+    fi
+    warn "Wake word is off by default because its always-on mic can break Messenger call audio on Gen-1 Portal+ (#86). Set INSTALL_ALEXA_WAKE_WORD=true in config.env to opt in."
   fi
-  if [ -n "$mapk" ] && [ -f "$mapk" ]; then
-    step "Installing hey (millennium)"
-    a install -r "$mapk" >/dev/null 2>&1 && ok "millennium installed" || warn "millennium install failed"
-  fi
-  a shell pm path "$MP" >/dev/null 2>&1 && a shell pm grant "$MP" android.permission.RECORD_AUDIO >/dev/null 2>&1
 
   # 5. Wait for ReadyState — EVENT-DRIVEN, not on a timer. falcon is already on screen (3b).
   #
@@ -648,8 +660,12 @@ restore_alexa() {
     sleep 5; i=$((i + 1))
   done
   if [ "$ready" = 1 ]; then
-    a shell pm path "$MP" >/dev/null 2>&1 && a shell am start -n "$MP/com.millennium.ui.HeyActivity" >/dev/null 2>&1
-    ok "Alexa connected (ReadyState) — say \"Hey Alexa, what's the weather?\""
+    if [ "$install_wake" = true ]; then
+      a shell pm path "$MP" >/dev/null 2>&1 && a shell am start -n "$MP/com.millennium.ui.HeyActivity" >/dev/null 2>&1
+      ok "Alexa connected (ReadyState) — say \"Hey Alexa, what's the weather?\""
+    else
+      ok "Alexa connected (ReadyState); wake word left off for Messenger call compatibility"
+    fi
     printf "  %sOnce linked, you can hide falcon's icon from the launcher — it runs headless.%s\n" "$D" "$N"
   else
     warn "Alexa didn't connect within ~6 min. Check Wi-Fi + that the Amazon account is linked, then re-run './provision.sh --alexa'."
@@ -670,7 +686,7 @@ maybe_restore_alexa() {
   if [ -z "$want" ]; then
     if [ -t 0 ]; then
       printf "\n%sRestore Amazon Alexa on this Portal?%s Revives the original Alexa app —\n" "$B" "$N"
-      printf "  hands-free \"Hey Alexa\", with text, voice and visual answers. %s[y/N]%s " "$B" "$N"
+      printf "  text, voice and visual answers. Wake word is a separate opt-in. %s[y/N]%s " "$B" "$N"
       local ans; read -r ans || ans=""
       case "$ans" in [Yy]*) want=true ;; *) want=false ;; esac
     else


### PR DESCRIPTION
## Summary
- make the Millennium wake-word helper opt-in via `INSTALL_ALEXA_WAKE_WORD=false`
- remove any existing `com.millennium` install when re-running the Alexa step with the safer default
- update the Alexa/provisioning docs to separate falcon setup from the always-on wake-word helper

## Why
Issue #86 reports broken Messenger microphone audio on a Gen-1 Portal+ when Alexa is enabled, with `Restore-Portal` immediately fixing calls. Repo evidence points at Millennium as the smallest defensible mitigation target: restore removes only `com.millennium` and deliberately leaves falcon installed, while Millennium is the component that owns the always-on wake-word microphone path.

This keeps falcon/account linking intact and makes the background microphone helper explicit opt-in until the device interaction is better understood.

## Validation
- `bash -n provisioning/provision.sh`
- Windows script ASCII guard via Python byte scan
- `git diff --check`

Not run locally:
- PowerShell parser check (`pwsh` is not installed in this environment)
- MkDocs strict build (`mkdocs` is not installed in this environment)
