### PR TITLE
Fix Calls bouncing back to Immortal when Immortal process is killed during stock-home handoff

### DIFF
--- a/app/src/main/java/com/immortal/launcher/DreamPolicy.kt
+++ b/app/src/main/java/com/immortal/launcher/DreamPolicy.kt
@@ -37,6 +37,9 @@ import android.util.Log
  */
 object DreamPolicy {
   private const val TAG = "ImmortalDream"
+  private const val PREFS = "dream_bridge"
+  private const val KEY_BRIDGE_AT = "bridge_at"
+  private const val KEY_IN_STOCK_HANDOFF = "in_stock_handoff"
 
   /** Set by [PhotoDreamService] just before finish() on a user tap. */
   @Volatile var userExitAt: Long = 0L
@@ -48,6 +51,11 @@ object DreamPolicy {
    * make us relaunch our photo frame over the top of the stock home and trap the
    * user there (the reported "Calls kicks me back into Immortal"). While a bridge
    * is in flight we suppress that relaunch.
+   *
+   * Persisted to SharedPreferences via [markBridge]/[clearBridge] so that if the
+   * Immortal process is killed while the stock home is in the foreground (Android
+   * reclaims it as a non-foreground launcher), a freshly-spawned process still sees
+   * the bridge and returns SUPPRESSED instead of REDREAM.
    */
   @Volatile var bridgeAt: Long = 0L
 
@@ -59,6 +67,42 @@ object DreamPolicy {
    * idle as usual — we only skip the aggressive "permanent frame" relaunch.
    */
   @Volatile var inStockHandoff: Boolean = false
+
+  /**
+   * Called from [ImmortalApp.onCreate] to restore bridge state after a process restart.
+   * Without this, a new process spawned for a dream-service invocation sees default
+   * (zeroed) values and classifies the dream stop as REDREAM, relaunching the photo
+   * frame over the in-progress call.
+   */
+  fun initFromPrefs(context: Context) {
+    val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    bridgeAt = prefs.getLong(KEY_BRIDGE_AT, 0L)
+    inStockHandoff = prefs.getBoolean(KEY_IN_STOCK_HANDOFF, false)
+    if (inStockHandoff) Log.i(TAG, "restored bridge from prefs: bridgeAt=$bridgeAt inStockHandoff=true")
+  }
+
+  /** Called by [HomeActivity.launchStockHome] — persists bridge so new processes see it. */
+  fun markBridge(context: Context) {
+    val now = System.currentTimeMillis()
+    bridgeAt = now
+    inStockHandoff = true
+    context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        .edit()
+        .putLong(KEY_BRIDGE_AT, now)
+        .putBoolean(KEY_IN_STOCK_HANDOFF, true)
+        .apply()
+  }
+
+  /** Called by [HomeActivity.onResume] when the user returns — clears persisted bridge. */
+  fun clearBridge(context: Context) {
+    inStockHandoff = false
+    bridgeAt = 0L
+    context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        .edit()
+        .remove(KEY_BRIDGE_AT)
+        .remove(KEY_IN_STOCK_HANDOFF)
+        .apply()
+  }
 
   fun hasBattery(context: Context): Boolean =
       runCatching {

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -247,7 +247,7 @@ class HomeActivity : ComponentActivity() {
     super.onResume()
     // The user is back on Immortal, so any stock-launcher call handoff is over:
     // allow the photo frame to resume its normal screensaver behaviour.
-    DreamPolicy.inStockHandoff = false
+    DreamPolicy.clearBridge(this)
     SettingsGuard.reaffirmScreensaver(this)
     // The user is back on the launcher: end the idle session and, inside the overnight window,
     // arm the touch-renewed "you have the device" session. SleepScheduler owns that policy.
@@ -295,8 +295,9 @@ class HomeActivity : ComponentActivity() {
     // Suppress the screensaver-relaunch race while the stock home comes forward, and
     // keep suppressing the holding-frame relaunch until the user returns to Immortal
     // (cleared in onResume) so the frame can't slam over an in-progress call.
-    DreamPolicy.bridgeAt = System.currentTimeMillis()
-    DreamPolicy.inStockHandoff = true
+    // Persisted to SharedPreferences so new Immortal processes spawned after Android
+    // kills our process also see the bridge and return SUPPRESSED (not REDREAM).
+    DreamPolicy.markBridge(this)
 
     // Preferred path: a short burst of system Back presses reliably surfaces Meta's stock
     // launcher (verified on the Portal TV) — unlike the portal:// deep link or a HOME launch,

--- a/app/src/main/java/com/immortal/launcher/ImmortalApp.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalApp.kt
@@ -26,6 +26,12 @@ class ImmortalApp : Application() {
     // default-home role (→ "Select Home app" chooser). This relaunches us straight back so the
     // user never sees it. Installed up front so a crash during the rest of onCreate is covered too.
     CrashGuard.install(this)
+    // Restore bridge state persisted by HomeActivity.launchStockHome. If Android killed our
+    // process while the stock Portal home was in the foreground and a new process is now
+    // starting to handle a PhotoDreamService instance, DreamPolicy would otherwise see
+    // default (zeroed) values and classify the dream-stop as REDREAM — relaunching the photo
+    // frame over the in-progress call. Must run before the DREAMING_STOPPED receiver below.
+    DreamPolicy.initFromPrefs(this)
     // The shared presence source of truth: owns DREAMING_STARTED / SCREEN_OFF / POWER and
     // exposes one PresenceState for the screensaver (in-process) and the Snapcast companion
     // (broadcast). DREAMING_STOPPED stays here because it also drives the frame relaunch, and


### PR DESCRIPTION
## Summary

- **Root cause:** When Android kills the Immortal process while the stock Portal home is in the foreground (reclaiming it as a non-foreground launcher), the next `PhotoDreamService` invocation starts in a brand-new process. That process's `DreamPolicy` has default values (`bridgeAt=0`, `inStockHandoff=false`), so `classifyDreamStop` returns `REDREAM` and relaunches `PhotoFramePreviewActivity` over the in-progress call — the reported "Calls kicks me back into Immortal".

- **Confirmed on device (Portal+ Gen 1, Android 9):** Two consecutive dreams are fired when the stock home takes over. The first fires in the original process (pid 14748), returns SUPPRESSED correctly. The second fires in a new process (pid 15407) with default DreamPolicy state, returns REDREAM, overlays the photo frame.

- **Fix:** `DreamPolicy.markBridge(context)` and `clearBridge(context)` persist/clear the bridge state in SharedPreferences. `DreamPolicy.initFromPrefs(context)` is called first thing in `ImmortalApp.onCreate()` (before the `DREAMING_STOPPED` receiver registers) so any newly-spawned process restores the correct state.

## Files changed

- `DreamPolicy.kt` — adds `markBridge`, `clearBridge`, `initFromPrefs` (SharedPreferences persistence)
- `HomeActivity.kt` — `launchStockHome` calls `DreamPolicy.markBridge(this)`, `onResume` calls `DreamPolicy.clearBridge(this)`  
- `ImmortalApp.kt` — calls `DreamPolicy.initFromPrefs(this)` before registering the receiver

## Test plan

- [ ] Tap Calls tile → stock Portal home opens and stays open (photo frame does NOT overlay)
- [ ] Make or browse contacts, then press back → returns to Immortal home cleanly
- [ ] Idle on stock home > 8s, back button back → still no photo frame overlay during the call session
- [ ] Unit tests pass (`./gradlew :app:testDebugUnitTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)