### PR TITLE
Persist the Calls handoff bridge durably (commit, not apply)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/DreamPolicy.kt
+++ b/app/src/main/java/com/immortal/launcher/DreamPolicy.kt
@@ -86,11 +86,17 @@ object DreamPolicy {
     val now = System.currentTimeMillis()
     bridgeAt = now
     inStockHandoff = true
+    // commit() (synchronous), not apply(): the whole point of persisting the bridge is the case
+    // where Android kills our process during the stock-home handoff. apply() only schedules an
+    // async disk write, which QueuedWork is not guaranteed to flush before a low-memory kill — so
+    // the freshly-spawned process could read stale (zeroed) prefs and relaunch the frame over the
+    // call anyway. commit() flushes before we proceed to bring the stock home forward; the write is
+    // a single long+bool to a dedicated prefs file, fired once at a deliberate Calls tap.
     context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
         .edit()
         .putLong(KEY_BRIDGE_AT, now)
         .putBoolean(KEY_IN_STOCK_HANDOFF, true)
-        .apply()
+        .commit()
   }
 
   /** Called by [HomeActivity.onResume] when the user returns — clears persisted bridge. */


### PR DESCRIPTION
## Summary

Follow-up hardening to #90. `DreamPolicy.markBridge` persisted the stock-home handoff bridge with `apply()`, which only schedules an **async** SharedPreferences write.

The entire reason the bridge is persisted (#90) is the case where Android kills the Immortal process *during* the handoff. If the kill lands before `QueuedWork` flushes the `apply()`, the freshly-spawned process reads stale (zeroed) prefs, classifies the dream-stop as `REDREAM`, and relaunches the photo frame over the in-progress call — the exact bug #90 set out to fix.

This switches the write to `commit()` so the bridge is on disk before we bring the stock home forward.

## Why `commit()` here (and not elsewhere)

- The write is a single `long` + `bool` to a dedicated `dream_bridge` prefs file, fired once at a deliberate Calls tap, so the synchronous cost is negligible (no ANR risk).
- `clearBridge` deliberately stays on `apply()`: losing a clear on a process kill is harmless and self-heals on the next `HomeActivity.onResume`.

## Why not a time-based bound on `inStockHandoff`

The other option considered was expiring `inStockHandoff` after a timeout. That is **unsafe**: a long phone call legitimately keeps the bridge active for its whole duration, so a time bound could let the photo frame slam over an active call — reintroducing #90's bug. The suppression is intentionally cleared by returning to the launcher, not by a clock.

## Files changed

- `DreamPolicy.kt` — `markBridge` now uses `commit()` instead of `apply()`, with a comment explaining the kill-durability requirement.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — 234 tests, 0 failures
- [ ] On-device (Portal+ Gen 1): tap Calls, force a process kill during the stock-home handoff, confirm the photo frame does not overlay the call after the new process spawns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4SmhtgSd5B5sdTiV216XM)_