### PR TITLE
Keyless standalone tools: Converter, IssPasses, Aurora, StarField, SkyColors

### DIFF
--- a/app/src/main/java/com/immortal/launcher/Aurora.kt
+++ b/app/src/main/java/com/immortal/launcher/Aurora.kt
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import java.net.HttpURLConnection
+import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.sin
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Keyless "is there a chance of aurora *here* tonight" check for the home screen —
+ * location-driven, works in any country and either hemisphere.
+ *
+ * The planetary K-index (Kp 0–9) measures global geomagnetic disturbance, but whether
+ * *you* can see the aurora depends on how far the glowing oval has pushed toward the
+ * equator versus how close you sit to the magnetic pole. So [status]:
+ *   1. pulls the latest Kp + the next-24 h forecast peak from NOAA SWPC (keyless);
+ *   2. converts the device's geographic lat/lon to **geomagnetic latitude** (dipole
+ *      tilt — a Portal in Tromsø and one in Tasmania get judged correctly); and
+ *   3. compares that to the Kp-driven equatorward edge of the auroral oval to decide
+ *      whether there's no chance, a horizon-glow chance, or aurora likely overhead.
+ *
+ * The tile only "lights up" when there's actually something to go outside for.
+ */
+object Aurora {
+
+  /** How good the odds are at the device's latitude right now / tonight. */
+  enum class Chance {
+    NONE,
+    SLIM,
+    POSSIBLE,
+    LIKELY,
+  }
+
+  data class Status(
+      val kpNow: Double,
+      val kpForecast: Double, // peak Kp over the next ~24 h
+      val geomagLat: Double, // device geomagnetic latitude (deg, signed)
+      val chance: Chance,
+      val headline: String,
+      val detail: String,
+      /** "N" or "S" — which horizon to face (poleward in the device's hemisphere). */
+      val lookToward: String,
+  )
+
+  /**
+   * Current aurora outlook for the device, or null if location/network is unavailable.
+   * Touches the network only for the two SWPC feeds; all the latitude math is local.
+   */
+  // The tile fetches on every home-screen entry; cache the Kp pair briefly so we don't
+  // hammer NOAA. Kp is a 3-hourly index — 15 minutes is plenty fresh.
+  private const val KP_CACHE_MS = 15L * 60 * 1000
+  @Volatile private var cachedKp: Pair<Double, Double>? = null
+  @Volatile private var cachedKpAt = 0L
+
+  fun status(context: Context): Status? {
+    val (lat, lon) = Weather.coordinates(context) ?: return null
+    val (kpNow, kpForecast) = kpPair() ?: return null
+    return classify(lat, lon, kpNow, kpForecast)
+  }
+
+  /** (kpNow, kpForecastPeak) from cache or a fresh fetch. Null if it can't be fetched. */
+  private fun kpPair(): Pair<Double, Double>? {
+    val cached = cachedKp
+    if (cached != null && System.currentTimeMillis() - cachedKpAt < KP_CACHE_MS) return cached
+    val kpNow = fetchCurrentKp() ?: return cached // fall back to stale cache if offline
+    val kpForecast = fetchForecastPeakKp().coerceAtLeast(kpNow)
+    val pair = kpNow to kpForecast
+    cachedKp = pair
+    cachedKpAt = System.currentTimeMillis()
+    return pair
+  }
+
+  // ---- The science (pure, unit-tested) -----------------------------------------
+
+  private const val DEG = PI / 180.0
+
+  // IGRF geomagnetic north pole (epoch ~2020): the dipole axis the oval hangs from.
+  private const val POLE_LAT = 80.65
+  private const val POLE_LON = -72.68
+
+  /**
+   * Lowest **geomagnetic** latitude at which the aurora typically reaches the horizon,
+   * indexed by integer Kp 0..9. From the standard NOAA/space-weather viewing tables
+   * (very nearly linear: ≈ 66.5 − 2.05·Kp).
+   */
+  private val KP_BOUNDARY =
+      doubleArrayOf(66.5, 64.5, 62.4, 60.4, 58.3, 56.3, 54.2, 52.2, 50.1, 48.1)
+
+  /** Interpolated equatorward oval edge (geomagnetic deg) for a fractional [kp]. */
+  fun boundaryLat(kp: Double): Double {
+    val k = kp.coerceIn(0.0, 9.0)
+    val lo = k.toInt()
+    if (lo >= 9) return KP_BOUNDARY[9]
+    val frac = k - lo
+    return KP_BOUNDARY[lo] + (KP_BOUNDARY[lo + 1] - KP_BOUNDARY[lo]) * frac
+  }
+
+  /** Geomagnetic latitude (signed deg) of a geographic point, via the tilted dipole. */
+  fun geomagLatitude(latDeg: Double, lonDeg: Double): Double {
+    val lat = latDeg * DEG
+    val lon = lonDeg * DEG
+    val pLat = POLE_LAT * DEG
+    val pLon = POLE_LON * DEG
+    val sinMag =
+        sin(lat) * sin(pLat) + cos(lat) * cos(pLat) * cos(lon - pLon)
+    return asin(sinMag.coerceIn(-1.0, 1.0)) / DEG
+  }
+
+  /** Decide the outlook from location + Kp. [kpView] (forecast-aware) drives the oval;
+   * [kpNow] is reported for context. Public + side-effect-free for tests. */
+  fun classify(latDeg: Double, lonDeg: Double, kpNow: Double, kpView: Double): Status {
+    val geomag = geomagLatitude(latDeg, lonDeg)
+    val absMag = abs(geomag)
+    val boundary = boundaryLat(kpView)
+    val margin = absMag - boundary // ≥0 means the oval has reached you
+    val northern = geomag >= 0
+    val look = if (northern) "N" else "S"
+    val poleWord = if (northern) "northern" else "southern"
+
+    // SLIM = the oval isn't reaching you now, but you're poleward of the Kp-9 limit
+    // (48.1°), so a severe storm *could*. Below that limit, it's never visible here.
+    val chance =
+        when {
+          margin >= -0.5 -> Chance.LIKELY
+          margin >= -4.0 -> Chance.POSSIBLE
+          absMag >= boundaryLat(9.0) -> Chance.SLIM
+          else -> Chance.NONE
+        }
+
+    val kpStr = fmtKp(kpView)
+    val headline =
+        when (chance) {
+          Chance.LIKELY -> "Aurora likely overhead tonight"
+          Chance.POSSIBLE -> "Aurora possible low on the $poleWord horizon"
+          Chance.SLIM -> "Slim chance — only in a strong storm"
+          Chance.NONE -> "No aurora chance at your latitude"
+        }
+    val detail =
+        when (chance) {
+          Chance.NONE ->
+              "Kp $kpStr. At ${fmt(absMag)}° geomagnetic you're too far from the pole — " +
+                  "even a max Kp 9 storm only reaches ${fmt(boundaryLat(9.0))}°."
+          Chance.SLIM ->
+              "Kp $kpStr now — too low to reach you (you're at ${fmt(absMag)}° geomagnetic, " +
+                  "oval edge ${fmt(boundary)}°). Only a major storm would bring it; worth watching."
+          else ->
+              "Kp $kpStr now, oval edge near ${fmt(boundary)}° geomagnetic; you're at " +
+                  "${fmt(absMag)}°. Look toward the $poleWord horizon after dark, away from city lights."
+        }
+    return Status(
+        kpNow = kpNow,
+        kpForecast = kpView,
+        geomagLat = geomag,
+        chance = chance,
+        headline = headline,
+        detail = detail,
+        lookToward = look,
+    )
+  }
+
+  fun fmtKp(kp: Double): String =
+      if (kp == kp.toInt().toDouble()) kp.toInt().toString()
+      else String.format(Locale.US, "%.1f", kp)
+
+  private fun fmt(d: Double): String = String.format(Locale.US, "%.0f", d)
+
+  // ---- NOAA SWPC feeds (keyless) -----------------------------------------------
+
+  /** Latest observed planetary Kp, or null on failure. */
+  private fun fetchCurrentKp(): Double? =
+      runCatching {
+            val arr = JSONArray(httpGet("https://services.swpc.noaa.gov/products/noaa-planetary-k-index.json"))
+            // The most recent reading is the last element. SWPC now serves an array of
+            // objects ({"time_tag":…,"Kp":2.0,…}); older versions served an array of
+            // arrays with a header row (["time_tag","Kp",…]). Handle both.
+            if (arr.length() < 1) return null
+            kpOf(arr.get(arr.length() - 1))
+          }
+          .getOrNull()
+
+  /** Peak forecast Kp over the next ~24 h (0.0 if unavailable). */
+  private fun fetchForecastPeakKp(): Double =
+      runCatching {
+            val arr = JSONArray(httpGet("https://services.swpc.noaa.gov/products/noaa-planetary-k-index-forecast.json"))
+            val now = System.currentTimeMillis()
+            val horizon = now + 24L * 60 * 60 * 1000
+            val fmt = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+            fmt.timeZone = TimeZone.getTimeZone("UTC")
+            var peak = 0.0
+            for (i in 0 until arr.length()) {
+              val row = arr.get(i)
+              // Only future ("predicted") rows; observed/estimated ones are the past.
+              if (kindOf(row) != "predicted") continue
+              val t = runCatching { fmt.parse(timeOf(row))?.time }.getOrNull() ?: continue
+              if (t in now..horizon) {
+                val kp = kpOf(row) ?: continue
+                if (kp > peak) peak = kp
+              }
+            }
+            peak
+          }
+          .getOrDefault(0.0)
+
+  // The SWPC feeds switched from array-of-arrays (with a header row) to array-of-objects;
+  // these read a field from either shape so a future flip back doesn't break the tile.
+  private fun kpOf(row: Any?): Double? =
+      when (row) {
+        is JSONObject -> row.optDouble("Kp", row.optDouble("kp", Double.NaN)).takeIf { !it.isNaN() }
+        is JSONArray -> row.optString(1).toDoubleOrNull()
+        else -> null
+      }
+
+  private fun timeOf(row: Any?): String =
+      when (row) {
+        is JSONObject -> row.optString("time_tag")
+        is JSONArray -> row.optString(0)
+        else -> ""
+      }
+
+  private fun kindOf(row: Any?): String =
+      when (row) {
+        is JSONObject -> row.optString("observed")
+        is JSONArray -> row.optString(2)
+        else -> ""
+      }
+
+  private fun httpGet(spec: String): String {
+    val c = URL(spec).openConnection() as HttpURLConnection
+    c.connectTimeout = 8000
+    c.readTimeout = 10000
+    c.setRequestProperty("User-Agent", "Immortal/1.0")
+    return c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/Converter.kt
+++ b/app/src/main/java/com/immortal/launcher/Converter.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import java.net.HttpURLConnection
+import java.net.URL
+import org.json.JSONObject
+
+/**
+ * Walk-up-and-use unit + currency converter. Units convert fully offline; currency
+ * uses the keyless Frankfurter API (European Central Bank reference rates), cached so
+ * a mostly-offline Portal keeps converting at the last-known rate.
+ */
+object Converter {
+
+  private const val PREFS = "immortal_converter"
+
+  /** A measurement family. [units] map a display name to its factor relative to the
+   * family's base unit; temperature is special-cased (affine, not a pure factor). */
+  data class Category(val name: String, val units: List<String>)
+
+  val LENGTH =
+      linkedMapOf(
+          "m" to 1.0, "km" to 1000.0, "cm" to 0.01, "mm" to 0.001,
+          "mi" to 1609.344, "yd" to 0.9144, "ft" to 0.3048, "in" to 0.0254)
+  val MASS =
+      linkedMapOf("kg" to 1.0, "g" to 0.001, "lb" to 0.45359237, "oz" to 0.028349523125, "st" to 6.35029318)
+  val VOLUME =
+      linkedMapOf(
+          "L" to 1.0, "mL" to 0.001, "gal (US)" to 3.785411784, "qt (US)" to 0.946352946,
+          "cup (US)" to 0.2365882365, "fl oz (US)" to 0.0295735295625)
+  val SPEED =
+      linkedMapOf("km/h" to 1.0, "m/s" to 3.6, "mph" to 1.609344, "kn" to 1.852)
+
+  val UNIT_CATEGORIES =
+      listOf(
+          "Length" to LENGTH,
+          "Mass" to MASS,
+          "Volume" to VOLUME,
+          "Speed" to SPEED,
+          "Temperature" to linkedMapOf("°C" to 1.0, "°F" to 1.0, "K" to 1.0),
+      )
+
+  /** Convert [value] from [from] to [to] within [category]. Pure + unit-tested. */
+  fun convert(category: String, from: String, to: String, value: Double): Double {
+    if (category == "Temperature") return convertTemp(from, to, value)
+    val map = UNIT_CATEGORIES.firstOrNull { it.first == category }?.second ?: return value
+    val f = map[from] ?: return value
+    val t = map[to] ?: return value
+    return value * f / t // to base, then to target
+  }
+
+  /** Affine temperature conversion across °C / °F / K. */
+  fun convertTemp(from: String, to: String, value: Double): Double {
+    val celsius =
+        when (from) {
+          "°F" -> (value - 32.0) * 5.0 / 9.0
+          "K" -> value - 273.15
+          else -> value
+        }
+    return when (to) {
+      "°F" -> celsius * 9.0 / 5.0 + 32.0
+      "K" -> celsius + 273.15
+      else -> celsius
+    }
+  }
+
+  // ---- Currency (keyless Frankfurter / ECB) ------------------------------------
+
+  /** A small, common set so the picker stays glanceable on a 50–100 cm screen. */
+  val CURRENCIES =
+      listOf("EUR", "USD", "GBP", "RON", "PLN", "CHF", "SEK", "NOK", "DKK", "CAD", "AUD", "JPY", "CZK", "HUF")
+
+  /** Convert [amount] [from]→[to] using cached/fetched ECB rates. Null if no rate is
+   * available (offline with an empty cache). */
+  fun convertCurrency(context: Context, from: String, to: String, amount: Double): Double? {
+    if (from == to) return amount
+    val rates = rates(context, from) ?: return null
+    val r = rates[to] ?: return null
+    return amount * r
+  }
+
+  /** Rates with [base] = 1.0, fetched from Frankfurter and cached per base. */
+  private fun rates(context: Context, base: String): Map<String, Double>? {
+    val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    val cacheKey = "rates_$base"
+    val tsKey = "rates_${base}_ts"
+    val fresh = System.currentTimeMillis() - prefs.getLong(tsKey, 0L) < 6L * 60 * 60 * 1000
+    if (fresh) {
+      prefs.getString(cacheKey, null)?.let { return parseRates(it) }
+    }
+    val fetched =
+        runCatching {
+              httpGet("https://api.frankfurter.app/latest?from=$base&to=${CURRENCIES.filter { it != base }.joinToString(",")}")
+            }
+            .getOrNull()
+    if (fetched != null && parseRates(fetched) != null) {
+      prefs.edit().putString(cacheKey, fetched).putLong(tsKey, System.currentTimeMillis()).apply()
+      return parseRates(fetched)
+    }
+    // Stale cache beats nothing.
+    return prefs.getString(cacheKey, null)?.let { parseRates(it) }
+  }
+
+  private fun parseRates(json: String): Map<String, Double>? =
+      runCatching {
+            val r = JSONObject(json).getJSONObject("rates")
+            buildMap {
+              r.keys().forEach { k -> put(k, r.getDouble(k)) }
+            }
+          }
+          .getOrNull()
+          ?.takeIf { it.isNotEmpty() }
+
+  private fun httpGet(spec: String): String {
+    val c = URL(spec).openConnection() as HttpURLConnection
+    c.connectTimeout = 8000
+    c.readTimeout = 10000
+    c.setRequestProperty("User-Agent", "Immortal/1.0")
+    return c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/IssPasses.kt
+++ b/app/src/main/java/com/immortal/launcher/IssPasses.kt
@@ -1,0 +1,713 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import java.net.HttpURLConnection
+import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.asin
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+import org.json.JSONObject
+
+/**
+ * Keyless "when does the ISS fly over you" predictor for the home screen.
+ *
+ * Everything past the one-off TLE download runs offline on-device: a self-contained
+ * near-Earth **SGP4** propagator ([Sat]) turns the two-line element set into a sky
+ * position minute-by-minute, and [predict] scans the next ~36 h for the times the
+ * station climbs above the horizon — start/peak/end, peak elevation, compass
+ * direction, and whether it'll actually be *visible* to the naked eye (station
+ * sunlit while the sky here is dark).
+ *
+ * Why SGP4 and not an API: the old keyless "ISS pass" endpoints (open-notify) are
+ * dead, and the survivors are key-walled. The orbital model is the standard
+ * NORAD/Vallado one (validated against the canonical test vector in
+ * `IssPassesTest`), so a single keyless TLE fetch — Celestrak first, wheretheiss.at
+ * as fallback — is all the network this needs, and a cached TLE keeps working for
+ * days without it.
+ */
+object IssPasses {
+
+  private const val PREFS = "immortal_iss"
+  private const val CATNR = 25544 // ISS (ZARYA)
+
+  // A TLE drifts slowly; refreshing a couple of times a day is plenty and keeps a
+  // mostly-offline Portal honest without hammering the source.
+  private const val TLE_FRESH_MS = 12L * 60 * 60 * 1000
+
+  /** A single above-horizon pass. Times are epoch millis (device-local zone on
+   * display). [maxElevationDeg] is the peak height; [visible] means naked-eye. */
+  data class Pass(
+      val startMillis: Long,
+      val peakMillis: Long,
+      val endMillis: Long,
+      val maxElevationDeg: Int,
+      val startDir: String,
+      val peakDir: String,
+      val endDir: String,
+      val visible: Boolean,
+  )
+
+  /**
+   * Upcoming passes over the device, soonest first (empty on any failure / no fix).
+   * Network is only touched to (re)fetch the TLE; the search itself is local.
+   *
+   * @param max how many passes to return.
+   * @param horizonDeg ignore grazing passes whose peak is below this (10° default —
+   *   anything lower is lost behind buildings/trees from an indoor Portal anyway).
+   */
+  fun predict(context: Context, max: Int = 5, horizonDeg: Double = 10.0): List<Pass> {
+    val (lat, lon) = Weather.coordinates(context) ?: return emptyList()
+    val sat = loadSat(context) ?: return emptyList()
+    return runCatching { scan(sat, lat, lon, max, horizonDeg) }.getOrDefault(emptyList())
+  }
+
+  /** The very next pass (or null), for the compact home tile subtitle. */
+  fun next(context: Context): Pass? = predict(context, max = 1).firstOrNull()
+
+  // ---- Pass search -------------------------------------------------------------
+
+  private const val STEP_S = 30.0 // sky-position sampling step
+  private const val SPAN_H = 36 // how far ahead to look
+
+  private fun scan(sat: Sat, latDeg: Double, lonDeg: Double, max: Int, horizonDeg: Double): List<Pass> {
+    val obs = observerEcef(latDeg, lonDeg)
+    val latRad = latDeg * DEG
+    val lonRad = lonDeg * DEG
+    val nowMs = System.currentTimeMillis()
+    val steps = (SPAN_H * 3600 / STEP_S).toInt()
+
+    val passes = ArrayList<Pass>()
+    var inPass = false
+    var startMs = 0L
+    var startAz = 0.0
+    var peakEl = -90.0
+    var peakAz = 0.0
+    var peakMs = 0L
+    var anyVisible = false
+    var prevAz = 0.0
+    var prevMs = 0L
+
+    for (i in 0..steps) {
+      val tMs = nowMs + (i * STEP_S * 1000).toLong()
+      val look = lookAngle(sat, tMs, obs, latRad, lonRad) ?: continue
+      val elDeg = look.first / DEG
+      val azDeg = look.second / DEG
+      if (elDeg >= 0.0) {
+        if (!inPass) {
+          inPass = true
+          startMs = tMs
+          startAz = azDeg
+          peakEl = elDeg
+          peakAz = azDeg
+          peakMs = tMs
+          anyVisible = false
+        }
+        if (elDeg > peakEl) {
+          peakEl = elDeg
+          peakAz = azDeg
+          peakMs = tMs
+        }
+        if (!anyVisible && isVisible(sat, tMs, obs, latRad, lonRad, elDeg)) anyVisible = true
+        prevAz = azDeg
+        prevMs = tMs
+      } else if (inPass) {
+        inPass = false
+        if (peakEl >= horizonDeg) {
+          passes.add(
+              Pass(
+                  startMillis = startMs,
+                  peakMillis = peakMs,
+                  endMillis = prevMs,
+                  maxElevationDeg = peakEl.toInt(),
+                  startDir = compass(startAz),
+                  peakDir = compass(peakAz),
+                  endDir = compass(prevAz),
+                  visible = anyVisible,
+              ))
+          if (passes.size >= max) return passes
+        }
+      }
+    }
+    return passes
+  }
+
+  /** Topocentric look angle (elevationRad, azimuthRad) of the satellite, or null if
+   * the propagator decayed/failed at this instant. */
+  private fun lookAngle(
+      sat: Sat,
+      tMs: Long,
+      obs: DoubleArray,
+      latRad: Double,
+      lonRad: Double,
+  ): Pair<Double, Double>? {
+    val teme = sat.propagate(minutesSinceEpoch(sat, tMs)) ?: return null
+    val ecef = temeToEcef(teme, julianDate(tMs))
+    return topocentric(ecef, obs, latRad, lonRad)
+  }
+
+  /** Naked-eye check at [elDeg]: the station must be sunlit while the observer's sky
+   * is dark (sun below the −6° civil-twilight line). */
+  private fun isVisible(
+      sat: Sat,
+      tMs: Long,
+      obs: DoubleArray,
+      latRad: Double,
+      lonRad: Double,
+      elDeg: Double,
+  ): Boolean {
+    if (elDeg < 0) return false
+    val jd = julianDate(tMs)
+    val sunEci = sunEci(jd)
+    val sunEcef = temeToEcef(sunEci, jd) // sun direction is ~unchanged by the GMST spin error
+    val sunEl = topocentric(sunEcef, obs, latRad, lonRad).first / DEG
+    if (sunEl > -6.0) return false // sky too bright
+    val teme = sat.propagate(minutesSinceEpoch(sat, tMs)) ?: return false
+    return satSunlit(teme, sunEci)
+  }
+
+  /** True if the station is out of Earth's cylindrical shadow (lit by the sun). */
+  private fun satSunlit(satKm: DoubleArray, sunEci: DoubleArray): Boolean {
+    val sunMag = mag(sunEci)
+    val sx = sunEci[0] / sunMag
+    val sy = sunEci[1] / sunMag
+    val sz = sunEci[2] / sunMag
+    val proj = satKm[0] * sx + satKm[1] * sy + satKm[2] * sz
+    if (proj > 0) return true // sun-facing side: always lit
+    val satMag2 = satKm[0] * satKm[0] + satKm[1] * satKm[1] + satKm[2] * satKm[2]
+    val perp = sqrt((satMag2 - proj * proj).coerceAtLeast(0.0))
+    return perp > RADIUS_EARTH_KM // misses the umbra cylinder
+  }
+
+  // ---- TLE fetch + cache -------------------------------------------------------
+
+  /** Build a propagator from the cached TLE, refreshing over the network if stale /
+   * absent. Null if we have no TLE and can't fetch one. */
+  private fun loadSat(context: Context): Sat? {
+    val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    val age = System.currentTimeMillis() - prefs.getLong("tle_time", 0L)
+    var l1 = prefs.getString("tle1", null)
+    var l2 = prefs.getString("tle2", null)
+    if (l1 == null || l2 == null || age > TLE_FRESH_MS) {
+      val fetched = fetchTle()
+      if (fetched != null) {
+        l1 = fetched.first
+        l2 = fetched.second
+        prefs
+            .edit()
+            .putString("tle1", l1)
+            .putString("tle2", l2)
+            .putLong("tle_time", System.currentTimeMillis())
+            .apply()
+      }
+    }
+    if (l1 == null || l2 == null) return null
+    return runCatching { Sat.fromTle(l1, l2) }.getOrNull()
+  }
+
+  /** Keyless ISS TLE — Celestrak first (canonical), wheretheiss.at as fallback. */
+  private fun fetchTle(): Pair<String, String>? {
+    runCatching {
+      val body =
+          httpGet("https://celestrak.org/NORAD/elements/gp.php?CATNR=$CATNR&FORMAT=tle")
+      val lines = body.lines().map { it.trim() }.filter { it.isNotEmpty() }
+      val l1 = lines.firstOrNull { it.startsWith("1 ") }
+      val l2 = lines.firstOrNull { it.startsWith("2 ") }
+      if (l1 != null && l2 != null) return l1 to l2
+    }
+    runCatching {
+      val j = JSONObject(httpGet("https://api.wheretheiss.at/v1/satellites/$CATNR/tles"))
+      val l1 = j.optString("line1").trim()
+      val l2 = j.optString("line2").trim()
+      if (l1.startsWith("1 ") && l2.startsWith("2 ")) return l1 to l2
+    }
+    return null
+  }
+
+  private fun httpGet(spec: String): String {
+    val c = URL(spec).openConnection() as HttpURLConnection
+    c.connectTimeout = 8000
+    c.readTimeout = 10000
+    c.setRequestProperty("User-Agent", "Immortal/1.0")
+    return c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
+  }
+
+  // ---- Geometry helpers --------------------------------------------------------
+
+  const val RADIUS_EARTH_KM = 6378.135
+  private const val DEG = PI / 180.0
+  private const val TWO_PI = 2.0 * PI
+  private val E2 = 0.006694385 // WGS-72 first eccentricity squared
+
+  /** Minutes between the TLE epoch and [tMs]. */
+  private fun minutesSinceEpoch(sat: Sat, tMs: Long): Double =
+      (julianDate(tMs) - sat.jdEpoch) * 1440.0
+
+  /** Julian date (UT1≈UTC) from epoch millis. */
+  private fun julianDate(tMs: Long): Double = 2440587.5 + tMs / 86_400_000.0
+
+  /** Observer ECEF position (km) at sea level on the WGS-72 ellipsoid. */
+  private fun observerEcef(latDeg: Double, lonDeg: Double): DoubleArray {
+    val lat = latDeg * DEG
+    val lon = lonDeg * DEG
+    val sinLat = sin(lat)
+    val n = RADIUS_EARTH_KM / sqrt(1.0 - E2 * sinLat * sinLat)
+    val x = n * cos(lat) * cos(lon)
+    val y = n * cos(lat) * sin(lon)
+    val z = (n * (1.0 - E2)) * sinLat
+    return doubleArrayOf(x, y, z)
+  }
+
+  /** Rotate a TEME (ECI) vector into Earth-fixed (ECEF) coords using GMST. Ignores
+   * polar motion / nutation — negligible for pointing a tile at the sky. */
+  private fun temeToEcef(eci: DoubleArray, jd: Double): DoubleArray {
+    val g = gmst(jd)
+    val c = cos(g)
+    val s = sin(g)
+    return doubleArrayOf(
+        c * eci[0] + s * eci[1],
+        -s * eci[0] + c * eci[1],
+        eci[2],
+    )
+  }
+
+  /** (elevationRad, azimuthRad-from-north) of an ECEF target from the observer. */
+  private fun topocentric(
+      target: DoubleArray,
+      obs: DoubleArray,
+      latRad: Double,
+      lonRad: Double,
+  ): Pair<Double, Double> {
+    val rx = target[0] - obs[0]
+    val ry = target[1] - obs[1]
+    val rz = target[2] - obs[2]
+    val sinLat = sin(latRad)
+    val cosLat = cos(latRad)
+    val sinLon = sin(lonRad)
+    val cosLon = cos(lonRad)
+    val south = sinLat * cosLon * rx + sinLat * sinLon * ry - cosLat * rz
+    val east = -sinLon * rx + cosLon * ry
+    val zen = cosLat * cosLon * rx + cosLat * sinLon * ry + sinLat * rz
+    val range = sqrt(rx * rx + ry * ry + rz * rz)
+    val el = asin((zen / range).coerceIn(-1.0, 1.0))
+    var az = atan2(east, -south)
+    if (az < 0) az += TWO_PI
+    return el to az
+  }
+
+  /** Greenwich Mean Sidereal Time (rad) — the standard SGP4 `gstime`. */
+  private fun gmst(jd: Double): Double {
+    val t = (jd - 2451545.0) / 36525.0
+    var g =
+        -6.2e-6 * t * t * t +
+            0.093104 * t * t +
+            (876600.0 * 3600 + 8640184.812866) * t +
+            67310.54841
+    g = (g * DEG / 240.0) % TWO_PI // seconds of time -> rad
+    if (g < 0) g += TWO_PI
+    return g
+  }
+
+  /** Low-precision geocentric sun position (km, ECI) — enough to tell day from night
+   * and lit from shadowed. (Astronomical Almanac, ~0.01° accuracy.) */
+  private fun sunEci(jd: Double): DoubleArray {
+    val n = jd - 2451545.0
+    val l = (280.460 + 0.9856474 * n) * DEG
+    val g = (357.528 + 0.9856003 * n) * DEG
+    val lambda = l + (1.915 * sin(g) + 0.020 * sin(2 * g)) * DEG
+    val eps = (23.439 - 0.0000004 * n) * DEG
+    val au = 149_597_870.7
+    return doubleArrayOf(
+        au * cos(lambda),
+        au * cos(eps) * sin(lambda),
+        au * sin(eps) * sin(lambda),
+    )
+  }
+
+  private fun mag(v: DoubleArray): Double = sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
+
+  private val DIRS =
+      arrayOf("N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW")
+
+  /** Azimuth (deg from north) -> 16-point compass label. */
+  fun compass(azDeg: Double): String {
+    var a = azDeg % 360.0
+    if (a < 0) a += 360.0
+    return DIRS[(((a + 11.25) / 22.5).toInt()) % 16]
+  }
+
+  /** Format a pass time as the device-local "h:mm a" / weekday for the UI. */
+  fun timeLabel(millis: Long): String =
+      SimpleDateFormat("EEE h:mm a", Locale.getDefault()).format(Date(millis))
+
+  // ---- SGP4 (near-Earth) -------------------------------------------------------
+
+  /**
+   * A near-Earth SGP4 propagator built from a TLE. Deep-space (period ≥ 225 min) is
+   * intentionally omitted — the ISS, like all LEO targets, is firmly near-Earth.
+   * [propagate] returns the TEME position in km at `tsinceMin` minutes from epoch
+   * (null if the orbit decayed). Constants are WGS-72, matching the model the TLEs
+   * are generated against.
+   */
+  class Sat private constructor(
+      val jdEpoch: Double,
+      private val ecco: Double,
+      private val inclo: Double,
+      private val nodeo: Double,
+      private val argpo: Double,
+      private val mo: Double,
+      private val no: Double, // mean motion, rad/min (Kozai-recovered)
+      private val ao: Double,
+      private val con41: Double,
+      private val x1mth2: Double,
+      private val x7thm1: Double,
+      private val xlcof: Double,
+      private val aycof: Double,
+      private val cc1: Double,
+      private val cc4: Double,
+      private val cc5: Double,
+      private val t2cof: Double,
+      private val mdot: Double,
+      private val argpdot: Double,
+      private val nodedot: Double,
+      private val nodecf: Double,
+      private val omgcof: Double,
+      private val xmcof: Double,
+      private val eta: Double,
+      private val sinmao: Double,
+      private val delmo: Double,
+      private val bstar: Double,
+      private val isimp: Boolean,
+      private val d2: Double,
+      private val d3: Double,
+      private val d4: Double,
+      private val t3cof: Double,
+      private val t4cof: Double,
+      private val t5cof: Double,
+  ) {
+
+    /** TEME position (km) at [tsinceMin] minutes past epoch; null on decay. */
+    fun propagate(tsinceMin: Double): DoubleArray? {
+      val xmdf = mo + mdot * tsinceMin
+      val argpdf = argpo + argpdot * tsinceMin
+      val nodedf = nodeo + nodedot * tsinceMin
+      var argpm = argpdf
+      var mm = xmdf
+      val t2 = tsinceMin * tsinceMin
+      val nodem = nodedf + nodecf * t2
+      var tempa = 1.0 - cc1 * tsinceMin
+      var tempe = bstar * cc4 * tsinceMin
+      var templ = t2cof * t2
+      if (!isimp) {
+        val delomg = omgcof * tsinceMin
+        val delmtemp = 1.0 + eta * cos(xmdf)
+        val delm = xmcof * (delmtemp * delmtemp * delmtemp - delmo)
+        val temp = delomg + delm
+        mm = xmdf + temp
+        argpm = argpdf - temp
+        val t3 = t2 * tsinceMin
+        val t4 = t3 * tsinceMin
+        tempa = tempa - d2 * t2 - d3 * t3 - d4 * t4
+        tempe += bstar * cc5 * (sin(mm) - sinmao)
+        templ += t3cof * t3 + t4 * (t4cof + tsinceMin * t5cof)
+      }
+
+      val am = ao * tempa * tempa
+      val nm = XKE / am.pow(1.5)
+      var em = ecco - tempe
+      if (em >= 1.0 || em < -0.001) return null // decayed
+      if (em < 1.0e-6) em = 1.0e-6
+      mm += no * templ
+      var xlm = mm + argpm + nodem
+      val nodemR = nodem % TWO_PI
+      argpm %= TWO_PI
+      xlm %= TWO_PI
+      mm = (xlm - argpm - nodemR) % TWO_PI
+
+      // Long-period periodics (near-Earth: inclination unchanged).
+      val axnl = em * cos(argpm)
+      val temp4 = 1.0 / (am * (1.0 - em * em))
+      val aynl = em * sin(argpm) + temp4 * aycof
+      val xl = mm + argpm + nodemR + temp4 * xlcof * axnl
+
+      // Kepler's equation for (E + omega).
+      val u = (xl - nodemR) % TWO_PI
+      var eo1 = u
+      var tem5 = 9999.9
+      var ktr = 1
+      var sineo1 = 0.0
+      var coseo1 = 0.0
+      while (abs(tem5) >= 1.0e-12 && ktr <= 10) {
+        sineo1 = sin(eo1)
+        coseo1 = cos(eo1)
+        tem5 = 1.0 - coseo1 * axnl - sineo1 * aynl
+        tem5 = (u - aynl * coseo1 + axnl * sineo1 - eo1) / tem5
+        if (abs(tem5) >= 0.95) tem5 = if (tem5 > 0) 0.95 else -0.95
+        eo1 += tem5
+        ktr++
+      }
+
+      // Short-period preliminary quantities.
+      val ecose = axnl * coseo1 + aynl * sineo1
+      val esine = axnl * sineo1 - aynl * coseo1
+      val el2 = axnl * axnl + aynl * aynl
+      val pl = am * (1.0 - el2)
+      if (pl < 0.0) return null
+      val rl = am * (1.0 - ecose)
+      val betal = sqrt(1.0 - el2)
+      val tmp = esine / (1.0 + betal)
+      val sinu = am / rl * (sineo1 - aynl - axnl * tmp)
+      val cosu = am / rl * (coseo1 - axnl + aynl * tmp)
+      var su = atan2(sinu, cosu)
+      val sin2u = (cosu + cosu) * sinu
+      val cos2u = 1.0 - 2.0 * sinu * sinu
+      val temp = 1.0 / pl
+      val temp1 = 0.5 * J2 * temp
+      val temp2 = temp1 * temp
+
+      // Apply short-period periodics (no deep-space corrections).
+      val mrt = rl * (1.0 - 1.5 * temp2 * betal * con41) + 0.5 * temp1 * x1mth2 * cos2u
+      su -= 0.25 * temp2 * x7thm1 * sin2u
+      val xnode = nodemR + 1.5 * temp2 * cos(inclo) * sin2u
+      val xinc = inclo + 1.5 * temp2 * cos(inclo) * sin(inclo) * cos2u
+
+      // Orientation vectors -> position.
+      val sinsu = sin(su)
+      val cossu = cos(su)
+      val snod = sin(xnode)
+      val cnod = cos(xnode)
+      val sini = sin(xinc)
+      val cosi = cos(xinc)
+      val xmx = -snod * cosi
+      val xmy = cnod * cosi
+      val ux = xmx * sinsu + cnod * cossu
+      val uy = xmy * sinsu + snod * cossu
+      val uz = sini * sinsu
+      return doubleArrayOf(
+          mrt * ux * RADIUS_EARTH_KM,
+          mrt * uy * RADIUS_EARTH_KM,
+          mrt * uz * RADIUS_EARTH_KM,
+      )
+    }
+
+    companion object {
+      /** Parse the two TLE data lines and run SGP4 initialisation. */
+      fun fromTle(line1: String, line2: String): Sat {
+        // --- field extraction (fixed columns per the TLE spec) ---
+        val epochYr = line1.substring(18, 20).trim().toInt()
+        val epochDay = line1.substring(20, 32).trim().toDouble()
+        val bstar = expField(line1.substring(53, 61))
+        val inclo = line2.substring(8, 16).trim().toDouble() * DEG
+        val nodeo = line2.substring(17, 25).trim().toDouble() * DEG
+        val ecco = ("0." + line2.substring(26, 33).trim()).toDouble()
+        val argpo = line2.substring(34, 42).trim().toDouble() * DEG
+        val mo = line2.substring(43, 51).trim().toDouble() * DEG
+        val noRevPerDay = line2.substring(52, 63).trim().toDouble()
+        val noKozai = noRevPerDay * TWO_PI / 1440.0 // rad/min
+
+        val year = if (epochYr < 57) 2000 + epochYr else 1900 + epochYr
+        val jdEpoch = jdFromEpoch(year, epochDay)
+
+        return init(jdEpoch, ecco, inclo, nodeo, argpo, mo, noKozai, bstar)
+      }
+
+      /** SGP4 initialisation (near-Earth), WGS-72 constants. */
+      private fun init(
+          jdEpoch: Double,
+          ecco: Double,
+          inclo: Double,
+          nodeo: Double,
+          argpo: Double,
+          mo: Double,
+          noKozai: Double,
+          bstar: Double,
+      ): Sat {
+        val ss = 78.0 / RADIUS_EARTH_KM + 1.0
+        val qzms2t = ((120.0 - 78.0) / RADIUS_EARTH_KM).pow(4.0)
+        val x2o3 = 2.0 / 3.0
+
+        val cosio = cos(inclo)
+        val cosio2 = cosio * cosio
+        val eccsq = ecco * ecco
+        val omeosq = 1.0 - eccsq
+        val rteosq = sqrt(omeosq)
+
+        // Recover the un-Kozai'd mean motion and semi-major axis.
+        val ak = (XKE / noKozai).pow(x2o3)
+        val d1 = 0.75 * J2 * (3.0 * cosio2 - 1.0) / (rteosq * omeosq)
+        var del = d1 / (ak * ak)
+        val adel = ak * (1.0 - del * del - del * (1.0 / 3.0 + 134.0 * del * del / 81.0))
+        del = d1 / (adel * adel)
+        val no = noKozai / (1.0 + del)
+
+        val ao = (XKE / no).pow(x2o3)
+        val sinio = sin(inclo)
+        val po = ao * omeosq
+        val con42 = 1.0 - 5.0 * cosio2
+        val con41 = 3.0 * cosio2 - 1.0
+        val posq = po * po
+        val rp = ao * (1.0 - ecco)
+
+        var sfour = ss
+        var qzms24 = qzms2t
+        val perige = (rp - 1.0) * RADIUS_EARTH_KM
+        if (perige < 156.0) {
+          sfour = perige - 78.0
+          if (perige < 98.0) sfour = 20.0
+          qzms24 = ((120.0 - sfour) / RADIUS_EARTH_KM).pow(4.0)
+          sfour = sfour / RADIUS_EARTH_KM + 1.0
+        }
+        val pinvsq = 1.0 / posq
+        val tsi = 1.0 / (ao - sfour)
+        val eta = ao * ecco * tsi
+        val etasq = eta * eta
+        val eeta = ecco * eta
+        val psisq = abs(1.0 - etasq)
+        val coef = qzms24 * tsi.pow(4.0)
+        val coef1 = coef / psisq.pow(3.5)
+        val cc2 =
+            coef1 * no *
+                (ao * (1.0 + 1.5 * etasq + eeta * (4.0 + etasq)) +
+                    0.375 * J2 * tsi / psisq * con41 * (8.0 + 3.0 * etasq * (8.0 + etasq)))
+        val cc1 = bstar * cc2
+        var cc3 = 0.0
+        if (ecco > 1.0e-4) cc3 = -2.0 * coef * tsi * J3OJ2 * no * sinio / ecco
+        val x1mth2 = 1.0 - cosio2
+        val cc4 =
+            2.0 * no * coef1 * ao * omeosq *
+                (eta * (2.0 + 0.5 * etasq) + ecco * (0.5 + 2.0 * etasq) -
+                    J2 * tsi / (ao * psisq) *
+                        (-3.0 * con41 * (1.0 - 2.0 * eeta + etasq * (1.5 - 0.5 * eeta)) +
+                            0.75 * x1mth2 * (2.0 * etasq - eeta * (1.0 + etasq)) * cos(2.0 * argpo)))
+        val cc5 = 2.0 * coef1 * ao * omeosq * (1.0 + 2.75 * (etasq + eeta) + eeta * etasq)
+        val cosio4 = cosio2 * cosio2
+        val temp1 = 1.5 * J2 * pinvsq * no
+        val temp2 = 0.5 * temp1 * J2 * pinvsq
+        val temp3 = -0.46875 * J4 * pinvsq * pinvsq * no
+        val mdot =
+            no + 0.5 * temp1 * rteosq * con41 +
+                0.0625 * temp2 * rteosq * (13.0 - 78.0 * cosio2 + 137.0 * cosio4)
+        val argpdot =
+            -0.5 * temp1 * con42 +
+                0.0625 * temp2 * (7.0 - 114.0 * cosio2 + 395.0 * cosio4) +
+                temp3 * (3.0 - 36.0 * cosio2 + 49.0 * cosio4)
+        val xhdot1 = -temp1 * cosio
+        val nodedot =
+            xhdot1 +
+                (0.5 * temp2 * (4.0 - 19.0 * cosio2) + 2.0 * temp3 * (3.0 - 7.0 * cosio2)) * cosio
+        val omgcof = bstar * cc3 * cos(argpo)
+        var xmcof = 0.0
+        if (ecco > 1.0e-4) xmcof = -x2o3 * coef * bstar / eeta
+        val nodecf = 3.5 * omeosq * xhdot1 * cc1
+        val t2cof = 1.5 * cc1
+        val xlcof = -0.25 * J3OJ2 * sinio * (3.0 + 5.0 * cosio) / (1.0 + cosio)
+        val aycof = -0.5 * J3OJ2 * sinio
+        val delmo = (1.0 + eta * cos(mo)).pow(3.0)
+        val sinmao = sin(mo)
+        val x7thm1 = 7.0 * cosio2 - 1.0
+
+        var isimp = false
+        var d2 = 0.0
+        var d3 = 0.0
+        var d4 = 0.0
+        var t3cof = 0.0
+        var t4cof = 0.0
+        var t5cof = 0.0
+        if (rp < 220.0 / RADIUS_EARTH_KM + 1.0) {
+          isimp = true
+        } else {
+          val cc1sq = cc1 * cc1
+          d2 = 4.0 * ao * tsi * cc1sq
+          val temp = d2 * tsi * cc1 / 3.0
+          d3 = (17.0 * ao + sfour) * temp
+          d4 = 0.5 * temp * ao * tsi * (221.0 * ao + 31.0 * sfour) * cc1
+          t3cof = d2 + 2.0 * cc1sq
+          t4cof = 0.25 * (3.0 * d3 + cc1 * (12.0 * d2 + 10.0 * cc1sq))
+          t5cof = 0.2 * (3.0 * d4 + 12.0 * cc1 * d3 + 6.0 * d2 * d2 + 15.0 * cc1sq * (2.0 * d3 + cc1sq))
+        }
+
+        return Sat(
+            jdEpoch = jdEpoch,
+            ecco = ecco,
+            inclo = inclo,
+            nodeo = nodeo,
+            argpo = argpo,
+            mo = mo,
+            no = no,
+            ao = ao,
+            con41 = con41,
+            x1mth2 = x1mth2,
+            x7thm1 = x7thm1,
+            xlcof = xlcof,
+            aycof = aycof,
+            cc1 = cc1,
+            cc4 = cc4,
+            cc5 = cc5,
+            t2cof = t2cof,
+            mdot = mdot,
+            argpdot = argpdot,
+            nodedot = nodedot,
+            nodecf = nodecf,
+            omgcof = omgcof,
+            xmcof = xmcof,
+            eta = eta,
+            sinmao = sinmao,
+            delmo = delmo,
+            bstar = bstar,
+            isimp = isimp,
+            d2 = d2,
+            d3 = d3,
+            d4 = d4,
+            t3cof = t3cof,
+            t4cof = t4cof,
+            t5cof = t5cof,
+        )
+      }
+
+      /** TLE exponent field, e.g. "-11606-4" -> -0.11606e-4, " 28098-4" -> 0.28098e-4. */
+      private fun expField(raw: String): Double {
+        val s = raw.trim()
+        if (s.isEmpty() || s == "00000-0" || s == "00000+0") return 0.0
+        val sign = if (s.startsWith("-")) -1.0 else 1.0
+        val body = s.trimStart('+', '-')
+        val expIdx = body.indexOfLast { it == '+' || it == '-' }
+        val mantissa = ("0." + body.substring(0, expIdx)).toDouble()
+        val exp = body.substring(expIdx).toInt()
+        return sign * mantissa * 10.0.pow(exp.toDouble())
+      }
+
+      /** Julian date from a TLE epoch (4-digit year + fractional day-of-year, where
+       * day 1.0 = Jan 1 00:00 UT). Standard Gregorian conversion. */
+      private fun jdFromEpoch(year: Int, dayOfYear: Double): Double {
+        // JD of Jan 1, 00:00 UT of `year`.
+        val a = (14 - 1) / 12 // month = 1
+        val y = year + 4800 - a
+        val m = 1 + 12 * a - 3
+        val jdn = 1 + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045
+        val jdJan1 = jdn - 0.5
+        return jdJan1 + (dayOfYear - 1.0)
+      }
+    }
+  }
+
+  // WGS-72 gravitational constants (the model TLEs are fit against).
+  private val XKE = 60.0 / sqrt(RADIUS_EARTH_KM * RADIUS_EARTH_KM * RADIUS_EARTH_KM / 398600.8)
+  private const val J2 = 0.001082616
+  private const val J3 = -0.00000253881
+  private const val J4 = -0.00000165597
+  private const val J3OJ2 = J3 / J2
+}

--- a/app/src/main/java/com/immortal/launcher/SkyColors.kt
+++ b/app/src/main/java/com/immortal/launcher/SkyColors.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+
+/**
+ * Maps the time of day to a sky-coloured gradient (top → bottom), driven by the
+ * real sunrise/sunset so the launcher background tells time ambiently: dawn pinks,
+ * midday blue, dusk orange, night near-black. Pure + unit-testable.
+ */
+object SkyColors {
+
+  // Palette anchors (top, bottom) for each phase of the day.
+  private val NIGHT = Color(0xFF0B1026) to Color(0xFF05060E)
+  private val DAWN = Color(0xFF2A3A6B) to Color(0xFFEF9A6B) // deep blue over warm pink
+  private val MORNING = Color(0xFF3A7BD5) to Color(0xFF8FD3F4)
+  private val MIDDAY = Color(0xFF2980B9) to Color(0xFF6DD5FA)
+  private val EVENING = Color(0xFF3A7BD5) to Color(0xFF8FD3F4)
+  private val DUSK = Color(0xFF2C3E66) to Color(0xFFE96443) // blue over sunset orange
+  private val TWILIGHT = Color(0xFF1A1F3D) to Color(0xFF3A2A4D)
+
+  /** Gradient (top, bottom) for [nowMin] given today's [sunriseMin]/[sunsetMin]
+   * (all minutes-of-day, 0..1439). Blends smoothly between phase anchors. */
+  fun gradientFor(nowMin: Int, sunriseMin: Int, sunsetMin: Int): Pair<Color, Color> {
+    val dawnStart = sunriseMin - 40
+    val dawnEnd = sunriseMin + 40
+    val morningEnd = sunriseMin + 120
+    val midday = (sunriseMin + sunsetMin) / 2
+    val eveningStart = sunsetMin - 120
+    val duskStart = sunsetMin - 40
+    val duskEnd = sunsetMin + 40
+    val twilightEnd = sunsetMin + 80
+
+    return when {
+      nowMin < dawnStart -> NIGHT
+      nowMin < dawnEnd -> blend(NIGHT, DAWN, frac(nowMin, dawnStart, dawnEnd))
+      nowMin < morningEnd -> blend(DAWN, MORNING, frac(nowMin, dawnEnd, morningEnd))
+      nowMin < midday -> blend(MORNING, MIDDAY, frac(nowMin, morningEnd, midday))
+      nowMin < eveningStart -> blend(MIDDAY, EVENING, frac(nowMin, midday, eveningStart))
+      nowMin < duskStart -> blend(EVENING, DUSK, frac(nowMin, eveningStart, duskStart))
+      nowMin < duskEnd -> blend(DUSK, TWILIGHT, frac(nowMin, duskStart, duskEnd))
+      nowMin < twilightEnd -> blend(TWILIGHT, NIGHT, frac(nowMin, duskEnd, twilightEnd))
+      else -> NIGHT
+    }
+  }
+
+  private fun frac(now: Int, start: Int, end: Int): Float =
+      if (end <= start) 1f else ((now - start).toFloat() / (end - start)).coerceIn(0f, 1f)
+
+  private fun blend(a: Pair<Color, Color>, b: Pair<Color, Color>, t: Float): Pair<Color, Color> =
+      lerp(a.first, b.first, t) to lerp(a.second, b.second, t)
+}

--- a/app/src/main/java/com/immortal/launcher/StarField.kt
+++ b/app/src/main/java/com/immortal/launcher/StarField.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import kotlin.math.PI
+import kotlin.math.asin
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * The real night sky behind the home grid after dark. A compact catalogue of the
+ * brightest stars (RA/Dec/magnitude) is projected to the device's local horizon using
+ * the observer's latitude/longitude and the current time, so the constellations on
+ * screen are the ones actually overhead. A few familiar asterisms are joined with lines.
+ *
+ * All math is local and pure ([project] is unit-tested); no catalogue download, no
+ * network. Accuracy is "looks like the sky," not observatory-grade.
+ */
+object StarField {
+
+  /** A catalogue star. [raHours] 0–24, [dec] degrees, [mag] visual magnitude (lower =
+   * brighter), [name] for the handful that get labelled. */
+  data class Star(val raHours: Double, val dec: Double, val mag: Double, val name: String = "")
+
+  /** Where a star lands: [az] degrees from north, [alt] degrees above the horizon. */
+  data class AltAz(val az: Double, val alt: Double)
+
+  private const val DEG = PI / 180.0
+
+  /**
+   * ~60 of the brightest stars, enough to read the sky. RA in hours, Dec in degrees
+   * (J2000). Named ones anchor the asterisms in [LINES].
+   */
+  val STARS =
+      listOf(
+          // Orion
+          Star(5.2423, -8.2017, 0.18, "Rigel"), // 0
+          Star(5.9195, 7.4071, 0.45, "Betelgeuse"), // 1
+          Star(5.6035, -1.2019, 1.69, "Alnilam"), // 2 (belt centre)
+          Star(5.5334, -0.2991, 2.23, "Mintaka"), // 3 (belt)
+          Star(5.6793, -1.9426, 1.74, "Alnitak"), // 4 (belt)
+          Star(5.4188, 6.3497, 1.64, "Bellatrix"), // 5
+          Star(5.7959, -9.6696, 2.07, "Saiph"), // 6
+          // Big Dipper (Ursa Major)
+          Star(11.0621, 61.7510, 1.81, "Dubhe"), // 7
+          Star(11.0307, 56.3824, 2.34, "Merak"), // 8
+          Star(11.8972, 53.6948, 2.41, "Phecda"), // 9
+          Star(12.2571, 57.0326, 3.31, "Megrez"), // 10
+          Star(12.9005, 55.9598, 1.76, "Alioth"), // 11
+          Star(13.3987, 54.9254, 2.23, "Mizar"), // 12
+          Star(13.7923, 49.3133, 1.85, "Alkaid"), // 13
+          // Cassiopeia
+          Star(0.6751, 56.5373, 2.24, "Caph"), // 14
+          Star(0.9451, 60.7167, 2.24, "Schedar"), // 15
+          Star(1.4302, 60.2353, 2.47, "Gamma Cas"), // 16
+          Star(1.9066, 63.6701, 2.68, "Ruchbah"), // 17
+          Star(1.4307, 59.1498, 3.35, "Segin"), // 18
+          // Bright scattered stars for context
+          Star(6.7525, -16.7161, -1.46, "Sirius"),
+          Star(7.6550, 5.2250, 0.34, "Procyon"),
+          Star(7.5766, 31.8884, 1.14, "Pollux"),
+          Star(7.4763, 28.0262, 1.58, "Castor"),
+          Star(4.5987, 16.5093, 0.87, "Aldebaran"),
+          Star(5.2782, 45.9980, 0.08, "Capella"),
+          Star(14.2610, 19.1824, -0.05, "Arcturus"),
+          Star(18.6156, 38.7837, 0.03, "Vega"),
+          Star(19.8464, 8.8683, 0.77, "Altair"),
+          Star(20.6905, 45.2803, 1.25, "Deneb"),
+          Star(22.9608, -29.6222, 1.17, "Fomalhaut"),
+          Star(13.4199, -11.1614, 0.98, "Spica"),
+          Star(16.4901, -26.4320, 1.06, "Antares"),
+          Star(10.1395, 11.9672, 1.35, "Regulus"),
+          Star(1.6286, -57.2367, 0.45, "Achernar"),
+          Star(0.1398, 29.0904, 2.07, "Alpheratz"),
+          Star(3.4054, 49.8612, 1.79, "Mirfak"),
+          Star(2.1191, 23.4624, 2.01, "Hamal"),
+          Star(9.4597, -8.6586, 1.99, "Alphard"),
+          Star(17.5822, 12.5600, 2.08, "Rasalhague"),
+          Star(21.7364, 9.8750, 2.38, "Enif"),
+          Star(23.0629, 28.0828, 2.42, "Scheat"),
+          Star(23.0793, 15.2053, 2.49, "Markab"),
+      )
+
+  /** Index pairs joined into recognizable asterism lines. */
+  val LINES =
+      listOf(
+          // Orion: belt + shoulders/knees
+          3 to 2, 2 to 4, 1 to 5, 5 to 3, 4 to 6, 6 to 0, 0 to 3, 1 to 4,
+          // Big Dipper
+          7 to 8, 8 to 9, 9 to 10, 10 to 11, 11 to 12, 12 to 13, 10 to 7,
+          // Cassiopeia "W"
+          14 to 15, 15 to 16, 16 to 17, 17 to 18,
+      )
+
+  /**
+   * Project a star to local horizon coordinates. [lst] is Local Sidereal Time in hours.
+   * Pure + unit-tested.
+   */
+  fun project(star: Star, latDeg: Double, lst: Double): AltAz {
+    val ha = ((lst - star.raHours) * 15.0) * DEG // hour angle in radians
+    val dec = star.dec * DEG
+    val lat = latDeg * DEG
+    val sinAlt = sin(dec) * sin(lat) + cos(dec) * cos(lat) * cos(ha)
+    val alt = asin(sinAlt.coerceIn(-1.0, 1.0))
+    val cosA = (sin(dec) - sin(alt) * sin(lat)) / (cos(alt) * cos(lat))
+    val a = acosSafe(cosA)
+    val az = if (sin(ha) > 0) 2 * PI - a else a
+    return AltAz(az / DEG, alt / DEG)
+  }
+
+  // Guards the zenith 0/0 case: at the exact zenith the azimuth is undefined (NaN),
+  // which would otherwise become a NaN draw coordinate. Default it to north.
+  private fun acosSafe(x: Double): Double =
+      if (x.isNaN()) 0.0 else kotlin.math.acos(x.coerceIn(-1.0, 1.0))
+
+  /** Local Sidereal Time (hours, 0–24) for [lonDeg] at epoch [millis]. */
+  fun localSiderealTime(millis: Long, lonDeg: Double): Double {
+    val jd = 2440587.5 + millis / 86_400_000.0
+    val d = jd - 2451545.0
+    // Greenwich mean sidereal time in degrees (IAU approx), then add longitude.
+    var gmst = 280.46061837 + 360.98564736629 * d
+    gmst %= 360.0
+    if (gmst < 0) gmst += 360.0
+    var lst = (gmst + lonDeg) / 15.0
+    lst %= 24.0
+    if (lst < 0) lst += 24.0
+    return lst
+  }
+
+  /** Approximate sun altitude (deg) — used to decide if it's dark enough for stars. */
+  fun sunAltitude(millis: Long, latDeg: Double, lonDeg: Double): Double {
+    val jd = 2440587.5 + millis / 86_400_000.0
+    val n = jd - 2451545.0
+    val l = (280.460 + 0.9856474 * n) * DEG
+    val g = (357.528 + 0.9856003 * n) * DEG
+    val lambda = l + (1.915 * sin(g) + 0.020 * sin(2 * g)) * DEG
+    val eps = (23.439 - 0.0000004 * n) * DEG
+    val ra = atan2(cos(eps) * sin(lambda), cos(lambda)) / DEG / 15.0 // hours
+    val dec = asin(sin(eps) * sin(lambda)) / DEG
+    return project(Star(ra, dec, 0.0), latDeg, localSiderealTime(millis, lonDeg)).alt
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/Weather.kt
+++ b/app/src/main/java/com/immortal/launcher/Weather.kt
@@ -47,6 +47,11 @@ object Weather {
           }
           .getOrDefault("")
 
+  /** Public accessor for the device's cached lat/lon (resolving + caching it once if
+   * needed). Used by location-aware features like the ISS pass predictor. Null on
+   * failure. */
+  fun coordinates(context: Context): Pair<Double, Double>? = location(context)
+
   /** Cached lat/lon, or a fresh geolocation (cached on success). Also caches the city name. */
   private fun location(context: Context): Pair<Double, Double>? {
     val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)

--- a/app/src/test/java/com/immortal/launcher/AuroraTest.kt
+++ b/app/src/test/java/com/immortal/launcher/AuroraTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The aurora outlook logic — geomagnetic-latitude conversion, the Kp→oval-edge table,
+ * and the chance classification — verified offline (no device, no SWPC network).
+ */
+class AuroraTest {
+
+  @Test
+  fun `geomagnetic latitude lifts high-latitude Europe toward the pole`() {
+    // Tromsø (69.65N) sits under the auroral oval: its geomagnetic latitude is even
+    // higher than its geographic one because it's near the magnetic pole's meridian.
+    val tromso = Aurora.geomagLatitude(69.65, 18.96)
+    assertTrue("Tromsø geomag should be ~66-67°, was $tromso", tromso in 64.0..69.0)
+
+    // Reykjavík is geomagnetically very high too.
+    val reykjavik = Aurora.geomagLatitude(64.13, -21.90)
+    assertTrue("Reykjavík geomag should be high, was $reykjavik", reykjavik > 63.0)
+  }
+
+  @Test
+  fun `southern hemisphere yields negative geomagnetic latitude`() {
+    // Hobart, Tasmania — aurora australis territory.
+    val hobart = Aurora.geomagLatitude(-42.88, 147.33)
+    assertTrue("Hobart geomag should be negative, was $hobart", hobart < 0.0)
+  }
+
+  @Test
+  fun `boundary marches equatorward as Kp climbs`() {
+    assertEquals(66.5, Aurora.boundaryLat(0.0), 1e-9)
+    assertEquals(48.1, Aurora.boundaryLat(9.0), 1e-9)
+    // Monotonic decrease.
+    assertTrue(Aurora.boundaryLat(3.0) > Aurora.boundaryLat(6.0))
+    // Fractional interpolation lands between the table rows.
+    val mid = Aurora.boundaryLat(2.5)
+    assertTrue(mid < Aurora.boundaryLat(2.0) && mid > Aurora.boundaryLat(3.0))
+  }
+
+  @Test
+  fun `low geomagnetic latitude is never a chance`() {
+    // Madrid (40.4N) is ~43° geomagnetic — below even the Kp-9 oval edge (48°), so
+    // the aurora can't reach it at any storm strength.
+    val s = Aurora.classify(40.4, -3.7, kpNow = 5.0, kpView = 9.0)
+    assertEquals(Aurora.Chance.NONE, s.chance)
+    assertEquals("N", s.lookToward)
+  }
+
+  @Test
+  fun `quiet sun leaves mid-latitude with only a slim chance`() {
+    // Dublin (~56° geomagnetic) with Kp 1: oval edge ~64.5°, far poleward — but Dublin
+    // is above the Kp-9 limit, so it's SLIM (strong-storm-only), not impossible.
+    val s = Aurora.classify(53.35, -6.26, kpNow = 1.0, kpView = 1.0)
+    assertEquals(Aurora.Chance.SLIM, s.chance)
+  }
+
+  @Test
+  fun `big storm brings a real chance to mid-latitudes`() {
+    // Same Dublin Portal, but a severe Kp 8 storm pushes the oval down to ~50° geomag.
+    val s = Aurora.classify(53.35, -6.26, kpNow = 5.0, kpView = 8.0)
+    assertTrue(
+        "Kp8 should give Dublin a real chance",
+        s.chance == Aurora.Chance.POSSIBLE || s.chance == Aurora.Chance.LIKELY)
+  }
+
+  @Test
+  fun `high latitude sees aurora even on a calm day`() {
+    // Tromsø under Kp 2 is already at/over the oval edge.
+    val s = Aurora.classify(69.65, 18.96, kpNow = 2.0, kpView = 2.0)
+    assertTrue(s.chance == Aurora.Chance.LIKELY || s.chance == Aurora.Chance.POSSIBLE)
+  }
+
+  @Test
+  fun `kp formatting drops the decimal for whole numbers`() {
+    assertEquals("5", Aurora.fmtKp(5.0))
+    assertEquals("3.7", Aurora.fmtKp(3.67))
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/ConverterTest.kt
+++ b/app/src/test/java/com/immortal/launcher/ConverterTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Offline unit-conversion math (currency needs the network and isn't covered here). */
+class ConverterTest {
+
+  @Test
+  fun `length round-trips through the base unit`() {
+    assertEquals(1609.344, Converter.convert("Length", "mi", "m", 1.0), 1e-6)
+    assertEquals(1.0, Converter.convert("Length", "m", "mi", 1609.344), 1e-9)
+    assertEquals(12.0, Converter.convert("Length", "ft", "in", 1.0), 1e-9)
+    assertEquals(100.0, Converter.convert("Length", "m", "cm", 1.0), 1e-9)
+  }
+
+  @Test
+  fun `mass converts kg to pounds`() {
+    assertEquals(2.20462262, Converter.convert("Mass", "kg", "lb", 1.0), 1e-6)
+    assertEquals(16.0, Converter.convert("Mass", "lb", "oz", 1.0), 1e-6)
+  }
+
+  @Test
+  fun `temperature is affine, not a factor`() {
+    assertEquals(32.0, Converter.convertTemp("°C", "°F", 0.0), 1e-9)
+    assertEquals(212.0, Converter.convertTemp("°C", "°F", 100.0), 1e-9)
+    assertEquals(0.0, Converter.convertTemp("°F", "°C", 32.0), 1e-9)
+    assertEquals(273.15, Converter.convertTemp("°C", "K", 0.0), 1e-9)
+    assertEquals(37.0, Converter.convertTemp("°F", "°C", 98.6), 1e-9)
+  }
+
+  @Test
+  fun `speed converts kmh to mph`() {
+    assertEquals(62.137119, Converter.convert("Speed", "km/h", "mph", 100.0), 1e-4)
+  }
+
+  @Test
+  fun `same unit is identity`() {
+    assertEquals(5.0, Converter.convert("Volume", "L", "L", 5.0), 1e-9)
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/IssPassesTest.kt
+++ b/app/src/test/java/com/immortal/launcher/IssPassesTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import kotlin.math.sqrt
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Validates the self-contained SGP4 propagator against the canonical NORAD/Vallado
+ * verification vector (catalogue object 00005) published in "Revisiting Spacetrack
+ * Report #3" — the reference everyone's SGP4 is checked against. No device, no
+ * network: pure orbital math.
+ *
+ * Object 00005 is eccentric and near-Earth (same code path as the ISS), so matching
+ * its TEME position to sub-km at t=0 and t=360 min exercises the whole pipeline:
+ * Kozai recovery, the drag/secular terms, Kepler's solve and the short-period
+ * periodics.
+ */
+class IssPassesTest {
+
+  // The official SGP4-VER test element set for object 00005.
+  private val line1 = "1 00005U 58002B   00179.78495062  .00000023  00000-0  28098-4 0  4753"
+  private val line2 = "2 00005  34.2682 348.7242 1859667 331.7664  19.3264 10.82419157413667"
+
+  private fun dist(p: DoubleArray, x: Double, y: Double, z: Double): Double {
+    val dx = p[0] - x
+    val dy = p[1] - y
+    val dz = p[2] - z
+    return sqrt(dx * dx + dy * dy + dz * dz)
+  }
+
+  @Test
+  fun `sgp4 matches canonical vector at epoch`() {
+    val sat = IssPasses.Sat.fromTle(line1, line2)
+    val r = sat.propagate(0.0)!!
+    // Published TEME position (km) at tsince = 0.
+    val err = dist(r, 7022.46529266, -1400.08296755, 0.03995155)
+    assertTrue("t=0 position off by $err km\n  got=${r.toList()}", err < 0.1)
+  }
+
+  @Test
+  fun `sgp4 matches canonical vector at plus 360 minutes`() {
+    val sat = IssPasses.Sat.fromTle(line1, line2)
+    val r = sat.propagate(360.0)!!
+    // Published TEME position (km) at tsince = 360 min (exercises secular rates).
+    val err = dist(r, -7154.03120202, -3783.17682504, -3536.19412294)
+    assertTrue("t=360 position off by $err km\n  got=${r.toList()}", err < 1.0)
+  }
+
+  @Test
+  fun `bstar exponent field parses sign and exponent`() {
+    // " 28098-4" -> 0.28098e-4  (object 00005's drag term).
+    val sat = IssPasses.Sat.fromTle(line1, line2)
+    // If bstar parsed wrong, the t=0 vector above would already drift; this guards the
+    // negative-mantissa form too via a second TLE.
+    val negB = "1 25544U 98067A   24001.50000000  .00016717  00000-0 -30000-3 0  9007"
+    val l2 = "2 25544  51.6400 208.0000 0006703 130.0000 325.0000 15.50000000    07"
+    val iss = IssPasses.Sat.fromTle(negB, l2)
+    val r = iss.propagate(0.0)!!
+    // ISS sits ~6700-6800 km from Earth's centre; just sanity-check the magnitude.
+    val mag = sqrt(r[0] * r[0] + r[1] * r[1] + r[2] * r[2])
+    assertEquals(6780.0, mag, 120.0)
+  }
+
+  @Test
+  fun `compass maps azimuth to 16-point labels`() {
+    assertEquals("N", IssPasses.compass(0.0))
+    assertEquals("N", IssPasses.compass(359.0))
+    assertEquals("E", IssPasses.compass(90.0))
+    assertEquals("S", IssPasses.compass(180.0))
+    assertEquals("W", IssPasses.compass(270.0))
+    assertEquals("NE", IssPasses.compass(45.0))
+  }
+}


### PR DESCRIPTION
First of the split PRs carved out of #85, per @starbrightlab's lowest-risk-first plan.

Five keyless, standalone tools with no shared-state footprint:
- **Converter** — offline unit converter (length / mass / temperature / speed).
- **IssPasses** — "space station overhead" predictor: self-contained SGP4 propagator + topocentric look angles; one keyless TLE fetch, then fully offline.
- **Aurora** — geomagnetic aurora-chance estimate by latitude + Kp.
- **StarField** — ambient star-field renderer.
- **SkyColors** — time-of-day sky gradient.

Plus `Weather.coordinates()` (a small helper a few later PRs reuse) and unit tests for Converter, IssPasses, and Aurora.

Based on current `main`; `:app:assembleDebug` and the full `:app:testDebugUnitTest` are green.


🤖 Generated with [Claude Code](https://claude.com/claude-code)