### PR TITLE
Digital-clock screensaver (DigitalClock* + ClockSettingsActivity)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -181,6 +181,21 @@
             android:label="Sounds"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- "Clock": digital clock screensaver style / color / layout settings. -->
+        <activity
+            android:name=".ClockSettingsActivity"
+            android:exported="false"
+            android:label="Clock"
+            android:theme="@style/Theme.SampleApp" />
+
+        <!-- Full-screen digital clock preview, opened from the Preview button in
+             Clock settings. Excluded from recents. -->
+        <activity
+            android:name=".DigitalClockPreviewActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:theme="@style/Theme.SampleApp" />
+
         <!-- Connect a self-hosted Immich server as the screensaver source. -->
         <activity
             android:name=".ImmichConnectActivity"
@@ -403,6 +418,18 @@
         <!-- Custom screensaver (Dream), set via secure setting screensaver_components. -->
         <service
             android:name=".PhotoDreamService"
+            android:exported="true"
+            android:permission="android.permission.BIND_DREAM_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.dreams.DreamService" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </service>
+
+        <!-- Digital clock screensaver (Dream); the active one is chosen in
+             SettingsGuard.reaffirmScreensaver from DigitalClockConfig.enabled. -->
+        <service
+            android:name=".DigitalClockDreamService"
             android:exported="true"
             android:permission="android.permission.BIND_DREAM_SERVICE">
             <intent-filter>

--- a/app/src/main/java/com/immortal/launcher/ClockSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ClockSettingsActivity.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.immortal.launcher.settings.SettingsDomains
+import com.immortal.launcher.ui.theme.SampleAppTheme
+import org.json.JSONObject
+
+/**
+ * Dedicated settings screen for the digital clock. Opened from a "Clock" tile
+ * in the launcher's Settings folder. The clock-specific preferences (enable, style,
+ * color, font, size, layout, background, glow, show date, show seconds) render from
+ * the `digitalclock` registry domain — the same specs the phone remote uses. The
+ * screensaver-activation toggles route through the `immortal` domain so its `onApplied`
+ * fires. The back-gesture section (accessibility service, overlay permission, test) is
+ * genuinely bespoke system-action UI the registry can't model, so it stays hand-built.
+ */
+class ClockSettingsActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { ClockSettingsScreen() } }
+  }
+}
+
+@Composable
+private fun ClockSettingsScreen() {
+  val context = LocalContext.current
+  var clockConfig by remember { mutableStateOf(DigitalClockConfig.load(context)) }
+  var settings by remember { mutableStateOf(ImmortalSettings.load(context)) }
+
+  // Re-read on resume so a change in another screen is reflected here.
+  val lifecycleOwner = LocalLifecycleOwner.current
+  DisposableEffect(lifecycleOwner) {
+    val obs = LifecycleEventObserver { _, e ->
+      if (e == Lifecycle.Event.ON_RESUME) {
+        clockConfig = DigitalClockConfig.load(context)
+        settings = ImmortalSettings.load(context)
+      }
+    }
+    lifecycleOwner.lifecycle.addObserver(obs)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+  }
+
+  val activity = context as? Activity
+  val firstFocus = remember { FocusRequester() }
+  LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
+
+  Box(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .onPreviewKeyEvent { e ->
+                  if (e.key == Key.Back) {
+                    if (e.type == KeyEventType.KeyUp) activity?.finish()
+                    true
+                  } else false
+                }
+                .background(Color(0xFF101012))
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 28.dp, vertical = 32.dp),
+    ) {
+      Column(modifier = Modifier.widthIn(max = 1100.dp).focusRequester(firstFocus).focusGroup()) {
+        Text("Clock", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+        Text(
+            "Choose the digital clock and how it looks on the screensaver.",
+            color = Color(0xFF9A9A9A),
+            fontSize = 16.sp,
+            modifier = Modifier.padding(top = 6.dp),
+        )
+        Spacer(Modifier.size(26.dp))
+
+        // Clock preferences render from the `digitalclock` registry domain. Apply routes through
+        // the domain so its onApplied (reaffirm the dream when `enabled` toggles) fires here too.
+        SettingsList(SettingsDomains.digitalclock, clockConfig) { k, v ->
+          SettingsDomains.digitalclock.apply(context, JSONObject().put(k, v))
+          clockConfig = DigitalClockConfig.load(context)
+        }
+
+        // Preview button — opens fullscreen preview (a bespoke action, not a setting).
+        SectionLabel("Preview")
+        Card {
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp).clickable {
+                context.startActivity(
+                    Intent(context, DigitalClockPreviewActivity::class.java)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+              },
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Column(modifier = Modifier.weight(1f)) {
+              Text("Preview", color = Color.White, fontSize = 17.sp)
+              Text(
+                  "See the clock full-screen with your current settings.",
+                  color = Color(0xFF9A9A9A),
+                  fontSize = 13.sp,
+                  modifier = Modifier.padding(top = 2.dp),
+              )
+            }
+            Surface(
+                color = MaterialTheme.colorScheme.primary,
+                shape = RoundedCornerShape(10.dp),
+                modifier = Modifier.tvFocusable(RoundedCornerShape(10.dp)) {
+                  context.startActivity(
+                      Intent(context, DigitalClockPreviewActivity::class.java)
+                          .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+                },
+            ) {
+              Text(
+                  "Preview",
+                  color = Color.White,
+                  fontSize = 15.sp,
+                  modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+              )
+            }
+          }
+        }
+
+        Text(
+            "Changes apply immediately. Tap the clock icon on the home screen to start the screensaver.",
+            color = Color(0xFF7C7C7C),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
+        )
+      }
+    }
+    FolderBackButton(onClick = { activity?.finish() })
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/DigitalClockConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/DigitalClockConfig.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+
+object DigitalClockConfig {
+
+  private const val PREFS = "digital_clock_config"
+
+  const val COLOR_WHITE = "white"
+  const val COLOR_RED = "red"
+  const val COLOR_GREEN = "green"
+  const val COLOR_BLUE = "blue"
+  const val COLOR_YELLOW = "yellow"
+  const val COLOR_CYAN = "cyan"
+  const val COLOR_PINK = "pink"
+  const val COLOR_ORANGE = "orange"
+
+  const val FONT_LIGHT = "light"
+  const val FONT_NORMAL = "normal"
+  const val FONT_BOLD = "bold"
+  const val FONT_MONO = "mono"
+  const val FONT_SERIF = "serif"
+  // Bundled OFL-licensed display fonts (SIL Open Font License 1.1 — freely
+  // redistributable). Replacements chosen to match the visual intent of the
+  // original personal-use-only fonts:
+  //   DSEG7Classic-Regular  → digital_7.ttf   (7-segment LCD display)
+  //   DSEG14Classic-Regular → segment_led.ttf (14-segment LED display)
+  //   Orbitron-Regular      → technology.ttf  (geometric tech / LCD style)
+  //   Orbitron-Bold         → technology_bold.ttf
+  // Sources:
+  //   DSEG:    https://github.com/keshikan/DSEG   (OFL-1.1)
+  //   Orbitron: https://github.com/googlefonts/orbitron (OFL-1.1)
+  const val FONT_SEGMENT_LED = "segment_led"   // expects segment_led.ttf
+  const val FONT_DIGITAL_7 = "digital_7"       // expects digital_7.ttf
+  const val FONT_TECHNOLOGY = "technology"     // expects technology.ttf
+
+  const val SIZE_SMALL = "small"
+  const val SIZE_MEDIUM = "medium"
+  const val SIZE_LARGE = "large"
+  const val SIZE_XL = "xl"
+
+  // Layout positions
+  const val LAYOUT_CENTER = "center"       // clock centered on screen
+  const val LAYOUT_TOP = "top"             // clock near top
+  const val LAYOUT_BOTTOM = "bottom"       // clock near bottom
+  const val LAYOUT_MINIMAL = "minimal"     // clock only, no date, very large
+
+  // Background styles
+  const val BG_BLACK = "black"             // solid black
+  const val BG_GRADIENT = "gradient"       // radial gradient
+  const val BG_RED = "red"                 // solid dark red
+
+  // Glow intensity
+  const val GLOW_NONE = "none"
+  const val GLOW_SOFT = "soft"
+  const val GLOW_STRONG = "strong"
+
+  // Clock styles. Classic is the only style that respects the user's
+  // chosen font — the other styles use a built-in font and ignore
+  // the font setting. Minimal and Outline were removed because they
+  // didn't use the user's font and confused the font picker UX.
+  const val STYLE_CLASSIC = "classic"       // Large time + date below, uses user font
+  const val STYLE_FLIP = "flip"             // Retro flip clock with digit cards
+  const val STYLE_BOLD = "bold"             // Extra bold, thick numbers
+  const val STYLE_NEON = "neon"             // Bright neon glow
+  const val STYLE_SEGMENT = "segment"       // 7-segment display style
+  const val STYLE_ANALOG = "analog"         // Analog clock face
+
+  data class Settings(
+      val enabled: Boolean = false,
+      val color: String = COLOR_WHITE,
+      val font: String = FONT_LIGHT,
+      val size: String = SIZE_LARGE,
+      val layout: String = LAYOUT_CENTER,
+      val background: String = BG_BLACK,
+      val showDate: Boolean = true,
+      val showSeconds: Boolean = false,
+      val glow: String = GLOW_SOFT,
+      val style: String = STYLE_CLASSIC,
+  )
+
+  private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+  fun load(context: Context): Settings {
+    val p = prefs(context)
+    return Settings(
+        enabled = p.getBoolean("enabled", false),
+        color = p.getString("color", COLOR_WHITE) ?: COLOR_WHITE,
+        font = p.getString("font", FONT_LIGHT) ?: FONT_LIGHT,
+        size = p.getString("size", SIZE_LARGE) ?: SIZE_LARGE,
+        layout = p.getString("layout", LAYOUT_CENTER) ?: LAYOUT_CENTER,
+        background = p.getString("background", BG_BLACK) ?: BG_BLACK,
+        showDate = p.getBoolean("show_date", true),
+        showSeconds = p.getBoolean("show_seconds", false),
+        glow = p.getString("glow", GLOW_SOFT) ?: GLOW_SOFT,
+        style = p.getString("style", STYLE_CLASSIC) ?: STYLE_CLASSIC,
+    )
+  }
+
+  fun setEnabled(c: Context, enabled: Boolean) =
+      prefs(c).edit().putBoolean("enabled", enabled).apply()
+
+  fun setColor(c: Context, color: String) =
+      prefs(c).edit().putString("color", color).apply()
+
+  fun setFont(c: Context, font: String) =
+      prefs(c).edit().putString("font", font).apply()
+
+  fun setSize(c: Context, size: String) =
+      prefs(c).edit().putString("size", size).apply()
+
+  fun setLayout(c: Context, layout: String) =
+      prefs(c).edit().putString("layout", layout).apply()
+
+  fun setBackground(c: Context, bg: String) =
+      prefs(c).edit().putString("background", bg).apply()
+
+  fun setShowDate(c: Context, show: Boolean) =
+      prefs(c).edit().putBoolean("show_date", show).apply()
+
+  fun setShowSeconds(c: Context, show: Boolean) =
+      prefs(c).edit().putBoolean("show_seconds", show).apply()
+
+  fun setGlow(c: Context, glow: String) =
+      prefs(c).edit().putString("glow", glow).apply()
+
+  fun setStyle(c: Context, style: String) =
+      prefs(c).edit().putString("style", style).apply()
+}

--- a/app/src/main/java/com/immortal/launcher/DigitalClockDreamService.kt
+++ b/app/src/main/java/com/immortal/launcher/DigitalClockDreamService.kt
@@ -1,0 +1,81 @@
+package com.immortal.launcher
+
+import android.os.Handler
+import android.os.Looper
+import android.service.dreams.DreamService
+import android.util.Log
+import android.view.MotionEvent
+
+class DigitalClockDreamService : DreamService() {
+  private val handler = Handler(Looper.getMainLooper())
+  private var settings = DigitalClockConfig.Settings()
+  private var controller: DigitalClockView.Controller? = null
+
+  private var downX = 0f
+  private var downY = 0f
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    Log.i(TAG, "attached: digital clock dream starting")
+    isInteractive = true
+    isFullscreen = true
+    isScreenBright = true
+    settings = DigitalClockConfig.load(this)
+    controller = DigitalClockView.build(this, settings)
+    val root = controller!!.root
+    root.setOnTouchListener { _, ev ->
+      onTouch(ev)
+      true
+    }
+    setContentView(root)
+    tick.run()
+  }
+
+  override fun onDreamingStarted() {
+    super.onDreamingStarted()
+    Log.i(TAG, "onDreamingStarted")
+    SleepScheduler.onScreensaverStarted(this)
+  }
+
+  override fun onDetachedFromWindow() {
+    Log.i(TAG, "detached: digital clock dream ending")
+    handler.removeCallbacksAndMessages(null)
+    super.onDetachedFromWindow()
+  }
+
+  private fun onTouch(ev: MotionEvent) {
+    when (ev.actionMasked) {
+      MotionEvent.ACTION_DOWN -> {
+        downX = ev.x
+        downY = ev.y
+      }
+      MotionEvent.ACTION_UP -> {
+        val dx = ev.x - downX
+        val dy = ev.y - downY
+        if (kotlin.math.abs(dx) < 48 && kotlin.math.abs(dy) < 48) {
+          DreamPolicy.userExitAt = System.currentTimeMillis()
+          finish()
+        }
+      }
+    }
+  }
+
+  private val tick = object : Runnable {
+    override fun run() {
+      controller?.let {
+        DigitalClockView.update(it, settings)
+        // Anti-burn-in: drift the whole clock along a slow, invisible path so the lit
+        // pixels of an always-on screen don't ghost in over time.
+        val now = System.currentTimeMillis()
+        val shift = AntiBurnIn.shift(now, 14f)
+        it.root.translationX = shift.x
+        it.root.translationY = shift.y
+      }
+      handler.postDelayed(this, if (settings.showSeconds) 500L else 1_000L)
+    }
+  }
+
+  private companion object {
+    const val TAG = "ImmortalDigitalClock"
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/DigitalClockPreviewActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/DigitalClockPreviewActivity.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.MotionEvent
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+
+/**
+ * Full-screen preview of the digital clock with the current settings. Opened
+ * from the "Preview" button in Immortal Settings, so the user can see what the
+ * clock looks like before waiting for the screensaver to activate.
+ *
+ * Tap anywhere to exit.
+ */
+class DigitalClockPreviewActivity : ComponentActivity() {
+  private val handler = Handler(Looper.getMainLooper())
+  private var controller: DigitalClockView.Controller? = null
+  private var settings = DigitalClockConfig.Settings()
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    // Immersive fullscreen
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    WindowInsetsControllerCompat(window, window.decorView).apply {
+      hide(WindowInsetsCompat.Type.systemBars())
+      systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+    }
+    // Keep screen on while previewing
+    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
+    settings = DigitalClockConfig.load(this)
+    controller = DigitalClockView.build(this, settings)
+    setContentView(controller!!.root)
+    tick.run()
+  }
+
+  override fun onTouchEvent(event: MotionEvent?): Boolean {
+    if (event?.action == MotionEvent.ACTION_UP) {
+      finish()
+      return true
+    }
+    return super.onTouchEvent(event)
+  }
+
+  override fun onDestroy() {
+    handler.removeCallbacksAndMessages(null)
+    super.onDestroy()
+  }
+
+  private val tick = object : Runnable {
+    override fun run() {
+      controller?.let { DigitalClockView.update(it, settings) }
+      handler.postDelayed(this, if (settings.showSeconds) 500L else 1_000L)
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/DigitalClockView.kt
+++ b/app/src/main/java/com/immortal/launcher/DigitalClockView.kt
@@ -1,0 +1,476 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Typeface
+import android.view.Gravity
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.TextView
+import java.util.Calendar
+
+/**
+ * Shared builder for the digital clock UI. Used by both the
+ * [DigitalClockDreamService] (the actual screensaver) and the
+ * [DigitalClockPreviewActivity] (in-app preview). Returns a root view
+ * plus a [Controller] that the caller uses to update the time.
+ *
+ * The caller is responsible for the update loop: call [Controller.update]
+ * periodically to refresh the clock text and (for analog) the hands.
+ */
+object DigitalClockView {
+
+  data class Controller(
+      val root: View,
+      val clockText: TextView?,
+      val dateText: TextView?,
+      val flipHour: TextView?,
+      val flipMinute: TextView?,
+      val flipSecond: TextView?,
+      val analog: AnalogClockView?,
+  )
+
+  fun build(context: Context, settings: DigitalClockConfig.Settings): Controller {
+    val root = FrameLayout(context)
+    root.setBackgroundColor(backgroundColor(settings))
+
+    if (settings.background == DigitalClockConfig.BG_GRADIENT) {
+      val gradient = android.graphics.drawable.GradientDrawable(
+          android.graphics.drawable.GradientDrawable.Orientation.TOP_BOTTOM,
+          intArrayOf(Color.parseColor("#FF1A1A2E"), Color.parseColor("#FF16213E"), Color.BLACK)
+      )
+      root.background = gradient
+    }
+
+    val textColor = clockColor(settings)
+    val sizeSp = clockSizeSp(settings)
+    val analog = AnalogClockView(context).apply {
+      setColor(textColor)
+      setSize(sizeSp)
+      setShowSeconds(settings.showSeconds)
+    }
+
+    // Analog style: single custom view centered, optional date at bottom.
+    if (settings.style == DigitalClockConfig.STYLE_ANALOG) {
+      // Size to ~55% of the smaller screen dimension so it fits comfortably
+      // on any Portal model (Portal+, TV, Go, Mini) with margin for the date.
+      val dm = context.resources.displayMetrics
+      val screenMin = kotlin.math.min(dm.widthPixels, dm.heightPixels)
+      val analogSize = (screenMin * 0.55f).toInt()
+      root.addView(analog, FrameLayout.LayoutParams(analogSize, analogSize, Gravity.CENTER))
+      val dateView = if (settings.showDate) buildDateView(context, settings, textColor).also {
+        val lp = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
+        )
+        lp.bottomMargin = 80
+        root.addView(it, lp)
+      } else null
+      return Controller(root, null, dateView, null, null, null, analog)
+    }
+
+    val container = LinearLayout(context).apply {
+      orientation = LinearLayout.VERTICAL
+      gravity = Gravity.CENTER
+    }
+
+    val clockText: TextView?
+    val flipHour: TextView?
+    val flipMinute: TextView?
+    val flipSecond: TextView?
+    if (settings.style == DigitalClockConfig.STYLE_FLIP) {
+      val h = flipHourView(context, settings, textColor)
+      val m = flipMinuteView(context, settings, textColor)
+      val s = if (settings.showSeconds) flipSecondView(context, settings, textColor) else null
+      val row = LinearLayout(context).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER
+      }
+      row.addView(h)
+      row.addView(flipSeparator(context, settings, textColor))
+      row.addView(m)
+      if (s != null) {
+        row.addView(flipSeparator(context, settings, textColor))
+        row.addView(s)
+      }
+      container.addView(row)
+      clockText = null
+      flipHour = h
+      flipMinute = m
+      flipSecond = s
+    } else {
+      val text = TextView(context).apply {
+        textSize = sizeSp
+        setTextColor(textColor)
+        typeface = clockTypefaceForStyle(context, settings)
+        gravity = Gravity.CENTER
+        applyClockStyleEffects(context, this, settings, textColor)
+      }
+      container.addView(text)
+      clockText = text
+      flipHour = null
+      flipMinute = null
+      flipSecond = null
+    }
+
+    val dateText: TextView? = if (settings.showDate) {
+      val v = buildDateView(context, settings, textColor)
+      container.addView(v)
+      v
+    } else null
+
+    val containerGravity = when (settings.layout) {
+      DigitalClockConfig.LAYOUT_TOP -> Gravity.TOP or Gravity.CENTER_HORIZONTAL
+      DigitalClockConfig.LAYOUT_BOTTOM -> Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
+      else -> Gravity.CENTER
+    }
+    val lp = FrameLayout.LayoutParams(
+        FrameLayout.LayoutParams.WRAP_CONTENT,
+        FrameLayout.LayoutParams.WRAP_CONTENT,
+        containerGravity
+    )
+    if (settings.layout == DigitalClockConfig.LAYOUT_TOP) lp.topMargin = 120
+    else if (settings.layout == DigitalClockConfig.LAYOUT_BOTTOM) lp.bottomMargin = 120
+    root.addView(container, lp)
+
+    clockText?.textSize = sizeSp
+
+    return Controller(root, clockText, dateText, flipHour, flipMinute, flipSecond, analog)
+  }
+
+  fun update(controller: Controller, settings: DigitalClockConfig.Settings) {
+    val cal = Calendar.getInstance()
+    val use24Hour = ImmortalSettings.use24HourClock(controller.root.context)
+    val now = java.util.Date()
+
+    controller.analog?.update()
+    controller.clockText?.let {
+      val pattern = when {
+        settings.showSeconds -> if (use24Hour) "H:mm:ss" else "h:mm:ss"
+        use24Hour -> "H:mm"
+        else -> "h:mm"
+      }
+      it.text = java.text.SimpleDateFormat(pattern, java.util.Locale.getDefault()).format(now)
+    }
+    if (controller.flipHour != null) {
+      val h = if (use24Hour) cal.get(Calendar.HOUR_OF_DAY) else cal.get(Calendar.HOUR)
+      val hour12 = if (h == 0) 12 else if (h > 12) h - 12 else h
+      val displayHour = if (use24Hour) h else hour12
+      controller.flipHour.text = displayHour.toString().padStart(2, '0')
+      controller.flipMinute?.text = cal.get(Calendar.MINUTE).toString().padStart(2, '0')
+      controller.flipSecond?.text = cal.get(Calendar.SECOND).toString().padStart(2, '0')
+    }
+    controller.dateText?.text = java.text.SimpleDateFormat("EEEE, MMMM d", java.util.Locale.getDefault()).format(now)
+  }
+
+  private fun buildDateView(context: Context, settings: DigitalClockConfig.Settings, color: Int): TextView {
+    val v = TextView(context)
+    v.textSize = dateSizeSp(settings)
+    v.setTextColor(color)
+    v.typeface = Typeface.create("sans-serif-light", Typeface.NORMAL)
+    v.gravity = Gravity.CENTER
+    v.alpha = 0.8f
+    applyGlow(v, settings, color, 6f, 2f)
+    return v
+  }
+
+  private fun flipHourView(context: Context, settings: DigitalClockConfig.Settings, color: Int) = makeFlipCard(context, settings, color)
+  private fun flipMinuteView(context: Context, settings: DigitalClockConfig.Settings, color: Int) = makeFlipCard(context, settings, color)
+  private fun flipSecondView(context: Context, settings: DigitalClockConfig.Settings, color: Int) = makeFlipCard(context, settings, color)
+  private fun makeFlipCard(context: Context, settings: DigitalClockConfig.Settings, color: Int): TextView {
+    return TextView(context).apply {
+      textSize = clockSizeSp(settings) * 0.6f
+      setTextColor(color)
+      gravity = Gravity.CENTER
+      setPadding(24, 12, 24, 12)
+    }
+  }
+  private fun flipSeparator(context: Context, settings: DigitalClockConfig.Settings, color: Int): TextView {
+    return TextView(context).apply {
+      text = ":"
+      textSize = clockSizeSp(settings) * 0.5f
+      setTextColor(color)
+      gravity = Gravity.CENTER
+    }
+  }
+
+  private fun applyClockStyleEffects(context: Context, view: TextView, settings: DigitalClockConfig.Settings, color: Int) {
+    when (settings.style) {
+      DigitalClockConfig.STYLE_BOLD -> {
+        view.setTypeface(Typeface.create(clockTypefaceForStyle(context, settings), Typeface.BOLD))
+        view.setShadowLayer(8f, 2f, 2f, color and 0x00FFFFFF or 0xAA000000.toInt())
+      }
+      DigitalClockConfig.STYLE_NEON -> {
+        view.setShadowLayer(30f, 0f, 0f, color and 0x00FFFFFF or 0xCC000000.toInt())
+        view.setShadowLayer(12f, 0f, 0f, color)
+      }
+      DigitalClockConfig.STYLE_SEGMENT -> {
+        view.typeface = Typeface.create(Typeface.MONOSPACE, Typeface.BOLD)
+        view.letterSpacing = 0.15f
+        view.setShadowLayer(8f, 0f, 2f, color and 0x00FFFFFF or 0xAA000000.toInt())
+      }
+      else -> applyGlow(view, settings, color)
+    }
+  }
+
+  private fun applyGlow(view: TextView, settings: DigitalClockConfig.Settings, baseColor: Int, radius: Float = 12f, dy: Float = 4f) {
+    when (settings.glow) {
+      DigitalClockConfig.GLOW_NONE -> view.setShadowLayer(0f, 0f, 0f, 0)
+      DigitalClockConfig.GLOW_SOFT -> {
+        val softColor = (baseColor and 0x00FFFFFF) or 0x66000000.toInt()
+        view.setShadowLayer(radius, 0f, dy, softColor)
+      }
+      DigitalClockConfig.GLOW_STRONG -> {
+        val wideColor = (baseColor and 0x00FFFFFF) or 0x99000000.toInt()
+        view.setShadowLayer(radius * 2, 0f, 0f, wideColor)
+        view.setShadowLayer(radius * 1.4f, 0f, dy * 0.5f, baseColor)
+      }
+    }
+  }
+
+  private fun backgroundColor(settings: DigitalClockConfig.Settings): Int = when (settings.background) {
+    DigitalClockConfig.BG_BLACK -> Color.BLACK
+    DigitalClockConfig.BG_RED -> Color.parseColor("#FF1A0500")
+    else -> Color.BLACK
+  }
+
+  private fun clockSizeSp(settings: DigitalClockConfig.Settings): Float = when (settings.size) {
+    DigitalClockConfig.SIZE_SMALL -> 120f
+    DigitalClockConfig.SIZE_MEDIUM -> 180f
+    DigitalClockConfig.SIZE_LARGE -> 240f
+    DigitalClockConfig.SIZE_XL -> 320f
+    else -> 240f
+  }
+
+  private fun dateSizeSp(settings: DigitalClockConfig.Settings): Float = when (settings.size) {
+    DigitalClockConfig.SIZE_SMALL -> 24f
+    DigitalClockConfig.SIZE_MEDIUM -> 32f
+    DigitalClockConfig.SIZE_LARGE -> 40f
+    DigitalClockConfig.SIZE_XL -> 52f
+    else -> 40f
+  }
+
+  private fun clockColor(settings: DigitalClockConfig.Settings): Int = when (settings.color) {
+    DigitalClockConfig.COLOR_RED -> Color.parseColor("#FFF44336")
+    DigitalClockConfig.COLOR_GREEN -> Color.parseColor("#FF4CAF50")
+    DigitalClockConfig.COLOR_BLUE -> Color.parseColor("#FF2196F3")
+    DigitalClockConfig.COLOR_YELLOW -> Color.parseColor("#FFFFEB3B")
+    DigitalClockConfig.COLOR_CYAN -> Color.parseColor("#FF00BCD4")
+    DigitalClockConfig.COLOR_PINK -> Color.parseColor("#FFE91E63")
+    DigitalClockConfig.COLOR_ORANGE -> Color.parseColor("#FFFF9800")
+    else -> Color.WHITE
+  }
+
+  private fun clockTypeface(context: Context, settings: DigitalClockConfig.Settings): Typeface = when (settings.font) {
+    // Use the guaranteed-distinct Typeface constants so every font option
+    // actually looks different (previous versions used family-name strings
+    // that silently fell back to the same default on Android 9).
+    DigitalClockConfig.FONT_LIGHT -> Typeface.create("sans-serif-thin", Typeface.NORMAL)
+        .let { if (it == Typeface.DEFAULT) Typeface.SANS_SERIF else it }
+    DigitalClockConfig.FONT_BOLD -> Typeface.create(Typeface.SANS_SERIF, Typeface.BOLD)
+    DigitalClockConfig.FONT_MONO -> Typeface.MONOSPACE
+    DigitalClockConfig.FONT_SERIF -> Typeface.SERIF
+    // Bundled custom fonts — drop the .ttf into app/src/main/assets/fonts/
+    DigitalClockConfig.FONT_SEGMENT_LED -> loadBundledFont(context, "fonts/segment_led.ttf")
+    DigitalClockConfig.FONT_DIGITAL_7 -> loadBundledFont(context, "fonts/digital_7.ttf")
+    DigitalClockConfig.FONT_TECHNOLOGY -> loadBundledFont(context, "fonts/technology.ttf")
+    else -> Typeface.SANS_SERIF
+  }
+
+  /** Cached bundled fonts keyed by asset path so we only load each one once. */
+  private val bundledFontCache = mutableMapOf<String, Typeface>()
+
+  /**
+   * Load a bundled .ttf font from the assets/fonts/ directory. Returns a
+   * sensible fallback if the file is missing, so a font option silently
+   * degrades to the default instead of crashing.
+   */
+  private fun loadBundledFont(context: Context, assetPath: String): Typeface {
+    bundledFontCache[assetPath]?.let { return it }
+    val tf = runCatching {
+      Typeface.createFromAsset(context.assets, assetPath)
+    }.getOrNull() ?: return Typeface.SANS_SERIF
+    bundledFontCache[assetPath] = tf
+    return tf
+  }
+
+  private fun clockTypefaceForStyle(context: Context, settings: DigitalClockConfig.Settings): Typeface = when (settings.style) {
+    DigitalClockConfig.STYLE_BOLD -> Typeface.create(Typeface.SANS_SERIF, Typeface.BOLD)
+    DigitalClockConfig.STYLE_SEGMENT -> Typeface.MONOSPACE
+    DigitalClockConfig.STYLE_NEON -> Typeface.create("sans-serif-thin", Typeface.NORMAL)
+        .let { if (it == Typeface.DEFAULT) Typeface.SANS_SERIF else it }
+    DigitalClockConfig.STYLE_FLIP -> Typeface.MONOSPACE
+    else -> clockTypeface(context, settings)
+  }
+}
+
+/**
+ * High-quality analog clock face drawn with Canvas. Hour, minute, and
+ * optional second hands rotate to show the current time.
+ *
+ * Supports the full color palette: the face, markers, numbers, and hands
+ * all tint with the selected clock color, with the second hand in a
+ * contrasting red for legibility. Hour and minute hands use a slight
+ * taper (drawn as two segments) for a more refined look.
+ *
+ * Pure drawable view — no Compose dependency.
+ */
+class AnalogClockView(context: android.content.Context) : View(context) {
+  private var hour = 0
+  private var minute = 0
+  private var second = 0
+  private var showSeconds = false
+  private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+  private val fillPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+  private var clockColor = Color.WHITE
+  // Size preference: small=0.10, medium=0.13, large=0.16, xl=0.20 (fraction of view width).
+  // Numbers scale with the view size while still respecting the user's chosen size setting.
+  private var sizeFraction = 0.13f
+
+  fun setColor(c: Int) { clockColor = c; invalidate() }
+  fun setSize(sp: Float) { /* kept for API compat; size is now derived from the view */ }
+  fun setSizeFraction(f: Float) { sizeFraction = f; invalidate() }
+  fun setShowSeconds(s: Boolean) { showSeconds = s; invalidate() }
+
+  init {
+    update()
+  }
+
+  fun update() {
+    val cal = Calendar.getInstance()
+    hour = cal.get(Calendar.HOUR)
+    minute = cal.get(Calendar.MINUTE)
+    second = cal.get(Calendar.SECOND)
+    invalidate()
+  }
+
+  override fun onDraw(canvas: android.graphics.Canvas) {
+    super.onDraw(canvas)
+    val w = width.toFloat()
+    val h = height.toFloat()
+    val cx = w / 2f
+    val cy = h / 2f
+    val radius = kotlin.math.min(w, h) / 2f * 0.88f
+
+    // Base unit: ~1.2% of radius. All stroke widths and text sizes scale
+    // proportionally so the clock looks balanced at any physical size.
+    val unit = radius * 0.012f
+
+    // Subtle outer ring for depth (very faint, same hue as the clock)
+    paint.color = clockColor and 0x00FFFFFF or 0x33000000.toInt()
+    paint.style = Paint.Style.STROKE
+    paint.strokeWidth = unit * 0.5f
+    canvas.drawCircle(cx, cy, radius + unit * 2, paint)
+
+    // Main face circle
+    paint.color = clockColor
+    paint.style = Paint.Style.STROKE
+    paint.strokeWidth = unit * 1.2f
+    canvas.drawCircle(cx, cy, radius, paint)
+
+    // Hour markers — longer and slightly thicker at 12/3/6/9 (cardinal points)
+    paint.strokeCap = Paint.Cap.ROUND
+    for (i in 0 until 12) {
+      val isCardinal = (i % 3) == 0
+      val angle = (i * 30 - 90) * Math.PI / 180.0
+      val outerR = radius - unit * 2
+      val innerR =
+          if (isCardinal) radius - unit * 10
+          else radius - unit * 5
+      paint.strokeWidth = if (isCardinal) unit * 2.5f else unit * 1.5f
+      val outerX = cx + (outerR * kotlin.math.cos(angle)).toFloat()
+      val outerY = cy + (outerR * kotlin.math.sin(angle)).toFloat()
+      val innerX = cx + (innerR * kotlin.math.cos(angle)).toFloat()
+      val innerY = cy + (innerR * kotlin.math.sin(angle)).toFloat()
+      canvas.drawLine(innerX, innerY, outerX, outerY, paint)
+    }
+
+    // Hour numbers — moved further inward (radius * 0.68f) so they don't
+    // collide with the hour markers. Cardinals are 1.2x the base size,
+    // non-cardinals are 0.85x. All sized in absolute pixels relative to
+    // the view radius, not a fraction of an arbitrary "size fraction".
+    paint.style = Paint.Style.FILL
+    paint.textAlign = Paint.Align.CENTER
+    paint.typeface = android.graphics.Typeface.create("sans-serif-light", android.graphics.Typeface.NORMAL)
+    val numbers = listOf(12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+    for ((i, n) in numbers.withIndex()) {
+      val isCardinal = (n % 3) == 0
+      val angle = (i * 30 - 90) * Math.PI / 180.0
+      val r = radius * 0.68f
+      paint.textSize = unit * (if (isCardinal) 5.0f else 3.6f)
+      if (isCardinal) {
+        paint.typeface = android.graphics.Typeface.create("sans-serif", android.graphics.Typeface.NORMAL)
+      } else {
+        paint.typeface = android.graphics.Typeface.create("sans-serif-light", android.graphics.Typeface.NORMAL)
+      }
+      val fontMetrics = paint.fontMetrics
+      val textOffset = -(fontMetrics.ascent + fontMetrics.descent) / 2f
+      val x = cx + (r * kotlin.math.cos(angle)).toFloat()
+      val y = cy + (r * kotlin.math.sin(angle)).toFloat() + textOffset
+      canvas.drawText(n.toString(), x, y, paint)
+    }
+
+    // Hour hand — shorter, slightly thicker
+    val hourAngle = ((hour + minute / 60f) * 30 - 90) * Math.PI / 180.0
+    paint.color = clockColor
+    paint.strokeWidth = unit * 3.5f
+    paint.strokeCap = Paint.Cap.ROUND
+    canvas.drawLine(
+        cx,
+        cy,
+        cx + (radius * 0.50f * kotlin.math.cos(hourAngle)).toFloat(),
+        cy + (radius * 0.50f * kotlin.math.sin(hourAngle)).toFloat(),
+        paint
+    )
+
+    // Minute hand — longer, thinner
+    val minuteAngle = (minute * 6 - 90) * Math.PI / 180.0
+    paint.strokeWidth = unit * 2.2f
+    paint.strokeCap = Paint.Cap.ROUND
+    canvas.drawLine(
+        cx,
+        cy,
+        cx + (radius * 0.78f * kotlin.math.cos(minuteAngle)).toFloat(),
+        cy + (radius * 0.78f * kotlin.math.sin(minuteAngle)).toFloat(),
+        paint
+    )
+
+    // Second hand (optional) — properly centered: drawn as a single line
+    // from a point behind the center to the tip, passing through center.
+    if (showSeconds) {
+      val secondAngle = (second * 6 - 90) * Math.PI / 180.0
+      // Use red for the second hand for classic contrast
+      paint.color = Color.parseColor("#FFE53935")
+      paint.strokeWidth = unit * 0.7f
+      paint.strokeCap = Paint.Cap.ROUND
+      val tailLen = radius * 0.12f
+      val tipLen = radius * 0.85f
+      // Draw from -tailLen behind center through center to +tipLen
+      val startX = cx + (tailLen * kotlin.math.cos(secondAngle + Math.PI)).toFloat()
+      val startY = cy + (tailLen * kotlin.math.sin(secondAngle + Math.PI)).toFloat()
+      val endX = cx + (tipLen * kotlin.math.cos(secondAngle)).toFloat()
+      val endY = cy + (tipLen * kotlin.math.sin(secondAngle)).toFloat()
+      canvas.drawLine(startX, startY, endX, endY, paint)
+      paint.color = clockColor
+    }
+
+    // Center dot — a filled circle with a small inner ring for detail
+    paint.color = clockColor
+    paint.style = Paint.Style.FILL
+    canvas.drawCircle(cx, cy, unit * 4, paint)
+    // Inner cutout (use the background color — black for the default theme)
+    fillPaint.color = Color.BLACK
+    fillPaint.style = Paint.Style.FILL
+    canvas.drawCircle(cx, cy, unit * 1.8f, fillPaint)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/SettingsGuard.kt
+++ b/app/src/main/java/com/immortal/launcher/SettingsGuard.kt
@@ -66,7 +66,14 @@ object SettingsGuard {
         Settings.Secure.putInt(resolver, "screensaver_enabled", 0)
         return@runCatching
       }
-      val ours = ComponentName(context, PhotoDreamService::class.java).flattenToShortString()
+      // Use the digital-clock screensaver if enabled, otherwise the photo frame.
+      val dreamServiceClass =
+          if (DigitalClockConfig.load(context).enabled) {
+            DigitalClockDreamService::class.java
+          } else {
+            PhotoDreamService::class.java
+          }
+      val ours = ComponentName(context, dreamServiceClass).flattenToShortString()
       if (Settings.Secure.getString(resolver, "screensaver_components") != ours) {
         Settings.Secure.putString(resolver, "screensaver_components", ours)
       }

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -12,6 +12,7 @@ import com.immortal.launcher.CalendarFeed
 import com.immortal.launcher.CalendarUrlEntryActivity
 import com.immortal.launcher.ChimeConfig
 import com.immortal.launcher.ChimeScheduler
+import com.immortal.launcher.DigitalClockConfig
 import com.immortal.launcher.DreamPolicy
 import com.immortal.launcher.FaceCatalog
 import com.immortal.launcher.FacePickerActivity
@@ -775,6 +776,178 @@ object SettingsDomains {
           },
       )
 
+  /**
+   * The digital clock screensaver ([DigitalClockConfig]). When enabled, it replaces the photo-frame
+   * dream with a large customisable clock (style, color, font, size, layout, background, glow, date,
+   * seconds). The enum setters write the raw string straight to prefs (no normalising), so each
+   * [EnumSpec] carries a strict [EnumSpec.coerce] that rejects an unrecognised value — matching the
+   * Immortal display-enum pattern.
+   *
+   * Toggling [DigitalClockConfig.Settings.enabled] switches the active Dream between
+   * [DigitalClockDreamService] and [PhotoDreamService]; that side effect lives in [onApplied]
+   * (reaffirm the dream once per batch) rather than inline in the setter or the Activity.
+   */
+  val digitalclock: SettingsDomain<DigitalClockConfig.Settings> =
+      SettingsDomain(
+          id = "digitalclock",
+          title = "Clock",
+          load = DigitalClockConfig::load,
+          specs =
+              listOf(
+                  BoolSpec(
+                      "enabled",
+                      "Digital clock",
+                      get = { it.enabled },
+                      set = DigitalClockConfig::setEnabled,
+                      help = "Use a large clock instead of the photo frame screensaver."),
+                  EnumSpec(
+                      "style",
+                      "Clock style",
+                      get = { it.style },
+                      set = DigitalClockConfig::setStyle,
+                      options =
+                          listOf(
+                              DigitalClockConfig.STYLE_CLASSIC to "Classic",
+                              DigitalClockConfig.STYLE_FLIP to "Flip",
+                              DigitalClockConfig.STYLE_BOLD to "Bold",
+                              DigitalClockConfig.STYLE_NEON to "Neon",
+                              DigitalClockConfig.STYLE_SEGMENT to "Segment",
+                              DigitalClockConfig.STYLE_ANALOG to "Analog"),
+                      coerce = oneOf(
+                          DigitalClockConfig.STYLE_CLASSIC, DigitalClockConfig.STYLE_FLIP,
+                          DigitalClockConfig.STYLE_BOLD, DigitalClockConfig.STYLE_NEON,
+                          DigitalClockConfig.STYLE_SEGMENT, DigitalClockConfig.STYLE_ANALOG),
+                      visible = { _, s -> s.enabled }),
+                  EnumSpec(
+                      "color",
+                      "Color",
+                      get = { it.color },
+                      set = DigitalClockConfig::setColor,
+                      options =
+                          listOf(
+                              DigitalClockConfig.COLOR_WHITE to "White",
+                              DigitalClockConfig.COLOR_RED to "Red",
+                              DigitalClockConfig.COLOR_GREEN to "Green",
+                              DigitalClockConfig.COLOR_BLUE to "Blue",
+                              DigitalClockConfig.COLOR_YELLOW to "Yellow",
+                              DigitalClockConfig.COLOR_CYAN to "Cyan",
+                              DigitalClockConfig.COLOR_PINK to "Pink",
+                              DigitalClockConfig.COLOR_ORANGE to "Orange"),
+                      coerce = oneOf(
+                          DigitalClockConfig.COLOR_WHITE, DigitalClockConfig.COLOR_RED,
+                          DigitalClockConfig.COLOR_GREEN, DigitalClockConfig.COLOR_BLUE,
+                          DigitalClockConfig.COLOR_YELLOW, DigitalClockConfig.COLOR_CYAN,
+                          DigitalClockConfig.COLOR_PINK, DigitalClockConfig.COLOR_ORANGE),
+                      visible = { _, s -> s.enabled }),
+                  EnumSpec(
+                      "font",
+                      "Font",
+                      get = { it.font },
+                      set = DigitalClockConfig::setFont,
+                      options =
+                          listOf(
+                              DigitalClockConfig.FONT_LIGHT to "Light",
+                              DigitalClockConfig.FONT_NORMAL to "Normal",
+                              DigitalClockConfig.FONT_BOLD to "Bold",
+                              DigitalClockConfig.FONT_MONO to "Mono",
+                              DigitalClockConfig.FONT_SERIF to "Serif",
+                              DigitalClockConfig.FONT_SEGMENT_LED to "LED",
+                              DigitalClockConfig.FONT_DIGITAL_7 to "Digital",
+                              DigitalClockConfig.FONT_TECHNOLOGY to "Tech"),
+                      coerce = oneOf(
+                          DigitalClockConfig.FONT_LIGHT, DigitalClockConfig.FONT_NORMAL,
+                          DigitalClockConfig.FONT_BOLD, DigitalClockConfig.FONT_MONO,
+                          DigitalClockConfig.FONT_SERIF, DigitalClockConfig.FONT_SEGMENT_LED,
+                          DigitalClockConfig.FONT_DIGITAL_7, DigitalClockConfig.FONT_TECHNOLOGY),
+                      visible = { _, s -> s.enabled }),
+                  EnumSpec(
+                      "size",
+                      "Size",
+                      get = { it.size },
+                      set = DigitalClockConfig::setSize,
+                      options =
+                          listOf(
+                              DigitalClockConfig.SIZE_SMALL to "Small",
+                              DigitalClockConfig.SIZE_MEDIUM to "Medium",
+                              DigitalClockConfig.SIZE_LARGE to "Large",
+                              DigitalClockConfig.SIZE_XL to "XL"),
+                      coerce = oneOf(
+                          DigitalClockConfig.SIZE_SMALL, DigitalClockConfig.SIZE_MEDIUM,
+                          DigitalClockConfig.SIZE_LARGE, DigitalClockConfig.SIZE_XL),
+                      visible = { _, s -> s.enabled }),
+                  EnumSpec(
+                      "layout",
+                      "Position",
+                      get = { it.layout },
+                      set = DigitalClockConfig::setLayout,
+                      options =
+                          listOf(
+                              DigitalClockConfig.LAYOUT_CENTER to "Center",
+                              DigitalClockConfig.LAYOUT_TOP to "Top",
+                              DigitalClockConfig.LAYOUT_BOTTOM to "Bottom",
+                              DigitalClockConfig.LAYOUT_MINIMAL to "Minimal"),
+                      coerce = oneOf(
+                          DigitalClockConfig.LAYOUT_CENTER, DigitalClockConfig.LAYOUT_TOP,
+                          DigitalClockConfig.LAYOUT_BOTTOM, DigitalClockConfig.LAYOUT_MINIMAL),
+                      visible = { _, s -> s.enabled }),
+                  EnumSpec(
+                      "background",
+                      "Background",
+                      get = { it.background },
+                      set = DigitalClockConfig::setBackground,
+                      options =
+                          listOf(
+                              DigitalClockConfig.BG_BLACK to "Black",
+                              DigitalClockConfig.BG_GRADIENT to "Gradient",
+                              DigitalClockConfig.BG_RED to "Red"),
+                      coerce = oneOf(
+                          DigitalClockConfig.BG_BLACK, DigitalClockConfig.BG_GRADIENT,
+                          DigitalClockConfig.BG_RED),
+                      visible = { _, s -> s.enabled }),
+                  EnumSpec(
+                      "glow",
+                      "Glow",
+                      get = { it.glow },
+                      set = DigitalClockConfig::setGlow,
+                      options =
+                          listOf(
+                              DigitalClockConfig.GLOW_NONE to "None",
+                              DigitalClockConfig.GLOW_SOFT to "Soft",
+                              DigitalClockConfig.GLOW_STRONG to "Strong"),
+                      coerce = oneOf(
+                          DigitalClockConfig.GLOW_NONE, DigitalClockConfig.GLOW_SOFT,
+                          DigitalClockConfig.GLOW_STRONG),
+                      visible = { _, s -> s.enabled }),
+                  BoolSpec(
+                      "showDate",
+                      "Show date",
+                      get = { it.showDate },
+                      set = DigitalClockConfig::setShowDate,
+                      visible = { _, s -> s.enabled }),
+                  BoolSpec(
+                      "showSeconds",
+                      "Show seconds",
+                      get = { it.showSeconds },
+                      set = DigitalClockConfig::setShowSeconds,
+                      visible = { _, s -> s.enabled }),
+              ),
+          sections =
+              mapOf(
+                  "style" to "Clock style",
+                  "color" to "Appearance",
+                  "font" to "Appearance",
+                  "size" to "Appearance",
+                  "layout" to "Layout & background",
+                  "background" to "Layout & background",
+                  "glow" to "Layout & background",
+                  "showDate" to "Extras",
+                  "showSeconds" to "Extras"),
+          defaults = { DigitalClockConfig.Settings() },
+          onApplied = { c, keys ->
+            if ("enabled" in keys) SettingsGuard.reaffirmScreensaver(c)
+          },
+      )
+
   val all: List<SettingsDomain<*>> =
-      listOf(screensaver, calendar, immortal, mqtt, quickbar, fleet, chime)
+      listOf(screensaver, calendar, immortal, mqtt, quickbar, fleet, chime, digitalclock)
 }

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -258,6 +258,7 @@ class SettingsDomainTest {
             SettingsDomains.immortal to
                 setOf("multiRoomEnabled", "snapcastHost", "maPort", "maUsername", "maPassword"),
             SettingsDomains.chime to emptySet(),
+            SettingsDomains.digitalclock to emptySet(),
         )
     rendered.forEach { (dom, exclude) ->
       val blank =
@@ -290,6 +291,19 @@ class SettingsDomainTest {
     assertTrue(
         "ChimeConfig.Settings has persisted fields neither in the registry nor accounted for: $uncovered",
         uncovered.isEmpty())
+  }
+
+  @Test
+  fun digitalClockRegistry_coversEveryPersistedField() {
+    // The on-device Clock screen renders its controls from this domain. Every field is a scalar
+    // bound by a spec — no managedElsewhere exceptions.
+    val fields =
+        com.immortal.launcher.DigitalClockConfig.Settings::class.java.declaredFields
+            .filter { !java.lang.reflect.Modifier.isStatic(it.modifiers) }
+            .map { it.name }
+            .toSet()
+    val specKeys = SettingsDomains.digitalclock.specs.map { it.key }.toSet()
+    assertEquals(fields, specKeys)
   }
 
   @Test


### PR DESCRIPTION
Part of the #85 split. A digital-clock screensaver, registry-native.

- `DigitalClockConfig` / `DigitalClockView` / `DigitalClockDreamService` / `DigitalClockPreviewActivity` + `ClockSettingsActivity`.
- New `digitalclock` `SettingsDomain` with its tripwire test.
- `SettingsGuard` picks the active Dream from `DigitalClockConfig.enabled` (on = digital clock, off = photo frame).

Self-contained. The "Device" section (activate-on-sleep/dock) is intentionally trimmed here and lands with the integration PR. Based on current `main`; `:app:assembleDebug` and the full `:app:testDebugUnitTest` are green.


🤖 Generated with [Claude Code](https://claude.com/claude-code)