### PR TITLE
Screensaver ambient + Welcome overlay + Sleep settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -181,6 +181,21 @@
             android:label="Sounds"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- "Clock": digital clock screensaver style / color / layout settings. -->
+        <activity
+            android:name=".ClockSettingsActivity"
+            android:exported="false"
+            android:label="Clock"
+            android:theme="@style/Theme.SampleApp" />
+
+        <!-- Full-screen digital clock preview, opened from the Preview button in
+             Clock settings. Excluded from recents. -->
+        <activity
+            android:name=".DigitalClockPreviewActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:theme="@style/Theme.SampleApp" />
+
         <!-- Connect a self-hosted Immich server as the screensaver source. -->
         <activity
             android:name=".ImmichConnectActivity"
@@ -403,6 +418,18 @@
         <!-- Custom screensaver (Dream), set via secure setting screensaver_components. -->
         <service
             android:name=".PhotoDreamService"
+            android:exported="true"
+            android:permission="android.permission.BIND_DREAM_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.dreams.DreamService" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </service>
+
+        <!-- Digital clock screensaver (Dream); the active one is chosen in
+             SettingsGuard.reaffirmScreensaver from DigitalClockConfig.enabled. -->
+        <service
+            android:name=".DigitalClockDreamService"
             android:exported="true"
             android:permission="android.permission.BIND_DREAM_SERVICE">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,13 @@
     <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!-- Gesture-wave-to-wake on the screensaver (GestureCamera). Optional feature so
+         camera-less models still install. -->
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <!-- Ambient dashboard: show upcoming events from the device calendar (CalendarHelper). -->
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
     <!-- Fleet Agent: a foreground service so WiFi device management survives a
          reboot on these non-root Portals (where adb-over-WiFi can't). -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -194,6 +201,20 @@
             android:name=".DigitalClockPreviewActivity"
             android:exported="false"
             android:excludeFromRecents="true"
+            android:theme="@style/Theme.SampleApp" />
+
+        <!-- "Welcome": welcome-back overlay greetings / colors / sizes / TTS. -->
+        <activity
+            android:name=".WelcomeSettingsActivity"
+            android:exported="false"
+            android:label="Welcome"
+            android:theme="@style/Theme.SampleApp" />
+
+        <!-- "Sleep": screensaver sleep-timer + audio/app behaviour on sleep. -->
+        <activity
+            android:name=".SleepSettingsActivity"
+            android:exported="false"
+            android:label="Sleep"
             android:theme="@style/Theme.SampleApp" />
 
         <!-- Connect a self-hosted Immich server as the screensaver source. -->

--- a/app/src/main/java/com/immortal/launcher/CalendarHelper.kt
+++ b/app/src/main/java/com/immortal/launcher/CalendarHelper.kt
@@ -1,0 +1,77 @@
+package com.immortal.launcher
+
+import android.content.Context
+import android.provider.CalendarContract
+import java.util.Calendar
+
+data class CalendarEvent(
+    val id: Long,
+    val title: String,
+    val begin: Long,
+    val end: Long,
+    val allDay: Boolean,
+    val location: String? = null,
+)
+
+object CalendarHelper {
+
+  /**
+   * Query the device calendar for upcoming events in the next 7 days.
+   * Returns an empty list if permission is not granted or no calendar accounts exist.
+   */
+  fun upcoming(context: Context, days: Int = 7): List<CalendarEvent> {
+    return runCatching {
+      val now = System.currentTimeMillis()
+      val end = now + days * 24L * 60L * 60L * 1000L
+      val uri = CalendarContract.Instances.CONTENT_URI.buildUpon().apply {
+        appendPath(now.toString())
+        appendPath(end.toString())
+      }.build()
+
+      val events = mutableListOf<CalendarEvent>()
+      context.contentResolver.query(
+          uri,
+          arrayOf(
+              CalendarContract.Instances.EVENT_ID,
+              CalendarContract.Instances.TITLE,
+              CalendarContract.Instances.BEGIN,
+              CalendarContract.Instances.END,
+              CalendarContract.Instances.ALL_DAY,
+              CalendarContract.Instances.EVENT_LOCATION,
+          ),
+          null,
+          null,
+          CalendarContract.Instances.BEGIN + " ASC"
+      )?.use { cursor ->
+        val idCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.EVENT_ID)
+        val titleCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.TITLE)
+        val beginCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.BEGIN)
+        val endCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.END)
+        val allDayCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.ALL_DAY)
+        val locCol = cursor.getColumnIndexOrThrow(CalendarContract.Instances.EVENT_LOCATION)
+        while (cursor.moveToNext()) {
+          val title = cursor.getString(titleCol) ?: continue
+          // Skip cancelled/declined events by checking for empty title
+          if (title.isBlank()) continue
+          events.add(
+              CalendarEvent(
+                  id = cursor.getLong(idCol),
+                  title = title,
+                  begin = cursor.getLong(beginCol),
+                  end = cursor.getLong(endCol),
+                  allDay = cursor.getInt(allDayCol) == 1,
+                  location = cursor.getString(locCol)?.takeIf { it.isNotBlank() },
+              )
+          )
+          if (events.size >= 10) break
+        }
+      }
+      events
+    }.getOrDefault(emptyList())
+  }
+
+  fun hasPermission(context: Context): Boolean {
+    return context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR) ==
+        android.content.pm.PackageManager.PERMISSION_GRANTED
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/ClockSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ClockSettingsActivity.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.immortal.launcher.settings.SettingsDomains
+import com.immortal.launcher.ui.theme.SampleAppTheme
+import org.json.JSONObject
+
+/**
+ * Dedicated settings screen for the digital clock. Opened from a "Clock" tile
+ * in the launcher's Settings folder. The clock-specific preferences (enable, style,
+ * color, font, size, layout, background, glow, show date, show seconds) render from
+ * the `digitalclock` registry domain — the same specs the phone remote uses. The
+ * screensaver-activation toggles route through the `immortal` domain so its `onApplied`
+ * fires. The back-gesture section (accessibility service, overlay permission, test) is
+ * genuinely bespoke system-action UI the registry can't model, so it stays hand-built.
+ */
+class ClockSettingsActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { ClockSettingsScreen() } }
+  }
+}
+
+@Composable
+private fun ClockSettingsScreen() {
+  val context = LocalContext.current
+  var clockConfig by remember { mutableStateOf(DigitalClockConfig.load(context)) }
+  var settings by remember { mutableStateOf(ImmortalSettings.load(context)) }
+
+  // Re-read on resume so a change in another screen is reflected here.
+  val lifecycleOwner = LocalLifecycleOwner.current
+  DisposableEffect(lifecycleOwner) {
+    val obs = LifecycleEventObserver { _, e ->
+      if (e == Lifecycle.Event.ON_RESUME) {
+        clockConfig = DigitalClockConfig.load(context)
+        settings = ImmortalSettings.load(context)
+      }
+    }
+    lifecycleOwner.lifecycle.addObserver(obs)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+  }
+
+  val activity = context as? Activity
+  val firstFocus = remember { FocusRequester() }
+  LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
+
+  Box(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .onPreviewKeyEvent { e ->
+                  if (e.key == Key.Back) {
+                    if (e.type == KeyEventType.KeyUp) activity?.finish()
+                    true
+                  } else false
+                }
+                .background(Color(0xFF101012))
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 28.dp, vertical = 32.dp),
+    ) {
+      Column(modifier = Modifier.widthIn(max = 1100.dp).focusRequester(firstFocus).focusGroup()) {
+        Text("Clock", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+        Text(
+            "Choose the digital clock and how it looks on the screensaver.",
+            color = Color(0xFF9A9A9A),
+            fontSize = 16.sp,
+            modifier = Modifier.padding(top = 6.dp),
+        )
+        Spacer(Modifier.size(26.dp))
+
+        // Clock preferences render from the `digitalclock` registry domain. Apply routes through
+        // the domain so its onApplied (reaffirm the dream when `enabled` toggles) fires here too.
+        SettingsList(SettingsDomains.digitalclock, clockConfig) { k, v ->
+          SettingsDomains.digitalclock.apply(context, JSONObject().put(k, v))
+          clockConfig = DigitalClockConfig.load(context)
+        }
+
+        // Preview button — opens fullscreen preview (a bespoke action, not a setting).
+        SectionLabel("Preview")
+        Card {
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp).clickable {
+                context.startActivity(
+                    Intent(context, DigitalClockPreviewActivity::class.java)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+              },
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Column(modifier = Modifier.weight(1f)) {
+              Text("Preview", color = Color.White, fontSize = 17.sp)
+              Text(
+                  "See the clock full-screen with your current settings.",
+                  color = Color(0xFF9A9A9A),
+                  fontSize = 13.sp,
+                  modifier = Modifier.padding(top = 2.dp),
+              )
+            }
+            Surface(
+                color = MaterialTheme.colorScheme.primary,
+                shape = RoundedCornerShape(10.dp),
+                modifier = Modifier.tvFocusable(RoundedCornerShape(10.dp)) {
+                  context.startActivity(
+                      Intent(context, DigitalClockPreviewActivity::class.java)
+                          .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+                },
+            ) {
+              Text(
+                  "Preview",
+                  color = Color.White,
+                  fontSize = 15.sp,
+                  modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp),
+              )
+            }
+          }
+        }
+
+        Text(
+            "Changes apply immediately. Tap the clock icon on the home screen to start the screensaver.",
+            color = Color(0xFF7C7C7C),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
+        )
+      }
+    }
+    FolderBackButton(onClick = { activity?.finish() })
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/DigitalClockConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/DigitalClockConfig.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+
+object DigitalClockConfig {
+
+  private const val PREFS = "digital_clock_config"
+
+  const val COLOR_WHITE = "white"
+  const val COLOR_RED = "red"
+  const val COLOR_GREEN = "green"
+  const val COLOR_BLUE = "blue"
+  const val COLOR_YELLOW = "yellow"
+  const val COLOR_CYAN = "cyan"
+  const val COLOR_PINK = "pink"
+  const val COLOR_ORANGE = "orange"
+
+  const val FONT_LIGHT = "light"
+  const val FONT_NORMAL = "normal"
+  const val FONT_BOLD = "bold"
+  const val FONT_MONO = "mono"
+  const val FONT_SERIF = "serif"
+  // Bundled OFL-licensed display fonts (SIL Open Font License 1.1 — freely
+  // redistributable). Replacements chosen to match the visual intent of the
+  // original personal-use-only fonts:
+  //   DSEG7Classic-Regular  → digital_7.ttf   (7-segment LCD display)
+  //   DSEG14Classic-Regular → segment_led.ttf (14-segment LED display)
+  //   Orbitron-Regular      → technology.ttf  (geometric tech / LCD style)
+  //   Orbitron-Bold         → technology_bold.ttf
+  // Sources:
+  //   DSEG:    https://github.com/keshikan/DSEG   (OFL-1.1)
+  //   Orbitron: https://github.com/googlefonts/orbitron (OFL-1.1)
+  const val FONT_SEGMENT_LED = "segment_led"   // expects segment_led.ttf
+  const val FONT_DIGITAL_7 = "digital_7"       // expects digital_7.ttf
+  const val FONT_TECHNOLOGY = "technology"     // expects technology.ttf
+
+  const val SIZE_SMALL = "small"
+  const val SIZE_MEDIUM = "medium"
+  const val SIZE_LARGE = "large"
+  const val SIZE_XL = "xl"
+
+  // Layout positions
+  const val LAYOUT_CENTER = "center"       // clock centered on screen
+  const val LAYOUT_TOP = "top"             // clock near top
+  const val LAYOUT_BOTTOM = "bottom"       // clock near bottom
+  const val LAYOUT_MINIMAL = "minimal"     // clock only, no date, very large
+
+  // Background styles
+  const val BG_BLACK = "black"             // solid black
+  const val BG_GRADIENT = "gradient"       // radial gradient
+  const val BG_RED = "red"                 // solid dark red
+
+  // Glow intensity
+  const val GLOW_NONE = "none"
+  const val GLOW_SOFT = "soft"
+  const val GLOW_STRONG = "strong"
+
+  // Clock styles. Classic is the only style that respects the user's
+  // chosen font — the other styles use a built-in font and ignore
+  // the font setting. Minimal and Outline were removed because they
+  // didn't use the user's font and confused the font picker UX.
+  const val STYLE_CLASSIC = "classic"       // Large time + date below, uses user font
+  const val STYLE_FLIP = "flip"             // Retro flip clock with digit cards
+  const val STYLE_BOLD = "bold"             // Extra bold, thick numbers
+  const val STYLE_NEON = "neon"             // Bright neon glow
+  const val STYLE_SEGMENT = "segment"       // 7-segment display style
+  const val STYLE_ANALOG = "analog"         // Analog clock face
+
+  data class Settings(
+      val enabled: Boolean = false,
+      val color: String = COLOR_WHITE,
+      val font: String = FONT_LIGHT,
+      val size: String = SIZE_LARGE,
+      val layout: String = LAYOUT_CENTER,
+      val background: String = BG_BLACK,
+      val showDate: Boolean = true,
+      val showSeconds: Boolean = false,
+      val glow: String = GLOW_SOFT,
+      val style: String = STYLE_CLASSIC,
+  )
+
+  private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+  fun load(context: Context): Settings {
+    val p = prefs(context)
+    return Settings(
+        enabled = p.getBoolean("enabled", false),
+        color = p.getString("color", COLOR_WHITE) ?: COLOR_WHITE,
+        font = p.getString("font", FONT_LIGHT) ?: FONT_LIGHT,
+        size = p.getString("size", SIZE_LARGE) ?: SIZE_LARGE,
+        layout = p.getString("layout", LAYOUT_CENTER) ?: LAYOUT_CENTER,
+        background = p.getString("background", BG_BLACK) ?: BG_BLACK,
+        showDate = p.getBoolean("show_date", true),
+        showSeconds = p.getBoolean("show_seconds", false),
+        glow = p.getString("glow", GLOW_SOFT) ?: GLOW_SOFT,
+        style = p.getString("style", STYLE_CLASSIC) ?: STYLE_CLASSIC,
+    )
+  }
+
+  fun setEnabled(c: Context, enabled: Boolean) =
+      prefs(c).edit().putBoolean("enabled", enabled).apply()
+
+  fun setColor(c: Context, color: String) =
+      prefs(c).edit().putString("color", color).apply()
+
+  fun setFont(c: Context, font: String) =
+      prefs(c).edit().putString("font", font).apply()
+
+  fun setSize(c: Context, size: String) =
+      prefs(c).edit().putString("size", size).apply()
+
+  fun setLayout(c: Context, layout: String) =
+      prefs(c).edit().putString("layout", layout).apply()
+
+  fun setBackground(c: Context, bg: String) =
+      prefs(c).edit().putString("background", bg).apply()
+
+  fun setShowDate(c: Context, show: Boolean) =
+      prefs(c).edit().putBoolean("show_date", show).apply()
+
+  fun setShowSeconds(c: Context, show: Boolean) =
+      prefs(c).edit().putBoolean("show_seconds", show).apply()
+
+  fun setGlow(c: Context, glow: String) =
+      prefs(c).edit().putString("glow", glow).apply()
+
+  fun setStyle(c: Context, style: String) =
+      prefs(c).edit().putString("style", style).apply()
+}

--- a/app/src/main/java/com/immortal/launcher/DigitalClockDreamService.kt
+++ b/app/src/main/java/com/immortal/launcher/DigitalClockDreamService.kt
@@ -1,0 +1,81 @@
+package com.immortal.launcher
+
+import android.os.Handler
+import android.os.Looper
+import android.service.dreams.DreamService
+import android.util.Log
+import android.view.MotionEvent
+
+class DigitalClockDreamService : DreamService() {
+  private val handler = Handler(Looper.getMainLooper())
+  private var settings = DigitalClockConfig.Settings()
+  private var controller: DigitalClockView.Controller? = null
+
+  private var downX = 0f
+  private var downY = 0f
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    Log.i(TAG, "attached: digital clock dream starting")
+    isInteractive = true
+    isFullscreen = true
+    isScreenBright = true
+    settings = DigitalClockConfig.load(this)
+    controller = DigitalClockView.build(this, settings)
+    val root = controller!!.root
+    root.setOnTouchListener { _, ev ->
+      onTouch(ev)
+      true
+    }
+    setContentView(root)
+    tick.run()
+  }
+
+  override fun onDreamingStarted() {
+    super.onDreamingStarted()
+    Log.i(TAG, "onDreamingStarted")
+    SleepScheduler.onScreensaverStarted(this)
+  }
+
+  override fun onDetachedFromWindow() {
+    Log.i(TAG, "detached: digital clock dream ending")
+    handler.removeCallbacksAndMessages(null)
+    super.onDetachedFromWindow()
+  }
+
+  private fun onTouch(ev: MotionEvent) {
+    when (ev.actionMasked) {
+      MotionEvent.ACTION_DOWN -> {
+        downX = ev.x
+        downY = ev.y
+      }
+      MotionEvent.ACTION_UP -> {
+        val dx = ev.x - downX
+        val dy = ev.y - downY
+        if (kotlin.math.abs(dx) < 48 && kotlin.math.abs(dy) < 48) {
+          DreamPolicy.userExitAt = System.currentTimeMillis()
+          finish()
+        }
+      }
+    }
+  }
+
+  private val tick = object : Runnable {
+    override fun run() {
+      controller?.let {
+        DigitalClockView.update(it, settings)
+        // Anti-burn-in: drift the whole clock along a slow, invisible path so the lit
+        // pixels of an always-on screen don't ghost in over time.
+        val now = System.currentTimeMillis()
+        val shift = AntiBurnIn.shift(now, 14f)
+        it.root.translationX = shift.x
+        it.root.translationY = shift.y
+      }
+      handler.postDelayed(this, if (settings.showSeconds) 500L else 1_000L)
+    }
+  }
+
+  private companion object {
+    const val TAG = "ImmortalDigitalClock"
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/DigitalClockPreviewActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/DigitalClockPreviewActivity.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.MotionEvent
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+
+/**
+ * Full-screen preview of the digital clock with the current settings. Opened
+ * from the "Preview" button in Immortal Settings, so the user can see what the
+ * clock looks like before waiting for the screensaver to activate.
+ *
+ * Tap anywhere to exit.
+ */
+class DigitalClockPreviewActivity : ComponentActivity() {
+  private val handler = Handler(Looper.getMainLooper())
+  private var controller: DigitalClockView.Controller? = null
+  private var settings = DigitalClockConfig.Settings()
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    // Immersive fullscreen
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    WindowInsetsControllerCompat(window, window.decorView).apply {
+      hide(WindowInsetsCompat.Type.systemBars())
+      systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+    }
+    // Keep screen on while previewing
+    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
+    settings = DigitalClockConfig.load(this)
+    controller = DigitalClockView.build(this, settings)
+    setContentView(controller!!.root)
+    tick.run()
+  }
+
+  override fun onTouchEvent(event: MotionEvent?): Boolean {
+    if (event?.action == MotionEvent.ACTION_UP) {
+      finish()
+      return true
+    }
+    return super.onTouchEvent(event)
+  }
+
+  override fun onDestroy() {
+    handler.removeCallbacksAndMessages(null)
+    super.onDestroy()
+  }
+
+  private val tick = object : Runnable {
+    override fun run() {
+      controller?.let { DigitalClockView.update(it, settings) }
+      handler.postDelayed(this, if (settings.showSeconds) 500L else 1_000L)
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/DigitalClockView.kt
+++ b/app/src/main/java/com/immortal/launcher/DigitalClockView.kt
@@ -1,0 +1,476 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Typeface
+import android.view.Gravity
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.TextView
+import java.util.Calendar
+
+/**
+ * Shared builder for the digital clock UI. Used by both the
+ * [DigitalClockDreamService] (the actual screensaver) and the
+ * [DigitalClockPreviewActivity] (in-app preview). Returns a root view
+ * plus a [Controller] that the caller uses to update the time.
+ *
+ * The caller is responsible for the update loop: call [Controller.update]
+ * periodically to refresh the clock text and (for analog) the hands.
+ */
+object DigitalClockView {
+
+  data class Controller(
+      val root: View,
+      val clockText: TextView?,
+      val dateText: TextView?,
+      val flipHour: TextView?,
+      val flipMinute: TextView?,
+      val flipSecond: TextView?,
+      val analog: AnalogClockView?,
+  )
+
+  fun build(context: Context, settings: DigitalClockConfig.Settings): Controller {
+    val root = FrameLayout(context)
+    root.setBackgroundColor(backgroundColor(settings))
+
+    if (settings.background == DigitalClockConfig.BG_GRADIENT) {
+      val gradient = android.graphics.drawable.GradientDrawable(
+          android.graphics.drawable.GradientDrawable.Orientation.TOP_BOTTOM,
+          intArrayOf(Color.parseColor("#FF1A1A2E"), Color.parseColor("#FF16213E"), Color.BLACK)
+      )
+      root.background = gradient
+    }
+
+    val textColor = clockColor(settings)
+    val sizeSp = clockSizeSp(settings)
+    val analog = AnalogClockView(context).apply {
+      setColor(textColor)
+      setSize(sizeSp)
+      setShowSeconds(settings.showSeconds)
+    }
+
+    // Analog style: single custom view centered, optional date at bottom.
+    if (settings.style == DigitalClockConfig.STYLE_ANALOG) {
+      // Size to ~55% of the smaller screen dimension so it fits comfortably
+      // on any Portal model (Portal+, TV, Go, Mini) with margin for the date.
+      val dm = context.resources.displayMetrics
+      val screenMin = kotlin.math.min(dm.widthPixels, dm.heightPixels)
+      val analogSize = (screenMin * 0.55f).toInt()
+      root.addView(analog, FrameLayout.LayoutParams(analogSize, analogSize, Gravity.CENTER))
+      val dateView = if (settings.showDate) buildDateView(context, settings, textColor).also {
+        val lp = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
+        )
+        lp.bottomMargin = 80
+        root.addView(it, lp)
+      } else null
+      return Controller(root, null, dateView, null, null, null, analog)
+    }
+
+    val container = LinearLayout(context).apply {
+      orientation = LinearLayout.VERTICAL
+      gravity = Gravity.CENTER
+    }
+
+    val clockText: TextView?
+    val flipHour: TextView?
+    val flipMinute: TextView?
+    val flipSecond: TextView?
+    if (settings.style == DigitalClockConfig.STYLE_FLIP) {
+      val h = flipHourView(context, settings, textColor)
+      val m = flipMinuteView(context, settings, textColor)
+      val s = if (settings.showSeconds) flipSecondView(context, settings, textColor) else null
+      val row = LinearLayout(context).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER
+      }
+      row.addView(h)
+      row.addView(flipSeparator(context, settings, textColor))
+      row.addView(m)
+      if (s != null) {
+        row.addView(flipSeparator(context, settings, textColor))
+        row.addView(s)
+      }
+      container.addView(row)
+      clockText = null
+      flipHour = h
+      flipMinute = m
+      flipSecond = s
+    } else {
+      val text = TextView(context).apply {
+        textSize = sizeSp
+        setTextColor(textColor)
+        typeface = clockTypefaceForStyle(context, settings)
+        gravity = Gravity.CENTER
+        applyClockStyleEffects(context, this, settings, textColor)
+      }
+      container.addView(text)
+      clockText = text
+      flipHour = null
+      flipMinute = null
+      flipSecond = null
+    }
+
+    val dateText: TextView? = if (settings.showDate) {
+      val v = buildDateView(context, settings, textColor)
+      container.addView(v)
+      v
+    } else null
+
+    val containerGravity = when (settings.layout) {
+      DigitalClockConfig.LAYOUT_TOP -> Gravity.TOP or Gravity.CENTER_HORIZONTAL
+      DigitalClockConfig.LAYOUT_BOTTOM -> Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
+      else -> Gravity.CENTER
+    }
+    val lp = FrameLayout.LayoutParams(
+        FrameLayout.LayoutParams.WRAP_CONTENT,
+        FrameLayout.LayoutParams.WRAP_CONTENT,
+        containerGravity
+    )
+    if (settings.layout == DigitalClockConfig.LAYOUT_TOP) lp.topMargin = 120
+    else if (settings.layout == DigitalClockConfig.LAYOUT_BOTTOM) lp.bottomMargin = 120
+    root.addView(container, lp)
+
+    clockText?.textSize = sizeSp
+
+    return Controller(root, clockText, dateText, flipHour, flipMinute, flipSecond, analog)
+  }
+
+  fun update(controller: Controller, settings: DigitalClockConfig.Settings) {
+    val cal = Calendar.getInstance()
+    val use24Hour = ImmortalSettings.use24HourClock(controller.root.context)
+    val now = java.util.Date()
+
+    controller.analog?.update()
+    controller.clockText?.let {
+      val pattern = when {
+        settings.showSeconds -> if (use24Hour) "H:mm:ss" else "h:mm:ss"
+        use24Hour -> "H:mm"
+        else -> "h:mm"
+      }
+      it.text = java.text.SimpleDateFormat(pattern, java.util.Locale.getDefault()).format(now)
+    }
+    if (controller.flipHour != null) {
+      val h = if (use24Hour) cal.get(Calendar.HOUR_OF_DAY) else cal.get(Calendar.HOUR)
+      val hour12 = if (h == 0) 12 else if (h > 12) h - 12 else h
+      val displayHour = if (use24Hour) h else hour12
+      controller.flipHour.text = displayHour.toString().padStart(2, '0')
+      controller.flipMinute?.text = cal.get(Calendar.MINUTE).toString().padStart(2, '0')
+      controller.flipSecond?.text = cal.get(Calendar.SECOND).toString().padStart(2, '0')
+    }
+    controller.dateText?.text = java.text.SimpleDateFormat("EEEE, MMMM d", java.util.Locale.getDefault()).format(now)
+  }
+
+  private fun buildDateView(context: Context, settings: DigitalClockConfig.Settings, color: Int): TextView {
+    val v = TextView(context)
+    v.textSize = dateSizeSp(settings)
+    v.setTextColor(color)
+    v.typeface = Typeface.create("sans-serif-light", Typeface.NORMAL)
+    v.gravity = Gravity.CENTER
+    v.alpha = 0.8f
+    applyGlow(v, settings, color, 6f, 2f)
+    return v
+  }
+
+  private fun flipHourView(context: Context, settings: DigitalClockConfig.Settings, color: Int) = makeFlipCard(context, settings, color)
+  private fun flipMinuteView(context: Context, settings: DigitalClockConfig.Settings, color: Int) = makeFlipCard(context, settings, color)
+  private fun flipSecondView(context: Context, settings: DigitalClockConfig.Settings, color: Int) = makeFlipCard(context, settings, color)
+  private fun makeFlipCard(context: Context, settings: DigitalClockConfig.Settings, color: Int): TextView {
+    return TextView(context).apply {
+      textSize = clockSizeSp(settings) * 0.6f
+      setTextColor(color)
+      gravity = Gravity.CENTER
+      setPadding(24, 12, 24, 12)
+    }
+  }
+  private fun flipSeparator(context: Context, settings: DigitalClockConfig.Settings, color: Int): TextView {
+    return TextView(context).apply {
+      text = ":"
+      textSize = clockSizeSp(settings) * 0.5f
+      setTextColor(color)
+      gravity = Gravity.CENTER
+    }
+  }
+
+  private fun applyClockStyleEffects(context: Context, view: TextView, settings: DigitalClockConfig.Settings, color: Int) {
+    when (settings.style) {
+      DigitalClockConfig.STYLE_BOLD -> {
+        view.setTypeface(Typeface.create(clockTypefaceForStyle(context, settings), Typeface.BOLD))
+        view.setShadowLayer(8f, 2f, 2f, color and 0x00FFFFFF or 0xAA000000.toInt())
+      }
+      DigitalClockConfig.STYLE_NEON -> {
+        view.setShadowLayer(30f, 0f, 0f, color and 0x00FFFFFF or 0xCC000000.toInt())
+        view.setShadowLayer(12f, 0f, 0f, color)
+      }
+      DigitalClockConfig.STYLE_SEGMENT -> {
+        view.typeface = Typeface.create(Typeface.MONOSPACE, Typeface.BOLD)
+        view.letterSpacing = 0.15f
+        view.setShadowLayer(8f, 0f, 2f, color and 0x00FFFFFF or 0xAA000000.toInt())
+      }
+      else -> applyGlow(view, settings, color)
+    }
+  }
+
+  private fun applyGlow(view: TextView, settings: DigitalClockConfig.Settings, baseColor: Int, radius: Float = 12f, dy: Float = 4f) {
+    when (settings.glow) {
+      DigitalClockConfig.GLOW_NONE -> view.setShadowLayer(0f, 0f, 0f, 0)
+      DigitalClockConfig.GLOW_SOFT -> {
+        val softColor = (baseColor and 0x00FFFFFF) or 0x66000000.toInt()
+        view.setShadowLayer(radius, 0f, dy, softColor)
+      }
+      DigitalClockConfig.GLOW_STRONG -> {
+        val wideColor = (baseColor and 0x00FFFFFF) or 0x99000000.toInt()
+        view.setShadowLayer(radius * 2, 0f, 0f, wideColor)
+        view.setShadowLayer(radius * 1.4f, 0f, dy * 0.5f, baseColor)
+      }
+    }
+  }
+
+  private fun backgroundColor(settings: DigitalClockConfig.Settings): Int = when (settings.background) {
+    DigitalClockConfig.BG_BLACK -> Color.BLACK
+    DigitalClockConfig.BG_RED -> Color.parseColor("#FF1A0500")
+    else -> Color.BLACK
+  }
+
+  private fun clockSizeSp(settings: DigitalClockConfig.Settings): Float = when (settings.size) {
+    DigitalClockConfig.SIZE_SMALL -> 120f
+    DigitalClockConfig.SIZE_MEDIUM -> 180f
+    DigitalClockConfig.SIZE_LARGE -> 240f
+    DigitalClockConfig.SIZE_XL -> 320f
+    else -> 240f
+  }
+
+  private fun dateSizeSp(settings: DigitalClockConfig.Settings): Float = when (settings.size) {
+    DigitalClockConfig.SIZE_SMALL -> 24f
+    DigitalClockConfig.SIZE_MEDIUM -> 32f
+    DigitalClockConfig.SIZE_LARGE -> 40f
+    DigitalClockConfig.SIZE_XL -> 52f
+    else -> 40f
+  }
+
+  private fun clockColor(settings: DigitalClockConfig.Settings): Int = when (settings.color) {
+    DigitalClockConfig.COLOR_RED -> Color.parseColor("#FFF44336")
+    DigitalClockConfig.COLOR_GREEN -> Color.parseColor("#FF4CAF50")
+    DigitalClockConfig.COLOR_BLUE -> Color.parseColor("#FF2196F3")
+    DigitalClockConfig.COLOR_YELLOW -> Color.parseColor("#FFFFEB3B")
+    DigitalClockConfig.COLOR_CYAN -> Color.parseColor("#FF00BCD4")
+    DigitalClockConfig.COLOR_PINK -> Color.parseColor("#FFE91E63")
+    DigitalClockConfig.COLOR_ORANGE -> Color.parseColor("#FFFF9800")
+    else -> Color.WHITE
+  }
+
+  private fun clockTypeface(context: Context, settings: DigitalClockConfig.Settings): Typeface = when (settings.font) {
+    // Use the guaranteed-distinct Typeface constants so every font option
+    // actually looks different (previous versions used family-name strings
+    // that silently fell back to the same default on Android 9).
+    DigitalClockConfig.FONT_LIGHT -> Typeface.create("sans-serif-thin", Typeface.NORMAL)
+        .let { if (it == Typeface.DEFAULT) Typeface.SANS_SERIF else it }
+    DigitalClockConfig.FONT_BOLD -> Typeface.create(Typeface.SANS_SERIF, Typeface.BOLD)
+    DigitalClockConfig.FONT_MONO -> Typeface.MONOSPACE
+    DigitalClockConfig.FONT_SERIF -> Typeface.SERIF
+    // Bundled custom fonts — drop the .ttf into app/src/main/assets/fonts/
+    DigitalClockConfig.FONT_SEGMENT_LED -> loadBundledFont(context, "fonts/segment_led.ttf")
+    DigitalClockConfig.FONT_DIGITAL_7 -> loadBundledFont(context, "fonts/digital_7.ttf")
+    DigitalClockConfig.FONT_TECHNOLOGY -> loadBundledFont(context, "fonts/technology.ttf")
+    else -> Typeface.SANS_SERIF
+  }
+
+  /** Cached bundled fonts keyed by asset path so we only load each one once. */
+  private val bundledFontCache = mutableMapOf<String, Typeface>()
+
+  /**
+   * Load a bundled .ttf font from the assets/fonts/ directory. Returns a
+   * sensible fallback if the file is missing, so a font option silently
+   * degrades to the default instead of crashing.
+   */
+  private fun loadBundledFont(context: Context, assetPath: String): Typeface {
+    bundledFontCache[assetPath]?.let { return it }
+    val tf = runCatching {
+      Typeface.createFromAsset(context.assets, assetPath)
+    }.getOrNull() ?: return Typeface.SANS_SERIF
+    bundledFontCache[assetPath] = tf
+    return tf
+  }
+
+  private fun clockTypefaceForStyle(context: Context, settings: DigitalClockConfig.Settings): Typeface = when (settings.style) {
+    DigitalClockConfig.STYLE_BOLD -> Typeface.create(Typeface.SANS_SERIF, Typeface.BOLD)
+    DigitalClockConfig.STYLE_SEGMENT -> Typeface.MONOSPACE
+    DigitalClockConfig.STYLE_NEON -> Typeface.create("sans-serif-thin", Typeface.NORMAL)
+        .let { if (it == Typeface.DEFAULT) Typeface.SANS_SERIF else it }
+    DigitalClockConfig.STYLE_FLIP -> Typeface.MONOSPACE
+    else -> clockTypeface(context, settings)
+  }
+}
+
+/**
+ * High-quality analog clock face drawn with Canvas. Hour, minute, and
+ * optional second hands rotate to show the current time.
+ *
+ * Supports the full color palette: the face, markers, numbers, and hands
+ * all tint with the selected clock color, with the second hand in a
+ * contrasting red for legibility. Hour and minute hands use a slight
+ * taper (drawn as two segments) for a more refined look.
+ *
+ * Pure drawable view — no Compose dependency.
+ */
+class AnalogClockView(context: android.content.Context) : View(context) {
+  private var hour = 0
+  private var minute = 0
+  private var second = 0
+  private var showSeconds = false
+  private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+  private val fillPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+  private var clockColor = Color.WHITE
+  // Size preference: small=0.10, medium=0.13, large=0.16, xl=0.20 (fraction of view width).
+  // Numbers scale with the view size while still respecting the user's chosen size setting.
+  private var sizeFraction = 0.13f
+
+  fun setColor(c: Int) { clockColor = c; invalidate() }
+  fun setSize(sp: Float) { /* kept for API compat; size is now derived from the view */ }
+  fun setSizeFraction(f: Float) { sizeFraction = f; invalidate() }
+  fun setShowSeconds(s: Boolean) { showSeconds = s; invalidate() }
+
+  init {
+    update()
+  }
+
+  fun update() {
+    val cal = Calendar.getInstance()
+    hour = cal.get(Calendar.HOUR)
+    minute = cal.get(Calendar.MINUTE)
+    second = cal.get(Calendar.SECOND)
+    invalidate()
+  }
+
+  override fun onDraw(canvas: android.graphics.Canvas) {
+    super.onDraw(canvas)
+    val w = width.toFloat()
+    val h = height.toFloat()
+    val cx = w / 2f
+    val cy = h / 2f
+    val radius = kotlin.math.min(w, h) / 2f * 0.88f
+
+    // Base unit: ~1.2% of radius. All stroke widths and text sizes scale
+    // proportionally so the clock looks balanced at any physical size.
+    val unit = radius * 0.012f
+
+    // Subtle outer ring for depth (very faint, same hue as the clock)
+    paint.color = clockColor and 0x00FFFFFF or 0x33000000.toInt()
+    paint.style = Paint.Style.STROKE
+    paint.strokeWidth = unit * 0.5f
+    canvas.drawCircle(cx, cy, radius + unit * 2, paint)
+
+    // Main face circle
+    paint.color = clockColor
+    paint.style = Paint.Style.STROKE
+    paint.strokeWidth = unit * 1.2f
+    canvas.drawCircle(cx, cy, radius, paint)
+
+    // Hour markers — longer and slightly thicker at 12/3/6/9 (cardinal points)
+    paint.strokeCap = Paint.Cap.ROUND
+    for (i in 0 until 12) {
+      val isCardinal = (i % 3) == 0
+      val angle = (i * 30 - 90) * Math.PI / 180.0
+      val outerR = radius - unit * 2
+      val innerR =
+          if (isCardinal) radius - unit * 10
+          else radius - unit * 5
+      paint.strokeWidth = if (isCardinal) unit * 2.5f else unit * 1.5f
+      val outerX = cx + (outerR * kotlin.math.cos(angle)).toFloat()
+      val outerY = cy + (outerR * kotlin.math.sin(angle)).toFloat()
+      val innerX = cx + (innerR * kotlin.math.cos(angle)).toFloat()
+      val innerY = cy + (innerR * kotlin.math.sin(angle)).toFloat()
+      canvas.drawLine(innerX, innerY, outerX, outerY, paint)
+    }
+
+    // Hour numbers — moved further inward (radius * 0.68f) so they don't
+    // collide with the hour markers. Cardinals are 1.2x the base size,
+    // non-cardinals are 0.85x. All sized in absolute pixels relative to
+    // the view radius, not a fraction of an arbitrary "size fraction".
+    paint.style = Paint.Style.FILL
+    paint.textAlign = Paint.Align.CENTER
+    paint.typeface = android.graphics.Typeface.create("sans-serif-light", android.graphics.Typeface.NORMAL)
+    val numbers = listOf(12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+    for ((i, n) in numbers.withIndex()) {
+      val isCardinal = (n % 3) == 0
+      val angle = (i * 30 - 90) * Math.PI / 180.0
+      val r = radius * 0.68f
+      paint.textSize = unit * (if (isCardinal) 5.0f else 3.6f)
+      if (isCardinal) {
+        paint.typeface = android.graphics.Typeface.create("sans-serif", android.graphics.Typeface.NORMAL)
+      } else {
+        paint.typeface = android.graphics.Typeface.create("sans-serif-light", android.graphics.Typeface.NORMAL)
+      }
+      val fontMetrics = paint.fontMetrics
+      val textOffset = -(fontMetrics.ascent + fontMetrics.descent) / 2f
+      val x = cx + (r * kotlin.math.cos(angle)).toFloat()
+      val y = cy + (r * kotlin.math.sin(angle)).toFloat() + textOffset
+      canvas.drawText(n.toString(), x, y, paint)
+    }
+
+    // Hour hand — shorter, slightly thicker
+    val hourAngle = ((hour + minute / 60f) * 30 - 90) * Math.PI / 180.0
+    paint.color = clockColor
+    paint.strokeWidth = unit * 3.5f
+    paint.strokeCap = Paint.Cap.ROUND
+    canvas.drawLine(
+        cx,
+        cy,
+        cx + (radius * 0.50f * kotlin.math.cos(hourAngle)).toFloat(),
+        cy + (radius * 0.50f * kotlin.math.sin(hourAngle)).toFloat(),
+        paint
+    )
+
+    // Minute hand — longer, thinner
+    val minuteAngle = (minute * 6 - 90) * Math.PI / 180.0
+    paint.strokeWidth = unit * 2.2f
+    paint.strokeCap = Paint.Cap.ROUND
+    canvas.drawLine(
+        cx,
+        cy,
+        cx + (radius * 0.78f * kotlin.math.cos(minuteAngle)).toFloat(),
+        cy + (radius * 0.78f * kotlin.math.sin(minuteAngle)).toFloat(),
+        paint
+    )
+
+    // Second hand (optional) — properly centered: drawn as a single line
+    // from a point behind the center to the tip, passing through center.
+    if (showSeconds) {
+      val secondAngle = (second * 6 - 90) * Math.PI / 180.0
+      // Use red for the second hand for classic contrast
+      paint.color = Color.parseColor("#FFE53935")
+      paint.strokeWidth = unit * 0.7f
+      paint.strokeCap = Paint.Cap.ROUND
+      val tailLen = radius * 0.12f
+      val tipLen = radius * 0.85f
+      // Draw from -tailLen behind center through center to +tipLen
+      val startX = cx + (tailLen * kotlin.math.cos(secondAngle + Math.PI)).toFloat()
+      val startY = cy + (tailLen * kotlin.math.sin(secondAngle + Math.PI)).toFloat()
+      val endX = cx + (tipLen * kotlin.math.cos(secondAngle)).toFloat()
+      val endY = cy + (tipLen * kotlin.math.sin(secondAngle)).toFloat()
+      canvas.drawLine(startX, startY, endX, endY, paint)
+      paint.color = clockColor
+    }
+
+    // Center dot — a filled circle with a small inner ring for detail
+    paint.color = clockColor
+    paint.style = Paint.Style.FILL
+    canvas.drawCircle(cx, cy, unit * 4, paint)
+    // Inner cutout (use the background color — black for the default theme)
+    fillPaint.color = Color.BLACK
+    fillPaint.style = Paint.Style.FILL
+    canvas.drawCircle(cx, cy, unit * 1.8f, fillPaint)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/GestureCamera.kt
+++ b/app/src/main/java/com/immortal/launcher/GestureCamera.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.ImageFormat
+import android.hardware.camera2.CameraCaptureSession
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraDevice
+import android.hardware.camera2.CameraManager
+import android.hardware.camera2.CaptureRequest
+import android.media.ImageReader
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+import androidx.core.content.ContextCompat
+import kotlin.math.abs
+
+/**
+ * Contact-free "wave to advance" for the photo frame / recipe view, using the standard
+ * Camera2 API only — the Meta Smart Camera SDK (gated behind signature permissions) is
+ * never touched. A low-resolution luminance stream is differenced frame-to-frame; a
+ * broad burst of motion across the view (a hand wave at 50–100 cm) fires [onWave],
+ * debounced so one wave is one event.
+ *
+ * Deliberately defensive: the front camera is shared on Portal and this runs inside the
+ * always-on dream, so *every* path is wrapped — any failure just disables the feature
+ * (logs and releases) rather than risking the launcher/dream process. Off by default;
+ * the user opts in, and it no-ops without the CAMERA permission.
+ *
+ * NOTE (experimental): feasibility on real Portal hardware is unverified. Frame-difference
+ * gesture detection is a heuristic, not the framed Smart Camera tracking. Keep the opt-in.
+ */
+class GestureCamera(
+    private val context: Context,
+    private val onWave: () -> Unit,
+) {
+  private var thread: HandlerThread? = null
+  private var handler: Handler? = null
+  private var device: CameraDevice? = null
+  private var session: CameraCaptureSession? = null
+  private var reader: ImageReader? = null
+
+  private var prev: IntArray? = null
+  private var lastWaveAt = 0L
+  @Volatile private var running = false
+
+  /** Begin watching for waves. Safe to call when unsupported/ungranted — it no-ops. */
+  fun start() {
+    if (running) return
+    if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) !=
+        PackageManager.PERMISSION_GRANTED) {
+      Log.i(TAG, "no camera permission — gesture control disabled")
+      return
+    }
+    runCatching {
+      val manager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+      val cameraId = pickFrontCamera(manager) ?: run {
+        Log.i(TAG, "no front camera — gesture control disabled")
+        return
+      }
+      thread = HandlerThread("immortal-gesture").apply { start() }
+      handler = Handler(thread!!.looper)
+      reader = ImageReader.newInstance(W, H, ImageFormat.YUV_420_888, 2).apply {
+        setOnImageAvailableListener(onFrame, handler)
+      }
+      running = true
+      openCamera(manager, cameraId)
+    }.onFailure {
+      Log.w(TAG, "gesture camera start failed", it)
+      stop()
+    }
+  }
+
+  /** Stop and release everything. Idempotent. */
+  fun stop() {
+    running = false
+    runCatching { session?.close() }
+    runCatching { device?.close() }
+    runCatching { reader?.close() }
+    runCatching { thread?.quitSafely() }
+    session = null
+    device = null
+    reader = null
+    thread = null
+    handler = null
+    prev = null
+  }
+
+  private fun pickFrontCamera(manager: CameraManager): String? =
+      manager.cameraIdList.firstOrNull {
+        manager.getCameraCharacteristics(it).get(CameraCharacteristics.LENS_FACING) ==
+            CameraCharacteristics.LENS_FACING_FRONT
+      } ?: manager.cameraIdList.firstOrNull()
+
+  @Suppress("MissingPermission") // checked in start()
+  private fun openCamera(manager: CameraManager, cameraId: String) {
+    manager.openCamera(cameraId, object : CameraDevice.StateCallback() {
+      override fun onOpened(camera: CameraDevice) {
+        device = camera
+        runCatching { createSession(camera) }.onFailure { Log.w(TAG, "session create failed", it); stop() }
+      }
+      override fun onDisconnected(camera: CameraDevice) { stop() }
+      override fun onError(camera: CameraDevice, error: Int) {
+        Log.w(TAG, "camera error $error")
+        stop()
+      }
+    }, handler)
+  }
+
+  private fun createSession(camera: CameraDevice) {
+    val surface = reader?.surface ?: return
+    @Suppress("DEPRECATION")
+    camera.createCaptureSession(listOf(surface), object : CameraCaptureSession.StateCallback() {
+      override fun onConfigured(s: CameraCaptureSession) {
+        if (!running) { runCatching { s.close() }; return }
+        session = s
+        runCatching {
+          val req = camera.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW).apply {
+            addTarget(surface)
+            set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE)
+          }
+          s.setRepeatingRequest(req.build(), null, handler)
+        }.onFailure { Log.w(TAG, "repeating request failed", it); stop() }
+      }
+      override fun onConfigureFailed(s: CameraCaptureSession) {
+        Log.w(TAG, "session configure failed"); stop()
+      }
+    }, handler)
+  }
+
+  // Downsample the Y plane into a GRID×GRID block grid; a wave is a large jump in the
+  // summed block-to-block difference, spread across many blocks (not a tiny local change).
+  private val onFrame = ImageReader.OnImageAvailableListener { r ->
+    val image = runCatching { r.acquireLatestImage() }.getOrNull() ?: return@OnImageAvailableListener
+    try {
+      if (!running) return@OnImageAvailableListener
+      val plane = image.planes[0]
+      val buf = plane.buffer
+      val rowStride = plane.rowStride
+      val width = image.width
+      val height = image.height
+      val grid = IntArray(GRID * GRID)
+      for (gy in 0 until GRID) {
+        for (gx in 0 until GRID) {
+          val px = (gx + 0.5f) / GRID * width
+          val py = (gy + 0.5f) / GRID * height
+          val idx = py.toInt() * rowStride + px.toInt()
+          grid[gy * GRID + gx] = if (idx in 0 until buf.limit()) (buf.get(idx).toInt() and 0xFF) else 0
+        }
+      }
+      detect(grid)
+    } finally {
+      runCatching { image.close() }
+    }
+  }
+
+  private fun detect(grid: IntArray) {
+    val p = prev
+    prev = grid
+    if (p == null) return
+    var changedBlocks = 0
+    var totalDelta = 0
+    for (i in grid.indices) {
+      val d = abs(grid[i] - p[i])
+      if (d > BLOCK_DELTA) { changedBlocks++; totalDelta += d }
+    }
+    // A wave moves across much of the frame at once.
+    val now = System.currentTimeMillis()
+    if (changedBlocks >= grid.size / 3 && totalDelta > FRAME_DELTA && now - lastWaveAt > DEBOUNCE_MS) {
+      lastWaveAt = now
+      runCatching { onWave() }
+    }
+  }
+
+  private companion object {
+    const val TAG = "ImmortalGesture"
+    const val W = 320
+    const val H = 240
+    const val GRID = 12 // 12×12 motion blocks
+    const val BLOCK_DELTA = 28 // per-block luminance change that counts as "moved"
+    const val FRAME_DELTA = 2200 // summed change across the frame for a wave
+    const val DEBOUNCE_MS = 1500L
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -18,6 +18,7 @@ import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.os.Handler
 import android.os.Looper
+import android.speech.tts.TextToSpeech
 import android.text.TextUtils
 import android.util.Log
 import android.view.Gravity
@@ -33,11 +34,14 @@ import androidx.exifinterface.media.ExifInterface
 import java.net.HttpURLConnection
 import java.net.URL
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.Executors
 import kotlin.math.abs
 import org.json.JSONObject
+
+private const val SHERPA_VOICE_PARAM = "sherpa_voice_name"
 
 /**
  * The photo-frame UI + update logic, decoupled from any host. Used by both
@@ -64,6 +68,8 @@ import org.json.JSONObject
  */
 class PhotoFrameController(
     private val context: Context,
+    /** Show the welcome-back overlay when [start] is called (set true for presence-triggered starts). */
+    val showWelcome: Boolean = false,
     private val unsplashKey: String = "",
     private val unsplashQuery: String = "nature,landscape,scenic",
     private val weatherRefreshMs: Long = 30 * 60_000L,
@@ -105,6 +111,31 @@ class PhotoFrameController(
   // The minute we last re-windowed the calendar, so the 1s tick only rebuilds it
   // when the clock minute changes (drops past events, refreshes Today/Tomorrow).
   private var lastCalMinute: Long = -1L
+
+  // Ambient dashboard: full-screen glanceable info card shown periodically (fork feature).
+  private var dashboardPanel: View? = null
+  private lateinit var dashClock: TextView
+  private lateinit var dashDate: TextView
+  private lateinit var dashWeather: TextView
+  private lateinit var dashEvent: TextView
+  private var dashboardVisible = false
+  // Weather string for the dashboard. The Face overlay fetches its own weather; this
+  // small keyless fetch feeds the ambient-dashboard card so it stays self-contained.
+  private var weatherText: String = ""
+
+  // Welcome-back overlay + TTS greeting (fork feature; off unless WelcomeConfig enables it).
+  private lateinit var welcomeOverlay: View
+  private var welcomeVisible = false
+  private val dismissWelcomeRunnable = Runnable { dismissWelcomeAnimated() }
+  private var tts: TextToSpeech? = null
+  @Volatile private var ttsReady = false
+  @Volatile private var pendingSpeech: String? = null
+
+  // Ambient soundscape (synthesized) played while the frame is up (fork feature).
+  private val soundscape = SoundscapePlayer()
+
+  // Optional contact-free "wave to advance" (Camera2 motion; opt-in, off by default).
+  private var gestureCamera: GestureCamera? = null
 
   private var settings = ScreensaverConfig.Settings()
 
@@ -177,6 +208,12 @@ class PhotoFrameController(
       MotionEvent.ACTION_UP -> {
         val dx = ev.x - downX
         val dy = ev.y - downY
+        // A tap while the welcome overlay is showing dismisses it early
+        // rather than exiting the screensaver.
+        if (welcomeVisible && abs(dx) < 48 && abs(dy) < 48) {
+          dismissWelcome()
+          return
+        }
         if (abs(dx) > 120 && abs(dx) > abs(dy) * 1.5f) {
           if (dx < 0) next() else prev()
         } else if (abs(dx) < 48 && abs(dy) < 48) {
@@ -197,6 +234,57 @@ class PhotoFrameController(
     // Build + drive the overlay from the user's selected face ([FaceCatalog]); faceOverride lets
     // the debug preview harness (and the overnight night clock) render a specific face instead.
     faceRenderer.start(faceOverride ?: FaceCatalog.active(context))
+
+    // --- fork features layered on top of the Face overlay ---
+    // Only spin up TTS when the welcome overlay will actually speak. The greeting uses the
+    // Android TTS service selected on the device, keeping any neural engine out-of-process.
+    val welcomeCfg = WelcomeConfig.load(context)
+    val ttsEnabled = showWelcome && settings.welcomeEnabled && welcomeCfg.enableTts
+    if (ttsEnabled) {
+      tts = TextToSpeech(context) { status ->
+        if (status == TextToSpeech.SUCCESS && !ttsReady) {
+          tts?.language = Locale.US
+          tts?.setPitch(1.0f)
+          tts?.setSpeechRate(0.9f)
+          // Apply the user's chosen voice; if none chosen, auto-pick the highest-quality
+          // voice the device has so the greeting sounds as good as possible by default.
+          runCatching {
+            val voices = tts?.voices
+            val chosen =
+                if (welcomeCfg.ttsVoice.isNotBlank()) voices?.firstOrNull { it.name == welcomeCfg.ttsVoice }
+                else voices
+                    ?.filter { it.locale.language == Locale.US.language && !it.isNetworkConnectionRequired }
+                    ?.maxByOrNull { it.quality }
+            chosen?.let {
+              tts?.language = it.locale
+              tts?.voice = it
+            }
+          }
+          ttsReady = true
+          pendingSpeech?.let { text ->
+            speakWelcome(text, welcomeCfg)
+            pendingSpeech = null
+          }
+        }
+      }
+    }
+
+    // Start the ambient soundscape (no-op when set to Off).
+    runCatching { soundscape.start(settings.soundscape, settings.soundscapeVolume) }
+
+    // Optional "wave to advance" — wholly guarded; any failure just disables it so the
+    // always-on dream process is never put at risk.
+    if (settings.gestureWave) {
+      runCatching {
+        gestureCamera = GestureCamera(context) { ui.post { runCatching { next() } } }.also { it.start() }
+      }
+    }
+
+    // Feed the ambient dashboard's weather, and schedule its cycle (first card after ~45s).
+    refreshWeather.run()
+    if (settings.ambientDashboard) ui.postDelayed(dashboardCycle, 45_000L)
+
+    if (showWelcome && settings.welcomeEnabled) showWelcomeOverlay()
     when (source) {
       is PhotoFrameSource.WebPage -> {
         // Web-page source takes over the whole frame — no photo feed, no Immortal overlay.
@@ -337,7 +425,16 @@ class PhotoFrameController(
   }
 
   fun stop() {
+    ui.removeCallbacks(dashboardCycle)
     ui.removeCallbacksAndMessages(null)
+    runCatching { gestureCamera?.stop() }
+    gestureCamera = null
+    runCatching { soundscape.stop() }
+    tts?.stop()
+    tts?.shutdown()
+    tts = null
+    ttsReady = false
+    pendingSpeech = null
     cancelKenBurns()
     faceRenderer.stop()
     if (this::videoView.isInitialized) runCatching { videoView.stopPlayback() }
@@ -367,6 +464,17 @@ class PhotoFrameController(
 
     root.addView(faceRenderer.view)
     buildCalendar(root)
+
+    // Ambient dashboard panel — full-screen glanceable card, hidden until cycled in.
+    dashboardPanel = buildDashboardPanel().also {
+      it.visibility = View.GONE
+      root.addView(it, FrameLayout.LayoutParams(MATCH, MATCH))
+    }
+
+    // Welcome-back overlay — added last so it renders above photos and the Face overlay.
+    welcomeOverlay = buildWelcomeOverlay()
+    welcomeOverlay.visibility = View.GONE
+    root.addView(welcomeOverlay, FrameLayout.LayoutParams(MATCH, MATCH))
     return root
   }
 
@@ -552,6 +660,231 @@ class PhotoFrameController(
     photo.scaleType =
         if (settings.fit == ScreensaverConfig.FIT_FIT) ImageView.ScaleType.FIT_CENTER
         else ImageView.ScaleType.CENTER_CROP
+  }
+
+  // --- welcome-back overlay (fork) --------------------------------------------
+
+  private fun buildWelcomeOverlay(): View {
+    val welcomeCfg = WelcomeConfig.load(context)
+
+    val overlay = FrameLayout(context)
+    // Semi-opaque dark scrim so the photo is faintly visible behind the greeting.
+    val bgAlpha = (welcomeCfg.backgroundOpacity * 255).toInt()
+    overlay.setBackgroundColor((bgAlpha shl 24) or 0x000000)
+
+    val col = LinearLayout(context)
+    col.orientation = LinearLayout.VERTICAL
+    col.gravity = Gravity.CENTER_HORIZONTAL
+    // Add horizontal padding to prevent text cutoff at screen edges
+    col.setPadding(dp(40), dp(20), dp(40), dp(20))
+
+    val hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
+    val greeting = when {
+      hour < 5  -> welcomeCfg.greetingNight
+      hour < 12 -> welcomeCfg.greetingMorning
+      hour < 17 -> welcomeCfg.greetingAfternoon
+      hour < 22 -> welcomeCfg.greetingEvening
+      else      -> welcomeCfg.greetingNight
+    }
+    val fullGreeting = if (welcomeCfg.userName.isNotBlank()) {
+      "$greeting, ${welcomeCfg.userName}"
+    } else {
+      greeting
+    }
+
+    if (welcomeCfg.showGreeting) {
+      val greetingView = text(welcomeCfg.greetingSize, welcomeCfg.greetingColor, false)
+      greetingView.text = fullGreeting
+      greetingView.gravity = Gravity.CENTER
+      greetingView.letterSpacing = welcomeCfg.greetingLetterSpacing
+      greetingView.maxLines = 2
+      val greetingLp = LinearLayout.LayoutParams(
+          LinearLayout.LayoutParams.MATCH_PARENT,
+          LinearLayout.LayoutParams.WRAP_CONTENT)
+      col.addView(greetingView, greetingLp)
+    }
+
+    if (welcomeCfg.showClock) {
+      val clockPattern = if (ImmortalSettings.use24HourClock(context)) "H:mm" else "h:mm"
+      val clockView = text(welcomeCfg.clockSize, welcomeCfg.clockColor, true)
+      clockView.text = SimpleDateFormat(clockPattern, Locale.getDefault()).format(Date())
+      clockView.gravity = Gravity.CENTER
+      clockView.maxLines = 1
+      val clockLp = LinearLayout.LayoutParams(
+          LinearLayout.LayoutParams.MATCH_PARENT,
+          LinearLayout.LayoutParams.WRAP_CONTENT)
+      col.addView(clockView, clockLp)
+    }
+
+    if (welcomeCfg.showDate) {
+      val dateView = text(welcomeCfg.dateSize, welcomeCfg.dateColor, false)
+      dateView.text = SimpleDateFormat("EEEE, MMM d", Locale.getDefault()).format(Date())
+      dateView.gravity = Gravity.CENTER
+      dateView.maxLines = 1
+      val dateLp = LinearLayout.LayoutParams(
+          LinearLayout.LayoutParams.MATCH_PARENT,
+          LinearLayout.LayoutParams.WRAP_CONTENT)
+      dateLp.topMargin = dp(4)
+      col.addView(dateView, dateLp)
+    }
+
+    // Use MATCH_PARENT width with the padding above to ensure text stays visible
+    overlay.addView(col, FrameLayout.LayoutParams(MATCH, WRAP, Gravity.CENTER))
+    return overlay
+  }
+
+  private fun showWelcomeOverlay() {
+    val welcomeCfg = WelcomeConfig.load(context)
+    welcomeVisible = true
+    welcomeOverlay.alpha = 0f
+    welcomeOverlay.visibility = View.VISIBLE
+    welcomeOverlay.animate().alpha(1f).setDuration(500).start()
+
+    // Speak the greeting if TTS is enabled
+    if (welcomeCfg.enableTts) {
+      val hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
+      val greeting = when {
+        hour < 5  -> welcomeCfg.greetingNight
+        hour < 12 -> welcomeCfg.greetingMorning
+        hour < 17 -> welcomeCfg.greetingAfternoon
+        hour < 22 -> welcomeCfg.greetingEvening
+        else      -> welcomeCfg.greetingNight
+      }
+      val fullGreeting = if (welcomeCfg.userName.isNotBlank()) {
+        "$greeting, ${welcomeCfg.userName}"
+      } else {
+        greeting
+      }
+      // Speak immediately if TTS is ready, otherwise queue it
+      if (ttsReady) {
+        speakWelcome(fullGreeting, welcomeCfg)
+      } else {
+        pendingSpeech = fullGreeting
+      }
+    }
+
+    // Auto-dismiss after configured duration.
+    ui.postDelayed(dismissWelcomeRunnable, welcomeCfg.durationMs.toLong())
+  }
+
+  /** Dismiss immediately (e.g. on tap). */
+  private fun dismissWelcome() {
+    if (!welcomeVisible) return
+    ui.removeCallbacks(dismissWelcomeRunnable)
+    tts?.stop()
+    pendingSpeech = null
+    dismissWelcomeAnimated()
+  }
+
+  private fun dismissWelcomeAnimated() {
+    welcomeVisible = false
+    welcomeOverlay.animate()
+        .alpha(0f)
+        .setDuration(600)
+        .withEndAction { welcomeOverlay.visibility = View.GONE }
+        .start()
+  }
+
+  private fun speakWelcome(text: String, cfg: WelcomeConfig.Settings) {
+    val params = welcomeTtsParams(cfg)
+    runCatching {
+      tts?.speak(text, TextToSpeech.QUEUE_FLUSH, params, "welcome_greeting")
+    }.onFailure { Log.w(TAG, "Welcome TTS speak failed", it) }
+  }
+
+  private fun welcomeTtsParams(cfg: WelcomeConfig.Settings): android.os.Bundle? =
+      if (cfg.ttsVoice.isBlank()) {
+        null
+      } else {
+        android.os.Bundle().apply { putString(SHERPA_VOICE_PARAM, cfg.ttsVoice) }
+      }
+
+  // --- ambient dashboard (fork) -----------------------------------------------
+
+  private fun buildDashboardPanel(): View {
+    val panel = FrameLayout(context)
+    panel.setBackgroundColor(0xF20D0D12.toInt()) // near-opaque dark
+    val col = LinearLayout(context)
+    col.orientation = LinearLayout.VERTICAL
+    col.gravity = Gravity.CENTER
+    panel.addView(col, FrameLayout.LayoutParams(WRAP, WRAP, Gravity.CENTER))
+    dashClock = text(120f, Color.WHITE, true).also { it.gravity = Gravity.CENTER; col.addView(it) }
+    dashDate = text(28f, Color.WHITE, false).also { it.gravity = Gravity.CENTER; col.addView(it) }
+    dashWeather = text(26f, Color.WHITE, false).also {
+      it.gravity = Gravity.CENTER
+      (it.layoutParams as? LinearLayout.LayoutParams)?.topMargin = dp(18)
+      col.addView(it)
+    }
+    dashEvent = text(22f, Color.WHITE, false).also {
+      it.gravity = Gravity.CENTER
+      (it.layoutParams as? LinearLayout.LayoutParams)?.topMargin = dp(10)
+      col.addView(it)
+    }
+    return panel
+  }
+
+  /** Shows the dashboard card for a few seconds, then returns to the photos. */
+  private val dashboardCycle =
+      object : Runnable {
+        override fun run() {
+          if (!settings.ambientDashboard) return
+          showDashboard()
+          ui.postDelayed({ hideDashboard() }, 9_000L)
+          ui.postDelayed(this, 90_000L) // reappear roughly every 90s
+        }
+      }
+
+  private fun showDashboard() {
+    val panel = dashboardPanel ?: return
+    val now = Date()
+    val clockPattern = if (ImmortalSettings.use24HourClock(context)) "H:mm" else "h:mm"
+    dashClock.text = SimpleDateFormat(clockPattern, Locale.getDefault()).format(now)
+    dashDate.text = SimpleDateFormat("EEEE, MMMM d", Locale.getDefault()).format(now)
+    dashWeather.text = weatherText
+    dashWeather.visibility = if (weatherText.isNotBlank()) View.VISIBLE else View.GONE
+    dashEvent.visibility = View.GONE
+    io.execute {
+      val ev = runCatching {
+        if (CalendarHelper.hasPermission(context)) CalendarHelper.upcoming(context).firstOrNull() else null
+      }.getOrNull()
+      ui.post {
+        if (ev != null) {
+          val cal = Calendar.getInstance().apply { timeInMillis = ev.begin }
+          val whenStr =
+              if (ev.allDay) SimpleDateFormat("MMM d", Locale.getDefault()).format(cal.time)
+              else SimpleDateFormat(if (ImmortalSettings.use24HourClock(context)) "HH:mm" else "h:mm a",
+                  Locale.getDefault()).format(cal.time)
+          dashEvent.text = "Next: $whenStr · ${ev.title}"
+          if (dashboardVisible) dashEvent.visibility = View.VISIBLE
+        }
+      }
+    }
+    panel.alpha = 0f
+    panel.visibility = View.VISIBLE
+    panel.animate().alpha(1f).setDuration(600).start()
+    dashboardVisible = true
+  }
+
+  private fun hideDashboard() {
+    val panel = dashboardPanel ?: return
+    panel.animate().alpha(0f).setDuration(600).withEndAction { panel.visibility = View.GONE }.start()
+    dashboardVisible = false
+  }
+
+  private val refreshWeather =
+      object : Runnable {
+        override fun run() {
+          fetchWeather()
+          ui.postDelayed(this, weatherRefreshMs)
+        }
+      }
+
+  private fun fetchWeather() {
+    io.execute {
+      // Shared resilient fetch: cached location + multi-provider geolocation.
+      val w = Weather.fetch(context)
+      if (w.isNotBlank()) weatherText = w
+    }
   }
 
   private fun text(sizeSp: Float, color: Int, light: Boolean): TextView {

--- a/app/src/main/java/com/immortal/launcher/PhotoFramePreviewActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFramePreviewActivity.kt
@@ -70,7 +70,7 @@ class PhotoFramePreviewActivity : ComponentActivity() {
       return
     }
 
-    frame = PhotoFrameController(this)
+    frame = PhotoFrameController(this, showWelcome = intent.getBooleanExtra(EXTRA_SHOW_WELCOME, false))
     frame.onExit = { finish() }
 
     if (nightClock) {
@@ -150,7 +150,10 @@ class PhotoFramePreviewActivity : ComponentActivity() {
     super.onDestroy()
   }
 
-  private companion object {
+  companion object {
+    /** When true, the launched frame shows the welcome-back overlay (presence-triggered starts). */
+    const val EXTRA_SHOW_WELCOME = "show_welcome"
+
     // A soft glow for the overnight bedside clock — dim but still legible in a dark room.
     const val NIGHT_BRIGHTNESS = 0.08f
   }

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -55,12 +55,50 @@ object ScreensaverConfig {
   const val CAL_SIDE_LEFT = "left"
   const val CAL_SIDE_RIGHT = "right"
 
+  // Ambient soundscape played while the screensaver is showing. All are synthesized
+  // on-device (no audio assets, no streaming), so they work offline on the Portal.
+  const val SOUND_OFF = "off"
+  const val SOUND_RAIN = "rain"
+  const val SOUND_OCEAN = "ocean"
+  const val SOUND_FIREPLACE = "fireplace"
+  const val SOUND_WHITE = "white"
+  const val SOUND_PINK = "pink"
+  const val SOUND_BROWN = "brown"
+  val SOUNDSCAPES =
+      listOf(SOUND_OFF, SOUND_RAIN, SOUND_OCEAN, SOUND_FIREPLACE, SOUND_WHITE, SOUND_PINK, SOUND_BROWN)
+  fun soundscapeLabel(s: String): String = when (s) {
+    SOUND_RAIN -> "Rain"
+    SOUND_OCEAN -> "Ocean waves"
+    SOUND_FIREPLACE -> "Fireplace"
+    SOUND_WHITE -> "White noise"
+    SOUND_PINK -> "Pink noise"
+    SOUND_BROWN -> "Brown noise"
+    else -> "Off"
+  }
+
+  // Online photo feeds (used when source == SOURCE_DEFAULT). All keyless.
+  const val FEED_PICSUM = "picsum" // Lorem Picsum random photos (current default)
+  const val FEED_MET = "met" // The Met Museum Open Access
+  const val FEED_ARTIC = "artic" // Art Institute of Chicago
+  const val FEED_WIKIMEDIA = "wikimedia" // Wikimedia Picture of the Day
+  const val FEED_APOD = "apod" // NASA Astronomy Picture of the Day (DEMO_KEY)
+  val FEEDS = listOf(FEED_PICSUM, FEED_MET, FEED_ARTIC, FEED_WIKIMEDIA, FEED_APOD)
+  fun feedLabel(feed: String): String = when (feed) {
+    FEED_MET -> "The Met — art"
+    FEED_ARTIC -> "Art Institute of Chicago"
+    FEED_WIKIMEDIA -> "Wikimedia Picture of the Day"
+    FEED_APOD -> "NASA Astronomy Picture"
+    else -> "Random photos (Picsum)"
+  }
+
   data class Settings(
       // Master on/off for Immortal's photo-frame screensaver. When off, Immortal
       // stops asserting itself as the system Dream and lets the Portal sleep / lets
       // the user run their own screensaver (e.g. Home Assistant + Immich frame).
       val enabled: Boolean = true,
       val source: String = SOURCE_DEFAULT,
+      // Which online feed to use when source == SOURCE_DEFAULT.
+      val feed: String = FEED_PICSUM,
       val folderPath: String? = null,
       val albumUrl: String? = null,
       // Immich (self-hosted) connection. albumId/Name null = the whole library.
@@ -122,6 +160,11 @@ object ScreensaverConfig {
       // Idle screen-off (off by default): minutes the screensaver runs before the
       // screen turns off. 0 = never (Immortal's always-on photo frame).
       val idleSleepMin: Int = 0,
+      // Sleep timer: a one-shot countdown before sleep.
+      val sleepTimerEnabled: Boolean = false,
+      val sleepTimerMin: Int = 30,
+      val pauseAudioOnSleep: Boolean = true,
+      val closeAppOnSleep: Boolean = true,
       // Overnight screen-off (off by default): keep the screen off between two times
       // each night. Times are minutes-from-midnight (e.g. 22:00 = 1320).
       val overnightEnabled: Boolean = false,
@@ -131,6 +174,21 @@ object ScreensaverConfig {
       // clock as a bedside clock, kept on through the window. Only meaningful when
       // [overnightEnabled].
       val overnightNightClock: Boolean = false,
+      // Ambient soundscape (synthesized) played while the screensaver shows. Off by
+      // default; [soundscapeVolume] is 0..100.
+      val soundscape: String = SOUND_OFF,
+      val soundscapeVolume: Int = 40,
+      // Ambient dashboard: periodically interrupt the photos with a full-screen
+      // glanceable info card (clock, weather, next event). Off by default.
+      val ambientDashboard: Boolean = false,
+      // Experimental: wave a hand in front of the camera to advance the photo frame
+      // (Camera2 motion detection, never the gated Smart Camera SDK). Off by default;
+      // no-ops without the CAMERA permission.
+      val gestureWave: Boolean = false,
+      // Welcome-back overlay: shown for ~3s when the screensaver first starts
+      // (i.e. when presence is detected and the Portal wakes from sleep). Shows
+      // a greeting, the time, and the date. Dismissed by tap or auto-fade.
+      val welcomeEnabled: Boolean = true,
       // What to open when the user taps the frame to dismiss it. null = the Immortal
       // launcher (the original behaviour). Otherwise a flattened ComponentName of an
       // installed app — Home Assistant users typically point this at their HA app so a
@@ -184,6 +242,7 @@ object ScreensaverConfig {
     return Settings(
         enabled = p.getBoolean("enabled", true),
         source = p.getString("source", SOURCE_DEFAULT) ?: SOURCE_DEFAULT,
+        feed = p.getString("feed", FEED_PICSUM) ?: FEED_PICSUM,
         folderPath = p.getString("folder_path", null),
         albumUrl = p.getString("album_url", null),
         immichUrl = p.getString("immich_url", null),
@@ -222,14 +281,34 @@ object ScreensaverConfig {
             runCatching { FrameMode.valueOf(p.getString("presence_mode", FrameMode.ALWAYS_ON.name)!!) }
                 .getOrDefault(FrameMode.ALWAYS_ON),
         idleSleepMin = p.getInt("idle_sleep_min", 0),
+        sleepTimerEnabled = p.getBoolean("sleep_timer_enabled", false),
+        sleepTimerMin = p.getInt("sleep_timer_min", 30),
+        pauseAudioOnSleep = p.getBoolean("pause_audio_on_sleep", true),
+        closeAppOnSleep = p.getBoolean("close_app_on_sleep", true),
         overnightEnabled = p.getBoolean("overnight_enabled", false),
         overnightStartMin = p.getInt("overnight_start_min", 22 * 60),
         overnightEndMin = p.getInt("overnight_end_min", 7 * 60),
         overnightNightClock = p.getBoolean("overnight_night_clock", false),
+        soundscape = p.getString("soundscape", SOUND_OFF) ?: SOUND_OFF,
+        soundscapeVolume = p.getInt("soundscape_volume", 40).coerceIn(0, 100),
+        ambientDashboard = p.getBoolean("ambient_dashboard", false),
+        gestureWave = p.getBoolean("gesture_wave", false),
+        welcomeEnabled = p.getBoolean("welcome_enabled", true),
         dismissAppComponent = p.getString("dismiss_app_component", null),
         dismissHaDashboard = p.getString("dismiss_ha_dashboard", null),
     )
   }
+
+  fun setSoundscape(c: Context, s: String) = prefs(c).edit().putString("soundscape", s).apply()
+
+  fun setSoundscapeVolume(c: Context, v: Int) =
+      prefs(c).edit().putInt("soundscape_volume", v.coerceIn(0, 100)).apply()
+
+  fun setAmbientDashboard(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("ambient_dashboard", on).apply()
+
+  fun setGestureWave(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("gesture_wave", on).apply()
 
   /** Keep the idle timeout sane (0 = off, else 1…120 min). */
   fun clampIdle(min: Int): Int = if (min <= 0) 0 else min.coerceIn(1, 120)
@@ -294,6 +373,10 @@ object ScreensaverConfig {
       prefs(c).edit().putString("web_url", url.trim()).putString("source", SOURCE_WEBURL).apply()
 
   fun useDefault(c: Context) = prefs(c).edit().putString("source", SOURCE_DEFAULT).apply()
+
+  /** Pick the online feed and switch the source back to the default (online) feed. */
+  fun setFeed(c: Context, feed: String) =
+      prefs(c).edit().putString("feed", feed).putString("source", SOURCE_DEFAULT).apply()
 
   fun setFit(c: Context, fit: String) = prefs(c).edit().putString("fit", fit).apply()
 
@@ -361,6 +444,23 @@ object ScreensaverConfig {
 
   fun setIdleSleepMin(c: Context, min: Int) =
       prefs(c).edit().putInt("idle_sleep_min", clampIdle(min)).apply()
+
+  fun setSleepTimerEnabled(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("sleep_timer_enabled", on).apply()
+
+  fun setSleepTimerMin(c: Context, min: Int) =
+      prefs(c).edit().putInt("sleep_timer_min", clampSleepTimer(min)).apply()
+
+  fun setPauseAudioOnSleep(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("pause_audio_on_sleep", on).apply()
+
+  fun setCloseAppOnSleep(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("close_app_on_sleep", on).apply()
+
+  fun clampSleepTimer(min: Int): Int = min.coerceIn(1, 240)
+
+  fun setWelcomeEnabled(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("welcome_enabled", on).apply()
 
   fun setOvernightEnabled(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("overnight_enabled", on).apply()

--- a/app/src/main/java/com/immortal/launcher/SettingsGuard.kt
+++ b/app/src/main/java/com/immortal/launcher/SettingsGuard.kt
@@ -66,7 +66,14 @@ object SettingsGuard {
         Settings.Secure.putInt(resolver, "screensaver_enabled", 0)
         return@runCatching
       }
-      val ours = ComponentName(context, PhotoDreamService::class.java).flattenToShortString()
+      // Use the digital-clock screensaver if enabled, otherwise the photo frame.
+      val dreamServiceClass =
+          if (DigitalClockConfig.load(context).enabled) {
+            DigitalClockDreamService::class.java
+          } else {
+            PhotoDreamService::class.java
+          }
+      val ours = ComponentName(context, dreamServiceClass).flattenToShortString()
       if (Settings.Secure.getString(resolver, "screensaver_components") != ours) {
         Settings.Secure.putString(resolver, "screensaver_components", ours)
       }

--- a/app/src/main/java/com/immortal/launcher/SleepScheduler.kt
+++ b/app/src/main/java/com/immortal/launcher/SleepScheduler.kt
@@ -11,6 +11,7 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.media.AudioManager
 import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
@@ -67,10 +68,12 @@ object SleepScheduler {
   }
 
   const val ACTION_IDLE = "com.immortal.launcher.SLEEP_IDLE"
+  const val ACTION_SLEEP_TIMER = "com.immortal.launcher.SLEEP_TIMER"
   const val ACTION_OVERNIGHT_START = "com.immortal.launcher.OVERNIGHT_START"
   const val ACTION_OVERNIGHT_END = "com.immortal.launcher.OVERNIGHT_END"
 
   private const val RC_IDLE = 1001
+  private const val RC_SLEEP_TIMER = 1004
   private const val RC_OVERNIGHT_START = 1002
   private const val RC_OVERNIGHT_END = 1003
 
@@ -156,6 +159,24 @@ object SleepScheduler {
     nightSessionActive = true
     main.postDelayed(nightSessionElapsed, overnightSessionMs(context))
   }
+
+  // ----- one-shot sleep timer ------------------------------------------------
+
+  /** Arm a one-shot sleep timer. */
+  fun armSleepTimer(context: Context) {
+    val cfg = ScreensaverConfig.load(context)
+    if (!cfg.sleepTimerEnabled) {
+      cancelSleepTimer(context)
+      return
+    }
+    val minutes = ScreensaverConfig.clampSleepTimer(cfg.sleepTimerMin)
+    val at = System.currentTimeMillis() + minutes * 60_000L
+    setAlarm(context, at, ACTION_SLEEP_TIMER, RC_SLEEP_TIMER)
+    Log.i(TAG, "sleep timer armed for $minutes min")
+  }
+
+  /** Cancel the one-shot sleep timer. */
+  fun cancelSleepTimer(context: Context) = cancel(context, ACTION_SLEEP_TIMER, RC_SLEEP_TIMER)
 
   // ----- overnight window ----------------------------------------------------
 
@@ -255,6 +276,13 @@ object SleepScheduler {
     Log.i(TAG, "overnight scheduled ${cfg.overnightStartMin}→${cfg.overnightEndMin}")
   }
 
+  fun sleepNow(context: Context, pauseAudio: Boolean = true, closeApp: Boolean = true) {
+    if (pauseAudio) pauseAudio(context)
+    if (closeApp) closeCurrentApp(context)
+    SettingsGuard.setSystemScreensaverEnabled(context, false)
+    ScreenControl.sleep(context)
+  }
+
   /** Apply the right state immediately (on boot, app start, or a settings change). */
   fun applyOvernightNow(context: Context) {
     scheduleOvernight(context)
@@ -295,6 +323,35 @@ object SleepScheduler {
     } else {
       ScreenControl.sleep(context)
     }
+  }
+
+  private fun pauseAudio(context: Context) {
+    runCatching {
+      val am = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+      am.dispatchMediaKeyEvent(
+          android.view.KeyEvent(
+              android.view.KeyEvent.ACTION_DOWN,
+              android.view.KeyEvent.KEYCODE_MEDIA_PAUSE
+          )
+      )
+      am.dispatchMediaKeyEvent(
+          android.view.KeyEvent(
+              android.view.KeyEvent.ACTION_UP,
+              android.view.KeyEvent.KEYCODE_MEDIA_PAUSE
+          )
+      )
+      Log.i(TAG, "media pause dispatched")
+    }.onFailure { Log.w(TAG, "failed to dispatch media pause", it) }
+  }
+
+  private fun closeCurrentApp(context: Context) {
+    val intent =
+        Intent(context, HomeActivity::class.java)
+            .setAction("com.immortal.launcher.CLOSE_CURRENT_APP")
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    runCatching { context.startActivity(intent) }
+        .onSuccess { Log.i(TAG, "close-app intent sent") }
+        .onFailure { Log.w(TAG, "failed to send close-app intent", it) }
   }
 
   /** Show [PhotoFramePreviewActivity], which renders the dimmed night clock while in the window. */

--- a/app/src/main/java/com/immortal/launcher/SleepSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/SleepSettingsActivity.kt
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Activity
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.immortal.launcher.settings.SettingsDomains
+import com.immortal.launcher.ui.theme.SampleAppTheme
+import kotlinx.coroutines.delay
+import kotlin.math.max
+import org.json.JSONObject
+
+class SleepSettingsActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { SleepSettingsScreen() } }
+  }
+}
+
+@Composable
+private fun SleepSettingsScreen() {
+  val context = LocalContext.current
+  var settings by remember { mutableStateOf(ScreensaverConfig.load(context)) }
+  var remainingMs by remember { mutableLongStateOf(0L) }
+  var running by remember { mutableStateOf(false) }
+  var timerEndsAtMs by remember { mutableLongStateOf(0L) }
+
+  LaunchedEffect(settings.sleepTimerEnabled) {
+    if (!settings.sleepTimerEnabled) {
+      remainingMs = 0L
+      running = false
+      timerEndsAtMs = 0L
+    }
+  }
+
+  LaunchedEffect(running, timerEndsAtMs) {
+    while (running && timerEndsAtMs > 0L) {
+      val left = max(0L, timerEndsAtMs - System.currentTimeMillis())
+      remainingMs = left
+      if (left == 0L) {
+        running = false
+        timerEndsAtMs = 0L
+        break
+      }
+      delay(1000L)
+    }
+  }
+
+  val timerText = remember(remainingMs) {
+    val total = remainingMs / 1000
+    val h = total / 3600
+    val m = (total % 3600) / 60
+    val s = total % 60
+    if (h > 0) String.format("%d:%02d:%02d", h, m, s) else String.format("%d:%02d", m, s)
+  }
+
+  val activity = context as? Activity
+  val firstFocus = remember { FocusRequester() }
+  LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
+
+  fun startCountdown() {
+    if (!settings.sleepTimerEnabled) return
+    SleepScheduler.armSleepTimer(context)
+    val durationMs = ScreensaverConfig.clampSleepTimer(settings.sleepTimerMin) * 60_000L
+    timerEndsAtMs = System.currentTimeMillis() + durationMs
+    remainingMs = durationMs
+    running = true
+  }
+
+  fun stopCountdown() {
+    SleepScheduler.cancelSleepTimer(context)
+    remainingMs = 0L
+    timerEndsAtMs = 0L
+    running = false
+  }
+
+  Box(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .background(Color(0xFF111111))
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 28.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+      Text("Sleep Timer", color = Color.White, fontSize = 30.sp, fontWeight = FontWeight.Bold)
+      Text(
+          if (settings.sleepTimerEnabled) "Set the timer, then start the countdown."
+          else "Enable Sleep Timer below before starting.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 15.sp,
+          textAlign = TextAlign.Center,
+      )
+
+      Surface(
+          color = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f),
+          shape = RoundedCornerShape(22.dp),
+          modifier = Modifier.fillMaxWidth(),
+      ) {
+        Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
+          Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text("Countdown", color = Color.White, fontSize = 18.sp)
+            Text(
+                if (remainingMs > 0) timerText else "00:00",
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 34.sp,
+                fontWeight = FontWeight.Bold,
+            )
+          }
+
+          Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.spacedBy(12.dp),
+          ) {
+            Surface(
+                color = MaterialTheme.colorScheme.primary,
+                shape = RoundedCornerShape(14.dp),
+                modifier =
+                    Modifier.weight(1f)
+                        .focusRequester(firstFocus)
+                        .tvFocusable(RoundedCornerShape(14.dp), focusScale = 1f) {
+                          startCountdown()
+                        },
+            ) {
+              Text(
+                  "Start countdown",
+                  color = Color.White,
+                  fontSize = 18.sp,
+                  fontWeight = FontWeight.SemiBold,
+                  textAlign = TextAlign.Center,
+                  modifier = Modifier.padding(vertical = 12.dp).fillMaxWidth(),
+              )
+            }
+            Surface(
+                color = if (running) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.secondary,
+                shape = RoundedCornerShape(14.dp),
+                modifier =
+                    Modifier.weight(1f)
+                        .tvFocusable(RoundedCornerShape(14.dp), focusScale = 1f) {
+                          stopCountdown()
+                        },
+            ) {
+              Text(
+                  "Stop",
+                  color = Color.White,
+                  fontSize = 18.sp,
+                  fontWeight = FontWeight.SemiBold,
+                  textAlign = TextAlign.Center,
+                  modifier = Modifier.padding(vertical = 12.dp).fillMaxWidth(),
+              )
+            }
+          }
+        }
+      }
+
+      SleepToggleRow("Sleep Timer", settings.sleepTimerEnabled) {
+        SettingsDomains.screensaver.apply(context, JSONObject().put("sleepTimerEnabled", it))
+        settings = ScreensaverConfig.load(context)
+        if (!it) stopCountdown()
+      }
+
+      if (settings.sleepTimerEnabled) {
+        SleepMinuteStepper(settings.sleepTimerMin) { v ->
+          val c = ScreensaverConfig.clampSleepTimer(v)
+          SettingsDomains.screensaver.apply(context, JSONObject().put("sleepTimerMin", c))
+          settings = ScreensaverConfig.load(context)
+          if (running) {
+            SleepScheduler.armSleepTimer(context)
+            val durationMs = c * 60_000L
+            timerEndsAtMs = System.currentTimeMillis() + durationMs
+            remainingMs = durationMs
+          }
+        }
+      }
+
+      SleepToggleRow("Pause audio before sleeping", settings.pauseAudioOnSleep) {
+        SettingsDomains.screensaver.apply(context, JSONObject().put("pauseAudioOnSleep", it))
+        settings = ScreensaverConfig.load(context)
+      }
+
+      SleepToggleRow("Close Immortal before sleeping", settings.closeAppOnSleep) {
+        SettingsDomains.screensaver.apply(context, JSONObject().put("closeAppOnSleep", it))
+        settings = ScreensaverConfig.load(context)
+      }
+
+      Spacer(Modifier.size(8.dp))
+      Text(
+          "When the timer reaches zero, Immortal pauses audio, closes itself, disables the screensaver, and locks the screen.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 13.sp,
+          textAlign = TextAlign.Center,
+      )
+    }
+  }
+  FolderBackButton(onClick = { activity?.finish() })
+}
+
+@Composable
+private fun SleepToggleRow(title: String, checked: Boolean, onChange: (Boolean) -> Unit) {
+  Row(
+      modifier =
+          Modifier.fillMaxWidth().tvFocusableRow { onChange(!checked) }
+              .padding(horizontal = 18.dp, vertical = 14.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(title, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+    Switch(checked = checked, onCheckedChange = null)
+  }
+}
+
+@Composable
+private fun SleepMinuteStepper(minutes: Int, onChange: (Int) -> Unit) {
+  val src = remember { MutableInteractionSource() }
+  val focused by src.collectIsFocusedAsState()
+  Row(
+      modifier =
+          Modifier.fillMaxWidth()
+              .onKeyEvent { e ->
+                if (e.type == KeyEventType.KeyDown) {
+                  when (e.key) {
+                    Key.DirectionLeft -> { onChange(max(1, minutes - 5)); true }
+                    Key.DirectionRight -> { onChange(minutes + 5); true }
+                    else -> false
+                  }
+                } else false
+              }
+              .focusable(interactionSource = src)
+              .background(if (focused) Color(0x402E6BE6) else Color.Transparent)
+              .padding(start = 18.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text("Turn off after", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+    ArrowButton("◀", focused) { onChange(max(1, minutes - 5)) }
+    Text(
+        "${minutes}m",
+        color = if (focused) Color.White else Color(0xFFDDDDDD),
+        fontSize = 17.sp,
+        fontWeight = FontWeight.SemiBold,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.widthIn(min = 64.dp),
+    )
+    ArrowButton("▶", focused) { onChange(minutes + 5) }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/SoundscapePlayer.kt
+++ b/app/src/main/java/com/immortal/launcher/SoundscapePlayer.kt
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import android.util.Log
+import kotlin.math.exp
+import kotlin.math.sin
+import kotlin.math.tanh
+import kotlin.random.Random
+
+/**
+ * Procedurally-synthesized ambient soundscapes for the screensaver. Everything is
+ * generated on the fly into an [AudioTrack] in streaming mode — no audio assets are
+ * bundled and nothing is streamed over the network, so it works fully offline on the
+ * Portal and adds nothing to the APK size.
+ *
+ * The palette is built from coloured noise put through proper filters and envelopes:
+ *  - white/pink/brown noise directly;
+ *  - rain      = high band wash + a stream of soft band-passed droplets over a low bed;
+ *  - ocean     = filtered brown swell with surf hiss that rises on each wave crest;
+ *  - fireplace = warm low rumble with band-limited crackle bursts.
+ *
+ * Output is stereo: slow elements (swell, rumble) are shared, the bright detail
+ * (hiss, droplets, crackle) is decorrelated per channel for natural width. A soft
+ * tanh limiter replaces hard clipping so nothing rasps.
+ *
+ * One instance plays one soundscape; call [stop] to release. Not thread-safe across
+ * concurrent [start]/[stop] from different threads — drive it from one owner.
+ */
+class SoundscapePlayer {
+  private val TAG = "ImmortalSound"
+  private val SAMPLE_RATE = 44100
+
+  @Volatile private var running = false
+  private var thread: Thread? = null
+  private var track: AudioTrack? = null
+
+  /** Start playing [soundscape] (a `ScreensaverConfig.SOUND_*`) at [volume] (0..100).
+   * No-op for SOUND_OFF or an unknown id. Safe to call when already stopped. */
+  fun start(soundscape: String, volume: Int) {
+    if (soundscape == ScreensaverConfig.SOUND_OFF) return
+    stop()
+    val gain = (volume.coerceIn(0, 100) / 100f)
+    if (gain <= 0f) return
+    running = true
+    thread = Thread { runCatching { render(soundscape, gain) }.onFailure { Log.w(TAG, "render stopped", it) } }
+        .also { it.isDaemon = true; it.start() }
+  }
+
+  /** Stop playback and release the track. Idempotent. */
+  fun stop() {
+    running = false
+    thread?.let { runCatching { it.join(500) } }
+    thread = null
+    track?.let { t -> runCatching { t.stop() }; runCatching { t.release() } }
+    track = null
+  }
+
+  private fun render(soundscape: String, gain: Float) {
+    val minBuf = AudioTrack.getMinBufferSize(
+        SAMPLE_RATE, AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_16BIT)
+    val bufFrames = (SAMPLE_RATE / 10) // ~100 ms chunks
+    val t = AudioTrack.Builder()
+        .setAudioAttributes(
+            AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                .build())
+        .setAudioFormat(
+            AudioFormat.Builder()
+                .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                .setSampleRate(SAMPLE_RATE)
+                .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
+                .build())
+        .setBufferSizeInBytes(maxOf(minBuf, bufFrames * 4))
+        .setTransferMode(AudioTrack.MODE_STREAM)
+        .build()
+    track = t
+    t.play()
+
+    val gen = Generator(soundscape, SAMPLE_RATE)
+    val out = ShortArray(bufFrames * 2) // interleaved stereo
+    val lr = FloatArray(2)
+    // Slow fade-in (~0.4 s) so starting the screensaver doesn't pop.
+    var fade = 0f
+    val fadeStep = 1f / (SAMPLE_RATE * 0.4f)
+    while (running) {
+      for (i in 0 until bufFrames) {
+        gen.next(lr)
+        if (fade < 1f) fade = (fade + fadeStep).coerceAtMost(1f)
+        // tanh soft-clip keeps peaks musical instead of rasping at the rails.
+        out[i * 2] = toPcm(tanh(lr[0] * gain * fade))
+        out[i * 2 + 1] = toPcm(tanh(lr[1] * gain * fade))
+      }
+      val n = t.write(out, 0, out.size)
+      if (n < 0) break
+    }
+  }
+
+  private fun toPcm(s: Float): Short = (s.coerceIn(-1f, 1f) * 32767f).toInt().toShort()
+
+  /** Pure DSP core: writes the next stereo sample (each in [-1, 1]) into [out].
+   *  Everything is gain-staged to sit comfortably below ±0.8 so the outer tanh only
+   *  ever rounds off the rare peak — no internal hard-clipping (the old source of the
+   *  gritty "disturbance"). */
+  private class Generator(private val kind: String, private val rate: Int) {
+    private val rnd = Random(System.nanoTime())
+
+    // Pink-noise running state (Paul Kellet's refined method).
+    private var b0 = 0f; private var b1 = 0f; private var b2 = 0f
+    private var b3 = 0f; private var b4 = 0f; private var b5 = 0f; private var b6 = 0f
+    // Brown-noise leaky integrator. Kept well-scaled (no ×6 blow-up) so it never clips.
+    private var brown = 0f
+    // Body low-pass states for ocean / fireplace.
+    private var lpA = 0f
+    private var lpB = 0f
+    // Per-channel low-pass states (warm rain wash + ocean surf), for stereo width.
+    private var rainLpL = 0f; private var rainLpR = 0f
+    private var surfLpL = 0f; private var surfLpR = 0f
+    // Wave LFOs for the ocean swell (two detuned so it never feels metronomic).
+    private var phase1 = 0f
+    private var phase2 = 0f
+    // Droplet / crackle envelopes (separate L/R for width).
+    private var dropL = 0f; private var dropR = 0f
+    private var dropFreqL = 0f; private var dropFreqR = 0f
+    private var dropPhaseL = 0f; private var dropPhaseR = 0f
+    private var crackleL = 0f; private var crackleR = 0f
+    private var crackleLpL = 0f; private var crackleLpR = 0f
+
+    private val TWO_PI = (2.0 * Math.PI).toFloat()
+
+    private fun white(): Float = rnd.nextFloat() * 2f - 1f
+
+    private fun pink(): Float {
+      val w = white()
+      b0 = 0.99886f * b0 + w * 0.0555179f
+      b1 = 0.99332f * b1 + w * 0.0750759f
+      b2 = 0.96900f * b2 + w * 0.1538520f
+      b3 = 0.86650f * b3 + w * 0.3104856f
+      b4 = 0.55000f * b4 + w * 0.5329522f
+      b5 = -0.7616f * b5 - w * 0.0168980f
+      val p = b0 + b1 + b2 + b3 + b4 + b5 + b6 + w * 0.5362f
+      b6 = w * 0.115926f
+      return p * 0.11f
+    }
+
+    /** Brown noise scaled to ~0.3 RMS — comfortably below clipping. */
+    private fun brown(): Float {
+      brown = 0.99f * brown + white() * 0.05f
+      return brown * 0.9f
+    }
+
+    fun next(out: FloatArray) {
+      when (kind) {
+        ScreensaverConfig.SOUND_WHITE -> { out[0] = white() * 0.45f; out[1] = white() * 0.45f }
+        ScreensaverConfig.SOUND_PINK -> { out[0] = pink() * 0.8f; out[1] = pink() * 0.8f }
+        ScreensaverConfig.SOUND_BROWN -> { val s = brown() * 0.9f; out[0] = s; out[1] = s }
+        ScreensaverConfig.SOUND_RAIN -> rain(out)
+        ScreensaverConfig.SOUND_OCEAN -> ocean(out)
+        ScreensaverConfig.SOUND_FIREPLACE -> fireplace(out)
+        else -> { out[0] = 0f; out[1] = 0f }
+      }
+    }
+
+    /** A warm broadband wash (gently low-passed white, not raw hiss) with occasional
+     *  soft droplet pings — a steady, calm rain rather than a buzzing tone. */
+    private fun rain(out: FloatArray) {
+      out[0] = rainChannel(true)
+      out[1] = rainChannel(false)
+    }
+
+    private fun rainChannel(left: Boolean): Float {
+      // Warm wash: one-pole low-pass on white softens the harsh top end.
+      val w = white()
+      val wash = if (left) { rainLpL += 0.45f * (w - rainLpL); rainLpL } else { rainLpR += 0.45f * (w - rainLpR); rainLpR }
+      var s = wash * 0.5f
+      // Sparse soft droplets (~16/sec per channel), each a short decaying sine.
+      if (left) {
+        if (rnd.nextInt(rate) < 16) { dropL = 0.4f + rnd.nextFloat() * 0.4f; dropFreqL = 2200f + rnd.nextFloat() * 2200f; dropPhaseL = 0f }
+        if (dropL > 0.001f) {
+          dropPhaseL += TWO_PI * dropFreqL / rate
+          s += sin(dropPhaseL.toDouble()).toFloat() * dropL * 0.22f
+          dropL *= exp(-32f / rate)
+        }
+      } else {
+        if (rnd.nextInt(rate) < 16) { dropR = 0.4f + rnd.nextFloat() * 0.4f; dropFreqR = 2200f + rnd.nextFloat() * 2200f; dropPhaseR = 0f }
+        if (dropR > 0.001f) {
+          dropPhaseR += TWO_PI * dropFreqR / rate
+          s += sin(dropPhaseR.toDouble()).toFloat() * dropR * 0.22f
+          dropR *= exp(-32f / rate)
+        }
+      }
+      return s
+    }
+
+    /** Filtered brown swell whose surf hiss rises and falls with each wave. */
+    private fun ocean(out: FloatArray) {
+      phase1 += TWO_PI * 0.075f / rate // ~13 s wave
+      phase2 += TWO_PI * 0.053f / rate // ~19 s wave (beats against it)
+      if (phase1 > TWO_PI) phase1 -= TWO_PI
+      if (phase2 > TWO_PI) phase2 -= TWO_PI
+      val s1 = (sin(phase1.toDouble()).toFloat() + 1f) / 2f
+      val s2 = (sin(phase2.toDouble()).toFloat() + 1f) / 2f
+      val swell = 0.3f + 0.7f * (0.6f * s1 + 0.4f * s2)
+      // Low body: heavily low-passed brown noise (deep rumble).
+      lpA += 0.05f * (brown() - lpA)
+      val body = lpA * 0.8f
+      // Surf hiss, brighter at the crest, decorrelated per channel.
+      val crest = swell * swell
+      val sL = white().let { surfLpL += 0.5f * (it - surfLpL); surfLpL } * crest * 0.45f
+      val sR = white().let { surfLpR += 0.5f * (it - surfLpR); surfLpR } * crest * 0.45f
+      out[0] = (body + sL) * swell
+      out[1] = (body + sR) * swell
+    }
+
+    /** Warm low rumble with random soft (low-passed) crackle pops, per channel. */
+    private fun fireplace(out: FloatArray) {
+      lpB += 0.04f * (brown() - lpB)
+      val rumble = lpB * 0.75f
+      out[0] = rumble + crackleChannel(true)
+      out[1] = rumble + crackleChannel(false)
+    }
+
+    private fun crackleChannel(left: Boolean): Float {
+      return if (left) {
+        if (rnd.nextInt(rate) < 30) crackleL = 0.6f + rnd.nextFloat() * 0.4f
+        crackleL *= exp(-45f / rate)
+        val pop = if (crackleL > 0.001f) white() * crackleL else 0f
+        crackleLpL += 0.6f * (pop - crackleLpL); crackleLpL * 0.6f
+      } else {
+        if (rnd.nextInt(rate) < 30) crackleR = 0.6f + rnd.nextFloat() * 0.4f
+        crackleR *= exp(-45f / rate)
+        val pop = if (crackleR > 0.001f) white() * crackleR else 0f
+        crackleLpR += 0.6f * (pop - crackleLpR); crackleLpR * 0.6f
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/WelcomeConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/WelcomeConfig.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+
+/**
+ * User configuration for the welcome-back overlay shown when the screensaver
+ * starts. Persisted across restarts.
+ */
+object WelcomeConfig {
+
+  private const val PREFS = "immortal_welcome"
+
+  data class Settings(
+      // Display duration in milliseconds before auto-dismiss
+      val durationMs: Int = 3200,
+
+      // Greeting text for different times of day (user-customizable)
+      val greetingNight: String = "Good night",      // 22:00 - 04:59
+      val greetingMorning: String = "Good morning",  // 05:00 - 11:59
+      val greetingAfternoon: String = "Good afternoon", // 12:00 - 16:59
+      val greetingEvening: String = "Good evening",  // 17:00 - 21:59
+
+      // User's name (appended to greeting if not empty)
+      val userName: String = "",
+
+      // Text colors (ARGB hex)
+      val greetingColor: Int = 0xFFDADADA.toInt(),
+      val clockColor: Int = 0xFFFFFFFF.toInt(),
+      val dateColor: Int = 0xFFDADADA.toInt(),
+
+      // Background scrim opacity (0.0 = transparent, 1.0 = opaque)
+      val backgroundOpacity: Float = 0.7f,
+
+      // Text sizes (SP)
+      val greetingSize: Float = 26f,
+      val clockSize: Float = 88f,
+      val dateSize: Float = 22f,
+
+      // Show/hide individual elements
+      val showGreeting: Boolean = true,
+      val showClock: Boolean = true,
+      val showDate: Boolean = true,
+
+      // Letter spacing for greeting text
+      val greetingLetterSpacing: Float = 0.08f,
+
+      // Text-to-speech
+      val enableTts: Boolean = false,
+
+      // Android TextToSpeech voice name (TextToSpeech.Voice.getName()); "" = engine default.
+      // The greeting speaks through Android TTS — Piper neural TTS was removed because its
+      // model download is unreliable on the Portal's connection. See project notes.
+      val ttsVoice: String = "",
+  )
+
+  fun clampDuration(ms: Int): Int = ms.coerceIn(1000, 10000)
+  fun clampOpacity(opacity: Float): Float = opacity.coerceIn(0f, 1f)
+  fun clampTextSize(size: Float): Float = size.coerceIn(10f, 120f)
+
+  private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+  fun load(context: Context): Settings {
+    val p = prefs(context)
+    return Settings(
+        durationMs = clampDuration(p.getInt("duration_ms", 3200)),
+        greetingNight = p.getString("greeting_night", "Good night") ?: "Good night",
+        greetingMorning = p.getString("greeting_morning", "Good morning") ?: "Good morning",
+        greetingAfternoon = p.getString("greeting_afternoon", "Good afternoon") ?: "Good afternoon",
+        greetingEvening = p.getString("greeting_evening", "Good evening") ?: "Good evening",
+        userName = p.getString("user_name", "") ?: "",
+        greetingColor = p.getInt("greeting_color", 0xFFDADADA.toInt()),
+        clockColor = p.getInt("clock_color", 0xFFFFFFFF.toInt()),
+        dateColor = p.getInt("date_color", 0xFFDADADA.toInt()),
+        backgroundOpacity = clampOpacity(p.getFloat("background_opacity", 0.7f)),
+        greetingSize = clampTextSize(p.getFloat("greeting_size", 26f)),
+        clockSize = clampTextSize(p.getFloat("clock_size", 88f)),
+        dateSize = clampTextSize(p.getFloat("date_size", 22f)),
+        showGreeting = p.getBoolean("show_greeting", true),
+        showClock = p.getBoolean("show_clock", true),
+        showDate = p.getBoolean("show_date", true),
+        greetingLetterSpacing = p.getFloat("greeting_letter_spacing", 0.08f),
+        enableTts = p.getBoolean("enable_tts", false),
+        ttsVoice = p.getString("tts_voice", "") ?: "",
+    )
+  }
+
+  fun setDuration(context: Context, ms: Int) {
+    prefs(context).edit().putInt("duration_ms", clampDuration(ms)).apply()
+  }
+
+  fun setGreetingNight(context: Context, text: String) {
+    prefs(context).edit().putString("greeting_night", text).apply()
+  }
+
+  fun setGreetingMorning(context: Context, text: String) {
+    prefs(context).edit().putString("greeting_morning", text).apply()
+  }
+
+  fun setGreetingAfternoon(context: Context, text: String) {
+    prefs(context).edit().putString("greeting_afternoon", text).apply()
+  }
+
+  fun setGreetingEvening(context: Context, text: String) {
+    prefs(context).edit().putString("greeting_evening", text).apply()
+  }
+
+  fun setGreetingColor(context: Context, color: Int) {
+    prefs(context).edit().putInt("greeting_color", color).apply()
+  }
+
+  fun setClockColor(context: Context, color: Int) {
+    prefs(context).edit().putInt("clock_color", color).apply()
+  }
+
+  fun setDateColor(context: Context, color: Int) {
+    prefs(context).edit().putInt("date_color", color).apply()
+  }
+
+  fun setBackgroundOpacity(context: Context, opacity: Float) {
+    prefs(context).edit().putFloat("background_opacity", clampOpacity(opacity)).apply()
+  }
+
+  fun setGreetingSize(context: Context, size: Float) {
+    prefs(context).edit().putFloat("greeting_size", clampTextSize(size)).apply()
+  }
+
+  fun setClockSize(context: Context, size: Float) {
+    prefs(context).edit().putFloat("clock_size", clampTextSize(size)).apply()
+  }
+
+  fun setDateSize(context: Context, size: Float) {
+    prefs(context).edit().putFloat("date_size", clampTextSize(size)).apply()
+  }
+
+  fun setShowGreeting(context: Context, show: Boolean) {
+    prefs(context).edit().putBoolean("show_greeting", show).apply()
+  }
+
+  fun setShowClock(context: Context, show: Boolean) {
+    prefs(context).edit().putBoolean("show_clock", show).apply()
+  }
+
+  fun setShowDate(context: Context, show: Boolean) {
+    prefs(context).edit().putBoolean("show_date", show).apply()
+  }
+
+  fun setGreetingLetterSpacing(context: Context, spacing: Float) {
+    prefs(context).edit().putFloat("greeting_letter_spacing", spacing).apply()
+  }
+
+  fun setUserName(context: Context, name: String) {
+    prefs(context).edit().putString("user_name", name).apply()
+  }
+
+  fun setEnableTts(context: Context, enable: Boolean) {
+    prefs(context).edit().putBoolean("enable_tts", enable).apply()
+  }
+
+  fun setTtsVoice(context: Context, name: String) {
+    prefs(context).edit().putString("tts_voice", name).apply()
+  }
+
+}

--- a/app/src/main/java/com/immortal/launcher/WelcomeSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/WelcomeSettingsActivity.kt
@@ -1,0 +1,553 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.*
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.settings.SettingsDomains
+import com.immortal.launcher.ui.theme.SampleAppTheme
+import org.json.JSONObject
+
+private const val SHERPA_VOICE_PARAM = "sherpa_voice_name"
+
+/**
+ * Settings screen for the welcome-back overlay. Customize greeting messages,
+ * colors, sizes, duration, and visibility of individual elements.
+ */
+class WelcomeSettingsActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { WelcomeSettingsScreen() } }
+  }
+}
+
+@Composable
+private fun WelcomeSettingsScreen() {
+  val context = LocalContext.current
+  var settings by remember { mutableStateOf(WelcomeConfig.load(context)) }
+
+  val activity = context as? Activity
+  val firstFocus = remember { FocusRequester() }
+  LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
+
+  // Android TTS voice audition. A single engine is kept alive for the screen's life to
+  // both enumerate installed voices and play test phrases. (Piper neural voices were
+  // dropped here — their model download is unreliable on the Portal. See project notes.)
+  // voices: name -> friendly label; first entry is the engine default.
+  var androidVoices by remember { mutableStateOf<List<Pair<String, String>>>(listOf("" to "Default voice")) }
+  val ttsEngine = remember { mutableStateOf<android.speech.tts.TextToSpeech?>(null) }
+  DisposableEffect(Unit) {
+    var engine: android.speech.tts.TextToSpeech? = null
+    engine = android.speech.tts.TextToSpeech(context.applicationContext) { status ->
+      if (status == android.speech.tts.TextToSpeech.SUCCESS) {
+        val found = runCatching {
+          engine?.voices
+              ?.filter { !it.isNetworkConnectionRequired }
+              ?.sortedWith(ttsVoiceSort())
+              ?.map { it.name to androidVoiceLabel(it) }
+              ?.distinctBy { it.first }
+              ?: emptyList()
+        }.getOrDefault(emptyList())
+        if (found.isNotEmpty()) androidVoices = listOf("" to "Default voice") + found
+      }
+    }
+    ttsEngine.value = engine
+    onDispose { runCatching { engine?.stop() }; runCatching { engine?.shutdown() } }
+  }
+  fun testVoice(voiceName: String) {
+    val t = ttsEngine.value ?: return
+    val selectedVoice =
+        if (voiceName.isNotBlank()) t.voices?.firstOrNull { it.name == voiceName } else null
+    val sample =
+        if (selectedVoice != null) {
+          runCatching { t.language = selectedVoice.locale }
+          runCatching { t.voice = selectedVoice }
+          if (selectedVoice.locale.language == "ro") {
+            "Salut, aceasta este vocea romaneasca."
+          } else {
+            "Hi, this is your welcome voice. Welcome home."
+          }
+        } else {
+          t.language = java.util.Locale.getDefault()
+          "Hi, this is your welcome voice. Welcome home."
+        }
+    val params =
+        android.os.Bundle().apply {
+          if (voiceName.isNotBlank()) putString(SHERPA_VOICE_PARAM, voiceName)
+        }
+    t.speak(sample,
+        android.speech.tts.TextToSpeech.QUEUE_FLUSH, params, "welcome_test")
+  }
+
+  Box(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .onPreviewKeyEvent { e ->
+                  if (e.key == Key.Back) {
+                    if (e.type == KeyEventType.KeyUp) activity?.finish()
+                    true
+                  } else false
+                }
+                .background(Color(0xFF101012))
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 28.dp, vertical = 32.dp),
+    ) {
+      Column(modifier = Modifier.widthIn(max = 1100.dp).focusRequester(firstFocus).focusGroup()) {
+        Text("Welcome Overlay", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+        Text(
+            "Customize the greeting shown when the screensaver wakes up.",
+            color = Color(0xFF9A9A9A),
+            fontSize = 16.sp,
+            modifier = Modifier.padding(top = 6.dp),
+        )
+        Spacer(Modifier.size(26.dp))
+
+        Card {
+          ToggleRow("Show greeting message", settings.showGreeting) {
+            SettingsDomains.welcome.apply(context, JSONObject().put("showGreeting", it))
+            settings = WelcomeConfig.load(context)
+          }
+          Divider()
+          ToggleRow("Show clock", settings.showClock) {
+            SettingsDomains.welcome.apply(context, JSONObject().put("showClock", it))
+            settings = WelcomeConfig.load(context)
+          }
+          Divider()
+          ToggleRow("Show date", settings.showDate) {
+            SettingsDomains.welcome.apply(context, JSONObject().put("showDate", it))
+            settings = WelcomeConfig.load(context)
+          }
+          Divider()
+          ToggleRow("Speak greeting (TTS)", settings.enableTts) {
+            SettingsDomains.welcome.apply(context, JSONObject().put("enableTts", it))
+            settings = WelcomeConfig.load(context)
+          }
+        }
+
+        Spacer(Modifier.size(26.dp))
+
+        SectionLabel("VOICE")
+        Card {
+          androidVoices.forEachIndexed { i, (name, label) ->
+            if (i > 0) Divider()
+            AndroidVoiceRow(
+                label = label,
+                selected = settings.ttsVoice == name,
+                onSelect = {
+                  WelcomeConfig.setTtsVoice(context, name)
+                  settings = settings.copy(ttsVoice = name)
+                },
+                onTest = { testVoice(name) },
+            )
+          }
+        }
+        Text(
+            "Voice for the spoken greeting, from the voices installed on this device. " +
+                "Tap Test to hear it. (Enable \"Speak greeting\" above for it to play on wake.)",
+            color = Color(0xFF7C7C7C),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
+        )
+
+        Spacer(Modifier.size(26.dp))
+
+        SectionLabel("GREETINGS")
+        Card {
+          EditableTextRow("Your name", settings.userName) { text ->
+            WelcomeConfig.setUserName(context, text)
+            settings = settings.copy(userName = text)
+          }
+          Divider()
+          EditableTextRow("Night (22:00-04:59)", settings.greetingNight) { text ->
+            WelcomeConfig.setGreetingNight(context, text)
+            settings = settings.copy(greetingNight = text)
+          }
+          Divider()
+          EditableTextRow("Morning (05:00-11:59)", settings.greetingMorning) { text ->
+            WelcomeConfig.setGreetingMorning(context, text)
+            settings = settings.copy(greetingMorning = text)
+          }
+          Divider()
+          EditableTextRow("Afternoon (12:00-16:59)", settings.greetingAfternoon) { text ->
+            WelcomeConfig.setGreetingAfternoon(context, text)
+            settings = settings.copy(greetingAfternoon = text)
+          }
+          Divider()
+          EditableTextRow("Evening (17:00-21:59)", settings.greetingEvening) { text ->
+            WelcomeConfig.setGreetingEvening(context, text)
+            settings = settings.copy(greetingEvening = text)
+          }
+        }
+
+        Spacer(Modifier.size(26.dp))
+
+        SectionLabel("TIMING")
+        Card {
+          DurationStepper(settings.durationMs / 1000) { sec ->
+            val ms = WelcomeConfig.clampDuration(sec * 1000)
+            SettingsDomains.welcome.apply(context, JSONObject().put("durationMs", ms))
+            settings = WelcomeConfig.load(context)
+          }
+        }
+        Text(
+            "How long the welcome overlay displays before auto-dismissing.",
+            color = Color(0xFF7C7C7C),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
+        )
+
+        Spacer(Modifier.size(26.dp))
+
+        SectionLabel("TEXT SIZES")
+        Card {
+          SizeStepper("Greeting", settings.greetingSize) { size ->
+            val clamped = WelcomeConfig.clampTextSize(size)
+            WelcomeConfig.setGreetingSize(context, clamped)
+            settings = settings.copy(greetingSize = clamped)
+          }
+          Divider()
+          SizeStepper("Clock", settings.clockSize) { size ->
+            val clamped = WelcomeConfig.clampTextSize(size)
+            WelcomeConfig.setClockSize(context, clamped)
+            settings = settings.copy(clockSize = clamped)
+          }
+          Divider()
+          SizeStepper("Date", settings.dateSize) { size ->
+            val clamped = WelcomeConfig.clampTextSize(size)
+            WelcomeConfig.setDateSize(context, clamped)
+            settings = settings.copy(dateSize = clamped)
+          }
+        }
+
+        Spacer(Modifier.size(26.dp))
+
+        SectionLabel("BACKGROUND")
+        Card {
+          OpacityStepper(settings.backgroundOpacity) { opacity ->
+            val clamped = WelcomeConfig.clampOpacity(opacity)
+            WelcomeConfig.setBackgroundOpacity(context, clamped)
+            settings = settings.copy(backgroundOpacity = clamped)
+          }
+        }
+        Text(
+            "Background darkness behind the welcome text (0% = transparent, 100% = opaque).",
+            color = Color(0xFF7C7C7C),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
+        )
+
+        Spacer(Modifier.size(28.dp))
+        Surface(
+            color = MaterialTheme.colorScheme.primary,
+            shape = RoundedCornerShape(16.dp),
+            modifier =
+                Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                  val intent = Intent(context, PhotoFramePreviewActivity::class.java)
+                  intent.putExtra(PhotoFramePreviewActivity.EXTRA_SHOW_WELCOME, true)
+                  context.startActivity(intent)
+                },
+        ) {
+          Text(
+              "Preview welcome overlay",
+              color = Color.White,
+              fontSize = 18.sp,
+              fontWeight = FontWeight.SemiBold,
+              textAlign = TextAlign.Center,
+              modifier = Modifier.padding(vertical = 16.dp).fillMaxWidth(),
+          )
+        }
+
+        Spacer(Modifier.size(16.dp))
+
+        Text(
+            "Tip: The welcome overlay appears when the screensaver starts from sleep. " +
+                "Tap anywhere on the overlay to dismiss it early, or wait for it to auto-fade.",
+            color = Color(0xFF7C7C7C),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(start = 4.dp, end = 4.dp),
+        )
+      }
+    }
+    FolderBackButton(onClick = { activity?.finish() })
+  }
+}
+
+private fun ttsVoiceSort(): Comparator<android.speech.tts.Voice> =
+    compareBy<android.speech.tts.Voice> { ttsVoiceGroup(it) }
+        .thenByDescending { it.quality }
+        .thenBy { it.locale.displayLanguage }
+        .thenBy { it.name }
+
+private fun ttsVoiceGroup(v: android.speech.tts.Voice): Int {
+  val n = v.name.lowercase()
+  return when {
+    n.startsWith("sherpa-kokoro-") -> 0
+    n.startsWith("sherpa-piper-ro_ro-") -> 1
+    n.startsWith("sherpa-piper-") -> 2
+    else -> 3
+  }
+}
+
+private fun ttsLocaleLabel(v: android.speech.tts.Voice): String {
+  val language = v.locale.getDisplayLanguage(java.util.Locale.US).ifBlank { v.locale.language }
+  val country = v.locale.country
+  return if (country.isBlank()) language else "$language (${country.uppercase()})"
+}
+
+private fun ttsQualityLabel(v: android.speech.tts.Voice): String? =
+    when {
+      v.quality >= android.speech.tts.Voice.QUALITY_VERY_HIGH -> "HQ+"
+      v.quality >= android.speech.tts.Voice.QUALITY_HIGH -> "HQ"
+      else -> null
+    }
+
+@Composable
+private fun AndroidVoiceRow(
+    label: String,
+    selected: Boolean,
+    onSelect: () -> Unit,
+    onTest: () -> Unit,
+) {
+  Row(
+      modifier =
+          Modifier.fillMaxWidth().tvFocusableRow { onSelect() }
+              .padding(horizontal = 18.dp, vertical = 12.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    RadioButton(selected = selected, onClick = null)
+    Text(label, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f).padding(start = 12.dp))
+    Surface(
+        color = MaterialTheme.colorScheme.primary,
+        shape = RoundedCornerShape(10.dp),
+        modifier = Modifier.tvFocusable(RoundedCornerShape(10.dp), focusScale = 1f) { onTest() },
+    ) {
+      Text(
+          "Test",
+          color = Color.White,
+          fontSize = 15.sp,
+          textAlign = TextAlign.Center,
+          modifier = Modifier.widthIn(min = 64.dp).padding(horizontal = 16.dp, vertical = 9.dp),
+      )
+    }
+  }
+}
+
+/** Turn an Android engine voice name like "en-us-x-sfg#female_1-local" into a label. */
+private fun androidVoiceLabel(v: android.speech.tts.Voice): String {
+  val n = v.name.lowercase()
+  if (n.startsWith("sherpa-kokoro-")) {
+    val voice = v.name.removePrefix("sherpa-kokoro-")
+    return listOfNotNull("Kokoro $voice", ttsLocaleLabel(v), ttsQualityLabel(v)).joinToString(" - ")
+  }
+  if (n == "sherpa-piper-ro_ro-mihai-medium") {
+    return listOfNotNull("Romanian Mihai", ttsLocaleLabel(v), ttsQualityLabel(v)).joinToString(" - ")
+  }
+  if (n.startsWith("sherpa-piper-")) {
+    val voice = v.name.removePrefix("sherpa-piper-").replace('-', ' ')
+    return listOfNotNull("Piper $voice", ttsLocaleLabel(v), ttsQualityLabel(v)).joinToString(" - ")
+  }
+  val gender = when {
+    n.contains("female") -> "Female"
+    n.contains("male") -> "Male"
+    else -> null
+  }
+  val num = Regex("(\\d+)").find(n)?.value
+  val base = listOfNotNull(gender, num?.let { "voice $it" }).joinToString(" ").ifBlank { v.name }
+  val region = v.locale.country.ifBlank { v.locale.language }.uppercase()
+  // Quality tier hint so the user can pick the better-sounding voices.
+  val q = when {
+    v.quality >= android.speech.tts.Voice.QUALITY_VERY_HIGH -> "HQ+"
+    v.quality >= android.speech.tts.Voice.QUALITY_HIGH -> "HQ"
+    else -> null
+  }
+  return listOfNotNull(base.takeIf { it.isNotBlank() }, region.takeIf { it.isNotBlank() }, q)
+      .joinToString(" · ")
+}
+
+@Composable
+private fun EditableTextRow(label: String, value: String, onChange: (String) -> Unit) {
+  var editing by remember { mutableStateOf(false) }
+  var tempValue by remember(value) { mutableStateOf(value) }
+
+  Row(
+      modifier =
+          Modifier.fillMaxWidth().tvFocusableRow {
+                if (!editing) {
+                  editing = true
+                  tempValue = value
+                }
+              }
+              .padding(horizontal = 18.dp, vertical = 14.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(label, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+    if (editing) {
+      OutlinedTextField(
+          value = tempValue,
+          onValueChange = { tempValue = it },
+          singleLine = true,
+          modifier = Modifier.width(200.dp),
+          colors = TextFieldDefaults.colors(
+              focusedTextColor = Color.White,
+              unfocusedTextColor = Color.White,
+              focusedContainerColor = Color(0xFF2A2A2C),
+              unfocusedContainerColor = Color(0xFF2A2A2C),
+          ),
+      )
+      Spacer(Modifier.width(8.dp))
+      TextButton(onClick = {
+        onChange(tempValue)
+        editing = false
+      }) {
+        Text("Save", color = Color(0xFF8AB4F8))
+      }
+    } else {
+      Text(
+          value,
+          color = Color(0xFFDDDDDD),
+          fontSize = 15.sp,
+          modifier = Modifier.padding(start = 8.dp),
+      )
+    }
+  }
+}
+
+@Composable
+private fun DurationStepper(seconds: Int, onChange: (Int) -> Unit) {
+  val src = remember { MutableInteractionSource() }
+  val focused by src.collectIsFocusedAsState()
+  Row(
+      modifier =
+          Modifier.fillMaxWidth()
+              .onKeyEvent { e ->
+                if (e.type == KeyEventType.KeyDown) {
+                  when (e.key) {
+                    Key.DirectionLeft -> { onChange(seconds - 1); true }
+                    Key.DirectionRight -> { onChange(seconds + 1); true }
+                    else -> false
+                  }
+                } else false
+              }
+              .focusable(interactionSource = src)
+              .background(if (focused) Color(0x402E6BE6) else Color.Transparent)
+              .padding(start = 18.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text("Display duration", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+    ArrowButton("◀", focused) { onChange(seconds - 1) }
+    Text(
+        "${seconds}s",
+        color = if (focused) Color.White else Color(0xFFDDDDDD),
+        fontSize = 17.sp,
+        fontWeight = FontWeight.SemiBold,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.widthIn(min = 52.dp),
+    )
+    ArrowButton("▶", focused) { onChange(seconds + 1) }
+  }
+}
+
+@Composable
+private fun SizeStepper(label: String, size: Float, onChange: (Float) -> Unit) {
+  val src = remember { MutableInteractionSource() }
+  val focused by src.collectIsFocusedAsState()
+  Row(
+      modifier =
+          Modifier.fillMaxWidth()
+              .onKeyEvent { e ->
+                if (e.type == KeyEventType.KeyDown) {
+                  when (e.key) {
+                    Key.DirectionLeft -> { onChange(size - 2); true }
+                    Key.DirectionRight -> { onChange(size + 2); true }
+                    else -> false
+                  }
+                } else false
+              }
+              .focusable(interactionSource = src)
+              .background(if (focused) Color(0x402E6BE6) else Color.Transparent)
+              .padding(start = 18.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(label, color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+    ArrowButton("◀", focused) { onChange(size - 2) }
+    Text(
+        "${size.toInt()}sp",
+        color = if (focused) Color.White else Color(0xFFDDDDDD),
+        fontSize = 17.sp,
+        fontWeight = FontWeight.SemiBold,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.widthIn(min = 64.dp),
+    )
+    ArrowButton("▶", focused) { onChange(size + 2) }
+  }
+}
+
+@Composable
+private fun OpacityStepper(opacity: Float, onChange: (Float) -> Unit) {
+  val src = remember { MutableInteractionSource() }
+  val focused by src.collectIsFocusedAsState()
+  val percent = (opacity * 100).toInt()
+  Row(
+      modifier =
+          Modifier.fillMaxWidth()
+              .onKeyEvent { e ->
+                if (e.type == KeyEventType.KeyDown) {
+                  when (e.key) {
+                    Key.DirectionLeft -> { onChange(opacity - 0.05f); true }
+                    Key.DirectionRight -> { onChange(opacity + 0.05f); true }
+                    else -> false
+                  }
+                } else false
+              }
+              .focusable(interactionSource = src)
+              .background(if (focused) Color(0x402E6BE6) else Color.Transparent)
+              .padding(start = 18.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text("Opacity", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+    ArrowButton("◀", focused) { onChange(opacity - 0.05f) }
+    Text(
+        "$percent%",
+        color = if (focused) Color.White else Color(0xFFDDDDDD),
+        fontSize = 17.sp,
+        fontWeight = FontWeight.SemiBold,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.widthIn(min = 64.dp),
+    )
+    ArrowButton("▶", focused) { onChange(opacity + 0.05f) }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -13,6 +13,7 @@ import com.immortal.launcher.CalendarUrlEntryActivity
 import com.immortal.launcher.ChimeConfig
 import com.immortal.launcher.ChimeScheduler
 import com.immortal.launcher.DigitalClockConfig
+import com.immortal.launcher.WelcomeConfig
 import com.immortal.launcher.DreamPolicy
 import com.immortal.launcher.FaceCatalog
 import com.immortal.launcher.FacePickerActivity
@@ -331,6 +332,77 @@ object SettingsDomains {
                       get = { it.overnightNightClock },
                       set = ScreensaverConfig::setOvernightNightClock,
                       visible = { _, s -> s.overnightEnabled }),
+                  // ---- Fork-specific screensaver controls ----
+                  EnumSpec(
+                      "feed",
+                      "Photo feed",
+                      get = { it.feed },
+                      set = ScreensaverConfig::setFeed,
+                      options = ScreensaverConfig.FEEDS.map { it to ScreensaverConfig.feedLabel(it) },
+                      coerce = { v -> v.takeIf { it in ScreensaverConfig.FEEDS } },
+                      visible = { _, s -> s.source == ScreensaverConfig.SOURCE_DEFAULT },
+                      help = "Which online photo feed to use with the built-in source."),
+                  BoolSpec(
+                      "sleepTimerEnabled",
+                      "Sleep timer",
+                      get = { it.sleepTimerEnabled },
+                      set = ScreensaverConfig::setSleepTimerEnabled,
+                      help = "Turn the screensaver off after a set time."),
+                  IntSpec(
+                      "sleepTimerMin",
+                      "Sleep after",
+                      get = { it.sleepTimerMin },
+                      set = ScreensaverConfig::setSleepTimerMin,
+                      min = 1,
+                      max = 240,
+                      step = 5,
+                      format = { "$it min" },
+                      visible = { _, s -> s.sleepTimerEnabled }),
+                  BoolSpec(
+                      "pauseAudioOnSleep",
+                      "Pause audio on sleep",
+                      get = { it.pauseAudioOnSleep },
+                      set = ScreensaverConfig::setPauseAudioOnSleep,
+                      visible = { _, s -> s.sleepTimerEnabled }),
+                  BoolSpec(
+                      "closeAppOnSleep",
+                      "Close app on sleep",
+                      get = { it.closeAppOnSleep },
+                      set = ScreensaverConfig::setCloseAppOnSleep,
+                      visible = { _, s -> s.sleepTimerEnabled }),
+                  EnumSpec(
+                      "soundscape",
+                      "Ambient sound",
+                      get = { it.soundscape },
+                      set = ScreensaverConfig::setSoundscape,
+                      options = ScreensaverConfig.SOUNDSCAPES.map { it to ScreensaverConfig.soundscapeLabel(it) },
+                      coerce = { v -> v.takeIf { it in ScreensaverConfig.SOUNDSCAPES } },
+                      help = "Synthesised ambient sound played while the screensaver shows."),
+                  IntSpec(
+                      "soundscapeVolume",
+                      "Soundscape volume",
+                      get = { it.soundscapeVolume },
+                      set = ScreensaverConfig::setSoundscapeVolume,
+                      min = 0,
+                      max = 100,
+                      step = 5,
+                      format = { "$it%" },
+                      visible = { _, s -> s.soundscape != ScreensaverConfig.SOUND_OFF }),
+                  BoolSpec(
+                      "ambientDashboard",
+                      "Ambient dashboard",
+                      get = { it.ambientDashboard },
+                      set = ScreensaverConfig::setAmbientDashboard),
+                  BoolSpec(
+                      "gestureWave",
+                      "Gesture wave to wake",
+                      get = { it.gestureWave },
+                      set = ScreensaverConfig::setGestureWave),
+                  BoolSpec(
+                      "welcomeEnabled",
+                      "Welcome screen",
+                      get = { it.welcomeEnabled },
+                      set = ScreensaverConfig::setWelcomeEnabled),
               ),
           sections =
               mapOf(
@@ -341,13 +413,23 @@ object SettingsDomains {
                   "includeVideo" to "Display",
                   "showNowPlaying" to "Display",
                   "antiBurnIn" to "Display",
+                  "feed" to "Display",
+                  "ambientDashboard" to "Display",
+                  "gestureWave" to "Display",
+                  "welcomeEnabled" to "Display",
                   "batterySaver" to "Power & sleep",
                   "presenceMode" to "Power & sleep",
                   "idleSleepMin" to "Power & sleep",
                   "overnightEnabled" to "Power & sleep",
                   "overnightStartMin" to "Power & sleep",
                   "overnightEndMin" to "Power & sleep",
-                  "overnightNightClock" to "Power & sleep"),
+                  "overnightNightClock" to "Power & sleep",
+                  "sleepTimerEnabled" to "Sleep timer",
+                  "sleepTimerMin" to "Sleep timer",
+                  "pauseAudioOnSleep" to "Sleep timer",
+                  "closeAppOnSleep" to "Sleep timer",
+                  "soundscape" to "Audio",
+                  "soundscapeVolume" to "Audio"),
           defaults = { ScreensaverConfig.Settings() },
           // The screensaver's post-apply side effects, lifted from the route layer (the same
           // reaffirm + overnight reschedule that `RemoteRoutes.applyConfig` / `FleetRoutes` run).
@@ -948,6 +1030,57 @@ object SettingsDomains {
           },
       )
 
+  /**
+   * The welcome-back overlay ([WelcomeConfig]) shown when the screensaver starts. The registry
+   * models the scalar toggles and the display duration; the Float fields (opacity, text sizes,
+   * letter spacing) and the ARGB color ints and the free-text greetings / voice picker stay in the
+   * bespoke [WelcomeSettingsActivity] — the registry has no [FloatSpec], and color pickers / text
+   * editors / TTS voice enumeration are bespoke UI it can't render. Those fields are listed in the
+   * tripwire's `managedElsewhere`.
+   */
+  val welcome: SettingsDomain<WelcomeConfig.Settings> =
+      SettingsDomain(
+          id = "welcome",
+          title = "Welcome",
+          load = WelcomeConfig::load,
+          specs =
+              listOf(
+                  IntSpec(
+                      "durationMs",
+                      "Display duration",
+                      get = { it.durationMs },
+                      set = WelcomeConfig::setDuration,
+                      min = 1000,
+                      max = 10000,
+                      step = 200,
+                      format = { "${it / 1000.0}s" },
+                      help = "How long the welcome overlay shows before auto-dismissing."),
+                  BoolSpec(
+                      "showGreeting",
+                      "Show greeting",
+                      get = { it.showGreeting },
+                      set = WelcomeConfig::setShowGreeting,
+                      help = "Show a time-of-day greeting (\"Good morning\")."),
+                  BoolSpec(
+                      "showClock",
+                      "Show clock",
+                      get = { it.showClock },
+                      set = WelcomeConfig::setShowClock),
+                  BoolSpec(
+                      "showDate",
+                      "Show date",
+                      get = { it.showDate },
+                      set = WelcomeConfig::setShowDate),
+                  BoolSpec(
+                      "enableTts",
+                      "Speak greeting",
+                      get = { it.enableTts },
+                      set = WelcomeConfig::setEnableTts,
+                      help = "Speak the greeting through Android TTS when the overlay shows."),
+              ),
+          defaults = { WelcomeConfig.Settings() },
+      )
+
   val all: List<SettingsDomain<*>> =
-      listOf(screensaver, calendar, immortal, mqtt, quickbar, fleet, chime, digitalclock)
+      listOf(screensaver, calendar, immortal, mqtt, quickbar, fleet, chime, digitalclock, welcome)
 }

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -12,6 +12,7 @@ import com.immortal.launcher.CalendarFeed
 import com.immortal.launcher.CalendarUrlEntryActivity
 import com.immortal.launcher.ChimeConfig
 import com.immortal.launcher.ChimeScheduler
+import com.immortal.launcher.DigitalClockConfig
 import com.immortal.launcher.DreamPolicy
 import com.immortal.launcher.FaceCatalog
 import com.immortal.launcher.FacePickerActivity
@@ -775,6 +776,178 @@ object SettingsDomains {
           },
       )
 
+  /**
+   * The digital clock screensaver ([DigitalClockConfig]). When enabled, it replaces the photo-frame
+   * dream with a large customisable clock (style, color, font, size, layout, background, glow, date,
+   * seconds). The enum setters write the raw string straight to prefs (no normalising), so each
+   * [EnumSpec] carries a strict [EnumSpec.coerce] that rejects an unrecognised value — matching the
+   * Immortal display-enum pattern.
+   *
+   * Toggling [DigitalClockConfig.Settings.enabled] switches the active Dream between
+   * [DigitalClockDreamService] and [PhotoDreamService]; that side effect lives in [onApplied]
+   * (reaffirm the dream once per batch) rather than inline in the setter or the Activity.
+   */
+  val digitalclock: SettingsDomain<DigitalClockConfig.Settings> =
+      SettingsDomain(
+          id = "digitalclock",
+          title = "Clock",
+          load = DigitalClockConfig::load,
+          specs =
+              listOf(
+                  BoolSpec(
+                      "enabled",
+                      "Digital clock",
+                      get = { it.enabled },
+                      set = DigitalClockConfig::setEnabled,
+                      help = "Use a large clock instead of the photo frame screensaver."),
+                  EnumSpec(
+                      "style",
+                      "Clock style",
+                      get = { it.style },
+                      set = DigitalClockConfig::setStyle,
+                      options =
+                          listOf(
+                              DigitalClockConfig.STYLE_CLASSIC to "Classic",
+                              DigitalClockConfig.STYLE_FLIP to "Flip",
+                              DigitalClockConfig.STYLE_BOLD to "Bold",
+                              DigitalClockConfig.STYLE_NEON to "Neon",
+                              DigitalClockConfig.STYLE_SEGMENT to "Segment",
+                              DigitalClockConfig.STYLE_ANALOG to "Analog"),
+                      coerce = oneOf(
+                          DigitalClockConfig.STYLE_CLASSIC, DigitalClockConfig.STYLE_FLIP,
+                          DigitalClockConfig.STYLE_BOLD, DigitalClockConfig.STYLE_NEON,
+                          DigitalClockConfig.STYLE_SEGMENT, DigitalClockConfig.STYLE_ANALOG),
+                      visible = { _, s -> s.enabled }),
+                  EnumSpec(
+                      "color",
+                      "Color",
+                      get = { it.color },
+                      set = DigitalClockConfig::setColor,
+                      options =
+                          listOf(
+                              DigitalClockConfig.COLOR_WHITE to "White",
+                              DigitalClockConfig.COLOR_RED to "Red",
+                              DigitalClockConfig.COLOR_GREEN to "Green",
+                              DigitalClockConfig.COLOR_BLUE to "Blue",
+                              DigitalClockConfig.COLOR_YELLOW to "Yellow",
+                              DigitalClockConfig.COLOR_CYAN to "Cyan",
+                              DigitalClockConfig.COLOR_PINK to "Pink",
+                              DigitalClockConfig.COLOR_ORANGE to "Orange"),
+                      coerce = oneOf(
+                          DigitalClockConfig.COLOR_WHITE, DigitalClockConfig.COLOR_RED,
+                          DigitalClockConfig.COLOR_GREEN, DigitalClockConfig.COLOR_BLUE,
+                          DigitalClockConfig.COLOR_YELLOW, DigitalClockConfig.COLOR_CYAN,
+                          DigitalClockConfig.COLOR_PINK, DigitalClockConfig.COLOR_ORANGE),
+                      visible = { _, s -> s.enabled }),
+                  EnumSpec(
+                      "font",
+                      "Font",
+                      get = { it.font },
+                      set = DigitalClockConfig::setFont,
+                      options =
+                          listOf(
+                              DigitalClockConfig.FONT_LIGHT to "Light",
+                              DigitalClockConfig.FONT_NORMAL to "Normal",
+                              DigitalClockConfig.FONT_BOLD to "Bold",
+                              DigitalClockConfig.FONT_MONO to "Mono",
+                              DigitalClockConfig.FONT_SERIF to "Serif",
+                              DigitalClockConfig.FONT_SEGMENT_LED to "LED",
+                              DigitalClockConfig.FONT_DIGITAL_7 to "Digital",
+                              DigitalClockConfig.FONT_TECHNOLOGY to "Tech"),
+                      coerce = oneOf(
+                          DigitalClockConfig.FONT_LIGHT, DigitalClockConfig.FONT_NORMAL,
+                          DigitalClockConfig.FONT_BOLD, DigitalClockConfig.FONT_MONO,
+                          DigitalClockConfig.FONT_SERIF, DigitalClockConfig.FONT_SEGMENT_LED,
+                          DigitalClockConfig.FONT_DIGITAL_7, DigitalClockConfig.FONT_TECHNOLOGY),
+                      visible = { _, s -> s.enabled }),
+                  EnumSpec(
+                      "size",
+                      "Size",
+                      get = { it.size },
+                      set = DigitalClockConfig::setSize,
+                      options =
+                          listOf(
+                              DigitalClockConfig.SIZE_SMALL to "Small",
+                              DigitalClockConfig.SIZE_MEDIUM to "Medium",
+                              DigitalClockConfig.SIZE_LARGE to "Large",
+                              DigitalClockConfig.SIZE_XL to "XL"),
+                      coerce = oneOf(
+                          DigitalClockConfig.SIZE_SMALL, DigitalClockConfig.SIZE_MEDIUM,
+                          DigitalClockConfig.SIZE_LARGE, DigitalClockConfig.SIZE_XL),
+                      visible = { _, s -> s.enabled }),
+                  EnumSpec(
+                      "layout",
+                      "Position",
+                      get = { it.layout },
+                      set = DigitalClockConfig::setLayout,
+                      options =
+                          listOf(
+                              DigitalClockConfig.LAYOUT_CENTER to "Center",
+                              DigitalClockConfig.LAYOUT_TOP to "Top",
+                              DigitalClockConfig.LAYOUT_BOTTOM to "Bottom",
+                              DigitalClockConfig.LAYOUT_MINIMAL to "Minimal"),
+                      coerce = oneOf(
+                          DigitalClockConfig.LAYOUT_CENTER, DigitalClockConfig.LAYOUT_TOP,
+                          DigitalClockConfig.LAYOUT_BOTTOM, DigitalClockConfig.LAYOUT_MINIMAL),
+                      visible = { _, s -> s.enabled }),
+                  EnumSpec(
+                      "background",
+                      "Background",
+                      get = { it.background },
+                      set = DigitalClockConfig::setBackground,
+                      options =
+                          listOf(
+                              DigitalClockConfig.BG_BLACK to "Black",
+                              DigitalClockConfig.BG_GRADIENT to "Gradient",
+                              DigitalClockConfig.BG_RED to "Red"),
+                      coerce = oneOf(
+                          DigitalClockConfig.BG_BLACK, DigitalClockConfig.BG_GRADIENT,
+                          DigitalClockConfig.BG_RED),
+                      visible = { _, s -> s.enabled }),
+                  EnumSpec(
+                      "glow",
+                      "Glow",
+                      get = { it.glow },
+                      set = DigitalClockConfig::setGlow,
+                      options =
+                          listOf(
+                              DigitalClockConfig.GLOW_NONE to "None",
+                              DigitalClockConfig.GLOW_SOFT to "Soft",
+                              DigitalClockConfig.GLOW_STRONG to "Strong"),
+                      coerce = oneOf(
+                          DigitalClockConfig.GLOW_NONE, DigitalClockConfig.GLOW_SOFT,
+                          DigitalClockConfig.GLOW_STRONG),
+                      visible = { _, s -> s.enabled }),
+                  BoolSpec(
+                      "showDate",
+                      "Show date",
+                      get = { it.showDate },
+                      set = DigitalClockConfig::setShowDate,
+                      visible = { _, s -> s.enabled }),
+                  BoolSpec(
+                      "showSeconds",
+                      "Show seconds",
+                      get = { it.showSeconds },
+                      set = DigitalClockConfig::setShowSeconds,
+                      visible = { _, s -> s.enabled }),
+              ),
+          sections =
+              mapOf(
+                  "style" to "Clock style",
+                  "color" to "Appearance",
+                  "font" to "Appearance",
+                  "size" to "Appearance",
+                  "layout" to "Layout & background",
+                  "background" to "Layout & background",
+                  "glow" to "Layout & background",
+                  "showDate" to "Extras",
+                  "showSeconds" to "Extras"),
+          defaults = { DigitalClockConfig.Settings() },
+          onApplied = { c, keys ->
+            if ("enabled" in keys) SettingsGuard.reaffirmScreensaver(c)
+          },
+      )
+
   val all: List<SettingsDomain<*>> =
-      listOf(screensaver, calendar, immortal, mqtt, quickbar, fleet, chime)
+      listOf(screensaver, calendar, immortal, mqtt, quickbar, fleet, chime, digitalclock)
 }

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -258,6 +258,7 @@ class SettingsDomainTest {
             SettingsDomains.immortal to
                 setOf("multiRoomEnabled", "snapcastHost", "maPort", "maUsername", "maPassword"),
             SettingsDomains.chime to emptySet(),
+            SettingsDomains.digitalclock to emptySet(),
         )
     rendered.forEach { (dom, exclude) ->
       val blank =
@@ -290,6 +291,19 @@ class SettingsDomainTest {
     assertTrue(
         "ChimeConfig.Settings has persisted fields neither in the registry nor accounted for: $uncovered",
         uncovered.isEmpty())
+  }
+
+  @Test
+  fun digitalClockRegistry_coversEveryPersistedField() {
+    // The on-device Clock screen renders its controls from this domain. Every field is a scalar
+    // bound by a spec — no managedElsewhere exceptions.
+    val fields =
+        com.immortal.launcher.DigitalClockConfig.Settings::class.java.declaredFields
+            .filter { !java.lang.reflect.Modifier.isStatic(it.modifiers) }
+            .map { it.name }
+            .toSet()
+    val specKeys = SettingsDomains.digitalclock.specs.map { it.key }.toSet()
+    assertEquals(fields, specKeys)
   }
 
   @Test

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -259,6 +259,7 @@ class SettingsDomainTest {
                 setOf("multiRoomEnabled", "snapcastHost", "maPort", "maUsername", "maPassword"),
             SettingsDomains.chime to emptySet(),
             SettingsDomains.digitalclock to emptySet(),
+            SettingsDomains.welcome to emptySet(),
         )
     rendered.forEach { (dom, exclude) ->
       val blank =
@@ -290,6 +291,30 @@ class SettingsDomainTest {
     val uncovered = fields - specKeys - managedElsewhere
     assertTrue(
         "ChimeConfig.Settings has persisted fields neither in the registry nor accounted for: $uncovered",
+        uncovered.isEmpty())
+  }
+
+  @Test
+  fun welcomeRegistry_coversEveryPersistedField_orExplicitlyAccountsForIt() {
+    // The registry has no FloatSpec, so the Float fields (opacity, text sizes, letter spacing) stay
+    // in the bespoke WelcomeSettingsActivity. The ARGB color ints use bespoke color pickers, the
+    // greeting texts are free-text editors, and the TTS voice is an on-device voice picker — all
+    // managed by the Activity. The 5 registry-ready fields (duration + 4 toggles) are spec'd.
+    val fields =
+        com.immortal.launcher.WelcomeConfig.Settings::class.java.declaredFields
+            .filter { !java.lang.reflect.Modifier.isStatic(it.modifiers) }
+            .map { it.name }
+            .toSet()
+    val specKeys = SettingsDomains.welcome.specs.map { it.key }.toSet()
+    val managedElsewhere =
+        setOf(
+            "greetingNight", "greetingMorning", "greetingAfternoon", "greetingEvening",
+            "userName", "greetingColor", "clockColor", "dateColor",
+            "backgroundOpacity", "greetingSize", "clockSize", "dateSize",
+            "greetingLetterSpacing", "ttsVoice")
+    val uncovered = fields - specKeys - managedElsewhere
+    assertTrue(
+        "WelcomeConfig.Settings has persisted fields neither in the registry nor accounted for: $uncovered",
         uncovered.isEmpty())
   }
 


### PR DESCRIPTION
Part of the #85 split. The photo-frame screensaver's ambient enhancements, the Welcome overlay, and the sleep/idle screen-off settings — grouped so each builds and tests green together (per your note on dependent features).

- **Welcome** domain: `WelcomeConfig` / `WelcomeSettingsActivity` (greeting, colors, sizes, TTS) + its registry tripwire test.
- **Screensaver ambient**: `PhotoFrameController` / `PhotoFramePreviewActivity` extras — `SoundscapePlayer` (procedural rain/ocean/fireplace/noise via AudioTrack, offline), cycling ambient-dashboard card (`CalendarHelper`), wave-to-advance (`GestureCamera`).
- **Sleep**: `SleepScheduler` / `SleepSettingsActivity` + `ScreensaverConfig` (idle timeout, overnight window, sleep timer).

Based on current `main`; `:app:assembleDebug` and the full `:app:testDebugUnitTest` are green.


🤖 Generated with [Claude Code](https://claude.com/claude-code)