### PR TITLE
Accessibility back-gesture service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,8 @@
          the agent from Android 10's background-activity-start restriction. Granted
          by provisioning; harmless if not held (the agent reports install mode). -->
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <!-- System-wide back-swipe gesture overlay runs as a special-use foreground service. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <!-- Lets the fleet agent's /logcat endpoint read system-wide logs. READ_LOGS is
          signature|privileged|development; the "development" flag means provisioning
          can grant it via `pm grant`. Without it the agent sees only its own logs. -->
@@ -457,6 +459,32 @@
                 <action android:name="android.service.dreams.DreamService" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+        </service>
+
+        <!-- System-wide "Go back" accessibility service. Enabled once in Accessibility
+             settings; lets Immortal perform a global BACK from the swipe overlay. -->
+        <service
+            android:name=".ImmortalBackGestureService"
+            android:exported="true"
+            android:label="@string/back_gesture_service_label"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/back_gesture_service_config" />
+        </service>
+
+        <!-- Foreground service that draws a thin right-edge strip and detects leftward
+             swipes to trigger BACK. Requires SYSTEM_ALERT_WINDOW. -->
+        <service
+            android:name=".SystemBackGestureService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="System-wide back-swipe gesture overlay" />
         </service>
     </application>
 

--- a/app/src/main/java/com/immortal/launcher/BackHelper.kt
+++ b/app/src/main/java/com/immortal/launcher/BackHelper.kt
@@ -1,0 +1,139 @@
+package com.immortal.launcher
+
+import android.app.ActivityManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+
+/**
+ * Shared helper for system-wide "go back" actions.
+ *
+ * Behaves like the system back button: one step at a time through the
+ * activity stack. The only Immortal-specific behavior is: if the back
+ * action would exit the current app to the home screen, we re-route to
+ * Immortal's HomeActivity so the user doesn't end up on the Portal's
+ * stock Aloha launcher.
+ *
+ * Used by both the ImmortalBackGestureService (accessibility) and the
+ * SystemBackGestureService (overlay).
+ */
+object BackHelper {
+
+  private const val TAG = "ImmortalBack"
+  private val handler = Handler(Looper.getMainLooper())
+
+  /**
+   * Perform a global BACK action, then ensure the user lands on the Immortal
+   * launcher (not the Portal's stock Aloha home) only if the back action
+   * would otherwise exit the current app to the home screen.
+   *
+   * The check is delayed by ~200ms so the activity stack has time to settle
+   * after the back action before we check what the top activity is.
+   */
+  fun performBack(context: Context) {
+    val topBefore = topActivityPackage(context)
+    if (requestGlobalBack(context)) {
+      handler.postDelayed({ maybeRerouteToImmortal(context, topBefore) }, 200)
+    }
+  }
+
+  fun performBack(context: Context, dispatchBack: () -> Boolean) {
+    val topBefore = topActivityPackage(context)
+    if (runCatching { dispatchBack() }.getOrDefault(false)) {
+      handler.postDelayed({ maybeRerouteToImmortal(context, topBefore) }, 200)
+    }
+  }
+
+  /**
+   * Force the Immortal launcher to the front. Safe to call multiple times.
+   */
+  fun ensureImmortalHome(context: Context) {
+    val intent =
+        Intent(Intent.ACTION_MAIN)
+            .addCategory(Intent.CATEGORY_HOME)
+            .addCategory(Intent.CATEGORY_DEFAULT)
+            .setComponent(
+                ComponentName(context, "com.immortal.launcher.HomeActivity")
+            )
+            .addFlags(
+                Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or
+                    Intent.FLAG_ACTIVITY_CLEAR_TOP
+            )
+    runCatching { context.startActivity(intent) }
+  }
+
+  // --- internals ---
+
+  /**
+   * After a back action, check whether we landed on the home screen. If so,
+   * re-route to Immortal. Otherwise, the back action already did the right
+   * thing (e.g. went from one app to another within the task stack) and we
+   * leave it alone.
+   */
+  private fun maybeRerouteToImmortal(context: Context, topBefore: String?) {
+    if (topBefore == null) return
+    val topAfter = topActivityPackage(context) ?: return
+    // If the top didn't change, the back action didn't pop anything — it would
+    // have gone to the home screen. Re-route to Immortal.
+    if (topAfter != topBefore) return
+    // Top didn't change but it's Immortal already — nothing to do.
+    if (topAfter == context.packageName) return
+    // The back action went to the home screen. Bring Immortal home to front.
+    if (isLikelyHomeScreen(context, topAfter)) {
+      ensureImmortalHome(context)
+    }
+  }
+
+  fun isBackServiceEnabled(context: Context): Boolean {
+    val am =
+        context.getSystemService(Context.ACCESSIBILITY_SERVICE)
+            as android.view.accessibility.AccessibilityManager
+    return am.getEnabledAccessibilityServiceList(
+            android.accessibilityservice.AccessibilityServiceInfo.FEEDBACK_ALL_MASK
+        )
+        .any {
+          it.resolveInfo.serviceInfo.packageName == context.packageName &&
+              it.resolveInfo.serviceInfo.name ==
+                  "com.immortal.launcher.ImmortalBackGestureService"
+        }
+  }
+
+  private fun requestGlobalBack(context: Context): Boolean {
+    if (isBackServiceEnabled(context)) {
+      val intent = Intent(ImmortalBackGestureService.ACTION_BACK).setPackage(context.packageName)
+      context.sendBroadcast(intent)
+      Log.i(TAG, "global back sent through Immortal accessibility service")
+      return true
+    }
+
+    Log.w(TAG, "global back requested but Immortal accessibility service is not enabled")
+    return false
+  }
+
+  private fun topActivityPackage(context: Context): String? {
+    return runCatching {
+      val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+      val tasks = am.appTasks
+      if (tasks.isNullOrEmpty()) return@runCatching null
+      val top = tasks[0].taskInfo.topActivity
+      top?.packageName
+    }.getOrNull()
+  }
+
+  /**
+   * Heuristic: is the given package the home screen? Checks for the
+   * "android.intent.category.HOME" intent filter.
+   */
+  private fun isLikelyHomeScreen(context: Context, pkg: String): Boolean {
+    return runCatching {
+      val homeIntent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_HOME)
+      val pm = context.packageManager
+      val resolves = pm.queryIntentActivities(homeIntent, 0)
+      resolves.any { it.activityInfo.packageName == pkg }
+    }.getOrDefault(false)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/ImmortalBackGestureService.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalBackGestureService.kt
@@ -1,0 +1,91 @@
+package com.immortal.launcher
+
+import android.accessibilityservice.AccessibilityService
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import android.util.Log
+import android.view.accessibility.AccessibilityEvent
+
+/**
+ * System-wide "Go back" accessibility action.
+ *
+ * When the user enables this service in Android Settings → Accessibility, an
+ * Immortal tile appears in the accessibility navigation bar. Tapping it
+ * performs GLOBAL_ACTION_BACK — same effect as the system back button —
+ * working in any app.
+ *
+ * Also listens for the IMMORTAL_BACK_ACTION broadcast so the launcher (or
+ * any other component) can trigger a back action programmatically:
+ *
+ *   adb shell am broadcast -a com.immortal.launcher.BACK
+ *
+ * The broadcast is useful when the accessibility service is enabled but
+ * the user wants to trigger back from a script, a Tile service, or another
+ * app.
+ */
+class ImmortalBackGestureService : AccessibilityService() {
+
+  private var receiver: BroadcastReceiver? = null
+
+  override fun onServiceConnected() {
+    super.onServiceConnected()
+    Log.i(TAG, "back-gesture accessibility service connected")
+    // Register a broadcast receiver so external triggers (e.g. adb, a
+    // Quick Settings tile) can fire a back action through this service.
+    receiver =
+        object : BroadcastReceiver() {
+          override fun onReceive(c: Context, intent: Intent) {
+            if (intent.action == ACTION_BACK) {
+              // Use the shared helper so the back action lands on Immortal
+              // (not the Portal's stock Aloha home screen).
+              BackHelper.performBack(this@ImmortalBackGestureService) {
+                performGlobalAction(AccessibilityService.GLOBAL_ACTION_BACK)
+              }
+            }
+          }
+        }
+    val filter = IntentFilter(ACTION_BACK)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+    } else {
+      @Suppress("UnspecifiedRegisterReceiverFlag")
+      registerReceiver(receiver, filter)
+    }
+  }
+
+  override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+    // No-op: this service doesn't consume events, it just exposes the
+    // global BACK action.
+  }
+
+  override fun onInterrupt() {
+    Log.w(TAG, "back-gesture service interrupted")
+  }
+
+  override fun onDestroy() {
+    receiver?.let { runCatching { unregisterReceiver(it) } }
+    receiver = null
+    super.onDestroy()
+  }
+
+  /**
+   * Public entry point for triggering a back action. Returns true if the
+   * action was dispatched successfully.
+   */
+  fun performBack(): Boolean {
+    var dispatched = false
+    BackHelper.performBack(this) {
+      dispatched = performGlobalAction(AccessibilityService.GLOBAL_ACTION_BACK)
+      dispatched
+    }
+    return dispatched
+  }
+
+  companion object {
+    const val TAG = "ImmortalBackGesture"
+    const val ACTION_BACK = "com.immortal.launcher.BACK"
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/SystemBackGestureService.kt
+++ b/app/src/main/java/com/immortal/launcher/SystemBackGestureService.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import android.view.Gravity
+import android.view.MotionEvent
+import android.view.View
+import android.view.WindowManager
+import android.widget.FrameLayout
+import androidx.core.app.NotificationCompat
+
+/**
+ * System-wide "back swipe" gesture.
+ *
+ * Runs as a foreground service and draws a thin transparent overlay on the
+ * right edge of the screen. When the user swipes leftward within that strip,
+ * the service asks the Immortal accessibility service to dispatch a global
+ * BACK action.
+ *
+ * Requirements:
+ *  - The user must grant Immortal the "Draw over other apps" permission
+ *    (Settings → Apps → Immortal → Display over other apps).
+ *  - For the back action to actually work, the Immortal accessibility service
+ *    must be enabled (see Clock settings → Back shortcut).
+ *
+ * The service is started by the launcher when the user enables the toggle
+ * in settings, and stopped when the user disables it or uninstalls the app.
+ */
+class SystemBackGestureService : Service() {
+
+  private var windowManager: WindowManager? = null
+  private var overlayView: View? = null
+
+  override fun onCreate() {
+    super.onCreate()
+    windowManager = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    startInForeground()
+    drawOverlay()
+  }
+
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    return START_STICKY
+  }
+
+  override fun onBind(intent: Intent?): IBinder? = null
+
+  override fun onDestroy() {
+    super.onDestroy()
+    removeOverlay()
+  }
+
+  private fun startInForeground() {
+    val channelId = "immortal_back_gesture"
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      val nm = getSystemService(NotificationManager::class.java)
+      if (nm.getNotificationChannel(channelId) == null) {
+        nm.createNotificationChannel(
+            NotificationChannel(
+                channelId,
+                "Back gesture",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply { description = "Listening for right-edge back swipes" }
+        )
+      }
+    }
+    val notification: Notification = NotificationCompat.Builder(this, channelId)
+        .setContentTitle("Immortal Back Gesture")
+        .setContentText("Swipe from the right edge to go back")
+        .setSmallIcon(android.R.drawable.ic_menu_revert)
+        .setOngoing(true)
+        .setPriority(NotificationCompat.PRIORITY_LOW)
+        .build()
+    startForeground(NOTIFICATION_ID, notification)
+  }
+
+  private fun drawOverlay() {
+    if (overlayView != null) return
+    val wm = windowManager ?: return
+    if (!android.provider.Settings.canDrawOverlays(this)) {
+      Log.w(TAG, "cannot draw overlays — permission not granted")
+      stopSelf()
+      return
+    }
+
+    val stripWidth = (40 * resources.displayMetrics.density).toInt()
+    val params = WindowManager.LayoutParams(
+        stripWidth,
+        WindowManager.LayoutParams.MATCH_PARENT,
+        WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
+        WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+            or WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
+            or WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+        PixelFormat.TRANSLUCENT
+    )
+    params.gravity = Gravity.TOP or Gravity.END
+
+    val view = FrameLayout(this)
+    view.setBackgroundColor(Color.TRANSPARENT)
+
+    var startX = 0f
+    var startY = 0f
+    view.setOnTouchListener { _, ev ->
+      when (ev.actionMasked) {
+        MotionEvent.ACTION_DOWN -> {
+          startX = ev.x
+          startY = ev.y
+          true
+        }
+        MotionEvent.ACTION_UP -> {
+          val dx = ev.x - startX
+          val dy = kotlin.math.abs(ev.y - startY)
+          if (dx < -120f && dy < 80f) {
+            // Swipe leftward from the right edge — perform a global BACK.
+            performGlobalBack()
+          }
+          true
+        }
+        else -> true
+      }
+    }
+    try {
+      wm.addView(view, params)
+      overlayView = view
+      Log.i(TAG, "back-gesture overlay added")
+    } catch (e: Exception) {
+      Log.e(TAG, "failed to add overlay", e)
+      stopSelf()
+    }
+  }
+
+  private fun removeOverlay() {
+    val wm = windowManager ?: return
+    val view = overlayView ?: return
+    runCatching { wm.removeView(view) }
+    overlayView = null
+  }
+
+  private fun performGlobalBack() {
+    // Use the shared helper so the back action lands on Immortal
+    // (not the Portal's stock Aloha home screen).
+    BackHelper.performBack(this)
+  }
+
+  companion object {
+    private const val TAG = "ImmortalBackGestureOverlay"
+    private const val NOTIFICATION_ID = 4242
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
     <string name="app_name">Immortal</string>
     <string name="install_confirm_desc">Lets Immortal confirm the app-install dialog automatically, so apps deployed over WiFi from the fleet manager install without a tap on this Portal.</string>
     <string name="bar_watch_desc">Lets Immortal show its quick buttons (like the app switcher) in step with the Portal\'s top bar — it watches for the bar being revealed. It doesn\'t read screen content.</string>
+    <string name="back_gesture_service_label">Immortal Back</string>
+    <string name="back_gesture_service_description">Swipe from the right edge of the screen to go back in any app. Immortal must be enabled in Accessibility settings for this to work.</string>
 </resources>

--- a/app/src/main/res/xml/back_gesture_service_config.xml
+++ b/app/src/main/res/xml/back_gesture_service_config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Configuration for ImmortalBackGestureService.
+     This service only dispatches the global BACK action; it never inspects
+     on-screen content. So it asks for the minimum:
+       - flagDefault: basic event delivery only.
+       - canPerformGestures: kept so the service can perform the global action.
+       - canRetrieveWindowContent="false": it does not read window content.
+       - no accessibilityEventTypes: onAccessibilityEvent is a no-op; the
+         service is driven by a broadcast, not by accessibility events.
+     Accessibility shortcut:
+       - The service is advertised in Android Settings → Accessibility and
+         exposes the global BACK action via performGlobalAction(). -->
+<accessibility-service
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagDefault"
+    android:canPerformGestures="true"
+    android:canRetrieveWindowContent="false"
+    android:description="@string/back_gesture_service_description"
+    android:notificationTimeout="100"
+    android:settingsActivity="com.immortal.launcher.ImmortalSettingsActivity" />


### PR DESCRIPTION
Part of the #85 split. An accessibility-service back gesture for the Portal (which has no nav bar).

- `BackHelper` + `ImmortalBackGestureService` / `SystemBackGestureService` + `res/xml/back_gesture_service_config.xml` + the two new strings + `FOREGROUND_SERVICE_SPECIAL_USE`.
- The services are usable via Android's Accessibility settings; the in-launcher enable toggle is intentionally deferred to the integration PR.

Self-contained. Based on current `main`; `:app:assembleDebug` and the full `:app:testDebugUnitTest` are green.


🤖 Generated with [Claude Code](https://claude.com/claude-code)