### PR TITLE
Provisioning kit, docs, app catalog, and build config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,13 @@ android {
     versionName = "1.52"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+    // Portal hardware is ARM only (gen-1/gen-2 Snapdragon, Portal TV Amlogic).
+    // Kept as a guard so any future native dependency can't drag x86/x86_64 .so
+    // files no Portal can run into the APK.
+    ndk {
+      abiFilters += listOf("arm64-v8a", "armeabi-v7a")
+    }
   }
 
   signingConfigs {

--- a/provisioning/.gitignore
+++ b/provisioning/.gitignore
@@ -1,6 +1,8 @@
 # Auto-downloaded Android platform-tools (fetched on first run if adb is missing)
 platform-tools/
 *.zip
+# Local machine-specific config overrides (source after config.env)
+local.env
 
 # Alexa-restore work dir: downloaded stock falcon (~120MB) + bsdiff + reconstructed apk
 alexa/

--- a/provisioning/bspatch.cmd
+++ b/provisioning/bspatch.cmd
@@ -1,0 +1,2 @@
+@echo off
+node "%~dp0bspatch.js" %*

--- a/provisioning/bspatch.js
+++ b/provisioning/bspatch.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// bspatch.js — bsdiff4 patch applier for Windows (uses Git's bunzip2.exe)
+// Usage: node bspatch.js <oldfile> <newfile> <patchfile>
+'use strict';
+const { execFileSync } = require('child_process');
+const fs   = require('fs');
+const os   = require('os');
+const path = require('path');
+
+// bsdiff's "offtin": 8-byte LE, high bit of byte 7 = sign
+function offtin(buf, off) {
+  let y = buf[off + 7] & 0x7F;
+  for (let i = 6; i >= 0; i--) y = y * 256 + buf[off + i];
+  if (buf[off + 7] & 0x80) y = -y;
+  return y;
+}
+
+// Find bunzip2 — prefer Git's copy since it's not normally on Windows PATH
+function findBunzip2() {
+  const candidates = [
+    'C:\\Program Files\\Git\\mingw64\\bin\\bunzip2.exe',
+    'C:\\Program Files (x86)\\Git\\mingw64\\bin\\bunzip2.exe',
+  ];
+  for (const c of candidates) if (fs.existsSync(c)) return c;
+  // fallback: hope it's on PATH
+  return 'bunzip2';
+}
+
+function bzDecompress(bunzip2, data) {
+  const tmp = path.join(os.tmpdir(), `bsp_${Date.now()}_${Math.random().toString(36).slice(2)}`);
+  fs.writeFileSync(tmp + '.bz2', data);
+  execFileSync(bunzip2, ['-f', tmp + '.bz2'], { stdio: 'pipe' });
+  const out = fs.readFileSync(tmp);
+  try { fs.unlinkSync(tmp); } catch (_) {}
+  return out;
+}
+
+const [,, oldPath, newPath, patchPath] = process.argv;
+if (!oldPath || !newPath || !patchPath) {
+  console.error('Usage: node bspatch.js <old> <new> <patch>'); process.exit(1);
+}
+
+const patch = fs.readFileSync(patchPath);
+const old   = fs.readFileSync(oldPath);
+
+if (patch.slice(0, 8).toString('ascii') !== 'BSDIFF40') {
+  console.error('Not a BSDIFF40 patch'); process.exit(1);
+}
+
+const ctrlLen = offtin(patch, 8);
+const diffLen = offtin(patch, 16);
+const newSize = offtin(patch, 24);
+
+const bz = findBunzip2();
+process.stderr.write(`bspatch: decompressing ctrl (${ctrlLen} bytes)...\n`);
+const ctrl  = bzDecompress(bz, patch.slice(32, 32 + ctrlLen));
+process.stderr.write(`bspatch: decompressing diff (${diffLen} bytes)...\n`);
+const diff  = bzDecompress(bz, patch.slice(32 + ctrlLen, 32 + ctrlLen + diffLen));
+process.stderr.write(`bspatch: decompressing extra...\n`);
+const extra = bzDecompress(bz, patch.slice(32 + ctrlLen + diffLen));
+
+const out = Buffer.alloc(newSize);
+let oldpos = 0, newpos = 0, ctrlpos = 0, diffpos = 0, extrapos = 0;
+
+while (newpos < newSize) {
+  const x = offtin(ctrl, ctrlpos); ctrlpos += 8;
+  const y = offtin(ctrl, ctrlpos); ctrlpos += 8;
+  const z = offtin(ctrl, ctrlpos); ctrlpos += 8;
+
+  for (let i = 0; i < x; i++) {
+    out[newpos + i] = ((oldpos + i < old.length ? old[oldpos + i] : 0) + diff[diffpos + i]) & 0xFF;
+  }
+  newpos += x; oldpos += x; diffpos += x;
+
+  extra.copy(out, newpos, extrapos, extrapos + y);
+  newpos += y; extrapos += y;
+
+  oldpos += z;
+}
+
+fs.writeFileSync(newPath, out);
+process.stderr.write(`bspatch: wrote ${out.length} bytes -> ${newPath}\n`);

--- a/provisioning/provision.ps1
+++ b/provisioning/provision.ps1
@@ -423,6 +423,7 @@ function Restore-Alexa {
     $bspatch = $null
     if ($cfg["BSPATCH_EXE"] -and (Test-Path $cfg["BSPATCH_EXE"])) { $bspatch = $cfg["BSPATCH_EXE"] }
     elseif (Get-Command bspatch -ErrorAction SilentlyContinue) { $bspatch = (Get-Command bspatch).Source }
+    elseif (Test-Path (Join-Path $ScriptDir "bspatch.cmd")) { $bspatch = Join-Path $ScriptDir "bspatch.cmd" }
     if (-not $bspatch) { Warn "bspatch not found (Windows ships none). Install it + set BSPATCH_EXE in config.env, or set FALCON_PATCHED_LOCAL to a prebuilt APK. Skipping Alexa."; return }
     $stock = if ($cfg["FALCON_STOCK_LOCAL"]) { $cfg["FALCON_STOCK_LOCAL"] } else { Join-Path $work "stock-falcon.apk" }
     if (-not (Test-Path $stock) -or ($cfg["FALCON_STOCK_SHA256"] -and (Get-Sha256 $stock) -ne $cfg["FALCON_STOCK_SHA256"])) {


### PR DESCRIPTION
Part of the #85 split. The non-code scaffolding — provisioning, docs, the Store catalog, and build config.

- `provisioning/`: `provision.ps1` (one-shot device setup), `config.env`, and a `bspatch` helper (`bspatch.cmd` + `bspatch.js`) for delta updates.
- `scripts/`: `widget-serve.js`, `wireless-adb.ps1`; `deploy.bat` + `wireless-adb.bat` wrappers.
- `docs/`: ARCHITECTURE, FEATURES, CUSTOMIZATION, CHANGES, README.
- `catalog.json` + `assets/catalog.json`: the curated Store app catalog.
- `build.gradle.kts`: ARM-only `abiFilters` guard (no Portal runs x86), the `compose.ui.ui-android` dependency, and dropping the `.debug` applicationId suffix so debug builds provision identically to release; matching `libs.versions.toml` entry.
- Updated `.gitignore` / `CHANGELOG` / `CLAUDE` / `README`.

Note: this one touches repo docs (`CLAUDE.md`, `README.md`, `CHANGELOG.md`) — happy to trim those to just the provisioning/build bits if you'd rather keep your docs as-is. Based on current `main`; `:app:assembleDebug` and the full `:app:testDebugUnitTest` are green.


🤖 Generated with [Claude Code](https://claude.com/claude-code)