### PR TITLE
Store: add Jarvis (portal-assistant) to Portal Originals

### DIFF
--- a/app/src/main/assets/catalog.json
+++ b/app/src/main/assets/catalog.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updated": "2026-06-22",
+  "updated": "2026-07-01",
   "note": "Portal app catalog, schema v2. All v2 fields are ADDITIVE so v1 clients keep working. Entries with source 'fdroid' resolve the current APK at install time via the F-Droid API, so they never go stale. Entries with source 'url' use a direct apkUrl (use this for your own custom Portal apps). Multi-ABI apps (e.g. VLC) ship separate per-architecture APKs on F-Droid; pin the arm64-v8a build with 'versionCode' since Portal is arm64. New in v2: iconUrl (https PNG; omit to get a monogram tile), author, homepage, submittedBy (community credit), longDescription (detail page), devices (['touch','tv'] — omit when the app runs on every Portal). minSdk drives the compatibility badge: the first-gen Portal/Portal+ and Portal TV are API 28, the 2019/2021 models are API 29.",
   "categories": [
     {
@@ -271,6 +271,20 @@
           "author": "veereshai",
           "homepage": "https://github.com/veereshai/HippoMuncher",
           "submittedBy": "veereshai"
+        },
+        {
+          "name": "Jarvis (portal-assistant)",
+          "packageName": "com.portal.assistant",
+          "source": "url",
+          "apkUrl": "https://github.com/rudysev/portal-assistant/releases/download/v2.1.0/portal-assistant-v2.1.0.apk",
+          "versionCode": 3,
+          "minSdk": 28,
+          "description": "Hands-free voice assistant — ask anything, control the device, open apps. BYO Gemini key.",
+          "longDescription": "A conversational AI assistant built for the Portal, powered by the Gemini Live API. Talk to it in plain language and it answers out loud in a natural voice — web lookups, device control, opening apps — running as background voice with just a small orange bar over whatever's on screen, plus a live on-screen chat when the app is open. It knows the device's local time and approximate location, so questions like \"what's the weather?\" just work. Bring your own free Google Gemini API key (aistudio.google.com/apikey) — it stays on the device. Tap-to-talk works everywhere; the hands-free \"Hey Jarvis\" wake word needs the companion portal-wake app and is Gen 1 only.",
+          "iconUrl": "https://raw.githubusercontent.com/rudysev/portal-assistant/main/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png",
+          "author": "rudysev",
+          "homepage": "https://github.com/rudysev/portal-assistant",
+          "submittedBy": "rudysev"
         }
       ]
     }

--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updated": "2026-06-22",
+  "updated": "2026-07-01",
   "note": "Portal app catalog, schema v2. All v2 fields are ADDITIVE so v1 clients keep working. Entries with source 'fdroid' resolve the current APK at install time via the F-Droid API, so they never go stale. Entries with source 'url' use a direct apkUrl (use this for your own custom Portal apps). Multi-ABI apps (e.g. VLC) ship separate per-architecture APKs on F-Droid; pin the arm64-v8a build with 'versionCode' since Portal is arm64. New in v2: iconUrl (https PNG; omit to get a monogram tile), author, homepage, submittedBy (community credit), longDescription (detail page), devices (['touch','tv'] — omit when the app runs on every Portal). minSdk drives the compatibility badge: the first-gen Portal/Portal+ and Portal TV are API 28, the 2019/2021 models are API 29.",
   "categories": [
     {
@@ -297,6 +297,20 @@
           "author": "compscirunner",
           "homepage": "https://github.com/compscirunner/portal-iss-tracker",
           "submittedBy": "compscirunner"
+        },
+        {
+          "name": "Jarvis (portal-assistant)",
+          "packageName": "com.portal.assistant",
+          "source": "url",
+          "apkUrl": "https://github.com/rudysev/portal-assistant/releases/download/v2.1.0/portal-assistant-v2.1.0.apk",
+          "versionCode": 3,
+          "minSdk": 28,
+          "description": "Hands-free voice assistant — ask anything, control the device, open apps. BYO Gemini key.",
+          "longDescription": "A conversational AI assistant built for the Portal, powered by the Gemini Live API. Talk to it in plain language and it answers out loud in a natural voice — web lookups, device control, opening apps — running as background voice with just a small orange bar over whatever's on screen, plus a live on-screen chat when the app is open. It knows the device's local time and approximate location, so questions like \"what's the weather?\" just work. Bring your own free Google Gemini API key (aistudio.google.com/apikey) — it stays on the device. Tap-to-talk works everywhere; the hands-free \"Hey Jarvis\" wake word needs the companion portal-wake app and is Gen 1 only.",
+          "iconUrl": "https://raw.githubusercontent.com/rudysev/portal-assistant/main/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png",
+          "author": "rudysev",
+          "homepage": "https://github.com/rudysev/portal-assistant",
+          "submittedBy": "rudysev"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Adds **Jarvis (portal-assistant)** — a hands-free conversational voice assistant for the Portal, powered by the Gemini Live API — to the **Portal Originals** category. https://github.com/rudysev/portal-assistant
- Entry details: package `com.portal.assistant`, `minSdk 28` (runs on every Portal), `versionCode 3` (v2.1), APK pinned to the [v2.1.0 release](https://github.com/rudysev/portal-assistant/releases/tag/v2.1.0), icon served from the repo's `main` branch.
- The listing calls out up front that users bring their own free Gemini API key, and that the hands-free "Hey Jarvis" wake word needs the companion portal-wake app (Gen 1 only); tap-to-talk works on any setup.
- The same entry is added to the bundled fallback catalog (`app/src/main/assets/catalog.json`). Note for maintainers: the bundled fallback appears to have drifted behind the hosted catalog (it's missing Snapcast and ISS Tracker) — not touched here, but flagging in case a sync is due.

## Testing
- `python3 scripts/validate_catalog.py --network` — 23 apps OK; the only warning is the pre-existing portalfin missing-versionCode one.
- Verified the icon URL serves (HTTP 200) and the release APK URL resolves (302 to the asset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)