### PR TITLE
catalog: pin Portal Overlays versionCode for in-place updates

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -317,6 +317,7 @@
           "packageName": "com.portal.overlays",
           "source": "url",
           "apkUrl": "https://github.com/GodricTM/PortalOverlays/releases/latest/download/PortalOverlays.apk",
+          "versionCode": 12,
           "minSdk": 28,
           "description": "Floating always-on-top HUD — nav buttons, widgets, notification banners, and a now-playing screen saver.",
           "longDescription": "A background service that layers a configurable HUD over whatever's on screen: floating Back / Home / Recents / Control-Center navigation, draggable clock, weather, battery and sticky-note widgets, a status strip, ntfy.sh push banners, and a system-notification mirror (WhatsApp, Messenger, and the like) via a notification listener. Urgent alerts get a full-attention 'breaking news' popup that is read aloud. It also ships its own now-playing screen saver — cover art, clock, battery and a music visualizer over a black, photo, or web-page background (for example an Immich Kiosk feed). Keyless and no Google services; weather is Open-Meteo. Spoken alerts use the sideloaded Portal TTS engine (https://github.com/GodricTM/portal-tts-engine) when it is installed, and are silently skipped when it is not.",


### PR DESCRIPTION
Small follow-up to #107. The Portal Overlays entry landed without a `versionCode`, so as you noted the store can only delete-and-reinstall on update — which wipes the app's on-device settings. That isn't acceptable for this app, so this pins `"versionCode": 12` (the shipped v1.8 release) while keeping the `releases/latest/download` URL, enabling proper in-place updates.

Same shape as the existing `hippomuncher` and `isstracker` entries (latest-download URL + `versionCode`). I'll bump this here on each Portal Overlays release.

One-line additive change to `catalog.json`; JSON parses and `versionCode` is an integer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)