### PR TITLE
Ambient extras: voice notes, bedtime stories, lamp, time progress

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,9 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <!-- Ambient dashboard: show upcoming events from the device calendar (CalendarHelper). -->
     <uses-permission android:name="android.permission.READ_CALENDAR" />
+    <!-- Voice notes: AudioNote records short memos via the handset mic. Requested at
+         runtime; recording is a no-op until granted. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <!-- Fleet Agent: a foreground service so WiFi device management survives a
          reboot on these non-root Portals (where adb-over-WiFi can't). -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
@@ -224,6 +227,23 @@
             android:name=".SleepSettingsActivity"
             android:exported="false"
             android:label="Sleep"
+            android:theme="@style/Theme.SampleApp" />
+
+        <!-- Lamp mode: full-screen warm-white light panel. -->
+        <activity
+            android:name=".LampActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:screenOrientation="landscape"
+            android:label="Lamp"
+            android:theme="@style/Theme.SampleApp" />
+
+        <!-- Bedtime stories: public-domain tales read aloud via TTS. -->
+        <activity
+            android:name=".BedtimeStoryActivity"
+            android:exported="false"
+            android:screenOrientation="landscape"
+            android:label="Bedtime story"
             android:theme="@style/Theme.SampleApp" />
 
         <!-- Connect a self-hosted Immich server as the screensaver source. -->

--- a/app/src/main/assets/fonts/OFL.txt
+++ b/app/src/main/assets/fonts/OFL.txt
@@ -1,0 +1,29 @@
+All fonts in this directory are licensed under the SIL Open Font License 1.1.
+
+digital_7.ttf  — DSEG7Classic-Regular
+segment_led.ttf — DSEG14Classic-Regular
+  Copyright (c) 2017 Keshikan (http://www.keshikan.net)
+  Source: https://github.com/keshikan/DSEG
+
+technology.ttf     — Orbitron Regular
+technology_bold.ttf — Orbitron Bold
+  Copyright (c) 2009, Matt McInerney (matt@pixelspread.com)
+  Copyright (c) 2011, Google Inc. (https://www.google.com/get/noto/)
+  Source: https://github.com/googlefonts/orbitron
+
+---
+SIL OPEN FONT LICENSE Version 1.1
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of the Font Software, to use, study, copy, merge, embed, modify, redistribute,
+and sell modified and unmodified copies of the Font Software, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies of the Font Software.
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY ARISING FROM THE USE OF THE FONT SOFTWARE.
+
+Full license text: https://scripts.sil.org/OFL

--- a/app/src/main/java/com/immortal/launcher/AudioNote.kt
+++ b/app/src/main/java/com/immortal/launcher/AudioNote.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.MediaPlayer
+import android.media.MediaRecorder
+import android.os.Build
+import android.util.Log
+
+/**
+ * Records and plays the single "leave a note" voice memo to [NotesConfig.audioFile].
+ * Uses the standard handset mic (RECORD_AUDIO) — the far-field array needs a Meta-
+ * signed permission Immortal can't hold, which is fine for a short up-close memo.
+ * One instance owns one recorder/player at a time; call [release] when done.
+ */
+class AudioNote(private val context: Context) {
+  private val TAG = "ImmortalNote"
+  private var recorder: MediaRecorder? = null
+  private var player: MediaPlayer? = null
+
+  val isRecording: Boolean get() = recorder != null
+  val isPlaying: Boolean get() = player?.isPlaying == true
+
+  /** Begin recording to the note file (overwrites any previous memo). */
+  fun startRecording(): Boolean = runCatching {
+    stopPlaying()
+    val file = NotesConfig.audioFile(context)
+    @Suppress("DEPRECATION")
+    val rec = if (Build.VERSION.SDK_INT >= 31) MediaRecorder(context) else MediaRecorder()
+    file.delete() // start fresh; a leftover/partial file can't be appended to
+    rec.setAudioSource(MediaRecorder.AudioSource.MIC)
+    rec.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+    rec.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+    // Explicit, widely-supported params. Without these some devices write a file
+    // whose header the player later refuses ("records but won't play").
+    rec.setAudioChannels(1)
+    rec.setAudioSamplingRate(44100)
+    rec.setAudioEncodingBitRate(128000)
+    rec.setOutputFile(file.absolutePath)
+    rec.prepare()
+    rec.start()
+    recordStartMs = System.currentTimeMillis()
+    recorder = rec
+    true
+  }.getOrElse { Log.w(TAG, "startRecording failed", it); false }
+
+  private var recordStartMs = 0L
+
+  /** Peak input level since the last poll, 0..32767. ~0 means the mic is hearing
+   *  near-silence (speaker too far from the device). Drives the UI meter. */
+  fun peakLevel(): Int = runCatching { recorder?.maxAmplitude ?: 0 }.getOrDefault(0)
+
+  /** Stop and finalize the recording. Returns true if a playable file resulted. */
+  fun stopRecording(): Boolean {
+    val r = recorder ?: return NotesConfig.hasAudioNote(context)
+    recorder = null
+    // MediaRecorder.stop() throws if stopped almost immediately (no encoded frames),
+    // leaving a corrupt file. Guard against a too-short tap.
+    val tooShort = System.currentTimeMillis() - recordStartMs < 500
+    val stopped = runCatching { r.stop() }.isSuccess
+    runCatching { r.release() }
+    if (!stopped || tooShort) {
+      Log.w(TAG, "recording too short / stop failed — discarding")
+      runCatching { NotesConfig.audioFile(context).delete() }
+      return false
+    }
+    val f = NotesConfig.audioFile(context)
+    Log.i(TAG, "recorded ${f.length()} bytes to ${f.absolutePath}")
+    return f.exists() && f.length() > 0
+  }
+
+  /** Play the saved memo, invoking [onDone] when it finishes (or fails). */
+  fun play(onDone: () -> Unit = {}) {
+    val file = NotesConfig.audioFile(context)
+    if (!file.exists() || file.length() == 0L) {
+      Log.w(TAG, "play: no file (${file.length()} bytes)"); onDone(); return
+    }
+    runCatching {
+      stopPlaying()
+      val mp = MediaPlayer()
+      mp.setAudioAttributes(
+          AudioAttributes.Builder()
+              .setUsage(AudioAttributes.USAGE_MEDIA)
+              .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH).build())
+      // Use a file descriptor — more reliable than a path string across devices.
+      java.io.FileInputStream(file).use { fis -> mp.setDataSource(fis.fd) }
+      mp.setOnCompletionListener { stopPlaying(); onDone() }
+      mp.setOnErrorListener { _, what, extra ->
+        Log.w(TAG, "MediaPlayer error what=$what extra=$extra"); stopPlaying(); onDone(); true
+      }
+      mp.prepare()
+      mp.start()
+      player = mp
+    }.onFailure { Log.w(TAG, "play failed", it); onDone() }
+  }
+
+  fun stopPlaying() {
+    player?.let { p -> runCatching { p.stop() }; runCatching { p.release() } }
+    player = null
+  }
+
+  fun release() {
+    stopRecording()
+    stopPlaying()
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/BedtimeStoryActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/BedtimeStoryActivity.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.os.Bundle
+import android.speech.tts.TextToSpeech
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.ui.theme.SampleAppTheme
+import java.util.Locale
+
+/**
+ * Bedtime story tile — public-domain children's stories ([Stories]) shown in big, calm
+ * text and read aloud through Android's built-in TextToSpeech, so the Portal's screen +
+ * speaker work together in a child's room. No downloads, no network.
+ */
+class BedtimeStoryActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    setContent { SampleAppTheme(darkTheme = true) { BedtimeScreen() } }
+  }
+}
+
+@Composable
+private fun BedtimeScreen() {
+  val context = LocalContext.current
+  var selected by remember { mutableStateOf<Stories.Story?>(null) }
+  var speaking by remember { mutableStateOf(false) }
+
+  // One TTS instance for the screen's lifetime; stop + shut it down on exit.
+  val tts = remember {
+    var engine: TextToSpeech? = null
+    engine = TextToSpeech(context.applicationContext) { status ->
+      if (status == TextToSpeech.SUCCESS) {
+        runCatching { engine?.language = Locale.getDefault() }
+      }
+    }
+    engine
+  }
+  DisposableEffect(Unit) {
+    onDispose { runCatching { tts?.stop(); tts?.shutdown() } }
+  }
+
+  fun readAloud(story: Stories.Story) {
+    runCatching {
+      tts?.stop()
+      val text = story.title + ". " + story.paragraphs.joinToString(" ")
+      // Slow, gentle pace for bedtime.
+      tts?.setSpeechRate(0.85f)
+      tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, "story")
+      speaking = true
+    }
+  }
+
+  Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0E0E1A)), contentAlignment = Alignment.Center) {
+    val story = selected
+    if (story == null) {
+      // Story picker.
+      Column(
+          modifier = Modifier.widthIn(max = 620.dp).padding(28.dp)
+              .verticalScroll(rememberScrollState()),
+          verticalArrangement = Arrangement.spacedBy(14.dp),
+      ) {
+        Text("🌙 Bedtime stories", color = Color.White, fontSize = 26.sp, fontWeight = FontWeight.Bold)
+        Stories.ALL.forEach { s ->
+          Surface(color = Color(0x18FFFFFF), shape = RoundedCornerShape(16.dp),
+              modifier = Modifier.fillMaxWidth()
+                  .tvFocusableRow { selected = s; readAloud(s) }) {
+            Row(modifier = Modifier.padding(18.dp), verticalAlignment = Alignment.CenterVertically) {
+              Text(s.emoji, fontSize = 30.sp, modifier = Modifier.padding(end = 14.dp))
+              Text(s.title, color = Color.White, fontSize = 20.sp, fontWeight = FontWeight.SemiBold)
+            }
+          }
+        }
+      }
+    } else {
+      BackHandler {
+        runCatching { tts?.stop() }
+        speaking = false
+        selected = null
+      }
+      // Reader.
+      Column(
+          modifier = Modifier.widthIn(max = 720.dp).padding(32.dp)
+              .verticalScroll(rememberScrollState()),
+          verticalArrangement = Arrangement.spacedBy(20.dp),
+      ) {
+        Text("${story.emoji}  ${story.title}", color = Color.White, fontSize = 30.sp,
+            fontWeight = FontWeight.Bold)
+        story.paragraphs.forEach { p ->
+          Text(p, color = Color(0xFFEDEDED), fontSize = 23.sp, lineHeight = 34.sp)
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.fillMaxWidth()) {
+          StoryButton(if (speaking) "Stop" else "Read aloud", Color(0xFF512DA8), Modifier.fillMaxWidth()) {
+            if (speaking) { runCatching { tts?.stop() }; speaking = false } else readAloud(story)
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun StoryButton(label: String, color: Color, modifier: Modifier = Modifier, onClick: () -> Unit) {
+  Surface(color = color, shape = RoundedCornerShape(14.dp),
+      modifier = modifier.tvFocusableRow { onClick() }) {
+    Text(label, color = Color.White, fontSize = 18.sp, fontWeight = FontWeight.SemiBold,
+        textAlign = TextAlign.Center, modifier = Modifier.padding(vertical = 16.dp).fillMaxWidth())
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/LampActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/LampActivity.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Lamp mode — fills the always-on panel with warm white at a chosen brightness so a
+ * Portal becomes an instant nightlight / reading light / video-call fill light. The big
+ * panel was a wasted light source; this puts it to work.
+ *
+ * Tap anywhere to show/hide the controls; the screen is forced bright and kept awake
+ * while the lamp is on. The window brightness override is released when you leave.
+ */
+class LampActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    setContent { com.immortal.launcher.ui.theme.SampleAppTheme(darkTheme = true) { LampScreen(::applyBrightness) } }
+  }
+
+  /** Drive the panel directly via the window so the lamp ignores the system auto-dim. */
+  private fun applyBrightness(level: Float) {
+    window.attributes = window.attributes.apply { screenBrightness = level.coerceIn(0.05f, 1f) }
+  }
+}
+
+@Composable
+private fun LampScreen(onBrightness: (Float) -> Unit) {
+  val context = androidx.compose.ui.platform.LocalContext.current
+  var brightness by remember { mutableFloatStateOf(0.9f) }
+  var warmth by remember { mutableFloatStateOf(0.6f) } // 0 = white, 1 = candle
+  var showControls by remember { mutableStateOf(true) }
+  // Red night-light: a deep red panel preserves dark-adapted night vision.
+  var red by remember { mutableStateOf(false) }
+
+  // Warm-white: pull the blue (and a touch of green) down as warmth rises.
+  val g = (255 - warmth * 60).toInt().coerceIn(0, 255)
+  val b = (255 - warmth * 170).toInt().coerceIn(0, 255)
+  val lampColor = if (red) Color(0xFFFF0000) else Color(255, g, b)
+
+  androidx.compose.runtime.LaunchedEffect(brightness) {
+    onBrightness(brightness)
+  }
+
+  Box(
+      modifier = Modifier.fillMaxSize().background(lampColor)
+          .clickable { showControls = !showControls },
+      contentAlignment = Alignment.Center,
+  ) {
+    if (showControls) {
+      Surface(color = Color(0x66000000), shape = RoundedCornerShape(20.dp),
+          modifier = Modifier.widthIn(max = 520.dp).padding(24.dp)) {
+        Column(modifier = Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+          Text("💡 Lamp", color = Color.White, fontSize = 20.sp, textAlign = TextAlign.Center,
+              modifier = Modifier.fillMaxWidth())
+          Text("Brightness", color = Color.White, fontSize = 15.sp)
+          Slider(value = brightness, onValueChange = { brightness = it }, valueRange = 0.05f..1f)
+          if (!red) {
+            Text("Warmth", color = Color.White, fontSize = 15.sp)
+            Slider(value = warmth, onValueChange = { warmth = it }, valueRange = 0f..1f)
+          }
+          // Night-light toggle: switch the whole panel to deep red for night use,
+          // which preserves dark-adapted vision. Brightness still applies.
+          Surface(
+              color = if (red) Color(0x55FF3B30) else Color(0x33FFFFFF),
+              shape = RoundedCornerShape(16.dp),
+              modifier = Modifier.fillMaxWidth().padding(top = 8.dp)
+                  .clickable { red = !red },
+          ) {
+            Text(if (red) "🔴  Night light · on" else "🔴  Night light",
+                color = Color.White, fontSize = 17.sp, textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 14.dp))
+          }
+          // Sleep button: genuinely turns the screen off via device-admin lockNow(),
+          // exactly like the home screen's moon sleep button (ScreenControl.sleep).
+          // The Portal has no keyguard, so a tap wakes it straight back to the lamp.
+          Surface(
+              color = Color(0x33FFFFFF), shape = RoundedCornerShape(16.dp),
+              modifier = Modifier.fillMaxWidth().padding(top = 8.dp)
+                  .clickable { ScreenControl.sleep(context) },
+          ) {
+            Text("🌙  Sleep", color = Color.White, fontSize = 17.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth().padding(vertical = 14.dp))
+          }
+          Text("Tap anywhere to hide these controls. Back to exit.",
+              color = Color(0xCCFFFFFF), fontSize = 13.sp, textAlign = TextAlign.Center,
+              modifier = Modifier.fillMaxWidth())
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/NotesConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/NotesConfig.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import java.io.File
+
+/**
+ * The home-screen "fridge notes": one typed sticky note and one recorded voice memo
+ * that sit on the launcher for whoever walks up next. Contact-free and local — the
+ * text lives in SharedPrefs, the audio in a single file in [audioFile].
+ */
+object NotesConfig {
+
+  private const val PREFS = "immortal_notes"
+  private const val KEY_TEXT = "text_note"
+
+  private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+  fun loadText(context: Context): String = prefs(context).getString(KEY_TEXT, "") ?: ""
+
+  fun saveText(context: Context, text: String) =
+      prefs(context).edit().putString(KEY_TEXT, text).apply()
+
+  fun clearText(context: Context) = prefs(context).edit().remove(KEY_TEXT).apply()
+
+  /** Single voice-memo file. */
+  fun audioFile(context: Context): File = File(context.filesDir, "leave_note.m4a")
+
+  fun hasAudioNote(context: Context): Boolean = audioFile(context).let { it.exists() && it.length() > 0 }
+
+  fun clearAudio(context: Context) {
+    runCatching { audioFile(context).delete() }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/Stories.kt
+++ b/app/src/main/java/com/immortal/launcher/Stories.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+/**
+ * Bundled public-domain children's stories for the bedtime tile. All are classic fables
+ * (Aesop) and traditional tales, long out of copyright, so they can ship in an
+ * open-source APK. Kept short and gentle — they're read aloud via Android TTS while the
+ * text shows big on screen, pairing the Portal's screen + speaker for a child's room.
+ */
+object Stories {
+
+  data class Story(val title: String, val emoji: String, val paragraphs: List<String>)
+
+  val ALL =
+      listOf(
+          Story(
+              "The Tortoise and the Hare",
+              "🐢",
+              listOf(
+                  "A speedy hare once made fun of a slow-moving tortoise. Tired of the teasing, the tortoise said, \"Let us have a race.\" The hare laughed, but agreed.",
+                  "The fox set them off. The hare dashed almost out of sight at once, then stopped. To show how little he thought of the tortoise, he lay down beside the path to nap.",
+                  "The tortoise walked, and walked, and walked. He never stopped, not once, until he reached the finish line.",
+                  "The hare woke with a start and ran his hardest — but the tortoise had already won. \"Slow and steady,\" the tortoise smiled, \"wins the race.\"",
+              )),
+          Story(
+              "The Lion and the Mouse",
+              "🦁",
+              listOf(
+                  "A great lion lay asleep in the sun. A little mouse ran across his nose and woke him. The lion caught the mouse in his huge paw.",
+                  "\"Please let me go,\" squeaked the mouse, \"and one day I may help you.\" The lion laughed at the thought, but he was kind, and let the little mouse go.",
+                  "Not long after, hunters caught the lion in a strong net. He roared and roared, but he could not get free.",
+                  "The little mouse heard him. She came and gnawed the ropes, one by one, until the lion was free. \"You see,\" said the mouse, \"even a little friend can be a great friend.\"",
+              )),
+          Story(
+              "The Little Red Hen",
+              "🐔",
+              listOf(
+                  "A little red hen found some grains of wheat. \"Who will help me plant the wheat?\" she asked. \"Not I,\" said the cat, the dog, and the pig. \"Then I will,\" said the hen. And she did.",
+                  "When the wheat was tall, she asked, \"Who will help me cut it?\" \"Not I,\" they all said. \"Then I will,\" said the hen. And she did.",
+                  "She asked who would help carry it to the mill, and bake the bread. Each time they said, \"Not I.\" Each time the hen said, \"Then I will.\" And she did.",
+                  "At last the warm bread was ready. \"Who will help me eat it?\" \"I will!\" they all cried. \"No,\" said the little red hen. \"I planted, and cut, and baked it myself. And I will eat it myself.\" And she did.",
+              )),
+          Story(
+              "The North Wind and the Sun",
+              "☀️",
+              listOf(
+                  "The North Wind and the Sun argued about who was stronger. They saw a traveler walking along, and agreed: whoever could make him take off his coat was the stronger.",
+                  "The North Wind blew first. He blew cold and hard. But the harder he blew, the tighter the traveler wrapped his coat around himself.",
+                  "Then it was the Sun's turn. The Sun shone gently, warmer and warmer. Soon the traveler grew so warm that he took his coat right off.",
+                  "\"Gentleness,\" said the Sun, \"can do what force cannot.\"",
+              )),
+          Story(
+              "The Ant and the Grasshopper",
+              "🐜",
+              listOf(
+                  "All summer long the grasshopper sang and played, while the ants worked hard, carrying food to store away.",
+                  "\"Why work so hard?\" laughed the grasshopper. \"Come and sing with me!\" But the ants kept working, gathering grain for the winter.",
+                  "When the cold winter came, the grasshopper had nothing to eat. The ants, warm in their nest, had plenty.",
+                  "The grasshopper learned that there is a time to play and a time to work — and it is wise to make ready while you can.",
+              )),
+      )
+}

--- a/app/src/main/java/com/immortal/launcher/SystemSounds.kt
+++ b/app/src/main/java/com/immortal/launcher/SystemSounds.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.content.Intent
+import android.media.AudioManager
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+
+/**
+ * The system-wide "touch & keypress sounds" master flag
+ * ([Settings.System.SOUND_EFFECTS_ENABLED]).
+ *
+ * Portal ships it **off** (`0`), which silences the whole `/system/media/audio/ui`
+ * keypress set for *every* app — including any sound the launcher itself plays via
+ * `View.playSoundEffect`, which is gated on this same flag. The "Touch & keypress
+ * sounds" toggle in [ImmortalSettingsActivity] flips it.
+ *
+ * Writing it needs the WRITE_SETTINGS app-op ("Modify system settings"). The toggle
+ * routes the user to [requestWriteAccess] when it isn't held; the provisioning kit
+ * can also pre-grant it (`appops set com.immortal.launcher android:write_settings allow`).
+ */
+object SystemSounds {
+
+  /** Whether the system-wide touch/keypress sound effects are currently on. */
+  fun touchSoundsEnabled(context: Context): Boolean =
+      runCatching {
+        Settings.System.getInt(
+            context.contentResolver, Settings.System.SOUND_EFFECTS_ENABLED, 0)
+      }.getOrDefault(0) != 0
+
+  /** Whether we may write [Settings.System] (the WRITE_SETTINGS app-op). */
+  fun canWrite(context: Context): Boolean =
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) Settings.System.canWrite(context)
+      else true
+
+  /**
+   * Flip the system-wide touch/keypress sounds. Also (un)loads the AudioManager
+   * effect cache so the change takes hold without a reboot. Returns true only if
+   * the new value actually stuck (i.e. the write was permitted).
+   */
+  fun setTouchSounds(context: Context, on: Boolean): Boolean {
+    runCatching {
+      Settings.System.putInt(
+          context.contentResolver,
+          Settings.System.SOUND_EFFECTS_ENABLED,
+          if (on) 1 else 0)
+    }
+    runCatching {
+      val am = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+      if (on) am.loadSoundEffects() else am.unloadSoundEffects()
+    }
+    return touchSoundsEnabled(context) == on
+  }
+
+  /** Open the system "Modify system settings" grant screen for this app. */
+  fun requestWriteAccess(context: Context) {
+    runCatching {
+      context.startActivity(
+          Intent(
+              Settings.ACTION_MANAGE_WRITE_SETTINGS,
+              Uri.parse("package:${context.packageName}"))
+              .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/TimeProgress.kt
+++ b/app/src/main/java/com/immortal/launcher/TimeProgress.kt
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import java.util.Calendar
+import kotlinx.coroutines.delay
+
+/**
+ * "How far through the day/week/month/year are we" — pure date math plus the
+ * glanceable visualisations that sit on the dashboard and (the sun arc) in the
+ * home header. Deliberately offline and locale-aware; everything is derived from
+ * the device clock so it works on a Portal with no network.
+ */
+object TimeProgress {
+
+  /** A snapshot of where "now" sits inside the current week, month and year. */
+  data class Spans(
+      val year: Int,
+      val yearFraction: Float, // 0f..1f through the calendar year
+      val monthFraction: Float,
+      val weekFraction: Float,
+      val dayOfYear: Int, // 1-based
+      val daysInYear: Int,
+      val dayOfMonth: Int, // 1-based
+      val daysInMonth: Int,
+      val monthName: String,
+      val firstDayOffset: Int, // weekday column (0=Mon..6=Sun) that day 1 falls on
+  )
+
+  fun compute(nowMillis: Long = System.currentTimeMillis()): Spans {
+    val now = Calendar.getInstance().apply { timeInMillis = nowMillis }
+    val year = now.get(Calendar.YEAR)
+
+    val startOfYear = (now.clone() as Calendar).apply { set(Calendar.DAY_OF_YEAR, 1); clearTime() }
+    val startOfNextYear = (startOfYear.clone() as Calendar).apply { add(Calendar.YEAR, 1) }
+    val yearFraction = fraction(startOfYear, startOfNextYear, nowMillis)
+
+    val startOfMonth = (now.clone() as Calendar).apply { set(Calendar.DAY_OF_MONTH, 1); clearTime() }
+    val startOfNextMonth = (startOfMonth.clone() as Calendar).apply { add(Calendar.MONTH, 1) }
+    val monthFraction = fraction(startOfMonth, startOfNextMonth, nowMillis)
+
+    // Week runs Monday..Sunday regardless of locale first-day so the bar reads
+    // the way most people picture "the week".
+    val startOfWeek = (now.clone() as Calendar).apply {
+      clearTime()
+      val dow = get(Calendar.DAY_OF_WEEK) // Sun=1..Sat=7
+      val backToMonday = (dow + 5) % 7 // Mon->0, Sun->6
+      add(Calendar.DAY_OF_MONTH, -backToMonday)
+    }
+    val startOfNextWeek = (startOfWeek.clone() as Calendar).apply { add(Calendar.DAY_OF_MONTH, 7) }
+    val weekFraction = fraction(startOfWeek, startOfNextWeek, nowMillis)
+
+    val day1 = (startOfMonth.clone() as Calendar)
+    val firstDayOffset = (day1.get(Calendar.DAY_OF_WEEK) + 5) % 7 // Mon=0..Sun=6
+
+    return Spans(
+        year = year,
+        yearFraction = yearFraction,
+        monthFraction = monthFraction,
+        weekFraction = weekFraction,
+        dayOfYear = now.get(Calendar.DAY_OF_YEAR),
+        daysInYear = now.getActualMaximum(Calendar.DAY_OF_YEAR),
+        dayOfMonth = now.get(Calendar.DAY_OF_MONTH),
+        daysInMonth = now.getActualMaximum(Calendar.DAY_OF_MONTH),
+        monthName = now.getDisplayName(Calendar.MONTH, Calendar.LONG, java.util.Locale.getDefault())
+            ?: "",
+        firstDayOffset = firstDayOffset,
+    )
+  }
+
+  private fun fraction(start: Calendar, end: Calendar, nowMillis: Long): Float {
+    val span = (end.timeInMillis - start.timeInMillis).toFloat()
+    if (span <= 0f) return 0f
+    return ((nowMillis - start.timeInMillis) / span).coerceIn(0f, 1f)
+  }
+
+  private fun Calendar.clearTime() {
+    set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+    set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dashboard card
+// ─────────────────────────────────────────────────────────────────────────────
+
+private val accent = Color(0xFF0866FF)
+private val track = Color(0x22FFFFFF)
+private val past = Color(0xFF5A5A5E)
+private val future = Color(0x33FFFFFF)
+
+/** The "your year is N% gone" card: week / month / year bars, a 365-dot year
+ *  strip with today lit, and the current month as a fading calendar. */
+@Composable
+fun TimeProgressCard(modifier: Modifier = Modifier) {
+  var spans by remember { mutableStateOf(TimeProgress.compute()) }
+  LaunchedEffect(Unit) {
+    while (true) {
+      spans = TimeProgress.compute()
+      delay(60_000)
+    }
+  }
+  Column(
+      modifier = modifier.fillMaxWidth(0.92f)
+          .background(Color(0x14FFFFFF), RoundedCornerShape(18.dp))
+          .padding(18.dp),
+      verticalArrangement = Arrangement.spacedBy(14.dp),
+  ) {
+    Text(
+        "${spans.year} is ${(spans.yearFraction * 100).toInt()}% gone",
+        color = Color.White, fontSize = 20.sp, fontWeight = FontWeight.Bold,
+    )
+    ProgressRow("This week", spans.weekFraction)
+    ProgressRow(spans.monthName, spans.monthFraction)
+    ProgressRow("${spans.year}", spans.yearFraction)
+    YearDots(dayOfYear = spans.dayOfYear, daysInYear = spans.daysInYear)
+    MonthGrid(
+        daysInMonth = spans.daysInMonth,
+        today = spans.dayOfMonth,
+        firstDayOffset = spans.firstDayOffset,
+        monthName = spans.monthName,
+    )
+  }
+}
+
+@Composable
+private fun ProgressRow(label: String, fraction: Float) {
+  Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+      Text(label, color = Color(0xFFDADADA), fontSize = 14.sp)
+      Text("${(fraction * 100).toInt()}%", color = Color(0xFF9A9A9A), fontSize = 14.sp)
+    }
+    Box(
+        modifier = Modifier.fillMaxWidth().height(8.dp)
+            .background(track, RoundedCornerShape(4.dp)),
+    ) {
+      Box(
+          modifier = Modifier.fillMaxHeight().fillMaxWidth(fraction.coerceIn(0f, 1f))
+              .background(accent, RoundedCornerShape(4.dp)),
+      )
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sun arc (home header)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A sun riding an arc from sunrise (left) to sunset (right), live position.
+ *  [sunriseMin]/[sunsetMin] are minutes-of-day; [riseLabel]/[setLabel] are the
+ *  pre-formatted clock strings shown under the two horizon ends. */
+@Composable
+fun SunArc(
+    sunriseMin: Int,
+    sunsetMin: Int,
+    riseLabel: String,
+    setLabel: String,
+    modifier: Modifier = Modifier,
+) {
+  var nowMin by remember { mutableStateOf(currentMinuteOfDay()) }
+  LaunchedEffect(Unit) {
+    while (true) { nowMin = currentMinuteOfDay(); delay(60_000) }
+  }
+  val daylight = (sunsetMin - sunriseMin).coerceAtLeast(1)
+  val f = ((nowMin - sunriseMin).toFloat() / daylight).coerceIn(0f, 1f)
+  val isDay = nowMin in sunriseMin..sunsetMin
+  val sunColor = if (isDay) Color(0xFFFFC83D) else Color(0xFF6A6A6E)
+
+  Column(modifier = modifier.fillMaxWidth(0.62f)) {
+    Canvas(modifier = Modifier.fillMaxWidth().height(34.dp)) {
+      val margin = 10f
+      val w = size.width - margin * 2
+      val baseY = size.height - 4f
+      val arcH = size.height - 8f
+      fun pt(t: Float) = Offset(
+          x = margin + t * w,
+          y = baseY - kotlin.math.sin(Math.PI * t).toFloat() * arcH,
+      )
+      // The full day arc, dashed and faint.
+      val full = Path().apply {
+        val start = pt(0f); moveTo(start.x, start.y)
+        var t = 0f
+        while (t <= 1f) { val p = pt(t); lineTo(p.x, p.y); t += 0.02f }
+      }
+      drawPath(
+          full, color = Color(0x40FFFFFF),
+          style = Stroke(width = 2f, pathEffect = PathEffect.dashPathEffect(floatArrayOf(6f, 8f))),
+      )
+      // The elapsed portion, solid + warm.
+      if (isDay && f > 0f) {
+        val done = Path().apply {
+          val start = pt(0f); moveTo(start.x, start.y)
+          var t = 0f
+          while (t <= f) { val p = pt(t); lineTo(p.x, p.y); t += 0.02f }
+        }
+        drawPath(done, color = Color(0x99FFC83D), style = Stroke(width = 3f))
+      }
+      // Horizon ends.
+      drawCircle(Color(0x66FFFFFF), 3f, pt(0f))
+      drawCircle(Color(0x66FFFFFF), 3f, pt(1f))
+      // The sun itself, with a soft glow.
+      val sun = pt(f)
+      drawCircle(sunColor.copy(alpha = 0.25f), 12f, sun)
+      drawCircle(sunColor, 6f, sun)
+    }
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+      Text("☀ $riseLabel", color = Color(0xFFB0B0B0), fontSize = 13.sp)
+      Text("☾ $setLabel", color = Color(0xFFB0B0B0), fontSize = 13.sp)
+    }
+  }
+}
+
+private fun currentMinuteOfDay(): Int {
+  val c = Calendar.getInstance()
+  return c.get(Calendar.HOUR_OF_DAY) * 60 + c.get(Calendar.MINUTE)
+}
+
+/** 365 (or 366) dots, one per day. Past days dim, today bright, future faint. */
+@Composable
+private fun YearDots(dayOfYear: Int, daysInYear: Int) {
+  val cols = 31 // ~12 rows; reads as a tidy block
+  Canvas(
+      modifier = Modifier.fillMaxWidth()
+          .height((((daysInYear + cols - 1) / cols) * 9).dp),
+  ) {
+    val gap = size.width / cols
+    val r = (gap * 0.30f).coerceAtMost(size.height / (((daysInYear + cols - 1) / cols)) * 0.30f)
+    for (i in 0 until daysInYear) {
+      val col = i % cols
+      val row = i / cols
+      val cx = gap * col + gap / 2f
+      val cy = gap * row + gap / 2f
+      val color = when {
+        i + 1 < dayOfYear -> past
+        i + 1 == dayOfYear -> accent
+        else -> future
+      }
+      drawCircle(color = color, radius = r, center = Offset(cx, cy))
+    }
+  }
+}
+
+/** Current month as a Mon-first calendar grid; past days fade, today is lit. */
+@Composable
+private fun MonthGrid(daysInMonth: Int, today: Int, firstDayOffset: Int, monthName: String) {
+  Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Text(monthName, color = Color(0xFF8A8A8A), fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
+    val cells = firstDayOffset + daysInMonth
+    val rows = (cells + 6) / 7
+    var dayCounter = 1
+    for (row in 0 until rows) {
+      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        for (col in 0 until 7) {
+          val cellIndex = row * 7 + col
+          val isDay = cellIndex >= firstDayOffset && dayCounter <= daysInMonth
+          if (isDay) {
+            val d = dayCounter
+            val bg = if (d == today) accent else Color.Transparent
+            val fg = when {
+              d == today -> Color.White
+              d < today -> Color(0xFF6A6A6E)
+              else -> Color(0xFFDADADA)
+            }
+            Box(
+                modifier = Modifier.weight(1f).height(22.dp)
+                    .background(bg, RoundedCornerShape(5.dp)),
+                contentAlignment = Alignment.Center,
+            ) {
+              Text("$d", color = fg, fontSize = 12.sp,
+                  fontWeight = if (d == today) FontWeight.Bold else FontWeight.Normal)
+            }
+            dayCounter++
+          } else {
+            Box(modifier = Modifier.weight(1f).height(22.dp))
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Re-lands #100 rebased onto current main (its manifest additions conflicted after the other splits landed). GodricTM's commit cherry-picked onto main; the only resolution was the additive manifest merge (RECORD_AUDIO permission + the Lamp/BedtimeStory activities alongside the entries the later PRs added).

- **AudioNote** + **NotesConfig**: short voice memos via the handset mic (`MediaRecorder`, requested at runtime, no-op until granted). Local file only, no upload.
- **BedtimeStoryActivity** + **Stories**: public-domain tales read aloud via the built-in `TextToSpeech` (no network).
- **LampActivity**: full-screen warm-white light panel.
- **TimeProgress**: day/month/year progress bars.
- **SystemSounds**: UI-sound helper.

Verified locally: `:app:assembleDebug` + `:app:testDebugUnitTest` green (258 tests, 0 failures). Supersedes #100.

Co-authored-by: GodricTM <GodricTM@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4SmhtgSd5B5sdTiV216XM)_