### PR TITLE
Almanac content packs: feast days, name days, prayer times, transit

### DIFF
--- a/app/src/main/java/com/immortal/launcher/CalendarPacks.kt
+++ b/app/src/main/java/com/immortal/launcher/CalendarPacks.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import java.util.Calendar
+
+/**
+ * Installable calendar packs — the name-day idea, broadened. A household adds the pack
+ * that fits it: Romanian name-days + Orthodox feasts (the original, toggled by the
+ * existing header flags), Irish bank holidays + saints, or daily Islamic prayer times.
+ * Each pack contributes one or more lines to the home header; they're all keyless and
+ * computed on-device.
+ *
+ * The Romanian/Orthodox pack keeps using [ImmortalSettings] flags (so existing installs
+ * are untouched); the newer packs store their on/off here.
+ */
+object CalendarPacks {
+
+  private const val PREFS = "immortal_packs"
+
+  const val IRISH = "irish"
+  const val PRAYER = "prayer"
+
+  data class Pack(val id: String, val title: String, val blurb: String)
+
+  /** Packs the user can switch on (beyond the built-in Romanian/Orthodox header flags). */
+  val AVAILABLE =
+      listOf(
+          Pack(IRISH, "Irish holidays", "Bank holidays + saints' days (St Patrick's, St Brigid's…)"),
+          Pack(PRAYER, "Prayer times", "Daily Islamic prayer times for your location"),
+      )
+
+  fun isEnabled(context: Context, id: String): Boolean =
+      prefs(context).getBoolean(id, false)
+
+  fun setEnabled(context: Context, id: String, on: Boolean) {
+    prefs(context).edit().putBoolean(id, on).apply()
+  }
+
+  /** Header lines contributed by the enabled add-on packs, in display order. */
+  fun headerLines(context: Context, now: Calendar = Calendar.getInstance()): List<String> {
+    val out = ArrayList<String>(2)
+    if (isEnabled(context, IRISH)) {
+      val h = IrishHolidays.forToday(now)
+      if (h.isNotEmpty()) out.add("🍀 $h")
+    }
+    if (isEnabled(context, PRAYER)) {
+      val line = PrayerTimes.nextLine(context, now)
+      if (line.isNotEmpty()) out.add(line)
+    }
+    return out
+  }
+
+  private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+}

--- a/app/src/main/java/com/immortal/launcher/DailyContent.kt
+++ b/app/src/main/java/com/immortal/launcher/DailyContent.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Bundled "something every day" content for the home-screen daily tile: a quote, a
+ * word, or a trivia question. Everything is local (no network, no GMS) so the tile
+ * is instant and works offline; the item is chosen deterministically from the epoch
+ * day, so it's stable for the whole day and rotates at midnight.
+ */
+object DailyContent {
+
+  enum class Mode { OFF, QUOTE, WORD, TRIVIA }
+
+  fun modeOf(key: String): Mode = when (key) {
+    "quote" -> Mode.QUOTE
+    "word" -> Mode.WORD
+    "trivia" -> Mode.TRIVIA
+    else -> Mode.OFF
+  }
+
+  fun keyOf(mode: Mode): String = when (mode) {
+    Mode.QUOTE -> "quote"
+    Mode.WORD -> "word"
+    Mode.TRIVIA -> "trivia"
+    Mode.OFF -> "off"
+  }
+
+  data class Quote(val text: String, val author: String)
+  data class Word(val word: String, val pronunciation: String, val definition: String)
+  data class Trivia(val question: String, val answer: String)
+
+  /** Days since the Unix epoch, in the device's default zone (good enough — a fixed
+   * Portal doesn't travel). Used as the rotation index. */
+  fun epochDay(nowMillis: Long = System.currentTimeMillis()): Long {
+    val offset = java.util.TimeZone.getDefault().getOffset(nowMillis)
+    return TimeUnit.MILLISECONDS.toDays(nowMillis + offset)
+  }
+
+  fun quoteOfDay(nowMillis: Long = System.currentTimeMillis()): Quote =
+      QUOTES[(epochDay(nowMillis) % QUOTES.size).toInt()]
+
+  fun wordOfDay(nowMillis: Long = System.currentTimeMillis()): Word =
+      WORDS[(epochDay(nowMillis) % WORDS.size).toInt()]
+
+  fun triviaOfDay(nowMillis: Long = System.currentTimeMillis()): Trivia =
+      TRIVIA[(epochDay(nowMillis) % TRIVIA.size).toInt()]
+
+  private val QUOTES = listOf(
+      Quote("The best way to predict the future is to invent it.", "Alan Kay"),
+      Quote("Simplicity is the ultimate sophistication.", "Leonardo da Vinci"),
+      Quote("What we think, we become.", "Buddha"),
+      Quote("It always seems impossible until it's done.", "Nelson Mandela"),
+      Quote("The only way to do great work is to love what you do.", "Steve Jobs"),
+      Quote("In the middle of difficulty lies opportunity.", "Albert Einstein"),
+      Quote("Well done is better than well said.", "Benjamin Franklin"),
+      Quote("Whatever you are, be a good one.", "Abraham Lincoln"),
+      Quote("The journey of a thousand miles begins with one step.", "Lao Tzu"),
+      Quote("Happiness depends upon ourselves.", "Aristotle"),
+      Quote("Turn your wounds into wisdom.", "Oprah Winfrey"),
+      Quote("Do what you can, with what you have, where you are.", "Theodore Roosevelt"),
+      Quote("Quality is not an act, it is a habit.", "Aristotle"),
+      Quote("The future belongs to those who believe in their dreams.", "Eleanor Roosevelt"),
+      Quote("Everything you can imagine is real.", "Pablo Picasso"),
+      Quote("Act as if what you do makes a difference. It does.", "William James"),
+      Quote("Life is really simple, but we insist on making it complicated.", "Confucius"),
+      Quote("A year from now you may wish you had started today.", "Karen Lamb"),
+      Quote("The mind is everything. What you think you become.", "Buddha"),
+      Quote("Patience is bitter, but its fruit is sweet.", "Aristotle"),
+      Quote("Little by little, one travels far.", "J.R.R. Tolkien"),
+      Quote("Courage is grace under pressure.", "Ernest Hemingway"),
+      Quote("Stay hungry, stay foolish.", "Steve Jobs"),
+      Quote("Energy and persistence conquer all things.", "Benjamin Franklin"),
+      Quote("The secret of getting ahead is getting started.", "Mark Twain"),
+      Quote("Done is better than perfect.", "Sheryl Sandberg"),
+      Quote("Be kind whenever possible. It is always possible.", "Dalai Lama"),
+      Quote("If you can dream it, you can do it.", "Walt Disney"),
+      Quote("Make each day your masterpiece.", "John Wooden"),
+      Quote("The harder you work for something, the greater you'll feel when you achieve it.", "Anonymous"),
+  )
+
+  private val WORDS = listOf(
+      Word("ephemeral", "ih-FEM-er-uhl", "Lasting for a very short time."),
+      Word("petrichor", "PET-ri-kor", "The pleasant smell of earth after rain."),
+      Word("serendipity", "ser-uhn-DIP-i-tee", "Finding something good without looking for it."),
+      Word("ineffable", "in-EF-uh-buhl", "Too great to be expressed in words."),
+      Word("sonder", "SON-der", "The realization that each passerby has a life as vivid as your own."),
+      Word("limerence", "LIM-er-uhns", "The state of being infatuated with another person."),
+      Word("halcyon", "HAL-see-uhn", "Denoting a period that was idyllically happy and peaceful."),
+      Word("susurrus", "soo-SUR-uhs", "A whispering or rustling sound."),
+      Word("mellifluous", "muh-LIF-loo-uhs", "A sound that is sweet and smooth to hear."),
+      Word("eloquent", "EL-uh-kwuhnt", "Fluent or persuasive in speaking or writing."),
+      Word("luminous", "LOO-mi-nuhs", "Full of or shedding light; bright or shining."),
+      Word("quintessential", "kwin-tuh-SEN-shuhl", "Representing the most perfect example of a quality."),
+      Word("vivacious", "vi-VAY-shuhs", "Attractively lively and animated."),
+      Word("solitude", "SOL-i-tood", "The state of being alone, often by choice."),
+      Word("resilience", "ri-ZIL-yuhns", "The capacity to recover quickly from difficulties."),
+      Word("wanderlust", "WON-der-lust", "A strong desire to travel and explore the world."),
+      Word("nebulous", "NEB-yuh-luhs", "In the form of a cloud or haze; vague."),
+      Word("cogent", "KOH-juhnt", "Clear, logical, and convincing."),
+      Word("ebullient", "ih-BUUL-yuhnt", "Cheerful and full of energy."),
+      Word("aplomb", "uh-PLOM", "Self-confidence or assurance in a demanding situation."),
+      Word("sanguine", "SANG-gwin", "Optimistic or positive, especially in a bad situation."),
+      Word("alacrity", "uh-LAK-ri-tee", "Brisk and cheerful readiness."),
+      Word("munificent", "myoo-NIF-i-suhnt", "Larger or more generous than is usual."),
+      Word("perspicacious", "pur-spi-KAY-shuhs", "Having a ready insight into things; shrewd."),
+      Word("ardent", "AR-duhnt", "Enthusiastic or passionate."),
+      Word("verdant", "VUR-duhnt", "Green with grass or other rich vegetation."),
+      Word("effervescent", "ef-er-VES-uhnt", "Vivacious and enthusiastic."),
+      Word("intrepid", "in-TREP-id", "Fearless; adventurous."),
+      Word("lithe", "lyth", "Thin, supple, and graceful."),
+      Word("zenith", "ZEE-nith", "The time at which something is most powerful or successful."),
+  )
+
+  private val TRIVIA = listOf(
+      Trivia("What is the largest planet in our solar system?", "Jupiter"),
+      Trivia("How many bones are in the adult human body?", "206"),
+      Trivia("What is the capital of Australia?", "Canberra"),
+      Trivia("Which element has the chemical symbol 'O'?", "Oxygen"),
+      Trivia("Who painted the Mona Lisa?", "Leonardo da Vinci"),
+      Trivia("What is the tallest mountain on Earth?", "Mount Everest"),
+      Trivia("How many continents are there?", "Seven"),
+      Trivia("What is the largest ocean on Earth?", "The Pacific Ocean"),
+      Trivia("In what year did the first human walk on the Moon?", "1969"),
+      Trivia("What is the smallest prime number?", "2"),
+      Trivia("Which language has the most native speakers?", "Mandarin Chinese"),
+      Trivia("What gas do plants absorb from the atmosphere?", "Carbon dioxide"),
+      Trivia("What is the hardest natural substance on Earth?", "Diamond"),
+      Trivia("How many strings does a standard guitar have?", "Six"),
+      Trivia("What is the capital of Japan?", "Tokyo"),
+      Trivia("Which planet is known as the Red Planet?", "Mars"),
+      Trivia("What is the currency of the United Kingdom?", "Pound sterling"),
+      Trivia("How many sides does a hexagon have?", "Six"),
+      Trivia("What is the longest river in the world?", "The Nile"),
+      Trivia("Who wrote 'Romeo and Juliet'?", "William Shakespeare"),
+      Trivia("What is the freezing point of water in Celsius?", "0 degrees"),
+      Trivia("Which country is home to the kangaroo?", "Australia"),
+      Trivia("What is the largest mammal in the world?", "The blue whale"),
+      Trivia("How many colors are in a rainbow?", "Seven"),
+      Trivia("What is the capital of Romania?", "Bucharest"),
+      Trivia("Which metal is liquid at room temperature?", "Mercury"),
+      Trivia("How many minutes are in a full day?", "1440"),
+      Trivia("What is the speed of light (approx, km/s)?", "300,000 km/s"),
+      Trivia("Which organ pumps blood through the body?", "The heart"),
+      Trivia("What is the largest country by land area?", "Russia"),
+  )
+}

--- a/app/src/main/java/com/immortal/launcher/FeastDays.kt
+++ b/app/src/main/java/com/immortal/launcher/FeastDays.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import java.util.Calendar
+import java.util.GregorianCalendar
+
+/**
+ * Orthodox feast-day calendar (Romanian Orthodox use). Covers the Twelve Great
+ * Feasts plus Pascha and a few widely-marked days:
+ *  - FIXED feasts fall on the same Gregorian date each year (the Romanian Church
+ *    keeps the revised-Julian calendar for fixed feasts, so e.g. Christmas is Dec 25);
+ *  - MOVABLE feasts are computed relative to Orthodox Pascha, whose date follows the
+ *    Julian paschalion. We compute it with the Meeus Julian algorithm, then convert
+ *    to the Gregorian calendar (+13 days, valid 1900–2099).
+ *
+ * [forToday] returns the feast for today, or "" if it isn't a tracked feast.
+ */
+object FeastDays {
+
+  // Fixed great feasts: month*100 + day -> name.
+  private val FIXED: Map<Int, String> = mapOf(
+      106 to "Boboteaza (Theophany)",
+      107 to "Soborul Sf. Ioan Botezătorul",
+      202 to "Întâmpinarea Domnului",
+      325 to "Buna Vestire",
+      806 to "Schimbarea la Față",
+      815 to "Adormirea Maicii Domnului",
+      908 to "Nașterea Maicii Domnului",
+      914 to "Înălțarea Sfintei Cruci",
+      1121 to "Intrarea în Biserică a Maicii Domnului",
+      1225 to "Nașterea Domnului (Crăciun)",
+  )
+
+  // Movable feasts: day offset from Pascha -> name.
+  private val MOVABLE: Map<Int, String> = mapOf(
+      -48 to "Lăsatul secului",
+      -7 to "Florii (Palm Sunday)",
+      -2 to "Vinerea Mare (Good Friday)",
+      0 to "Învierea Domnului (Paște)",
+      1 to "A doua zi de Paște",
+      39 to "Înălțarea Domnului",
+      49 to "Rusaliile (Pentecost)",
+  )
+
+  /** Orthodox Pascha for [year] as a Gregorian-calendar date (midnight, local zone). */
+  fun orthodoxEaster(year: Int): Calendar {
+    val a = year % 4
+    val b = year % 7
+    val c = year % 19
+    val d = (19 * c + 15) % 30
+    val e = (2 * a + 4 * b - d + 34) % 7
+    val julianMonth = (d + e + 114) / 31 // 3 = March, 4 = April
+    val julianDay = ((d + e + 114) % 31) + 1
+    // Julian → Gregorian: +13 days for 1900–2099. Let Calendar normalize the rollover.
+    val cal = GregorianCalendar(year, julianMonth - 1, julianDay, 0, 0, 0)
+    cal.set(Calendar.MILLISECOND, 0)
+    cal.add(Calendar.DAY_OF_YEAR, 13)
+    return cal
+  }
+
+  /** Today's feast name, or "" if today isn't a tracked feast. Movable feasts win
+   * ties (they're the rarer, more notable events). */
+  fun forToday(now: Calendar = Calendar.getInstance()): String {
+    val today = startOfDay(now)
+    val pascha = startOfDay(orthodoxEaster(now.get(Calendar.YEAR)))
+    val offset = ((today.timeInMillis - pascha.timeInMillis) / DAY_MS).toInt()
+    MOVABLE[offset]?.let { return it }
+    return FIXED[(now.get(Calendar.MONTH) + 1) * 100 + now.get(Calendar.DAY_OF_MONTH)] ?: ""
+  }
+
+  private const val DAY_MS = 24L * 60 * 60 * 1000
+
+  private fun startOfDay(c: Calendar): Calendar {
+    val x = c.clone() as Calendar
+    x.set(Calendar.HOUR_OF_DAY, 0)
+    x.set(Calendar.MINUTE, 0)
+    x.set(Calendar.SECOND, 0)
+    x.set(Calendar.MILLISECOND, 0)
+    return x
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/IrishHolidays.kt
+++ b/app/src/main/java/com/immortal/launcher/IrishHolidays.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import java.util.Calendar
+import java.util.GregorianCalendar
+
+/**
+ * Irish calendar pack — public/bank holidays and a few well-known saints' days, for the
+ * "Irish" household. Pure date math (Easter is computed), so it works offline forever.
+ */
+object IrishHolidays {
+
+  /** Today's holiday/observance label, or "" if there isn't one. */
+  fun forToday(cal: Calendar = Calendar.getInstance()): String {
+    val y = cal.get(Calendar.YEAR)
+    val m = cal.get(Calendar.MONTH) + 1
+    val d = cal.get(Calendar.DAY_OF_MONTH)
+    val dow = cal.get(Calendar.DAY_OF_WEEK)
+    val weekOfMonth = (d - 1) / 7 + 1
+    val isLastMonday = dow == Calendar.MONDAY && d + 7 > daysInMonth(y, m)
+
+    // Fixed-date holidays + saints.
+    when (m to d) {
+      1 to 1 -> return "New Year's Day"
+      2 to 1 -> return "St Brigid's Day"
+      3 to 17 -> return "St Patrick's Day"
+      6 to 9 -> return "St Columba's Day"
+      12 to 25 -> return "Christmas Day"
+      12 to 26 -> return "St Stephen's Day"
+    }
+
+    // Movable bank holidays (first/last Monday of certain months).
+    if (dow == Calendar.MONDAY) {
+      if (m == 2 && weekOfMonth == 1) return "St Brigid's Day (bank holiday)"
+      if (m == 5 && weekOfMonth == 1) return "May Bank Holiday"
+      if (m == 6 && weekOfMonth == 1) return "June Bank Holiday"
+      if (m == 8 && weekOfMonth == 1) return "August Bank Holiday"
+      if (m == 10 && isLastMonday) return "October Bank Holiday"
+    }
+
+    // Easter Monday.
+    val easter = easterSunday(y)
+    val easterMonday = (easter.clone() as Calendar).apply { add(Calendar.DAY_OF_YEAR, 1) }
+    if (sameDay(cal, easterMonday)) return "Easter Monday"
+    if (sameDay(cal, easter)) return "Easter Sunday"
+    val goodFriday = (easter.clone() as Calendar).apply { add(Calendar.DAY_OF_YEAR, -2) }
+    if (sameDay(cal, goodFriday)) return "Good Friday"
+
+    return ""
+  }
+
+  private fun sameDay(a: Calendar, b: Calendar): Boolean =
+      a.get(Calendar.YEAR) == b.get(Calendar.YEAR) &&
+          a.get(Calendar.DAY_OF_YEAR) == b.get(Calendar.DAY_OF_YEAR)
+
+  private fun daysInMonth(year: Int, month1: Int): Int =
+      GregorianCalendar(year, month1 - 1, 1).getActualMaximum(Calendar.DAY_OF_MONTH)
+
+  /** Western (Gregorian) Easter Sunday — Anonymous/Meeus algorithm. */
+  fun easterSunday(year: Int): Calendar {
+    val a = year % 19
+    val b = year / 100
+    val c = year % 100
+    val d = b / 4
+    val e = b % 4
+    val f = (b + 8) / 25
+    val g = (b - f + 1) / 3
+    val h = (19 * a + b - d - g + 15) % 30
+    val i = c / 4
+    val k = c % 4
+    val l = (32 + 2 * e + 2 * i - h - k) % 7
+    val mth = (a + 11 * h + 22 * l) / 451
+    val month = (h + l - 7 * mth + 114) / 31 // 3=March, 4=April
+    val day = ((h + l - 7 * mth + 114) % 31) + 1
+    return GregorianCalendar(year, month - 1, day)
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/NameDays.kt
+++ b/app/src/main/java/com/immortal/launcher/NameDays.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import java.util.Calendar
+
+/**
+ * Romanian (Orthodox) name-day calendar — "onomastica". In Romania and much of
+ * Eastern Europe a person's name-day (ziua onomastică / ziua numelui) is celebrated
+ * like a second birthday, on the feast of the saint they're named after.
+ *
+ * This is the set of the widely-celebrated fixed-date name-days; it isn't every
+ * entry in the full church calendar, but it covers the names people actually mark.
+ * Keyed by "month-day" (1-based month). [forToday] returns today's names, or empty.
+ */
+object NameDays {
+
+  // month*100 + day -> celebrated names on that date.
+  private val TABLE: Map<Int, List<String>> = mapOf(
+      101 to listOf("Vasile", "Vasilica"),
+      106 to listOf("Iordan", "Iordana"),
+      107 to listOf("Ion", "Ioan", "Ioana", "Ionel", "Ionela", "Ionuț", "Nelu"),
+      117 to listOf("Antonie", "Antonia"),
+      118 to listOf("Atanasie", "Tanase"),
+      125 to listOf("Grigore", "Grigorina"),
+      130 to listOf("Vasile", "Grigore", "Ion"), // Sf. Trei Ierarhi
+      202 to listOf("Marin", "Marina"),
+      210 to listOf("Haralambie"),
+      217 to listOf("Tudor", "Teodor", "Teodora"),
+      301 to listOf("Albert", "Albertina"),
+      309 to listOf("Mucenic"),
+      325 to listOf("Maria"), // Buna Vestire
+      323 to listOf("Toma"),
+      404 to listOf("Gheorghe"),
+      423 to listOf("Gheorghe", "George", "Gheorghița", "Geta"),
+      425 to listOf("Marcu"),
+      508 to listOf("Ioan"),
+      521 to listOf("Constantin", "Elena", "Costel", "Costică", "Lenuța"),
+      522 to listOf("Emil", "Emilia"),
+      601 to listOf("Iustin"),
+      608 to listOf("Cosmin", "Cosmina"),
+      624 to listOf("Ioan"), // Sânziene / Nașterea Sf. Ioan Botezătorul
+      629 to listOf("Petru", "Pavel", "Petre", "Petrică", "Paul", "Paula"),
+      630 to listOf("Apostol"),
+      701 to listOf("Cosma", "Damian"),
+      708 to listOf("Procopie"),
+      715 to listOf("Vladimir", "Vlad"),
+      720 to listOf("Ilie", "Ilinca"),
+      725 to listOf("Ana", "Anca", "Anuța"),
+      726 to listOf("Veronica"),
+      727 to listOf("Pantelimon"),
+      801 to listOf("Macabei"),
+      806 to listOf("Schimbarea la Față"),
+      815 to listOf("Maria", "Marioara", "Mărioara", "Maricica"),
+      830 to listOf("Alexandru", "Alexandra", "Sandu", "Sanda"),
+      901 to listOf("Dragoș"),
+      908 to listOf("Maria", "Adelina"), // Nașterea Maicii Domnului
+      909 to listOf("Ioachim", "Ana"),
+      914 to listOf("Cruce"), // Înălțarea Sfintei Cruci
+      917 to listOf("Sofia", "Credința", "Speranța", "Iubirea"),
+      923 to listOf("Tecla"),
+      926 to listOf("Ioan"),
+      1014 to listOf("Paraschiva", "Parascheva"),
+      1023 to listOf("Iacob"),
+      1026 to listOf("Dumitru", "Dumitra", "Mitică", "Mitruț"),
+      1027 to listOf("Nestor"),
+      1108 to listOf("Mihai", "Mihaela", "Gabriel", "Gabriela", "Mihail", "Mișu"),
+      1111 to listOf("Mina"),
+      1113 to listOf("Ioan"),
+      1114 to listOf("Filip"),
+      1116 to listOf("Matei"),
+      1121 to listOf("Maria"), // Intrarea în Biserică a Maicii Domnului
+      1125 to listOf("Ecaterina", "Caterina", "Cătălin", "Cătălina"),
+      1130 to listOf("Andrei", "Andreea"),
+      1204 to listOf("Varvara", "Barbara"),
+      1205 to listOf("Sava"),
+      1206 to listOf("Nicolae", "Nicoleta", "Niculina", "Nicu", "Nicușor"),
+      1209 to listOf("Ana"),
+      1212 to listOf("Spiridon"),
+      1215 to listOf("Eleftérie"),
+      1217 to listOf("Daniel", "Daniela", "Dan", "Dana"),
+      1220 to listOf("Ignat"),
+      1225 to listOf("Crăciun"), // Nașterea Domnului
+      1226 to listOf("Emanuel", "Emanuela"),
+      1227 to listOf("Ștefan", "Ștefania", "Fănica"),
+  )
+
+  /** Names celebrated on [month] (1-12) / [day], or empty if none well-known. */
+  fun forDate(month: Int, day: Int): List<String> = TABLE[month * 100 + day] ?: emptyList()
+
+  /** Names celebrated today. */
+  fun forToday(now: Calendar = Calendar.getInstance()): List<String> =
+      forDate(now.get(Calendar.MONTH) + 1, now.get(Calendar.DAY_OF_MONTH))
+
+  /** A compact display string for today, e.g. "Nicolae, Nicoleta", or "". */
+  fun todayLabel(now: Calendar = Calendar.getInstance()): String = forToday(now).joinToString(", ")
+}

--- a/app/src/main/java/com/immortal/launcher/PrayerTimes.kt
+++ b/app/src/main/java/com/immortal/launcher/PrayerTimes.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import java.util.Calendar
+import java.util.TimeZone
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.acos
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.tan
+
+/**
+ * Daily Islamic prayer times computed on-device for the household that wants them — a
+ * calendar pack like the name-day/feast packs. Uses the Muslim World League convention
+ * (Fajr 18°, Isha 17°, standard Asr shadow factor) and the device's location + time
+ * zone. Pure astronomy; no network, no key.
+ */
+object PrayerTimes {
+
+  private const val DEG = PI / 180.0
+  private const val FAJR_ANGLE = 18.0
+  private const val ISHA_ANGLE = 17.0
+
+  /** The five times as "HH:mm" strings for [date], or null if location is unknown. */
+  fun forToday(context: Context, date: Calendar = Calendar.getInstance()): Map<String, String>? {
+    val (lat, lon) = Weather.coordinates(context) ?: return null
+    val tzHours = TimeZone.getDefault().getOffset(date.timeInMillis) / 3_600_000.0
+    return compute(lat, lon, tzHours, date)
+  }
+
+  /** Today's next (or current) prayer as a header line, e.g. "🕌 Maghrib 21:34". */
+  fun nextLine(context: Context, now: Calendar = Calendar.getInstance()): String {
+    val times = forToday(context, now) ?: return ""
+    val nowMin = now.get(Calendar.HOUR_OF_DAY) * 60 + now.get(Calendar.MINUTE)
+    val order = listOf("Fajr", "Dhuhr", "Asr", "Maghrib", "Isha")
+    for (name in order) {
+      val t = times[name] ?: continue
+      val (h, m) = t.split(":").map { it.toInt() }
+      if (h * 60 + m >= nowMin) return "🕌 $name $t"
+    }
+    // All passed today → first prayer tomorrow.
+    return times["Fajr"]?.let { "🕌 Fajr $it (tomorrow)" } ?: ""
+  }
+
+  /** Pure computation, exposed for tests. [tzHours] is the UTC offset in hours.
+   * Follows the standard PrayTimes sun-position model; all working angles are kept in
+   * degrees and normalized (the mean longitude grows unbounded, so it MUST be wrapped to
+   * 0–360 before it feeds the equation of time). */
+  fun compute(lat: Double, lon: Double, tzHours: Double, date: Calendar): Map<String, String> {
+    val d = julianDay(date) - 2451545.0
+    val g = fixAngle(357.529 + 0.98560028 * d) // mean anomaly, deg
+    val q = fixAngle(280.459 + 0.98564736 * d) // mean longitude, deg (normalized!)
+    val l = fixAngle(q + 1.915 * sin(g * DEG) + 0.020 * sin(2 * g * DEG)) // ecliptic lon, deg
+    val e = 23.439 - 0.00000036 * d // obliquity, deg
+    val decl = kotlin.math.asin(sin(e * DEG) * sin(l * DEG)) // radians
+    val ra = fixHours(atan2(cos(e * DEG) * sin(l * DEG), cos(l * DEG)) / DEG / 15.0) // hours
+    val eqt = q / 15.0 - ra // equation of time, hours
+
+    // Solar noon (Dhuhr) in local time.
+    val dhuhr = 12.0 + tzHours - lon / 15.0 - eqt
+    val latR = lat * DEG
+
+    // Hour angle (hours) for the sun reaching altitude [angleDeg] below(+)/above horizon.
+    fun hourAngle(angleDeg: Double): Double {
+      val cosH = (-sin(angleDeg * DEG) - sin(latR) * sin(decl)) / (cos(latR) * cos(decl))
+      return acos(cosH.coerceIn(-1.0, 1.0)) / DEG / 15.0
+    }
+
+    // Asr: shadow length factor 1 (Shafi'i) — the (positive) sun altitude where an
+    // object's shadow equals its length plus the noon shadow: alt = arccot(1 + tan|lat−decl|).
+    val asrAlt = atan2(1.0, 1.0 + tan(abs(latR - decl))) // radians, above horizon
+    val asrHA = run {
+      val cosH = (sin(asrAlt) - sin(latR) * sin(decl)) / (cos(latR) * cos(decl))
+      acos(cosH.coerceIn(-1.0, 1.0)) / DEG / 15.0
+    }
+
+    val sunrise = dhuhr - hourAngle(0.833)
+    val sunset = dhuhr + hourAngle(0.833)
+    val fajr = dhuhr - hourAngle(FAJR_ANGLE)
+    val asr = dhuhr + asrHA
+    val isha = dhuhr + hourAngle(ISHA_ANGLE)
+
+    return linkedMapOf(
+        "Fajr" to fmt(fajr),
+        "Sunrise" to fmt(sunrise),
+        "Dhuhr" to fmt(dhuhr),
+        "Asr" to fmt(asr),
+        "Maghrib" to fmt(sunset),
+        "Isha" to fmt(isha),
+    )
+  }
+
+  private fun fixHours(h: Double): Double {
+    var x = h % 24.0
+    if (x < 0) x += 24.0
+    return x
+  }
+
+  private fun fixAngle(a: Double): Double {
+    var x = a % 360.0
+    if (x < 0) x += 360.0
+    return x
+  }
+
+  private fun fmt(hours: Double): String {
+    val h = fixHours(hours)
+    var hh = h.toInt()
+    var mm = ((h - hh) * 60).toInt()
+    if (mm >= 60) { mm -= 60; hh = (hh + 1) % 24 }
+    return "%02d:%02d".format(hh, mm)
+  }
+
+  private fun julianDay(c: Calendar): Double {
+    val year = c.get(Calendar.YEAR)
+    val month = c.get(Calendar.MONTH) + 1
+    val day = c.get(Calendar.DAY_OF_MONTH)
+    val a = (14 - month) / 12
+    val y = year + 4800 - a
+    val m = month + 12 * a - 3
+    val jdn = day + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045
+    return jdn - 0.5
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/Transit.kt
+++ b/app/src/main/java/com/immortal/launcher/Transit.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import org.json.JSONObject
+
+/**
+ * Worldwide real-time public-transport departures via Transitous — a free,
+ * community-run [MOTIS](https://github.com/motis-project/motis) instance that
+ * aggregates GTFS + GTFS-realtime feeds from across the globe. No API key, no GMS.
+ *
+ * Two calls:
+ *  - [searchStops] geocodes a free-text query ("Connolly", "Alexanderplatz",
+ *    "Times Sq 42 St") to a list of stops the user picks from;
+ *  - [fetch] returns the next departures from a chosen stop, soonest first, with
+ *    realtime where the operator publishes it.
+ *
+ * Coverage depends on which feeds Transitous has imported, but it spans most of
+ * Europe, North America and beyond — anywhere with an open GTFS feed.
+ */
+object Transit {
+
+  private const val PREFS = "immortal_transit"
+  private const val BASE = "https://api.transitous.org/api/v1"
+
+  /** A transit stop/station the user can pick. [region] is a short locality hint. */
+  data class Stop(val id: String, val name: String, val region: String)
+
+  data class Departure(val route: String, val destination: String, val due: String)
+
+  fun savedStopId(context: Context): String = prefs(context).getString("stop_id", "") ?: ""
+
+  fun savedStopName(context: Context): String = prefs(context).getString("stop_name", "") ?: ""
+
+  fun saveStop(context: Context, stop: Stop) =
+      prefs(context).edit()
+          .putString("stop_id", stop.id.trim())
+          .putString("stop_name", stop.name.trim())
+          .apply()
+
+  private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+  /** Geocode [query] to transit stops (empty on failure / no match). */
+  fun searchStops(query: String, max: Int = 12): List<Stop> {
+    if (query.isBlank()) return emptyList()
+    return runCatching {
+      val json = httpGet("$BASE/geocode?text=${enc(query)}")
+      val arr = org.json.JSONArray(json)
+      val out = ArrayList<Stop>()
+      for (i in 0 until arr.length()) {
+        val o = arr.getJSONObject(i)
+        if (o.optString("type") != "STOP") continue
+        val id = o.optString("id")
+        val name = o.optString("name")
+        if (id.isBlank() || name.isBlank()) continue
+        out.add(Stop(id = id, name = name, region = regionOf(o)))
+        if (out.size >= max) break
+      }
+      out
+    }.getOrDefault(emptyList())
+  }
+
+  /** A short locality hint from the geocoder's admin "areas" (e.g. "Dublin, IE"). */
+  private fun regionOf(o: JSONObject): String {
+    val country = o.optString("country", "")
+    val areas = o.optJSONArray("areas")
+    var city = ""
+    if (areas != null) {
+      // Prefer the area the geocoder marked as the default/most relevant locality.
+      for (i in 0 until areas.length()) {
+        val a = areas.getJSONObject(i)
+        if (a.optBoolean("default", false) || a.optBoolean("matched", false)) {
+          city = a.optString("name"); break
+        }
+      }
+    }
+    return listOf(city, country).filter { it.isNotBlank() }.joinToString(", ")
+  }
+
+  /** Next departures for [stopId], soonest first (empty on any failure / no data). */
+  fun fetch(stopId: String, max: Int = 8): List<Departure> {
+    if (stopId.isBlank()) return emptyList()
+    return runCatching {
+      val json = httpGet("$BASE/stoptimes?stopId=${enc(stopId)}&n=$max")
+      val arr = JSONObject(json).optJSONArray("stopTimes") ?: return emptyList()
+      val now = System.currentTimeMillis()
+      (0 until arr.length()).mapNotNull { i ->
+        val o = arr.getJSONObject(i)
+        val place = o.optJSONObject("place")
+        // Realtime departure if present, else the scheduled time.
+        val depIso = place?.optString("departure")?.takeIf { it.isNotBlank() }
+            ?: place?.optString("scheduledDeparture")?.takeIf { it.isNotBlank() }
+            ?: return@mapNotNull null
+        val depMs = parseIso(depIso) ?: return@mapNotNull null
+        val route =
+            o.optString("routeShortName").ifBlank { o.optString("displayName") }
+                .ifBlank { o.optString("mode") }.ifBlank { "?" }
+        Departure(
+            route = route,
+            destination = o.optString("headsign").ifBlank { o.optString("routeLongName") },
+            due = dueLabel(depMs - now),
+        )
+      }
+    }.getOrDefault(emptyList())
+  }
+
+  private fun dueLabel(deltaMs: Long): String {
+    val mins = Math.round(deltaMs / 60000.0).toInt()
+    return if (mins <= 0) "Due" else "$mins min"
+  }
+
+  /** Parse a UTC ISO-8601 timestamp like "2026-06-14T16:05:00Z" (handles whole secs). */
+  private fun parseIso(s: String): Long? = runCatching {
+    val fmt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
+    fmt.timeZone = TimeZone.getTimeZone("UTC")
+    fmt.parse(s.removeSuffix("Z"))?.time
+  }.getOrNull()
+
+  private fun enc(s: String): String = URLEncoder.encode(s, "UTF-8")
+
+  private fun httpGet(spec: String): String {
+    val c = URL(spec).openConnection() as HttpURLConnection
+    c.connectTimeout = 8000
+    c.readTimeout = 10000
+    c.setRequestProperty("User-Agent", "Immortal/1.0")
+    return c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
+  }
+}


### PR DESCRIPTION
Part of the #85 split. Adds the almanac / daily-content data packs used by the ambient dashboard.

**Files (7, all self-contained, no manifest or registry-domain changes):**
- `CalendarPacks.kt`, `FeastDays.kt`, `IrishHolidays.kt`, `NameDays.kt`, `Transit.kt`, `DailyContent.kt` — pure data/lookup packs.
- `PrayerTimes.kt` — computes prayer times from `Weather.coordinates()` (landed in #94).

**Dependency:** builds on #94 (keyless tools) for `Weather.coordinates()`, now merged — so this is a clean PR on `main`.

Rebased onto current `main`. `./gradlew :app:assembleDebug :app:testDebugUnitTest` green.