### PR TITLE
Sunrise alarm / wake-light domain

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -201,6 +201,23 @@
             android:label="Sounds"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- "Sunrise alarm": gradual wake-light schedule + days. -->
+        <activity
+            android:name=".SunriseSettingsActivity"
+            android:exported="false"
+            android:label="Sunrise alarm"
+            android:theme="@style/Theme.SampleApp" />
+
+        <!-- Full-screen sunrise wake light, launched by SunriseReceiver at the alarm
+             time; shows over the lock screen and turns the screen on. -->
+        <activity
+            android:name=".WakeLightActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:showWhenLocked="true"
+            android:turnScreenOn="true"
+            android:theme="@style/Theme.SampleApp" />
+
         <!-- "Clock": digital clock screensaver style / color / layout settings. -->
         <activity
             android:name=".ClockSettingsActivity"
@@ -373,6 +390,11 @@
         <!-- Internal alarm for the ambient chime / spoken-time / golden-hour cues. -->
         <receiver
             android:name=".ChimeReceiver"
+            android:exported="false" />
+
+        <!-- Internal alarm for the sunrise wake light (launches WakeLightActivity). -->
+        <receiver
+            android:name=".SunriseReceiver"
             android:exported="false" />
 
         <!-- Device admin (force-lock only): lets Immortal turn the screen off for the

--- a/app/src/main/java/com/immortal/launcher/BootReceiver.kt
+++ b/app/src/main/java/com/immortal/launcher/BootReceiver.kt
@@ -23,6 +23,8 @@ class BootReceiver : BroadcastReceiver() {
       SleepScheduler.applyOvernightNow(context)
       // Likewise re-arm the ambient chime alarms.
       ChimeScheduler.reschedule(context)
+      // Re-arm the sunrise wake-light alarm.
+      SunriseScheduler.reschedule(context)
       // Re-open the WiFi fleet channel after the reboot (the whole point of an
       // in-app agent: it comes back without USB, unlike adb-over-WiFi here).
       FleetAgentService.ensureRunning(context)

--- a/app/src/main/java/com/immortal/launcher/ImmortalApp.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalApp.kt
@@ -66,6 +66,9 @@ class ImmortalApp : Application() {
     // Arm the ambient chime / spoken-time / golden-hour alarms per the user's config.
     ChimeScheduler.reschedule(this)
 
+    // Arm the next sunrise wake-light alarm per the user's config.
+    SunriseScheduler.reschedule(this)
+
     // Bring up the WiFi fleet agent if provisioning enabled it (no-op otherwise).
     FleetAgentService.ensureRunning(this)
 

--- a/app/src/main/java/com/immortal/launcher/SunriseConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/SunriseConfig.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import java.util.Calendar
+
+/**
+ * Sunrise alarm / wake light. At the set time on the chosen days, the screen brightens
+ * gradually from a deep ember to full daylight over [rampMinutes], optionally finishing
+ * with a soft chime crescendo — turning a bedroom Portal into a wake light. Persisted in
+ * SharedPrefs and re-armed by [ImmortalApp] / [BootReceiver].
+ */
+object SunriseConfig {
+
+  private const val PREFS = "immortal_sunrise"
+
+  data class Config(
+      val enabled: Boolean,
+      val hour: Int,
+      val minute: Int,
+      val rampMinutes: Int,
+      val chime: Boolean,
+      /** Sun-Sat; if all false the alarm is treated as one-shot (next occurrence). */
+      val days: Set<Int>, // Calendar.SUNDAY..Calendar.SATURDAY
+  )
+
+  fun load(context: Context): Config {
+    val p = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    val days = p.getStringSet("days", null)?.mapNotNull { it.toIntOrNull() }?.toSet() ?: defaultDays()
+    return Config(
+        enabled = p.getBoolean("enabled", false),
+        hour = p.getInt("hour", 7),
+        minute = p.getInt("minute", 0),
+        rampMinutes = p.getInt("ramp", 20),
+        chime = p.getBoolean("chime", true),
+        days = days,
+    )
+  }
+
+  fun save(context: Context, c: Config) {
+    context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
+        .putBoolean("enabled", c.enabled)
+        .putInt("hour", c.hour)
+        .putInt("minute", c.minute)
+        .putInt("ramp", c.rampMinutes)
+        .putBoolean("chime", c.chime)
+        .putStringSet("days", c.days.map { it.toString() }.toSet())
+        .apply()
+  }
+
+  // Per-field setters for the registry: clamping, side-effect-free, (Context, value) signature.
+  // The `days` Set<Int> has no scalar setter — it's managed by the bespoke day-picker in
+  // SunriseSettingsActivity (the registry models scalars, not sets).
+
+  fun setEnabled(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("enabled", on).apply()
+
+  fun setHour(c: Context, h: Int) =
+      prefs(c).edit().putInt("hour", h.coerceIn(0, 23)).apply()
+
+  fun setMinute(c: Context, m: Int) =
+      prefs(c).edit().putInt("minute", m.coerceIn(0, 59)).apply()
+
+  fun setRampMinutes(c: Context, m: Int) =
+      prefs(c).edit().putInt("ramp", m.coerceIn(1, 60)).apply()
+
+  fun setChime(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("chime", on).apply()
+
+  fun setDays(c: Context, days: Set<Int>) =
+      prefs(c).edit().putStringSet("days", days.map { it.toString() }.toSet()).apply()
+
+  private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+  private fun defaultDays(): Set<Int> =
+      setOf(Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY, Calendar.THURSDAY, Calendar.FRIDAY)
+
+  /** Next fire time (epoch millis) at/after now for [c], or null if disabled. Pure +
+   * testable: pass [from] to compute deterministically. */
+  fun nextTrigger(c: Config, from: Calendar = Calendar.getInstance()): Long? {
+    if (!c.enabled) return null
+    val cal = from.clone() as Calendar
+    cal.set(Calendar.SECOND, 0)
+    cal.set(Calendar.MILLISECOND, 0)
+    cal.set(Calendar.HOUR_OF_DAY, c.hour)
+    cal.set(Calendar.MINUTE, c.minute)
+    // Search up to 8 days out for the next matching day-of-week (or one-shot).
+    for (i in 0..7) {
+      val candidate = cal.clone() as Calendar
+      candidate.add(Calendar.DAY_OF_YEAR, i)
+      if (candidate.timeInMillis <= from.timeInMillis) continue
+      val dow = candidate.get(Calendar.DAY_OF_WEEK)
+      if (c.days.isEmpty() || dow in c.days) return candidate.timeInMillis
+    }
+    return null
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/SunriseReceiver.kt
+++ b/app/src/main/java/com/immortal/launcher/SunriseReceiver.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+
+/** Fires at the sunrise-alarm time: launches the full-screen wake light, then arms the
+ *  next occurrence. */
+class SunriseReceiver : BroadcastReceiver() {
+  override fun onReceive(context: Context, intent: Intent?) {
+    if (intent?.action != SunriseScheduler.ACTION_FIRE) return
+    val cfg = SunriseConfig.load(context)
+    if (cfg.enabled) showWakeLight(context, cfg)
+    // Arm the next day (or next matching weekday).
+    SunriseScheduler.reschedule(context)
+  }
+
+  /**
+   * Bring up the wake light. A direct `startActivity` from a receiver is blocked by the
+   * background-activity-launch rules on API 29+, so we use a **full-screen-intent
+   * notification** — the sanctioned alarm-clock path — which the system promotes to a
+   * full-screen activity even from the background / lock screen. We also try a direct
+   * start (harmless on API 28 where it's allowed and is a no-op duplicate otherwise).
+   */
+  private fun showWakeLight(context: Context, cfg: SunriseConfig.Config) {
+    val activity =
+        Intent(context, WakeLightActivity::class.java)
+            .putExtra(WakeLightActivity.EXTRA_RAMP_MIN, cfg.rampMinutes)
+            .putExtra(WakeLightActivity.EXTRA_CHIME, cfg.chime)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+
+    val pi =
+        PendingIntent.getActivity(
+            context, 0, activity,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+
+    val nm = context.getSystemService(NotificationManager::class.java)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      val channel =
+          NotificationChannel(CHANNEL, "Sunrise alarm", NotificationManager.IMPORTANCE_HIGH).apply {
+            description = "Wakes the screen for the sunrise alarm"
+          }
+      nm.createNotificationChannel(channel)
+    }
+    val notif =
+        Notification.Builder(context, CHANNEL)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle("Sunrise alarm")
+            .setContentText("Good morning")
+            .setCategory(Notification.CATEGORY_ALARM)
+            .setAutoCancel(true)
+            .setFullScreenIntent(pi, true)
+            .build()
+    runCatching { nm.notify(NOTIF_ID, notif) }
+    // Best-effort direct launch too (allowed on API 28 / when the launcher is foreground).
+    runCatching { context.startActivity(activity) }
+  }
+
+  private companion object {
+    const val CHANNEL = "immortal_sunrise"
+    const val NOTIF_ID = 42101
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/SunriseScheduler.kt
+++ b/app/src/main/java/com/immortal/launcher/SunriseScheduler.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+
+/** Arms the next sunrise-alarm fire via AlarmManager; [SunriseReceiver] launches the
+ *  wake light. Re-armed on boot and app start, and rescheduled after each fire. */
+object SunriseScheduler {
+  const val ACTION_FIRE = "com.immortal.launcher.SUNRISE_FIRE"
+  private const val RC = 0x5A1B
+
+  private fun alarms(c: Context) = c.getSystemService(AlarmManager::class.java)
+
+  private fun pi(c: Context, create: Boolean): PendingIntent? {
+    val flags = (if (create) PendingIntent.FLAG_UPDATE_CURRENT else PendingIntent.FLAG_NO_CREATE) or
+        PendingIntent.FLAG_IMMUTABLE
+    val intent = Intent(c, SunriseReceiver::class.java).setAction(ACTION_FIRE)
+    return PendingIntent.getBroadcast(c, RC, intent, flags)
+  }
+
+  /** Cancel any pending alarm and arm the next one per the saved config. */
+  fun reschedule(context: Context) {
+    pi(context, create = false)?.let { alarms(context).cancel(it); it.cancel() }
+    val cfg = SunriseConfig.load(context)
+    val at = SunriseConfig.nextTrigger(cfg) ?: return
+    val p = pi(context, create = true) ?: return
+    runCatching { alarms(context).setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, at, p) }
+        .onFailure { runCatching { alarms(context).setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, at, p) } }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/SunriseSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/SunriseSettingsActivity.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.settings.SettingsDomains
+import com.immortal.launcher.ui.theme.SampleAppTheme
+import org.json.JSONObject
+import java.util.Calendar
+
+/** Set the sunrise alarm: time, which days, ramp length, and the optional chime. */
+class SunriseSettingsActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { SunriseScreen() } }
+  }
+}
+
+private val DAY_LABELS =
+    listOf(
+        Calendar.MONDAY to "M", Calendar.TUESDAY to "T", Calendar.WEDNESDAY to "W",
+        Calendar.THURSDAY to "T", Calendar.FRIDAY to "F", Calendar.SATURDAY to "S",
+        Calendar.SUNDAY to "S")
+
+@Composable
+private fun SunriseScreen() {
+  val context = LocalContext.current
+  val initial = remember { SunriseConfig.load(context) }
+  var enabled by remember { mutableStateOf(initial.enabled) }
+  var hour by remember { mutableIntStateOf(initial.hour) }
+  var minute by remember { mutableIntStateOf(initial.minute) }
+  var ramp by remember { mutableIntStateOf(initial.rampMinutes) }
+  var chime by remember { mutableStateOf(initial.chime) }
+  var days by remember { mutableStateOf(initial.days) }
+
+  fun persist() {
+    // Set days first (bespoke — the registry models scalars, not sets), then route the scalar
+    // fields through the domain so its onApplied (SunriseScheduler.reschedule) fires once with
+    // the new days already in prefs.
+    SunriseConfig.setDays(context, days)
+    SettingsDomains.sunrise.apply(
+        context,
+        JSONObject()
+            .put("enabled", enabled)
+            .put("hour", hour)
+            .put("minute", minute)
+            .put("rampMinutes", ramp)
+            .put("chime", chime))
+  }
+
+  Box(modifier = Modifier.fillMaxSize().background(Color(0xFF1A1A1A)), contentAlignment = Alignment.TopCenter) {
+    Column(
+        modifier = Modifier.widthIn(max = 620.dp).padding(28.dp).verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(18.dp),
+    ) {
+      Text("🌅 Sunrise alarm", color = Color.White, fontSize = 26.sp, fontWeight = FontWeight.Bold)
+      Text("The screen brightens gradually to wake you, with an optional gentle chime.",
+          color = Color(0xFFB8B8B8), fontSize = 15.sp)
+
+      Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+        Text("Enabled", color = Color.White, fontSize = 18.sp, modifier = Modifier.weight(1f))
+        Switch(checked = enabled, onCheckedChange = { enabled = it; persist() })
+      }
+
+      // Time pickers (stepper rows).
+      Stepper("Hour", hour, 0, 23) { hour = it; persist() }
+      Stepper("Minute", minute, 0, 59, step = 5) { minute = it; persist() }
+
+      Text("Wake on", color = Color(0xFF9A9A9A), fontSize = 14.sp)
+      Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        DAY_LABELS.forEach { (d, label) ->
+          val on = d in days
+          Surface(color = if (on) MaterialTheme.colorScheme.primary else Color(0x22FFFFFF), shape = CircleShape,
+              modifier = Modifier.tvFocusable(CircleShape, focusScale = 1.08f) {
+                days = if (on) days - d else days + d; persist()
+              }) {
+            Text(label, color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center, modifier = Modifier.padding(14.dp))
+          }
+        }
+      }
+
+      Text("Ramp: $ramp min", color = Color.White, fontSize = 16.sp)
+      Slider(value = ramp.toFloat(), onValueChange = { ramp = it.toInt() },
+          valueRange = 1f..45f, onValueChangeFinished = { persist() })
+
+      Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+        Text("Chime at the end", color = Color.White, fontSize = 18.sp, modifier = Modifier.weight(1f))
+        Switch(checked = chime, onCheckedChange = { chime = it; persist() })
+      }
+
+      val next = remember(enabled, hour, minute, days) {
+        SunriseConfig.nextTrigger(SunriseConfig.Config(enabled, hour, minute, ramp, chime, days))
+      }
+      Text(
+          if (next != null)
+              "Next: " + java.text.SimpleDateFormat("EEE d MMM, HH:mm", java.util.Locale.getDefault())
+                  .format(java.util.Date(next))
+          else "Alarm is off.",
+          color = Color(0xFF8AB4F8), fontSize = 15.sp)
+
+      Surface(color = Color(0xFFEF6C00), shape = RoundedCornerShape(14.dp),
+          modifier = Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(14.dp)) {
+            context.startActivity(
+                Intent(context, WakeLightActivity::class.java)
+                    .putExtra(WakeLightActivity.EXTRA_RAMP_MIN, 1)
+                    .putExtra(WakeLightActivity.EXTRA_CHIME, chime))
+          }) {
+        Text("Preview (1-min ramp)", color = Color.White, fontSize = 17.sp, fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center, modifier = Modifier.padding(vertical = 14.dp).fillMaxWidth())
+      }
+    }
+  }
+}
+
+@Composable
+private fun Stepper(label: String, value: Int, min: Int, max: Int, step: Int = 1, onChange: (Int) -> Unit) {
+  Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+    Text(label, color = Color.White, fontSize = 18.sp, modifier = Modifier.weight(1f))
+    StepBtn("–") { onChange(((value - step).coerceAtLeast(min))) }
+    Text("%02d".format(value), color = Color.White, fontSize = 22.sp, fontWeight = FontWeight.Bold,
+        textAlign = TextAlign.Center, modifier = Modifier.padding(horizontal = 16.dp))
+    StepBtn("+") { onChange(((value + step).coerceAtMost(max))) }
+  }
+}
+
+@Composable
+private fun StepBtn(label: String, onClick: () -> Unit) {
+  Surface(color = Color(0x33FFFFFF), shape = CircleShape,
+      modifier = Modifier.tvFocusable(CircleShape, focusScale = 1.1f) { onClick() }) {
+    Text(label, color = Color.White, fontSize = 24.sp, fontWeight = FontWeight.Bold,
+        textAlign = TextAlign.Center, modifier = Modifier.padding(horizontal = 18.dp, vertical = 6.dp))
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/WakeLightActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/WakeLightActivity.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * The sunrise wake light: the screen brightens gradually from a deep ember through warm
+ * amber to bright daylight over the chosen ramp, optionally finishing with a soft chime
+ * crescendo. People pay real money for a wake light; here the always-on panel is one.
+ *
+ * Launched by [SunriseReceiver] at the alarm time. Tap anywhere to dismiss.
+ */
+class WakeLightActivity : ComponentActivity() {
+  companion object {
+    const val EXTRA_RAMP_MIN = "ramp_min"
+    const val EXTRA_CHIME = "chime"
+  }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    // Show over the lock screen and wake the device.
+    window.addFlags(
+        WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON or
+            WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON or
+            WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+            WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD)
+
+    val rampMin = intent.getIntExtra(EXTRA_RAMP_MIN, 20).coerceIn(1, 60)
+    val chime = intent.getBooleanExtra(EXTRA_CHIME, true)
+    setContent { WakeLightScreen(rampMin, chime, ::applyBrightness) { finish() } }
+  }
+
+  private fun applyBrightness(level: Float) {
+    window.attributes = window.attributes.apply { screenBrightness = level.coerceIn(0.02f, 1f) }
+  }
+}
+
+@Composable
+private fun WakeLightScreen(rampMin: Int, chime: Boolean, onBrightness: (Float) -> Unit, onDismiss: () -> Unit) {
+  val context = androidx.compose.ui.platform.LocalContext.current
+  // 0..1 progress through the ramp, animated over the full duration.
+  var target by remember { mutableFloatStateOf(0f) }
+  val progress by animateFloatAsState(
+      targetValue = target,
+      animationSpec = tween(durationMillis = rampMin * 60_000, easing = LinearEasing),
+      label = "sunriseRamp",
+  )
+  var chimed by remember { mutableStateOf(false) }
+
+  LaunchedEffect(Unit) { target = 1f }
+
+  // Drive the hardware backlight up alongside the on-screen colour.
+  LaunchedEffect(progress) {
+    onBrightness(0.05f + progress * 0.95f)
+    // Soft chime as we approach full light.
+    if (chime && !chimed && progress >= 0.85f) {
+      chimed = true
+      runCatching { ChimePlayer.playSunriseTone(context) }
+    }
+  }
+
+  // Ember -> amber -> warm daylight.
+  val ember = Color(0xFF2A0E00)
+  val amber = Color(0xFFFF8A3D)
+  val day = Color(0xFFFFF4E0)
+  val color = if (progress < 0.5f) lerp(ember, amber, progress * 2f) else lerp(amber, day, (progress - 0.5f) * 2f)
+
+  Box(
+      modifier = Modifier.fillMaxSize().background(color).clickable { onDismiss() },
+      contentAlignment = Alignment.BottomCenter,
+  ) {
+    Surface(color = Color(0x33000000), shape = RoundedCornerShape(16.dp),
+        modifier = Modifier.padding(28.dp)) {
+      Text("☀ Good morning — tap to dismiss",
+          color = Color(0xCCFFFFFF), fontSize = 16.sp,
+          modifier = Modifier.padding(horizontal = 18.dp, vertical = 10.dp))
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -10,6 +10,8 @@ package com.immortal.launcher.settings
 import android.content.Context
 import com.immortal.launcher.CalendarFeed
 import com.immortal.launcher.CalendarUrlEntryActivity
+import com.immortal.launcher.SunriseConfig
+import com.immortal.launcher.SunriseScheduler
 import com.immortal.launcher.ChimeConfig
 import com.immortal.launcher.ChimeScheduler
 import com.immortal.launcher.DigitalClockConfig
@@ -859,6 +861,75 @@ object SettingsDomains {
       )
 
   /**
+   * Sunrise alarm / wake light ([SunriseConfig]). At the set time on the chosen days, the screen
+   * brightens gradually, optionally finishing with a chime. The scalar fields (enabled, hour,
+   * minute, ramp minutes, chime) are registry specs; the `days` Set<Int> (which days of the week)
+   * is managed by the bespoke day-picker in [SunriseSettingsActivity] — the registry models scalars,
+   * not sets. Rescheduling ([SunriseScheduler.reschedule]) goes in [onApplied], fired once per batch.
+   */
+  val sunrise: SettingsDomain<SunriseConfig.Config> =
+      SettingsDomain(
+          id = "sunrise",
+          title = "Sunrise alarm",
+          load = SunriseConfig::load,
+          specs =
+              listOf(
+                  BoolSpec(
+                      "enabled",
+                      "Sunrise alarm",
+                      get = { it.enabled },
+                      set = SunriseConfig::setEnabled,
+                      help = "Wake to a gradual screen-brightening ramp, optionally finishing with a chime."),
+                  IntSpec(
+                      "hour",
+                      "Hour",
+                      get = { it.hour },
+                      set = SunriseConfig::setHour,
+                      min = 0,
+                      max = 23,
+                      step = 1,
+                      format = { "%02d:00".format(it) },
+                      visible = { _, s -> s.enabled }),
+                  IntSpec(
+                      "minute",
+                      "Minute",
+                      get = { it.minute },
+                      set = SunriseConfig::setMinute,
+                      min = 0,
+                      max = 59,
+                      step = 5,
+                      format = { ":%02d".format(it) },
+                      visible = { _, s -> s.enabled }),
+                  IntSpec(
+                      "rampMinutes",
+                      "Ramp minutes",
+                      get = { it.rampMinutes },
+                      set = SunriseConfig::setRampMinutes,
+                      min = 1,
+                      max = 60,
+                      step = 5,
+                      format = { "$it min" },
+                      help = "How long the screen takes to brighten from ember to full daylight.",
+                      visible = { _, s -> s.enabled }),
+                  BoolSpec(
+                      "chime",
+                      "Chime at end",
+                      get = { it.chime },
+                      set = SunriseConfig::setChime,
+                      help = "Finish the ramp with a soft chime crescendo.",
+                      visible = { _, s -> s.enabled }),
+              ),
+          sections =
+              mapOf(
+                  "hour" to "Time",
+                  "minute" to "Time",
+                  "rampMinutes" to "Ramp",
+                  "chime" to "Ramp"),
+          defaults = { SunriseConfig.Config(false, 7, 0, 20, true, setOf(2, 3, 4, 5, 6)) },
+          onApplied = { c, _ -> SunriseScheduler.reschedule(c) },
+      )
+
+  /**
    * The digital clock screensaver ([DigitalClockConfig]). When enabled, it replaces the photo-frame
    * dream with a large customisable clock (style, color, font, size, layout, background, glow, date,
    * seconds). The enum setters write the raw string straight to prefs (no normalising), so each
@@ -1082,5 +1153,5 @@ object SettingsDomains {
       )
 
   val all: List<SettingsDomain<*>> =
-      listOf(screensaver, calendar, immortal, mqtt, quickbar, fleet, chime, digitalclock, welcome)
+      listOf(screensaver, calendar, immortal, mqtt, quickbar, fleet, chime, digitalclock, welcome, sunrise)
 }

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -260,6 +260,7 @@ class SettingsDomainTest {
             SettingsDomains.chime to emptySet(),
             SettingsDomains.digitalclock to emptySet(),
             SettingsDomains.welcome to emptySet(),
+            SettingsDomains.sunrise to emptySet(),
         )
     rendered.forEach { (dom, exclude) ->
       val blank =
@@ -329,6 +330,24 @@ class SettingsDomainTest {
             .toSet()
     val specKeys = SettingsDomains.digitalclock.specs.map { it.key }.toSet()
     assertEquals(fields, specKeys)
+  }
+
+  @Test
+  fun sunriseRegistry_coversEveryPersistedField_orExplicitlyAccountsForIt() {
+    // `days` is a Set<Int> (which days of the week) managed by the bespoke day-picker in
+    // SunriseSettingsActivity — the registry models scalars, not sets. The 5 scalar fields
+    // are all bound by specs.
+    val fields =
+        com.immortal.launcher.SunriseConfig.Config::class.java.declaredFields
+            .filter { !java.lang.reflect.Modifier.isStatic(it.modifiers) }
+            .map { it.name }
+            .toSet()
+    val specKeys = SettingsDomains.sunrise.specs.map { it.key }.toSet()
+    val managedElsewhere = setOf("days")
+    val uncovered = fields - specKeys - managedElsewhere
+    assertTrue(
+        "SunriseConfig.Config has persisted fields neither in the registry nor accounted for: $uncovered",
+        uncovered.isEmpty())
   }
 
   @Test


### PR DESCRIPTION
Re-lands #115 rebased onto current main (rebased past the #113/#114 merges). GodricTM's commit cherry-picked onto main; it applied cleanly (no manifest conflict this time).

A gradual wake-light alarm: at the set time on chosen days the screen brightens over a ramp, optionally finishing with the golden-hour tone. New `sunrise` `SettingsDomain` for the scalar controls (day-of-week set is the bespoke picker; the `sunriseRegistry` tripwire accounts for `days`). Re-armed in `ImmortalApp.onCreate` + `BootReceiver`. Plays the tone via `ChimePlayer` from the merged chimes.

Verified: `:app:testDebugUnitTest` 259 tests, 0 failures (incl. the sunrise registry tripwire). Supersedes #115.

Co-authored-by: GodricTM <GodricTM@users.noreply.github.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4SmhtgSd5B5sdTiV216XM)_