### PR TITLE
LAN intercom / "ping the other room"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,8 +27,12 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <!-- Ambient dashboard: show upcoming events from the device calendar (CalendarHelper). -->
     <uses-permission android:name="android.permission.READ_CALENDAR" />
-    <!-- Voice notes: AudioNote records short memos via the handset mic. Requested at
-         runtime; recording is a no-op until granted. -->
+    <!-- LAN intercom / "ping the other room": broadcast audio over the local network. -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <!-- Voice notes: AudioNote records short memos via the handset mic; also used by the
+         LAN intercom. Requested at runtime; recording is a no-op until granted. -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <!-- Fleet Agent: a foreground service so WiFi device management survives a
          reboot on these non-root Portals (where adb-over-WiFi can't). -->
@@ -269,6 +273,13 @@
             android:exported="false"
             android:screenOrientation="landscape"
             android:label="Bedtime story"
+            android:theme="@style/Theme.SampleApp" />
+
+        <!-- "Intercom": LAN one-way intercom / baby monitor (LanAudio). -->
+        <activity
+            android:name=".IntercomActivity"
+            android:exported="false"
+            android:label="Intercom"
             android:theme="@style/Theme.SampleApp" />
 
         <!-- Connect a self-hosted Immich server as the screensaver source. -->

--- a/app/src/main/java/com/immortal/launcher/IntercomActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/IntercomActivity.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Activity
+import android.content.Context
+import android.net.wifi.WifiManager
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.ui.theme.SampleAppTheme
+
+/**
+ * Portal-to-Portal LAN intercom / baby monitor (one-way audio). One Portal
+ * broadcasts its mic; another listens. No servers, no GMS — raw PCM over TCP on the
+ * local network (see [LanAudio]). Needs the mic permission, requested on first use.
+ */
+class IntercomActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { IntercomScreen() } }
+  }
+}
+
+@Composable
+private fun IntercomScreen() {
+  val context = LocalContext.current
+  val activity = context as? Activity
+  val lan = remember { LanAudio() }
+  DisposableEffect(Unit) { onDispose { lan.stop() } }
+
+  var mode by remember { mutableStateOf("idle") } // idle | broadcasting | listening
+  var host by remember { mutableStateOf("") }
+  var status by remember { mutableStateOf("") }
+  val myIp = remember { localIp(context) }
+
+  // Kick off the broadcast and reflect whether the port actually bound, so the UI
+  // never claims it's broadcasting when the socket couldn't open.
+  fun beginBroadcast() {
+    status = "Starting…"
+    lan.startBroadcast { ok ->
+      if (ok) { mode = "broadcasting"; status = "Broadcasting this room's audio" }
+      else { mode = "idle"; status = "Couldn't start — the broadcast port is in use" }
+    }
+  }
+
+  val permLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
+      androidx.activity.result.contract.ActivityResultContracts.RequestPermission()) { granted ->
+    if (granted) beginBroadcast()
+    else status = "Microphone permission is needed to broadcast"
+  }
+
+  fun startBroadcast() {
+    val granted = android.content.pm.PackageManager.PERMISSION_GRANTED ==
+        context.checkSelfPermission(android.Manifest.permission.RECORD_AUDIO)
+    if (granted) beginBroadcast()
+    else permLauncher.launch(android.Manifest.permission.RECORD_AUDIO)
+  }
+
+  Box(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier = Modifier.fillMaxSize().background(Color(0xFF111111))
+            .verticalScroll(rememberScrollState()).padding(horizontal = 24.dp, vertical = 28.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+      Text("Intercom", color = Color.White, fontSize = 30.sp, fontWeight = FontWeight.Bold)
+      Text("One-way audio between two Portals on the same Wi-Fi. No internet, no servers.",
+          color = Color(0xFF9A9A9A), fontSize = 15.sp, textAlign = TextAlign.Center)
+
+      if (myIp.isNotBlank()) {
+        Surface(color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+            shape = RoundedCornerShape(14.dp), modifier = Modifier.fillMaxWidth()) {
+          Text("This Portal's address: $myIp", color = Color.White, fontSize = 15.sp,
+              modifier = Modifier.padding(16.dp))
+        }
+      }
+
+      if (status.isNotBlank()) {
+        Text(status, color = MaterialTheme.colorScheme.primary, fontSize = 15.sp, textAlign = TextAlign.Center)
+      }
+
+      // Broadcast (baby monitor in the nursery): this device's mic → the network.
+      ActionButton(
+          label = if (mode == "broadcasting") "■ Stop broadcasting" else "🔊 Broadcast this room",
+          primary = mode != "broadcasting",
+      ) {
+        if (mode == "broadcasting") { lan.stop(); mode = "idle"; status = "" } else startBroadcast()
+      }
+
+      // Listen (kitchen Portal): connect to the broadcasting Portal's address.
+      Surface(color = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f),
+          shape = RoundedCornerShape(18.dp), modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+          OutlinedTextField(value = host, onValueChange = { host = it }, singleLine = true,
+              label = { Text("Other Portal's address (e.g. 192.168.1.42)") },
+              modifier = Modifier.fillMaxWidth())
+          ActionButton(
+              label = if (mode == "listening") "■ Stop listening" else "👂 Listen",
+              primary = mode != "listening",
+          ) {
+            if (mode == "listening") { lan.stop(); mode = "idle"; status = "" }
+            else if (host.isNotBlank()) {
+              status = "Connecting…"
+              lan.startListening(host.trim()) { ok ->
+                status = if (ok) "Listening to $host" else "Couldn't connect to $host"
+                mode = if (ok) "listening" else "idle"
+              }
+            }
+          }
+        }
+      }
+      Spacer(Modifier.size(8.dp))
+    }
+  }
+  FolderBackButton(onClick = { lan.stop(); activity?.finish() })
+}
+
+@Composable
+private fun ActionButton(label: String, primary: Boolean, onClick: () -> Unit) {
+  Surface(
+      color = if (primary) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+      shape = RoundedCornerShape(14.dp),
+      modifier = Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(14.dp), focusScale = 1f) { onClick() },
+  ) {
+    Text(label, color = Color.White, fontSize = 17.sp, fontWeight = FontWeight.SemiBold,
+        textAlign = TextAlign.Center, modifier = Modifier.padding(vertical = 14.dp).fillMaxWidth())
+  }
+}
+
+@Suppress("DEPRECATION")
+private fun localIp(context: Context): String = runCatching {
+  val wm = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+  val ip = wm.connectionInfo.ipAddress
+  if (ip == 0) "" else String.format("%d.%d.%d.%d",
+      ip and 0xff, (ip shr 8) and 0xff, (ip shr 16) and 0xff, (ip shr 24) and 0xff)
+}.getOrDefault("")

--- a/app/src/main/java/com/immortal/launcher/LanAudio.kt
+++ b/app/src/main/java/com/immortal/launcher/LanAudio.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioRecord
+import android.media.AudioTrack
+import android.media.MediaRecorder
+import android.util.Log
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+
+/**
+ * A dependency-free, server-less LAN audio link for the Portal-to-Portal intercom /
+ * baby monitor. One device [broadcasts][startBroadcast] (mic → TCP), another
+ * [listens][startListening] (TCP → speaker). Raw 16-bit mono PCM at 16 kHz over a
+ * plain TCP socket on the local network — no signalling server, no GMS, no library.
+ *
+ * Uses the handset mic (RECORD_AUDIO); the far-field array needs a Meta-signed
+ * permission Immortal can't hold, but the handset mic is fine for a monitor.
+ */
+class LanAudio {
+  private val TAG = "ImmortalIntercom"
+  // Distinct from FleetConfig.DEFAULT_PORT (8723): on provisioned/remote-paired
+  // devices FleetAgentService already binds that port at launch, so reusing it
+  // here would make ServerSocket(PORT) in startBroadcast() fail to bind.
+  val PORT = 8724
+  private val SAMPLE_RATE = 16000
+
+  @Volatile private var running = false
+  private var serverThread: Thread? = null
+  private var clientThread: Thread? = null
+  private var serverSocket: ServerSocket? = null
+  private var clientSocket: Socket? = null
+
+  val isActive: Boolean get() = running
+
+  /** Capture the mic and stream it to every device that connects to this port.
+   * [onState] reports whether the listening socket bound, so the UI doesn't claim
+   * it's broadcasting when the port couldn't be opened (e.g. already in use). */
+  fun startBroadcast(onState: (Boolean) -> Unit = {}) {
+    stop()
+    running = true
+    serverThread = Thread {
+      val server = runCatching { ServerSocket(PORT) }
+          .onFailure { Log.w(TAG, "broadcast bind failed on :$PORT", it) }
+          .getOrNull()
+      if (server == null) {
+        running = false
+        onState(false)
+        return@Thread
+      }
+      serverSocket = server
+      onState(true)
+      runCatching {
+        server.soTimeout = 0
+        while (running) {
+          val socket = runCatching { server.accept() }.getOrNull() ?: continue
+          // Serve each listener on its own short-lived thread.
+          Thread { runCatching { pumpMicTo(socket.getOutputStream()) }.also { socket.close() } }
+              .apply { isDaemon = true; start() }
+        }
+      }.onFailure { Log.w(TAG, "broadcast failed", it) }
+    }.also { it.isDaemon = true; it.start() }
+  }
+
+  private fun pumpMicTo(out: OutputStream) {
+    val minBuf = AudioRecord.getMinBufferSize(
+        SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT)
+    val rec = AudioRecord(
+        MediaRecorder.AudioSource.MIC, SAMPLE_RATE,
+        AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT, maxOf(minBuf, 4096))
+    runCatching {
+      rec.startRecording()
+      val buf = ByteArray(2048)
+      while (running) {
+        val n = rec.read(buf, 0, buf.size)
+        if (n > 0) out.write(buf, 0, n) else break
+      }
+    }.onFailure { Log.w(TAG, "mic pump ended", it) }
+    runCatching { rec.stop() }; runCatching { rec.release() }
+  }
+
+  /** Connect to [host] and play whatever audio it streams. [onState] reports connect
+   * success/failure so the UI can show status. */
+  fun startListening(host: String, onState: (Boolean) -> Unit) {
+    stop()
+    running = true
+    clientThread = Thread {
+      val ok = runCatching {
+        val socket = Socket()
+        socket.connect(InetSocketAddress(host, PORT), 5000)
+        clientSocket = socket
+        true
+      }.getOrDefault(false)
+      onState(ok)
+      if (ok) runCatching { playFrom(clientSocket!!.getInputStream()) }
+          .onFailure { Log.w(TAG, "listen ended", it) }
+    }.also { it.isDaemon = true; it.start() }
+  }
+
+  private fun playFrom(input: InputStream) {
+    val minBuf = AudioTrack.getMinBufferSize(
+        SAMPLE_RATE, AudioFormat.CHANNEL_OUT_MONO, AudioFormat.ENCODING_PCM_16BIT)
+    val track = AudioTrack.Builder()
+        .setAudioAttributes(
+            AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH).build())
+        .setAudioFormat(
+            AudioFormat.Builder()
+                .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                .setSampleRate(SAMPLE_RATE)
+                .setChannelMask(AudioFormat.CHANNEL_OUT_MONO).build())
+        .setBufferSizeInBytes(maxOf(minBuf, 4096))
+        .setTransferMode(AudioTrack.MODE_STREAM).build()
+    runCatching {
+      track.play()
+      val buf = ByteArray(2048)
+      while (running) {
+        val n = input.read(buf)
+        if (n > 0) track.write(buf, 0, n) else break
+      }
+    }
+    runCatching { track.stop() }; runCatching { track.release() }
+  }
+
+  /** Stop broadcasting/listening and release sockets. Idempotent. */
+  fun stop() {
+    running = false
+    runCatching { serverSocket?.close() }; serverSocket = null
+    runCatching { clientSocket?.close() }; clientSocket = null
+    serverThread = null
+    clientThread = null
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/PingService.kt
+++ b/app/src/main/java/com/immortal/launcher/PingService.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.util.Log
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import kotlin.concurrent.thread
+
+/**
+ * "Ping the other room" — light up another Portal from this one with a tone, contact-free
+ * and server-free. A tiny UDP listener on every Immortal device waits for a broadcast
+ * ping on the LAN; when one arrives it plays the chime and speaks who sent it. No dialer,
+ * no accounts, nothing to sign in to — just a doorbell between rooms on your Wi-Fi.
+ *
+ * Started from [ImmortalApp]. [send] fires a one-off broadcast from the Ping tile.
+ */
+object PingService {
+
+  private const val TAG = "ImmortalPing"
+  private const val PORT = 50121
+  private const val MAGIC = "IMMORTAL_PING/1"
+
+  @Volatile private var socket: DatagramSocket? = null
+  @Volatile private var running = false
+  private var multicastLock: android.net.wifi.WifiManager.MulticastLock? = null
+
+  /** Begin listening for pings (idempotent). */
+  fun start(context: Context) {
+    if (running) return
+    running = true
+    val app = context.applicationContext
+    // Wi-Fi hardware filters out broadcast/multicast frames unless a lock is held, so
+    // without this the listener would simply never receive a ping on most devices.
+    runCatching {
+      val wifi = app.getSystemService(Context.WIFI_SERVICE) as android.net.wifi.WifiManager
+      multicastLock = wifi.createMulticastLock("immortal-ping").apply {
+        setReferenceCounted(false)
+        acquire()
+      }
+    }.onFailure { Log.w(TAG, "multicast lock failed (broadcast receive may not work)", it) }
+    thread(name = "immortal-ping-listener", isDaemon = true) {
+      runCatching {
+            val s = DatagramSocket(PORT).apply { broadcast = true; reuseAddress = true }
+            socket = s
+            val buf = ByteArray(256)
+            while (running) {
+              val pkt = DatagramPacket(buf, buf.size)
+              s.receive(pkt) // blocks
+              val msg = String(pkt.data, 0, pkt.length, Charsets.UTF_8)
+              if (msg.startsWith(MAGIC)) {
+                val sender = msg.substringAfter('|', "").take(40).ifBlank { "Someone" }
+                onPing(app, sender)
+              }
+            }
+          }
+          .onFailure { Log.w(TAG, "ping listener stopped", it) }
+    }
+  }
+
+  private fun onPing(context: Context, sender: String) {
+    runCatching {
+      ChimePlayer.playPing(context, repeats = 2)
+      ChimePlayer.announce(context, "$sender is calling")
+    }
+  }
+
+  /** Broadcast a ping to the LAN. [name] is shown/spoken on the receiving devices. */
+  fun send(context: Context, name: String) {
+    thread(name = "immortal-ping-send", isDaemon = true) {
+      runCatching {
+        DatagramSocket().use { s ->
+          s.broadcast = true
+          val payload = "$MAGIC|${name.take(40)}".toByteArray(Charsets.UTF_8)
+          val addr = InetAddress.getByName("255.255.255.255")
+          // A couple of repeats in case a frame is dropped.
+          repeat(3) {
+            s.send(DatagramPacket(payload, payload.size, addr, PORT))
+            Thread.sleep(120)
+          }
+        }
+      }.onFailure { Log.w(TAG, "ping send failed", it) }
+    }
+  }
+}


### PR DESCRIPTION
Re-lands #116 rebased onto current main (past #113/#114/#117). GodricTM's commit cherry-picked onto main; applied cleanly.

A one-way LAN intercom / baby monitor: one Portal broadcasts its mic (raw PCM over TCP to the broadcaster's address), another listens; plus a "ping the other room" chime via the merged `ChimePlayer`. `IntercomActivity` + `LanAudio` + `PingService`. Manifest adds `IntercomActivity` and `ACCESS_WIFI_STATE` / `CHANGE_WIFI_MULTICAST_STATE` / `MODIFY_AUDIO_SETTINGS` (`RECORD_AUDIO` already declared). The port-8723 collision flagged earlier is fixed (uses 8724 with a bind-failure callback).

Security review: broadcasting is user-initiated (explicit button + runtime `RECORD_AUDIO` prompt, clearly labeled "Broadcasting this room's audio"), LAN-only, no cloud/GMS. Known limitation for a future hardening pass: the stream is unauthenticated, so anyone on the same Wi-Fi who connects to the port during a broadcast can listen — typical for a simple LAN intercom, but a pairing token would be a good follow-up.

Verified: `:app:assembleDebug` + `:app:testDebugUnitTest` green (259 tests, 0 failures). Supersedes #116.

Co-authored-by: GodricTM <GodricTM@users.noreply.github.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4SmhtgSd5B5sdTiV216XM)_