### PR TITLE
Audit follow-up: config-registration tripwire + native integration spec

### DIFF
--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -386,4 +386,72 @@ class SettingsDomainTest {
       assertNull("enum '$key' must skip an unrecognised value", spec.coerce("not-a-real-value"))
     }
   }
+
+  @Test
+  fun everyPersistedConfig_isRegisteredAsADomain_orExplicitlyExcepted() {
+    // The per-domain tripwires above only fire for Configs that ARE registered — nothing forced a
+    // NEW *Config to be wired into the registry at all, which is how CameraConfig/TimerConfig/
+    // CountdownConfig/NotesConfig shipped with no on-device UI and no phone-remote exposure. This is
+    // the global gate: every *Config in the launcher source is either backed by a SettingsDomain
+    // (so the declarative registry renders it on-device AND on the remote for free) or is listed
+    // below with a reason. Adding a *Config without doing one of those turns this test red.
+    val dir = findLauncherSourceDir()
+    val configs =
+        (dir.listFiles { f -> f.name.endsWith("Config.kt") } ?: arrayOf())
+            .map { it.name.removeSuffix(".kt") }
+            .toSet()
+
+    // Scalar user settings that flow through a registered SettingsDomain (on-device + remote).
+    val registeredAsDomain =
+        setOf(
+            "ScreensaverConfig",
+            "ChimeConfig",
+            "DigitalClockConfig",
+            "WelcomeConfig",
+            "SunriseConfig",
+            "QuickBarConfig",
+            // Context-typed domains (no aggregate Settings class); pinned by their own tests above.
+            "MqttConfig",
+            "FleetConfig",
+        )
+
+    // Deliberately NOT scalar domains: collections of user-created entries, or user content, edited
+    // in their own Activity. The registry models scalars — a GroupSpec is the planned remote home
+    // (see docs/design/feature-integration.md). Each STILL must be reachable from a home tile /
+    // NavSpec; that reachability is enforced by the integration work, not by this unit test.
+    val exemptCollectionsOrContent =
+        mapOf(
+            "CameraConfig" to "collection: saved RTSP cameras (CameraViewerActivity)",
+            "TimerConfig" to "collection: kitchen timer instances (home chips)",
+            "CountdownConfig" to "collection: countdown events (CountdownSettingsActivity)",
+            "NotesConfig" to "user content: sticky / voice note (AudioNote)",
+        )
+
+    val classified = registeredAsDomain + exemptCollectionsOrContent.keys
+    val unclassified = configs - classified
+    assertTrue(
+        "Persisted *Config with no registry home and no documented exception: $unclassified. " +
+            "Either register a SettingsDomain (renders on-device + on the phone remote), or add it " +
+            "to exemptCollectionsOrContent with a reason and wire a tile/NavSpec to reach it.",
+        unclassified.isEmpty())
+    val stale = classified - configs
+    assertTrue(
+        "Config-registration tripwire lists names with no matching *Config.kt (renamed/removed?): $stale",
+        stale.isEmpty())
+  }
+
+  /** Locate `.../com/immortal/launcher` from whatever working dir the test runner uses. */
+  private fun findLauncherSourceDir(): java.io.File {
+    val rel = "src/main/java/com/immortal/launcher"
+    var base: java.io.File? = java.io.File("").absoluteFile
+    repeat(6) {
+      val b = base ?: return@repeat
+      for (cand in listOf(java.io.File(b, rel), java.io.File(b, "app/$rel"))) {
+        if (cand.isDirectory) return cand
+      }
+      base = b.parentFile
+    }
+    throw IllegalStateException(
+        "could not locate $rel from ${java.io.File("").absolutePath}")
+  }
 }

--- a/docs/design/feature-integration.md
+++ b/docs/design/feature-integration.md
@@ -1,0 +1,90 @@
+# Native feature integration
+
+How the fork feature set merged since Release 1.52 should be wired into Immortal so users can
+actually reach and configure it. This is the plan of record; it supersedes the deferred
+"integration PR / ForkHome" approach.
+
+## Why this doc exists
+
+The features landed as self-contained PRs, but their **entry points were deferred**. On a real
+device today, most of them are unreachable: no home tile launches the tool Activities, and the
+settings menu has no link to the new settings Activities. The registry code inside each feature is
+mostly correct — the gap is purely *integration*.
+
+## Why not ForkHome
+
+`ForkHome` (from the original #85) is a ~3,200-line **parallel home screen**: its own grid, its own
+tool-folders, dashboard pages, chips, and widgets. It re-implements subsystems Immortal already
+has. Adopting it would duplicate the home grid and re-introduce a second navigation model — the
+opposite of the guidance in `AGENTS.md` ("reuse existing subsystems"; "one nav model — Activities").
+
+We integrate the **Immortal-native** way instead, and borrow ForkHome's good *ideas* (ambient
+dashboard, timer/countdown chips, a status strip) into the existing subsystems over time — not the
+monolith. Same call we made on the portal-wake wake-word app: take the design, not the second app.
+
+## The two surfaces that own integration
+
+1. **Settings → the declarative registry** (`settings/`). A `SettingSpec` defined once drives the
+   on-device UI, the phone remote, and persistence. Rich sub-screens hang off a domain via a
+   `NavSpec` (renders as a nav row → Activity). The registry **models scalars**; collections and
+   free content live in their own Activity (a `GroupSpec` is their planned remote home).
+2. **Launching tools → the unified home grid** (`HomeActivity`). It already supports built-in tiles
+   (`BUILTIN_CALLS`/`STORE`/`UPDATES`), widgets, **folders** (`Curation`/`UserLayout`/`HomeGrid`),
+   and drag-reordering. New tool Activities become **built-in tiles**, grouped by default into a
+   **"Tools" folder** — the native analog of ForkHome's tool-folders, with zero new home code.
+
+## Per-feature plan
+
+| Feature | Kind | Reach it via | Remote |
+|---|---|---|---|
+| Chimes (`chime`) | scalar settings | `NavSpec` "Sounds" row → `ChimeSettingsActivity` | ✅ domain |
+| Digital clock (`digitalclock`) | screensaver | screensaver **Dream picker** + `NavSpec` → `ClockSettingsActivity` | ✅ domain |
+| Welcome overlay (`welcome`) | scalar settings | `NavSpec` in screensaver settings → `WelcomeSettingsActivity` | ✅ domain |
+| Sleep (`screensaver` fields) | scalar settings | `NavRow` in screensaver/immortal settings → `SleepSettingsActivity` | ✅ domain |
+| Sunrise / wake-light (`sunrise`) | scalar settings | `NavSpec` "Wake-up light" row → `SunriseSettingsActivity` | ✅ domain |
+| Back-gesture (#99) | service | `BoolSpec` toggle in `immortal` that deep-links Accessibility settings | ✅ domain |
+| SystemSounds | scalar | `BoolSpec` in `immortal`/`screensaver` | ✅ domain |
+| RTSP cameras | **collection** | Tools tile → `CameraViewerActivity` (list + add) | later: `GroupSpec` |
+| Kitchen timers | **collection** | Tools tile / home chip → timer UI | later: `GroupSpec` |
+| Countdowns | **collection** | Tools tile / `NavSpec` → `CountdownSettingsActivity` | later: `GroupSpec` |
+| Voice notes | **content** | Tools tile → `AudioNote` UI | n/a |
+| Lamp | action | Tools tile → `LampActivity` | n/a |
+| Bedtime stories | action | Tools tile → `BedtimeStoryActivity` | n/a |
+| Intercom / ping | action | Tools tile → `IntercomActivity` | n/a |
+| Wake-light overlay | auto (alarm) | fired by `SunriseReceiver` — no tile needed | n/a |
+| Almanac packs (feast/name days, prayer, transit, daily content) | data | ambient dashboard on the photo frame; toggles in `screensaver` | via screensaver |
+| Sky tools (ISS, aurora, starfield, sky colours) | background/data | render behind the grid / on the frame; toggles in `screensaver` | via screensaver |
+| Converter | tool | Tools tile → converter Activity | n/a |
+
+## The "Tools" folder
+
+Extend the home grid with a small registry of built-in **tool tiles** (a `TOOL_KEY` prefix, mirroring
+`BUILTIN_*`), dispatched in `HomeActivity`'s tile `when(key)` to `startActivity` each tool. Curate
+them into a default **"Tools"** folder (same mechanism as the existing "Settings" folder in
+`Curation.folders`) so they stay tidy but remain reorderable and removable via the existing layout
+system. No new grid, no `ForkHome`.
+
+## Registry guardrail (done)
+
+`SettingsDomainTest.everyPersistedConfig_isRegisteredAsADomain_orExplicitlyExcepted` now fails the
+build if a new `*Config` is neither backed by a `SettingsDomain` nor listed as a documented
+collection/content exception. This is the check that would have caught Camera/Timer/Countdown/Notes
+shipping with no registry home.
+
+## Sequencing (small PRs, in order)
+
+1. **This PR** — the global tripwire + this doc.
+2. **Settings reachability** — `NavSpec`/`NavRow` entries for Chime, Clock, Welcome, Sleep, Sunrise
+   (they're already registry domains; they just need to be linked). Smallest, highest-value.
+3. **Tools folder + tiles** — Camera, Timers, Countdowns, Notes, Lamp, Bedtime, Intercom, Converter.
+4. **Screensaver Dream picker** — surface the digital-clock Dream alongside the photo frame.
+5. **Ambient dashboard** — surface the almanac/sky content on the frame (borrow the ForkHome idea).
+6. **Toggles** — back-gesture enable, SystemSounds.
+
+Each step is independently shippable and testable. None require `ForkHome`.
+
+## Release gate
+
+Do not cut a release until at least steps 2–3 land — otherwise the merged features ship dark on the
+device (they are reachable on the phone remote for the registered scalar domains, but not on the
+Portal itself).


### PR DESCRIPTION
## Context

An audit of everything merged since Release 1.52 found that the fork feature set is largely **unreachable on-device** — the settings-menu links and home-screen launch points were deferred and never landed. The registry code inside each feature is mostly fine; the gap is integration. This PR adds two durable guardrails and the plan of record. It does **not** wire the features up yet (that's the sequenced work in the spec).

## What's here

**1. Global config-registration tripwire** (`SettingsDomainTest`)
The existing per-domain tripwires only fire for Configs that are *already* registered — nothing forced a **new** `*Config` into the registry. That's how `CameraConfig` / `TimerConfig` / `CountdownConfig` / `NotesConfig` shipped with no on-device UI and no phone-remote exposure. The new test fails the build unless every `*Config` is either backed by a `SettingsDomain` or listed as a documented collection/content exception.

**2. `docs/design/feature-integration.md`** — the plan of record for wiring these features in the **Immortal-native** way:
- **Settings** → the declarative registry (`NavSpec`/`NavRow` to the already-registered domains; `GroupSpec` later for the collection-style ones).
- **Launching tools** → the existing unified home grid as built-in tiles, grouped into a **"Tools" folder** (the `Curation` mechanism already used for the "Settings" folder).
- Explicitly **in place of** adopting the fork's ~3,200-line parallel `ForkHome` screen, which would duplicate the home grid and re-introduce a second nav model (against `AGENTS.md`). Borrow ForkHome's UX ideas, not the monolith.

A key correction the audit surfaced: Camera/Timer/Countdown are **collections** (`List<…>`) and Notes is **content**, not scalar settings — so they correctly should *not* be forced into scalar domains; they need reachable Activities (tiles), with `GroupSpec` as the eventual remote home.

## Verification
- `:app:testDebugUnitTest` — 260 tests, 0 failures (incl. the new tripwire).
- `mkdocs build --strict` builds clean.

## Note on the release gate
The spec recommends holding the next release until the settings-reachability + Tools-folder steps land, since the features otherwise ship dark on the Portal itself (they *are* reachable via the phone remote for the registered scalar domains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4SmhtgSd5B5sdTiV216XM)_