### PR TITLE
Tools tile + Tools screen for the launch-only features

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -237,6 +237,13 @@
             android:excludeFromRecents="true"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- "Tools": launcher screen for the in-process tool Activities, opened from the home tile. -->
+        <activity
+            android:name=".ToolsActivity"
+            android:exported="false"
+            android:label="Tools"
+            android:theme="@style/Theme.SampleApp" />
+
         <!-- "Cameras": RTSP/network camera viewer (VideoView, native RTSP). -->
         <activity
             android:name=".CameraViewerActivity"

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -602,6 +602,7 @@ private fun LauncherScreen(
         buildList {
           add(BUILTIN_CALLS)
           add(BUILTIN_STORE)
+          add(BUILTIN_TOOLS)
           widgets.forEach { add(WIDGET_KEY + it.key) }
           folderNames.forEach { add(FOLDER_KEY + it) }
           ungrouped.forEach { add(APP_KEY + it.component.packageName) }
@@ -957,6 +958,12 @@ private fun LauncherScreen(
                     HomeTileFrame(boundsMod, isDragged) { PortalHomeTile(onExitHome) }
                 key == BUILTIN_STORE ->
                     HomeTileFrame(boundsMod, isDragged) { StoreTile(onOpenStore) }
+                key == BUILTIN_TOOLS ->
+                    HomeTileFrame(boundsMod, isDragged) {
+                      ToolsTile {
+                        context.startActivity(Intent(context, ToolsActivity::class.java))
+                      }
+                    }
                 key == BUILTIN_UPDATES ->
                     HomeTileFrame(boundsMod, isDragged) {
                       UpdatesTile(update = update, status = updateStatus) {
@@ -1251,6 +1258,7 @@ private const val FOLDER_KEY = "folder:"
 private const val WIDGET_KEY = "widget-tile:"
 private const val BUILTIN_CALLS = "builtin:calls"
 private const val BUILTIN_STORE = "builtin:store"
+private const val BUILTIN_TOOLS = "builtin:tools"
 private const val BUILTIN_UPDATES = "builtin:updates"
 
 private const val UPDATE_CHECK_INTERVAL_MS = 6L * 60 * 60 * 1000 // 6 hours
@@ -2363,6 +2371,16 @@ private fun StoreTile(onClick: () -> Unit) {
       label = "App Store",
       background = Color(0xFF2D6CDF),
       glyph = ICON_DOWNLOAD,
+      onClick = onClick,
+  )
+}
+
+@Composable
+private fun ToolsTile(onClick: () -> Unit) {
+  BuiltInTile(
+      label = "Tools",
+      background = Color(0xFF5A5F6A),
+      glyph = ICON_WIDGETS,
       onClick = onClick,
   )
 }

--- a/app/src/main/java/com/immortal/launcher/ToolsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ToolsActivity.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.ui.theme.SampleAppTheme
+
+/**
+ * The "Tools" screen, opened from the built-in Tools tile on the home grid. A plain launcher for the
+ * in-process tool Activities that don't each warrant their own home tile. See
+ * docs/design/feature-integration.md (step 3).
+ *
+ * Only tools with a real, launchable Activity are listed. Timers, voice notes, and the unit
+ * converter shipped as data/logic with no screen (their UI lived in the unmerged ForkHome), so they
+ * are intentionally absent until their Activities are built.
+ */
+class ToolsActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { ToolsScreen() } }
+  }
+}
+
+@Composable
+private fun ToolsScreen() {
+  val context = LocalContext.current
+  val activity = context as? Activity
+  val firstFocus = remember { FocusRequester() }
+  LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .onPreviewKeyEvent { e ->
+                if (e.key == Key.Back) {
+                  if (e.type == KeyEventType.KeyUp) activity?.finish()
+                  true
+                } else false
+              }
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp).focusRequester(firstFocus).focusGroup()) {
+      Text("Tools", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+      Text(
+          "Extra utilities for your Portal.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+      Spacer(Modifier.size(26.dp))
+      Card {
+        ToolRow("Cameras", "View a saved RTSP camera feed") {
+          context.startActivity(Intent(context, CameraViewerActivity::class.java))
+        }
+        ToolRow("Countdowns", "Days until birthdays and events") {
+          context.startActivity(Intent(context, CountdownSettingsActivity::class.java))
+        }
+        ToolRow("Lamp", "A full-screen warm-white light") {
+          context.startActivity(Intent(context, LampActivity::class.java))
+        }
+        ToolRow("Bedtime story", "Public-domain tales read aloud") {
+          context.startActivity(Intent(context, BedtimeStoryActivity::class.java))
+        }
+        ToolRow("Intercom", "Talk to another Portal on your Wi-Fi") {
+          context.startActivity(Intent(context, IntercomActivity::class.java))
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun ToolRow(title: String, subtitle: String, onOpen: () -> Unit) {
+  Row(
+      modifier = Modifier.fillMaxWidth().tvFocusableRow { onOpen() }.padding(18.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Column(modifier = Modifier.weight(1f)) {
+      Text(title, color = Color.White, fontSize = 17.sp)
+      Text(
+          subtitle,
+          color = Color(0xFF9A9A9A),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 2.dp),
+      )
+    }
+    Text("›", color = Color(0xFF7C7C7C), fontSize = 26.sp)
+  }
+}


### PR DESCRIPTION
Step 3 of `docs/design/feature-integration.md`. **Please give this an on-device check before merging** — it touches the home grid, which unit tests don't cover (layout, drag, the reconciler placing the new tile).

## Problem
The tool features (camera viewer, countdowns, lamp, bedtime story, intercom) had no on-device entry point — no home tile, no menu. They were reachable by nothing.

## Approach (per our discussion)
The existing folder system only holds installed apps (folders are keyed by package), so seeding a literal "Tools folder" via `Curation` isn't possible without refactoring the grid to hold non-app tiles. Instead: **one built-in "Tools" tile** (exactly like Calls/Store/Updates) that opens a `ToolsActivity` launcher screen. Same "one tidy Tools grouping" intent, no risky grid surgery.

- `HomeActivity`: a `BUILTIN_TOOLS` tile (`BuiltInTile`, `ICON_WIDGETS`) placed between Store and the app tiles. The existing grid reconciler (#88) appends it to saved layouts, and it's fully drag/reorder/remove-able like any tile.
- `ToolsActivity`: a themed launcher listing the five tools that have a real Activity, using the standard settings-screen scaffold (dark theme, TV focus, back handling).

## Intentionally omitted
**Timers, voice notes, and the unit converter are not listed** — they shipped as data/logic with **no screen** (their UI lived in the unmerged `ForkHome`, e.g. the `AddTimerOverlay`). They need their own Activities built before they can get a Tools entry. Flagging as a known follow-up.

## Verification
- `:app:assembleDebug` + `:app:testDebugUnitTest` green (260 tests), APK builds.
- On-device check still wanted: does the Tools tile appear/drag correctly, and does each tool open?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4SmhtgSd5B5sdTiV216XM)_