### PR TITLE
Tools: ISS passes + aurora outlook (in-page overlays)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -237,6 +237,13 @@
             android:excludeFromRecents="true"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- "Tools": launcher screen for the in-process tool Activities, opened from the home tile. -->
+        <activity
+            android:name=".ToolsActivity"
+            android:exported="false"
+            android:label="Tools"
+            android:theme="@style/Theme.SampleApp" />
+
         <!-- "Cameras": RTSP/network camera viewer (VideoView, native RTSP). -->
         <activity
             android:name=".CameraViewerActivity"

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -602,6 +602,7 @@ private fun LauncherScreen(
         buildList {
           add(BUILTIN_CALLS)
           add(BUILTIN_STORE)
+          add(BUILTIN_TOOLS)
           widgets.forEach { add(WIDGET_KEY + it.key) }
           folderNames.forEach { add(FOLDER_KEY + it) }
           ungrouped.forEach { add(APP_KEY + it.component.packageName) }
@@ -957,6 +958,12 @@ private fun LauncherScreen(
                     HomeTileFrame(boundsMod, isDragged) { PortalHomeTile(onExitHome) }
                 key == BUILTIN_STORE ->
                     HomeTileFrame(boundsMod, isDragged) { StoreTile(onOpenStore) }
+                key == BUILTIN_TOOLS ->
+                    HomeTileFrame(boundsMod, isDragged) {
+                      ToolsTile {
+                        context.startActivity(Intent(context, ToolsActivity::class.java))
+                      }
+                    }
                 key == BUILTIN_UPDATES ->
                     HomeTileFrame(boundsMod, isDragged) {
                       UpdatesTile(update = update, status = updateStatus) {
@@ -1251,6 +1258,7 @@ private const val FOLDER_KEY = "folder:"
 private const val WIDGET_KEY = "widget-tile:"
 private const val BUILTIN_CALLS = "builtin:calls"
 private const val BUILTIN_STORE = "builtin:store"
+private const val BUILTIN_TOOLS = "builtin:tools"
 private const val BUILTIN_UPDATES = "builtin:updates"
 
 private const val UPDATE_CHECK_INTERVAL_MS = 6L * 60 * 60 * 1000 // 6 hours
@@ -2363,6 +2371,16 @@ private fun StoreTile(onClick: () -> Unit) {
       label = "App Store",
       background = Color(0xFF2D6CDF),
       glyph = ICON_DOWNLOAD,
+      onClick = onClick,
+  )
+}
+
+@Composable
+private fun ToolsTile(onClick: () -> Unit) {
+  BuiltInTile(
+      label = "Tools",
+      background = Color(0xFF5A5F6A),
+      glyph = ICON_WIDGETS,
       onClick = onClick,
   )
 }

--- a/app/src/main/java/com/immortal/launcher/HomeToolOverlays.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeToolOverlays.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * In-page overlays for the sky/space tools whose logic already landed but whose UI formerly lived
+ * only in ForkHome ([IssPasses], [Aurora]). Hosted full-page by [ToolsActivity] — each is a centered
+ * card over a scrim, with an `onDismiss` back to the Tools list. This file holds only rendering; the
+ * computation lives in the matching object. More tools (converter, timers, notes, day/year, speed
+ * test) hook into the same scaffolding in follow-up changes.
+ */
+
+/* ------------------------------------------------------------------ ISS passes */
+
+@Composable
+internal fun IssOverlay(onDismiss: () -> Unit) {
+  val context = LocalContext.current
+  var passes by remember { mutableStateOf<List<IssPasses.Pass>?>(null) }
+  LaunchedEffect(Unit) { passes = withContext(Dispatchers.IO) { IssPasses.predict(context) } }
+
+  BackHandler { onDismiss() }
+  Scrim(onDismiss) {
+    ToolCard {
+      Text("🛰️ Space station overhead", color = Color.White, fontSize = 22.sp, fontWeight = FontWeight.Bold)
+      val p = passes
+      when {
+        p == null -> Text("Finding passes…", color = Color(0xFFB0B0B0), fontSize = 16.sp)
+        p.isEmpty() ->
+            Text(
+                "No passes found. Check the device is online so it can fetch the latest orbit, " +
+                    "and that your location is set (it follows the weather tile).",
+                color = Color(0xFFB0B0B0),
+                fontSize = 15.sp,
+            )
+        else -> {
+          val first = p.first()
+          Text(
+              buildString {
+                append(if (first.visible) "Visible pass " else "Passes over ")
+                append(IssPasses.timeLabel(first.startMillis))
+                append(if (first.visible) " ✨" else "")
+              },
+              color = if (first.visible) Color(0xFFFFD54F) else Color.White,
+              fontSize = 17.sp,
+              fontWeight = FontWeight.SemiBold,
+          )
+          Column(
+              modifier = Modifier.fillMaxWidth().heightIn(max = 320.dp).verticalScroll(rememberScrollState()),
+              verticalArrangement = Arrangement.spacedBy(10.dp),
+          ) {
+            p.forEach { pass ->
+              Surface(color = Color(0x18FFFFFF), shape = RoundedCornerShape(12.dp), modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+                  Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(IssPasses.timeLabel(pass.startMillis), color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                    if (pass.visible) {
+                      Surface(color = Color(0x33FFD54F), shape = RoundedCornerShape(8.dp)) {
+                        Text("✨ visible", color = Color(0xFFFFD54F), fontSize = 13.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp))
+                      }
+                    }
+                  }
+                  Text(
+                      "Rises ${pass.startDir} · peak ${pass.maxElevationDeg}° to the ${pass.peakDir} · sets ${pass.endDir}",
+                      color = Color(0xFFB8B8B8),
+                      fontSize = 14.sp,
+                  )
+                }
+              }
+            }
+          }
+          Text(
+              "Times are local. ✨ means it should be bright enough to see — go outside and look up to the listed direction.",
+              color = Color(0xFF8A8A8A),
+              fontSize = 12.sp,
+          )
+        }
+      }
+      CloseButton("Close", onDismiss)
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ Aurora */
+
+@Composable
+internal fun AuroraOverlay(onDismiss: () -> Unit) {
+  val context = LocalContext.current
+  var status by remember { mutableStateOf<Aurora.Status?>(null) }
+  var loaded by remember { mutableStateOf(false) }
+  LaunchedEffect(Unit) {
+    status = withContext(Dispatchers.IO) { Aurora.status(context) }
+    loaded = true
+  }
+
+  BackHandler { onDismiss() }
+  Scrim(onDismiss) {
+    ToolCard {
+      Text("🌌 Aurora outlook", color = Color.White, fontSize = 22.sp, fontWeight = FontWeight.Bold)
+      val st = status
+      when {
+        !loaded -> Text("Checking the K-index…", color = Color(0xFFB0B0B0), fontSize = 16.sp)
+        st == null ->
+            Text(
+                "Couldn't fetch the K-index. Check the device is online and that your location is " +
+                    "set (it follows the weather tile).",
+                color = Color(0xFFB0B0B0),
+                fontSize = 15.sp,
+            )
+        else -> {
+          val accent =
+              when (st.chance) {
+                Aurora.Chance.LIKELY -> Color(0xFF69F0AE)
+                Aurora.Chance.POSSIBLE -> Color(0xFFB9F6CA)
+                Aurora.Chance.SLIM -> Color(0xFFB0BEC5)
+                Aurora.Chance.NONE -> Color(0xFF90A4AE)
+              }
+          Text(st.headline, color = accent, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+          Text(st.detail, color = Color(0xFFCFCFCF), fontSize = 15.sp, lineHeight = 21.sp)
+          Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+            AuroraStat("Kp now", Aurora.fmtKp(st.kpNow), Modifier.weight(1f))
+            AuroraStat("Next 24 h peak", Aurora.fmtKp(st.kpForecast), Modifier.weight(1f))
+            AuroraStat("Look", st.lookToward, Modifier.weight(1f))
+          }
+          Text(
+              "Source: NOAA SWPC planetary K-index. Best after dark, away from city lights, with a " +
+                  "clear ${if (st.lookToward == "N") "northern" else "southern"} horizon.",
+              color = Color(0xFF8A8A8A),
+              fontSize = 12.sp,
+          )
+        }
+      }
+      CloseButton("Close", onDismiss)
+    }
+  }
+}
+
+@Composable
+private fun AuroraStat(label: String, value: String, modifier: Modifier = Modifier) {
+  Surface(color = Color(0x18FFFFFF), shape = RoundedCornerShape(12.dp), modifier = modifier) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(vertical = 10.dp).fillMaxWidth()) {
+      Text(value, color = Color.White, fontSize = 20.sp, fontWeight = FontWeight.Bold)
+      Text(label, color = Color(0xFF9A9A9A), fontSize = 12.sp, textAlign = TextAlign.Center)
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ shared scaffolding */
+
+/** Full-screen scrim over the home page; tapping outside the card dismisses. */
+@Composable
+internal fun Scrim(onDismiss: () -> Unit, content: @Composable () -> Unit) {
+  Box(
+      contentAlignment = Alignment.Center,
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Color(0xCC000000))
+              .tvFocusable(RoundedCornerShape(0.dp), focusScale = 1f) { onDismiss() },
+  ) {
+    content()
+  }
+}
+
+/** The standard tool card: a rounded surface with a vertically-scrolling padded column. */
+@Composable
+internal fun ToolCard(maxWidth: Int = 560, content: @Composable () -> Unit) {
+  Surface(
+      color = MaterialTheme.colorScheme.surface,
+      shape = RoundedCornerShape(24.dp),
+      modifier = Modifier.widthIn(max = maxWidth.dp).heightIn(max = 760.dp).padding(24.dp),
+  ) {
+    Column(
+        modifier = Modifier.padding(24.dp).verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+      content()
+    }
+  }
+}
+
+@Composable
+internal fun CloseButton(label: String, onClick: () -> Unit) {
+  Surface(
+      color = Color(0x22FFFFFF),
+      shape = RoundedCornerShape(14.dp),
+      modifier = Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(14.dp), focusScale = 1f) { onClick() },
+  ) {
+    Text(label, color = Color.White, fontSize = 16.sp, textAlign = TextAlign.Center, modifier = Modifier.padding(vertical = 10.dp).fillMaxWidth())
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/ToolsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ToolsActivity.kt
@@ -28,7 +28,10 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -46,23 +49,39 @@ import androidx.compose.ui.unit.sp
 import com.immortal.launcher.ui.theme.SampleAppTheme
 
 /**
- * The "Tools" screen, opened from the built-in Tools tile on the home grid. A plain launcher for the
- * in-process tool Activities that don't each warrant their own home tile. See
- * docs/design/feature-integration.md (step 3).
+ * The full-page "Tools" screen, opened from the built-in Tools tile on the home grid. A plain
+ * launcher for the in-process tool features. See docs/design/feature-integration.md (step 3).
  *
- * Only tools with a real, launchable Activity are listed. Timers, voice notes, and the unit
- * converter shipped as data/logic with no screen (their UI lived in the unmerged ForkHome), so they
- * are intentionally absent until their Activities are built.
+ * Tools that already have their own Activity (cameras, countdowns, lamp, bedtime, intercom) launch
+ * it directly. Tools whose UI formerly lived only in ForkHome open as an in-page overlay hosted here
+ * (see [HomeToolOverlays]); this change adds the sky/space pair (ISS passes, aurora outlook).
  */
 class ToolsActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContent { SampleAppTheme(darkTheme = true) { ToolsScreen() } }
+    setContent { SampleAppTheme(darkTheme = true) { ToolsRoot(::finish) } }
+  }
+}
+
+/** Which in-page tool overlay is showing over the list (or [ToolPage.LIST] for the list itself). */
+private enum class ToolPage {
+  LIST,
+  ISS,
+  AURORA,
+}
+
+@Composable
+private fun ToolsRoot(onExit: () -> Unit) {
+  var page by remember { mutableStateOf(ToolPage.LIST) }
+  when (page) {
+    ToolPage.LIST -> ToolsScreen(onExit = onExit, onOpen = { page = it })
+    ToolPage.ISS -> IssOverlay { page = ToolPage.LIST }
+    ToolPage.AURORA -> AuroraOverlay { page = ToolPage.LIST }
   }
 }
 
 @Composable
-private fun ToolsScreen() {
+private fun ToolsScreen(onExit: () -> Unit, onOpen: (ToolPage) -> Unit) {
   val context = LocalContext.current
   val activity = context as? Activity
   val firstFocus = remember { FocusRequester() }
@@ -73,7 +92,7 @@ private fun ToolsScreen() {
           Modifier.fillMaxSize()
               .onPreviewKeyEvent { e ->
                 if (e.key == Key.Back) {
-                  if (e.type == KeyEventType.KeyUp) activity?.finish()
+                  if (e.type == KeyEventType.KeyUp) onExit()
                   true
                 } else false
               }
@@ -106,6 +125,8 @@ private fun ToolsScreen() {
         ToolRow("Intercom", "Talk to another Portal on your Wi-Fi") {
           context.startActivity(Intent(context, IntercomActivity::class.java))
         }
+        ToolRow("ISS passes", "When the space station flies over") { onOpen(ToolPage.ISS) }
+        ToolRow("Aurora outlook", "Northern-lights chance for your location") { onOpen(ToolPage.AURORA) }
       }
     }
   }

--- a/app/src/main/java/com/immortal/launcher/ToolsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ToolsActivity.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.ui.theme.SampleAppTheme
+
+/**
+ * The "Tools" screen, opened from the built-in Tools tile on the home grid. A plain launcher for the
+ * in-process tool Activities that don't each warrant their own home tile. See
+ * docs/design/feature-integration.md (step 3).
+ *
+ * Only tools with a real, launchable Activity are listed. Timers, voice notes, and the unit
+ * converter shipped as data/logic with no screen (their UI lived in the unmerged ForkHome), so they
+ * are intentionally absent until their Activities are built.
+ */
+class ToolsActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { ToolsScreen() } }
+  }
+}
+
+@Composable
+private fun ToolsScreen() {
+  val context = LocalContext.current
+  val activity = context as? Activity
+  val firstFocus = remember { FocusRequester() }
+  LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .onPreviewKeyEvent { e ->
+                if (e.key == Key.Back) {
+                  if (e.type == KeyEventType.KeyUp) activity?.finish()
+                  true
+                } else false
+              }
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp).focusRequester(firstFocus).focusGroup()) {
+      Text("Tools", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+      Text(
+          "Extra utilities for your Portal.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+      Spacer(Modifier.size(26.dp))
+      Card {
+        ToolRow("Cameras", "View a saved RTSP camera feed") {
+          context.startActivity(Intent(context, CameraViewerActivity::class.java))
+        }
+        ToolRow("Countdowns", "Days until birthdays and events") {
+          context.startActivity(Intent(context, CountdownSettingsActivity::class.java))
+        }
+        ToolRow("Lamp", "A full-screen warm-white light") {
+          context.startActivity(Intent(context, LampActivity::class.java))
+        }
+        ToolRow("Bedtime story", "Public-domain tales read aloud") {
+          context.startActivity(Intent(context, BedtimeStoryActivity::class.java))
+        }
+        ToolRow("Intercom", "Talk to another Portal on your Wi-Fi") {
+          context.startActivity(Intent(context, IntercomActivity::class.java))
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun ToolRow(title: String, subtitle: String, onOpen: () -> Unit) {
+  Row(
+      modifier = Modifier.fillMaxWidth().tvFocusableRow { onOpen() }.padding(18.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Column(modifier = Modifier.weight(1f)) {
+      Text(title, color = Color.White, fontSize = 17.sp)
+      Text(
+          subtitle,
+          color = Color(0xFF9A9A9A),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 2.dp),
+      )
+    }
+    Text("›", color = Color(0xFF7C7C7C), fontSize = 26.sp)
+  }
+}


### PR DESCRIPTION
Surfaces two tools whose logic already landed on `main` but had no on-device entry point — their UI lived only in the unmerged ForkHome: **ISS passes** (`IssPasses`) and **aurora outlook** (`Aurora`).

## Approach
Follows the native model from #121. The Tools screen gains a small `ToolPage` state machine: tapping a row for an in-page tool shows its overlay (a centered card over a scrim) hosted *inside* `ToolsActivity`, returning to the list on dismiss. Tools that already have their own Activity (cameras, countdowns, lamp, bedtime, intercom) still launch directly.

- `HomeToolOverlays.kt` (new): `IssOverlay`, `AuroraOverlay`, and the shared scaffolding (`Scrim`, `ToolCard`, `CloseButton`) that later tool overlays reuse.
- `ToolsActivity.kt`: `ToolPage` host + two new rows.

No new logic (reuses the landed `IssPasses`/`Aurora` objects), no manifest change, reuses the existing `tvFocusable`/theme scaffolding.

## Stacking
Stacks on **#121** (Tools tile + screen). Until #121 merges, this PR's diff includes its commit; I'll rebase onto `main` once it lands.

## Context
Part of re-adding, natively, the features that only lived in ForkHome (flagged on #121). Verified on device: the Tools screen lists both, each opens its card, aurora/ISS fetch and render, no fatals.

## Test
- `:app:assembleDebug` green on the #121 base.

---
_Generated with [Claude Code](https://claude.com/claude-code)_
