### PR TITLE
Tools: Cloudflare speed test

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -237,6 +237,13 @@
             android:excludeFromRecents="true"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- "Tools": launcher screen for the in-process tool Activities, opened from the home tile. -->
+        <activity
+            android:name=".ToolsActivity"
+            android:exported="false"
+            android:label="Tools"
+            android:theme="@style/Theme.SampleApp" />
+
         <!-- "Cameras": RTSP/network camera viewer (VideoView, native RTSP). -->
         <activity
             android:name=".CameraViewerActivity"

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -602,6 +602,7 @@ private fun LauncherScreen(
         buildList {
           add(BUILTIN_CALLS)
           add(BUILTIN_STORE)
+          add(BUILTIN_TOOLS)
           widgets.forEach { add(WIDGET_KEY + it.key) }
           folderNames.forEach { add(FOLDER_KEY + it) }
           ungrouped.forEach { add(APP_KEY + it.component.packageName) }
@@ -957,6 +958,12 @@ private fun LauncherScreen(
                     HomeTileFrame(boundsMod, isDragged) { PortalHomeTile(onExitHome) }
                 key == BUILTIN_STORE ->
                     HomeTileFrame(boundsMod, isDragged) { StoreTile(onOpenStore) }
+                key == BUILTIN_TOOLS ->
+                    HomeTileFrame(boundsMod, isDragged) {
+                      ToolsTile {
+                        context.startActivity(Intent(context, ToolsActivity::class.java))
+                      }
+                    }
                 key == BUILTIN_UPDATES ->
                     HomeTileFrame(boundsMod, isDragged) {
                       UpdatesTile(update = update, status = updateStatus) {
@@ -1251,6 +1258,7 @@ private const val FOLDER_KEY = "folder:"
 private const val WIDGET_KEY = "widget-tile:"
 private const val BUILTIN_CALLS = "builtin:calls"
 private const val BUILTIN_STORE = "builtin:store"
+private const val BUILTIN_TOOLS = "builtin:tools"
 private const val BUILTIN_UPDATES = "builtin:updates"
 
 private const val UPDATE_CHECK_INTERVAL_MS = 6L * 60 * 60 * 1000 // 6 hours
@@ -2363,6 +2371,16 @@ private fun StoreTile(onClick: () -> Unit) {
       label = "App Store",
       background = Color(0xFF2D6CDF),
       glyph = ICON_DOWNLOAD,
+      onClick = onClick,
+  )
+}
+
+@Composable
+private fun ToolsTile(onClick: () -> Unit) {
+  BuiltInTile(
+      label = "Tools",
+      background = Color(0xFF5A5F6A),
+      glyph = ICON_WIDGETS,
       onClick = onClick,
   )
 }

--- a/app/src/main/java/com/immortal/launcher/HomeToolOverlays.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeToolOverlays.kt
@@ -13,10 +13,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -179,6 +182,96 @@ private fun AuroraStat(label: String, value: String, modifier: Modifier = Modifi
     Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(vertical = 10.dp).fillMaxWidth()) {
       Text(value, color = Color.White, fontSize = 20.sp, fontWeight = FontWeight.Bold)
       Text(label, color = Color(0xFF9A9A9A), fontSize = 12.sp, textAlign = TextAlign.Center)
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ Speed test */
+
+@Composable
+internal fun SpeedTestOverlay(onDismiss: () -> Unit) {
+  var phase by remember { mutableStateOf(SpeedTest.Phase.PING) }
+  val r = remember { SpeedTest.Result() }
+  var runId by remember { mutableStateOf(0) }
+
+  LaunchedEffect(runId) {
+    r.reset()
+    phase = SpeedTest.Phase.PING
+    SpeedTest.run(result = r, onPhase = { phase = it })
+    phase = SpeedTest.Phase.DONE
+  }
+
+  BackHandler { onDismiss() }
+  Scrim(onDismiss) {
+    Surface(shape = RoundedCornerShape(28.dp), color = Color(0xFF1C1C1E)) {
+      Column(modifier = Modifier.width(380.dp).padding(24.dp)) {
+        Text("Speed test", color = Color.White, fontSize = 22.sp, fontWeight = FontWeight.Bold)
+        Text(
+            if (r.server.isNotEmpty()) r.server
+            else if (phase == SpeedTest.Phase.DONE) "Cloudflare" else "Finding server…",
+            color = Color(0xFF9A9A9A),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 2.dp),
+        )
+        Spacer(Modifier.size(22.dp))
+        Row(Modifier.fillMaxWidth()) {
+          SpeedMetric("Ping", r.pingMs, "ms", 0, active = phase == SpeedTest.Phase.PING, accent = Color(0xFFFFCA28), modifier = Modifier.weight(1f))
+          SpeedMetric("Jitter", r.jitterMs, "ms", 1, active = phase == SpeedTest.Phase.PING, accent = Color(0xFFFFCA28), modifier = Modifier.weight(1f))
+        }
+        Spacer(Modifier.size(20.dp))
+        SpeedMetric("↓  Download", r.downMbps, "Mbps", 1, active = phase == SpeedTest.Phase.DOWNLOAD, accent = Color(0xFF42A5F5), big = true)
+        Spacer(Modifier.size(16.dp))
+        SpeedMetric("↑  Upload", r.upMbps, "Mbps", 1, active = phase == SpeedTest.Phase.UPLOAD, accent = Color(0xFF66BB6A), big = true)
+        Spacer(Modifier.size(26.dp))
+        val busy = phase != SpeedTest.Phase.DONE
+        val label =
+            when (phase) {
+              SpeedTest.Phase.PING -> "Pinging…"
+              SpeedTest.Phase.DOWNLOAD -> "Testing download…"
+              SpeedTest.Phase.UPLOAD -> "Testing upload…"
+              SpeedTest.Phase.DONE -> "Run again"
+            }
+        Surface(
+            color = if (busy) Color(0x22FFFFFF) else MaterialTheme.colorScheme.primary,
+            shape = RoundedCornerShape(14.dp),
+            modifier = Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(14.dp), focusScale = 1f) { if (!busy) runId++ },
+        ) {
+          Text(label, color = Color.White, fontSize = 16.sp, textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth().padding(vertical = 13.dp))
+        }
+        Spacer(Modifier.size(10.dp))
+        CloseButton("Close", onDismiss)
+      }
+    }
+  }
+}
+
+@Composable
+private fun SpeedMetric(
+    label: String,
+    value: Double,
+    unit: String,
+    decimals: Int,
+    active: Boolean,
+    accent: Color,
+    modifier: Modifier = Modifier,
+    big: Boolean = false,
+) {
+  val shown = if (value > 0.0) String.format("%.${decimals}f", value) else "—"
+  if (big) {
+    Row(modifier.fillMaxWidth(), verticalAlignment = Alignment.Bottom) {
+      Text(label, color = Color(0xFFDADADA), fontSize = 17.sp, modifier = Modifier.weight(1f))
+      Text(shown, color = if (active) accent else Color.White, fontSize = 30.sp, fontWeight = FontWeight.Medium, lineHeight = 30.sp)
+      Spacer(Modifier.size(6.dp))
+      Text(unit, color = Color(0xFF9A9A9A), fontSize = 14.sp, modifier = Modifier.padding(bottom = 4.dp))
+    }
+  } else {
+    Column(modifier) {
+      Text(label.uppercase(), color = Color(0xFF8A8A8A), fontSize = 12.sp, letterSpacing = 0.5.sp)
+      Row(verticalAlignment = Alignment.Bottom, modifier = Modifier.padding(top = 4.dp)) {
+        Text(shown, color = if (active) accent else Color.White, fontSize = 24.sp, fontWeight = FontWeight.Medium, lineHeight = 24.sp)
+        Spacer(Modifier.size(4.dp))
+        Text(unit, color = Color(0xFF9A9A9A), fontSize = 12.sp, modifier = Modifier.padding(bottom = 3.dp))
+      }
     }
   }
 }

--- a/app/src/main/java/com/immortal/launcher/HomeToolOverlays.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeToolOverlays.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * In-page overlays for the sky/space tools whose logic already landed but whose UI formerly lived
+ * only in ForkHome ([IssPasses], [Aurora]). Hosted full-page by [ToolsActivity] — each is a centered
+ * card over a scrim, with an `onDismiss` back to the Tools list. This file holds only rendering; the
+ * computation lives in the matching object. More tools (converter, timers, notes, day/year, speed
+ * test) hook into the same scaffolding in follow-up changes.
+ */
+
+/* ------------------------------------------------------------------ ISS passes */
+
+@Composable
+internal fun IssOverlay(onDismiss: () -> Unit) {
+  val context = LocalContext.current
+  var passes by remember { mutableStateOf<List<IssPasses.Pass>?>(null) }
+  LaunchedEffect(Unit) { passes = withContext(Dispatchers.IO) { IssPasses.predict(context) } }
+
+  BackHandler { onDismiss() }
+  Scrim(onDismiss) {
+    ToolCard {
+      Text("🛰️ Space station overhead", color = Color.White, fontSize = 22.sp, fontWeight = FontWeight.Bold)
+      val p = passes
+      when {
+        p == null -> Text("Finding passes…", color = Color(0xFFB0B0B0), fontSize = 16.sp)
+        p.isEmpty() ->
+            Text(
+                "No passes found. Check the device is online so it can fetch the latest orbit, " +
+                    "and that your location is set (it follows the weather tile).",
+                color = Color(0xFFB0B0B0),
+                fontSize = 15.sp,
+            )
+        else -> {
+          val first = p.first()
+          Text(
+              buildString {
+                append(if (first.visible) "Visible pass " else "Passes over ")
+                append(IssPasses.timeLabel(first.startMillis))
+                append(if (first.visible) " ✨" else "")
+              },
+              color = if (first.visible) Color(0xFFFFD54F) else Color.White,
+              fontSize = 17.sp,
+              fontWeight = FontWeight.SemiBold,
+          )
+          Column(
+              modifier = Modifier.fillMaxWidth().heightIn(max = 320.dp).verticalScroll(rememberScrollState()),
+              verticalArrangement = Arrangement.spacedBy(10.dp),
+          ) {
+            p.forEach { pass ->
+              Surface(color = Color(0x18FFFFFF), shape = RoundedCornerShape(12.dp), modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)) {
+                  Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(IssPasses.timeLabel(pass.startMillis), color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
+                    if (pass.visible) {
+                      Surface(color = Color(0x33FFD54F), shape = RoundedCornerShape(8.dp)) {
+                        Text("✨ visible", color = Color(0xFFFFD54F), fontSize = 13.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp))
+                      }
+                    }
+                  }
+                  Text(
+                      "Rises ${pass.startDir} · peak ${pass.maxElevationDeg}° to the ${pass.peakDir} · sets ${pass.endDir}",
+                      color = Color(0xFFB8B8B8),
+                      fontSize = 14.sp,
+                  )
+                }
+              }
+            }
+          }
+          Text(
+              "Times are local. ✨ means it should be bright enough to see — go outside and look up to the listed direction.",
+              color = Color(0xFF8A8A8A),
+              fontSize = 12.sp,
+          )
+        }
+      }
+      CloseButton("Close", onDismiss)
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ Aurora */
+
+@Composable
+internal fun AuroraOverlay(onDismiss: () -> Unit) {
+  val context = LocalContext.current
+  var status by remember { mutableStateOf<Aurora.Status?>(null) }
+  var loaded by remember { mutableStateOf(false) }
+  LaunchedEffect(Unit) {
+    status = withContext(Dispatchers.IO) { Aurora.status(context) }
+    loaded = true
+  }
+
+  BackHandler { onDismiss() }
+  Scrim(onDismiss) {
+    ToolCard {
+      Text("🌌 Aurora outlook", color = Color.White, fontSize = 22.sp, fontWeight = FontWeight.Bold)
+      val st = status
+      when {
+        !loaded -> Text("Checking the K-index…", color = Color(0xFFB0B0B0), fontSize = 16.sp)
+        st == null ->
+            Text(
+                "Couldn't fetch the K-index. Check the device is online and that your location is " +
+                    "set (it follows the weather tile).",
+                color = Color(0xFFB0B0B0),
+                fontSize = 15.sp,
+            )
+        else -> {
+          val accent =
+              when (st.chance) {
+                Aurora.Chance.LIKELY -> Color(0xFF69F0AE)
+                Aurora.Chance.POSSIBLE -> Color(0xFFB9F6CA)
+                Aurora.Chance.SLIM -> Color(0xFFB0BEC5)
+                Aurora.Chance.NONE -> Color(0xFF90A4AE)
+              }
+          Text(st.headline, color = accent, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+          Text(st.detail, color = Color(0xFFCFCFCF), fontSize = 15.sp, lineHeight = 21.sp)
+          Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+            AuroraStat("Kp now", Aurora.fmtKp(st.kpNow), Modifier.weight(1f))
+            AuroraStat("Next 24 h peak", Aurora.fmtKp(st.kpForecast), Modifier.weight(1f))
+            AuroraStat("Look", st.lookToward, Modifier.weight(1f))
+          }
+          Text(
+              "Source: NOAA SWPC planetary K-index. Best after dark, away from city lights, with a " +
+                  "clear ${if (st.lookToward == "N") "northern" else "southern"} horizon.",
+              color = Color(0xFF8A8A8A),
+              fontSize = 12.sp,
+          )
+        }
+      }
+      CloseButton("Close", onDismiss)
+    }
+  }
+}
+
+@Composable
+private fun AuroraStat(label: String, value: String, modifier: Modifier = Modifier) {
+  Surface(color = Color(0x18FFFFFF), shape = RoundedCornerShape(12.dp), modifier = modifier) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(vertical = 10.dp).fillMaxWidth()) {
+      Text(value, color = Color.White, fontSize = 20.sp, fontWeight = FontWeight.Bold)
+      Text(label, color = Color(0xFF9A9A9A), fontSize = 12.sp, textAlign = TextAlign.Center)
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ shared scaffolding */
+
+/** Full-screen scrim over the home page; tapping outside the card dismisses. */
+@Composable
+internal fun Scrim(onDismiss: () -> Unit, content: @Composable () -> Unit) {
+  Box(
+      contentAlignment = Alignment.Center,
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Color(0xCC000000))
+              .tvFocusable(RoundedCornerShape(0.dp), focusScale = 1f) { onDismiss() },
+  ) {
+    content()
+  }
+}
+
+/** The standard tool card: a rounded surface with a vertically-scrolling padded column. */
+@Composable
+internal fun ToolCard(maxWidth: Int = 560, content: @Composable () -> Unit) {
+  Surface(
+      color = MaterialTheme.colorScheme.surface,
+      shape = RoundedCornerShape(24.dp),
+      modifier = Modifier.widthIn(max = maxWidth.dp).heightIn(max = 760.dp).padding(24.dp),
+  ) {
+    Column(
+        modifier = Modifier.padding(24.dp).verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+      content()
+    }
+  }
+}
+
+@Composable
+internal fun CloseButton(label: String, onClick: () -> Unit) {
+  Surface(
+      color = Color(0x22FFFFFF),
+      shape = RoundedCornerShape(14.dp),
+      modifier = Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(14.dp), focusScale = 1f) { onClick() },
+  ) {
+    Text(label, color = Color.White, fontSize = 16.sp, textAlign = TextAlign.Center, modifier = Modifier.padding(vertical = 10.dp).fillMaxWidth())
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/SpeedTest.kt
+++ b/app/src/main/java/com/immortal/launcher/SpeedTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * A keyless network speed test against Cloudflare's open speed endpoints (`speed.cloudflare.com`):
+ * serving data-centre, latency + jitter, download and upload. Each leg is wrapped independently, so
+ * one failing leaves that metric blank but lets the others complete. Results are published live via
+ * the [Result] snapshot-state holder so a UI can show progress; the whole thing runs on IO.
+ *
+ * Formerly lived inline in ForkHome; extracted here so it has a real home (and is unit-testable).
+ */
+object SpeedTest {
+
+  enum class Phase {
+    PING,
+    DOWNLOAD,
+    UPLOAD,
+    DONE,
+  }
+
+  /** Live, observable results. Fields update as each leg progresses. */
+  class Result {
+    var server by mutableStateOf("")
+    var pingMs by mutableStateOf(0.0)
+    var jitterMs by mutableStateOf(0.0)
+    var downMbps by mutableStateOf(0.0)
+    var upMbps by mutableStateOf(0.0)
+
+    fun reset() {
+      server = ""
+      pingMs = 0.0
+      jitterMs = 0.0
+      downMbps = 0.0
+      upMbps = 0.0
+    }
+  }
+
+  private const val BUDGET_MS = 10_000L
+
+  /** Runs the full test, emitting phase changes via [onPhase] and live values into [result]. */
+  suspend fun run(result: Result, onPhase: (Phase) -> Unit) {
+    withContext(Dispatchers.IO) {
+      // ---- serving data-centre (cdn-cgi/trace: colo=IATA, loc=country) ----
+      runCatching {
+        val conn = URL("https://speed.cloudflare.com/cdn-cgi/trace").openConnection() as HttpURLConnection
+        conn.connectTimeout = 6_000
+        conn.readTimeout = 6_000
+        val text = conn.inputStream.bufferedReader().use { it.readText() }
+        conn.disconnect()
+        val kv =
+            text.lineSequence()
+                .mapNotNull {
+                  val i = it.indexOf('=')
+                  if (i > 0) it.substring(0, i) to it.substring(i + 1) else null
+                }
+                .toMap()
+        result.server =
+            listOfNotNull("Cloudflare", kv["colo"], kv["loc"]).filter { it.isNotBlank() }.joinToString(" · ")
+      }
+
+      // ---- ping: TTFB of a 0-byte download, keep-alive reused; drop the warm-up ----
+      onPhase(Phase.PING)
+      runCatching {
+        val samples = ArrayList<Double>()
+        repeat(6) { i ->
+          val t0 = System.nanoTime()
+          val conn = URL("https://speed.cloudflare.com/__down?bytes=0").openConnection() as HttpURLConnection
+          conn.connectTimeout = 5_000
+          conn.readTimeout = 5_000
+          conn.inputStream.use { it.read() }
+          val ms = (System.nanoTime() - t0) / 1_000_000.0
+          if (i > 0) samples.add(ms) // first request pays TLS setup
+        }
+        if (samples.isNotEmpty()) {
+          val avg = samples.average()
+          result.pingMs = avg
+          result.jitterMs = samples.map { kotlin.math.abs(it - avg) }.average()
+        }
+      }
+
+      // ---- download: Cloudflare caps __down at <100 MB (100 MB → 403), so pull 50 MB
+      //      segments back-to-back until the 10s budget is spent. Keeps the pipe full on
+      //      fast links where a single segment finishes in well under 1s. ----
+      onPhase(Phase.DOWNLOAD)
+      runCatching {
+        val t0 = System.currentTimeMillis()
+        var bytes = 0L
+        var lastEmit = 0L
+        val buf = ByteArray(65_536)
+        while (System.currentTimeMillis() - t0 < BUDGET_MS) {
+          val conn =
+              URL("https://speed.cloudflare.com/__down?bytes=52428800").openConnection() as HttpURLConnection
+          conn.connectTimeout = 8_000
+          conn.readTimeout = 20_000
+          try {
+            conn.inputStream.use { s ->
+              while (true) {
+                val n = s.read(buf)
+                if (n == -1) break
+                bytes += n
+                val now = System.currentTimeMillis()
+                val sec = (now - t0) / 1000.0
+                if (now - lastEmit > 200 && sec > 0) {
+                  result.downMbps = bytes * 8.0 / 1_000_000.0 / sec
+                  lastEmit = now
+                }
+                if (now - t0 > BUDGET_MS) break
+              }
+            }
+          } finally {
+            conn.disconnect()
+          }
+        }
+        val sec = (System.currentTimeMillis() - t0) / 1000.0
+        if (sec > 0) result.downMbps = bytes * 8.0 / 1_000_000.0 / sec
+      }
+
+      // ---- upload: stream random bytes for up to 10s; measured during the write so a
+      //      truncated-response close doesn't lose the reading ----
+      onPhase(Phase.UPLOAD)
+      runCatching {
+        val conn = URL("https://speed.cloudflare.com/__up").openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.doOutput = true
+        conn.connectTimeout = 8_000
+        conn.readTimeout = 20_000
+        conn.setChunkedStreamingMode(0)
+        val chunk = ByteArray(65_536).also { java.util.Random().nextBytes(it) }
+        val t0 = System.currentTimeMillis()
+        var sent = 0L
+        var lastEmit = 0L
+        runCatching {
+          conn.outputStream.use { o ->
+            while (System.currentTimeMillis() - t0 < BUDGET_MS) {
+              o.write(chunk)
+              sent += chunk.size
+              val now = System.currentTimeMillis()
+              val sec = (now - t0) / 1000.0
+              if (now - lastEmit > 200 && sec > 0) {
+                result.upMbps = sent * 8.0 / 1_000_000.0 / sec
+                lastEmit = now
+              }
+            }
+            o.flush()
+          }
+          runCatching { conn.responseCode }
+        }
+        conn.disconnect()
+        val sec = (System.currentTimeMillis() - t0) / 1000.0
+        if (sec > 0 && sent > 0) result.upMbps = sent * 8.0 / 1_000_000.0 / sec
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/ToolsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ToolsActivity.kt
@@ -28,7 +28,10 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -46,23 +49,39 @@ import androidx.compose.ui.unit.sp
 import com.immortal.launcher.ui.theme.SampleAppTheme
 
 /**
- * The "Tools" screen, opened from the built-in Tools tile on the home grid. A plain launcher for the
- * in-process tool Activities that don't each warrant their own home tile. See
- * docs/design/feature-integration.md (step 3).
+ * The full-page "Tools" screen, opened from the built-in Tools tile on the home grid. A plain
+ * launcher for the in-process tool features. See docs/design/feature-integration.md (step 3).
  *
- * Only tools with a real, launchable Activity are listed. Timers, voice notes, and the unit
- * converter shipped as data/logic with no screen (their UI lived in the unmerged ForkHome), so they
- * are intentionally absent until their Activities are built.
+ * Tools that already have their own Activity (cameras, countdowns, lamp, bedtime, intercom) launch
+ * it directly. Tools whose UI formerly lived only in ForkHome open as an in-page overlay hosted here
+ * (see [HomeToolOverlays]); this change adds the sky/space pair (ISS passes, aurora outlook).
  */
 class ToolsActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContent { SampleAppTheme(darkTheme = true) { ToolsScreen() } }
+    setContent { SampleAppTheme(darkTheme = true) { ToolsRoot(::finish) } }
+  }
+}
+
+/** Which in-page tool overlay is showing over the list (or [ToolPage.LIST] for the list itself). */
+private enum class ToolPage {
+  LIST,
+  ISS,
+  AURORA,
+}
+
+@Composable
+private fun ToolsRoot(onExit: () -> Unit) {
+  var page by remember { mutableStateOf(ToolPage.LIST) }
+  when (page) {
+    ToolPage.LIST -> ToolsScreen(onExit = onExit, onOpen = { page = it })
+    ToolPage.ISS -> IssOverlay { page = ToolPage.LIST }
+    ToolPage.AURORA -> AuroraOverlay { page = ToolPage.LIST }
   }
 }
 
 @Composable
-private fun ToolsScreen() {
+private fun ToolsScreen(onExit: () -> Unit, onOpen: (ToolPage) -> Unit) {
   val context = LocalContext.current
   val activity = context as? Activity
   val firstFocus = remember { FocusRequester() }
@@ -73,7 +92,7 @@ private fun ToolsScreen() {
           Modifier.fillMaxSize()
               .onPreviewKeyEvent { e ->
                 if (e.key == Key.Back) {
-                  if (e.type == KeyEventType.KeyUp) activity?.finish()
+                  if (e.type == KeyEventType.KeyUp) onExit()
                   true
                 } else false
               }
@@ -106,6 +125,8 @@ private fun ToolsScreen() {
         ToolRow("Intercom", "Talk to another Portal on your Wi-Fi") {
           context.startActivity(Intent(context, IntercomActivity::class.java))
         }
+        ToolRow("ISS passes", "When the space station flies over") { onOpen(ToolPage.ISS) }
+        ToolRow("Aurora outlook", "Northern-lights chance for your location") { onOpen(ToolPage.AURORA) }
       }
     }
   }

--- a/app/src/main/java/com/immortal/launcher/ToolsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ToolsActivity.kt
@@ -68,6 +68,7 @@ private enum class ToolPage {
   LIST,
   ISS,
   AURORA,
+  SPEEDTEST,
 }
 
 @Composable
@@ -77,6 +78,7 @@ private fun ToolsRoot(onExit: () -> Unit) {
     ToolPage.LIST -> ToolsScreen(onExit = onExit, onOpen = { page = it })
     ToolPage.ISS -> IssOverlay { page = ToolPage.LIST }
     ToolPage.AURORA -> AuroraOverlay { page = ToolPage.LIST }
+    ToolPage.SPEEDTEST -> SpeedTestOverlay { page = ToolPage.LIST }
   }
 }
 
@@ -127,6 +129,7 @@ private fun ToolsScreen(onExit: () -> Unit, onOpen: (ToolPage) -> Unit) {
         }
         ToolRow("ISS passes", "When the space station flies over") { onOpen(ToolPage.ISS) }
         ToolRow("Aurora outlook", "Northern-lights chance for your location") { onOpen(ToolPage.AURORA) }
+        ToolRow("Speed test", "Check your internet speed (Cloudflare)") { onOpen(ToolPage.SPEEDTEST) }
       }
     }
   }

--- a/app/src/main/java/com/immortal/launcher/ToolsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ToolsActivity.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.ui.theme.SampleAppTheme
+
+/**
+ * The "Tools" screen, opened from the built-in Tools tile on the home grid. A plain launcher for the
+ * in-process tool Activities that don't each warrant their own home tile. See
+ * docs/design/feature-integration.md (step 3).
+ *
+ * Only tools with a real, launchable Activity are listed. Timers, voice notes, and the unit
+ * converter shipped as data/logic with no screen (their UI lived in the unmerged ForkHome), so they
+ * are intentionally absent until their Activities are built.
+ */
+class ToolsActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { ToolsScreen() } }
+  }
+}
+
+@Composable
+private fun ToolsScreen() {
+  val context = LocalContext.current
+  val activity = context as? Activity
+  val firstFocus = remember { FocusRequester() }
+  LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .onPreviewKeyEvent { e ->
+                if (e.key == Key.Back) {
+                  if (e.type == KeyEventType.KeyUp) activity?.finish()
+                  true
+                } else false
+              }
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp).focusRequester(firstFocus).focusGroup()) {
+      Text("Tools", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+      Text(
+          "Extra utilities for your Portal.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+      Spacer(Modifier.size(26.dp))
+      Card {
+        ToolRow("Cameras", "View a saved RTSP camera feed") {
+          context.startActivity(Intent(context, CameraViewerActivity::class.java))
+        }
+        ToolRow("Countdowns", "Days until birthdays and events") {
+          context.startActivity(Intent(context, CountdownSettingsActivity::class.java))
+        }
+        ToolRow("Lamp", "A full-screen warm-white light") {
+          context.startActivity(Intent(context, LampActivity::class.java))
+        }
+        ToolRow("Bedtime story", "Public-domain tales read aloud") {
+          context.startActivity(Intent(context, BedtimeStoryActivity::class.java))
+        }
+        ToolRow("Intercom", "Talk to another Portal on your Wi-Fi") {
+          context.startActivity(Intent(context, IntercomActivity::class.java))
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun ToolRow(title: String, subtitle: String, onOpen: () -> Unit) {
+  Row(
+      modifier = Modifier.fillMaxWidth().tvFocusableRow { onOpen() }.padding(18.dp),
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Column(modifier = Modifier.weight(1f)) {
+      Text(title, color = Color.White, fontSize = 17.sp)
+      Text(
+          subtitle,
+          color = Color(0xFF9A9A9A),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 2.dp),
+      )
+    }
+    Text("›", color = Color(0xFF7C7C7C), fontSize = 26.sp)
+  }
+}


### PR DESCRIPTION
Adds a **Cloudflare speed test** to the Tools screen: serving data-centre, latency + jitter, download and upload, with live updates and a run-again button.

Speed test previously lived **inline in ForkHome** — it had no standalone file, so unlike the other tools its logic was absent from `main` entirely. This extracts it into a proper, unit-testable `SpeedTest.kt` engine (`Phase` / `Result` / `suspend run()`), hitting Cloudflare's open endpoints (`cdn-cgi/trace`, `__down`, `__up`). Each leg is wrapped independently so one failing leaves that metric blank but lets the others finish. UI is a Tools overlay (`SpeedTestOverlay`) hosted by `ToolsActivity`, same pattern as the sky/space tools.

## Stacking
Stacks on #122 (ISS + aurora Tools overlays), which stacks on #121. The diff shows those commits until they merge; I'll rebase down onto `main` as each lands.

## Test
- `:app:assembleDebug` green.
- On device: real result against Cloudflare (LHR·IE), ping/jitter, live ↓/↑ Mbps, run-again works.

---
_Generated with [Claude Code](https://claude.com/claude-code)_
