### PR TITLE
Tools: sky and star-field wallpaper modes

### DIFF
--- a/app/src/main/java/com/immortal/launcher/AmbientBackground.kt
+++ b/app/src/main/java/com/immortal/launcher/AmbientBackground.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import java.util.Calendar
+
+/**
+ * Live, self-computed home backgrounds — formerly ForkHome-only, now selectable wallpaper modes
+ * ([WallpaperConfig.SKY] / [WallpaperConfig.STARFIELD]). Rendered behind the grid by
+ * [HomeBackground]. The sky gradient drifts through the day; the star field is the real night sky
+ * projected for the device's location, fading in through twilight. Logic lives in [SkyColors] /
+ * [StarField]; this is only rendering.
+ */
+
+/** A full-screen sky gradient driven by the real sunrise/sunset for the device's location. */
+@Composable
+internal fun SkyBackground() {
+  val context = LocalContext.current
+  val sun by
+      produceState<Weather.SunTimes?>(initialValue = null) {
+        value = withContext(Dispatchers.IO) { Weather.fetchSunTimes(context) }
+      }
+  var nowMin by remember { mutableStateOf(ambientMinuteOfDay()) }
+  LaunchedEffect(Unit) {
+    while (true) {
+      nowMin = ambientMinuteOfDay()
+      delay(5L * 60 * 1000)
+    }
+  }
+  val sr = sun?.let { ambientMinuteOfDay(it.sunriseMillis) } ?: 6 * 60
+  val ss = sun?.let { ambientMinuteOfDay(it.sunsetMillis) } ?: 20 * 60
+  val (top, bottom) = SkyColors.gradientFor(nowMin, sr, ss)
+  Box(
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Brush.verticalGradient(listOf(top, bottom))))
+}
+
+/**
+ * A thin day-progress line at the very top of the screen (midnight → midnight), tinted with the
+ * current sky colour so it matches the [SkyBackground].
+ */
+@Composable
+internal fun DayProgressBar(modifier: Modifier = Modifier) {
+  val context = LocalContext.current
+  val sun by
+      produceState<Weather.SunTimes?>(initialValue = null) {
+        value = withContext(Dispatchers.IO) { Weather.fetchSunTimes(context) }
+      }
+  var nowMin by remember { mutableStateOf(ambientMinuteOfDay()) }
+  LaunchedEffect(Unit) {
+    while (true) {
+      nowMin = ambientMinuteOfDay()
+      delay(60L * 1000)
+    }
+  }
+  val sr = sun?.let { ambientMinuteOfDay(it.sunriseMillis) } ?: 6 * 60
+  val ss = sun?.let { ambientMinuteOfDay(it.sunsetMillis) } ?: 20 * 60
+  val fill = SkyColors.gradientFor(nowMin, sr, ss).second
+  val progress = (nowMin / 1440f).coerceIn(0f, 1f)
+  Box(modifier = modifier.fillMaxWidth().height(4.dp).background(fill.copy(alpha = 0.18f))) {
+    Box(modifier = Modifier.fillMaxWidth(progress).fillMaxHeight().background(fill))
+  }
+}
+
+/**
+ * The real night sky projected to the device's horizon for the current time + location, with a few
+ * asterism lines. By day it's a deep dark panel; stars fade in through twilight.
+ */
+@Composable
+internal fun StarFieldBackground() {
+  val context = LocalContext.current
+  val coords by
+      produceState<Pair<Double, Double>?>(initialValue = null) {
+        value = withContext(Dispatchers.IO) { Weather.coordinates(context) }
+      }
+  var now by remember { mutableStateOf(System.currentTimeMillis()) }
+  LaunchedEffect(Unit) {
+    while (true) {
+      now = System.currentTimeMillis()
+      delay(30L * 1000)
+    }
+  }
+
+  Box(
+      modifier =
+          Modifier.fillMaxSize()
+              .background(
+                  Brush.verticalGradient(listOf(Color(0xFF05060F), Color(0xFF0C1430))))) {
+    val loc = coords ?: return@Box
+    val (lat, lon) = loc
+    val lst = StarField.localSiderealTime(now, lon)
+    val sunAlt = StarField.sunAltitude(now, lat, lon)
+    val nightFactor = ((-sunAlt) / 12.0).coerceIn(0.0, 1.0).toFloat()
+    if (nightFactor <= 0.01f) return@Box
+
+    val projected =
+        remember(now, lat, lon) { StarField.STARS.map { StarField.project(it, lat, lst) } }
+
+    Canvas(modifier = Modifier.fillMaxSize()) {
+      val w = size.width
+      val h = size.height
+      fun screenX(az: Double) = (az / 360.0 * w).toFloat()
+      fun screenY(alt: Double) = (h * (1.0 - alt / 90.0)).toFloat()
+
+      StarField.LINES.forEach { (a, b) ->
+        val pa = projected[a]
+        val pb = projected[b]
+        if (pa.alt > 0 && pb.alt > 0) {
+          val xa = screenX(pa.az)
+          val xb = screenX(pb.az)
+          if (kotlin.math.abs(xa - xb) < w / 2f) {
+            drawLine(
+                color = Color(0xFF6E8BD8).copy(alpha = 0.35f * nightFactor),
+                start = Offset(xa, screenY(pa.alt)),
+                end = Offset(xb, screenY(pb.alt)),
+                strokeWidth = 2f,
+            )
+          }
+        }
+      }
+
+      StarField.STARS.forEachIndexed { i, star ->
+        val p = projected[i]
+        if (p.alt <= 0) return@forEachIndexed
+        val radius = (2.6f - star.mag.toFloat() * 0.55f).coerceIn(0.8f, 4.5f)
+        val alpha = ((1.8f - star.mag.toFloat() * 0.32f).coerceIn(0.35f, 1f)) * nightFactor
+        drawCircle(
+            color = Color.White.copy(alpha = alpha),
+            radius = radius,
+            center = Offset(screenX(p.az), screenY(p.alt)),
+        )
+      }
+    }
+  }
+}
+
+private fun ambientMinuteOfDay(): Int {
+  val c = Calendar.getInstance()
+  return c.get(Calendar.HOUR_OF_DAY) * 60 + c.get(Calendar.MINUTE)
+}
+
+private fun ambientMinuteOfDay(millis: Long): Int {
+  val c = Calendar.getInstance().apply { timeInMillis = millis }
+  return c.get(Calendar.HOUR_OF_DAY) * 60 + c.get(Calendar.MINUTE)
+}

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -1478,6 +1478,22 @@ private fun WallpaperSection() {
               Modifier.fillMaxSize()
                   .background(Brush.verticalGradient(listOf(Color(0xFF2C3E50), Color(0xFF4CA1AF)))))
         }
+        WallpaperSwatch("Sky", selected = mode == WallpaperConfig.SKY, onClick = {
+          mode = WallpaperConfig.SKY
+          WallpaperConfig.setMode(context, WallpaperConfig.SKY)
+        }) {
+          Spacer(
+              Modifier.fillMaxSize()
+                  .background(Brush.verticalGradient(listOf(Color(0xFF3A7BD5), Color(0xFF8FD3F4)))))
+        }
+        WallpaperSwatch("Star field", selected = mode == WallpaperConfig.STARFIELD, onClick = {
+          mode = WallpaperConfig.STARFIELD
+          WallpaperConfig.setMode(context, WallpaperConfig.STARFIELD)
+        }) {
+          Spacer(
+              Modifier.fillMaxSize()
+                  .background(Brush.verticalGradient(listOf(Color(0xFF05060F), Color(0xFF0C1430)))))
+        }
       }
       Divider()
       Row(

--- a/app/src/main/java/com/immortal/launcher/Wallpaper.kt
+++ b/app/src/main/java/com/immortal/launcher/Wallpaper.kt
@@ -50,6 +50,10 @@ object WallpaperConfig {
   const val DARK = "dark"
   const val SCREENSAVER = "screensaver"
   const val PHOTO_PREFIX = "photo:"
+  // Live, self-computed backgrounds (no photo source): a sky gradient that drifts through the day,
+  // and the real night sky projected for the device's location. Formerly ForkHome-only.
+  const val SKY = "sky"
+  const val STARFIELD = "starfield"
 
   data class Config(val mode: String = DARK, val grain: Boolean = false)
 
@@ -158,6 +162,11 @@ fun HomeBackground(modifier: Modifier = Modifier) {
   val gradient = WallpaperConfig.gradientColors(mode)
   androidx.compose.foundation.layout.Box(modifier) {
     when {
+      mode == WallpaperConfig.SKY -> {
+        SkyBackground()
+        DayProgressBar()
+      }
+      mode == WallpaperConfig.STARFIELD -> StarFieldBackground()
       gradient != null -> {
         androidx.compose.foundation.layout.Box(
             Modifier.fillMaxSize().background(Brush.verticalGradient(gradient.map { Color(it) })))


### PR DESCRIPTION
## What changed

Adds two selectable home wallpaper modes:

- Sky: a live sunrise/sunset-driven sky gradient with a thin day-progress line.
- Star field: a location-aware projected night sky using the existing `StarField`, `SkyColors`, and `Weather` helpers.

The PR only wires the background modes into `WallpaperConfig`, `HomeBackground`, and the wallpaper picker. It does not include the Tools overlay work from the stacked PRs.

## Why

The sky/star-field background is independent of the Tools screen stack, so it can target `main` directly and review separately from the ISS/aurora/speed-test overlays.

## Validation

- `JAVA_HOME="C:\Program Files\Android\Android Studio\jbr" ./gradlew.bat testDebugUnitTest`