### PR TITLE
Ambient almanac dashboard line + pack / sound / back-gesture toggles (steps 5–6)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -11,6 +11,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
@@ -216,6 +217,8 @@ private fun ImmortalSettingsScreen() {
           onOpen = { context.startActivity(Intent(context, BootAppsActivity::class.java)) })
 
       DeviceHealthNavRow(onOpen = { context.startActivity(Intent(context, DeviceHealthActivity::class.java)) })
+
+      MoreFeaturesSection()
 
       Text(
           "Changes apply as soon as you go back to the home screen.",
@@ -559,6 +562,44 @@ private fun QuickButtonsSection() {
       fontSize = 13.sp,
       modifier = Modifier.padding(top = 10.dp, start = 4.dp, end = 4.dp),
   )
+}
+
+/**
+ * Almanac calendar packs, system touch sounds, and the back-gesture accessibility service —
+ * feature-integration steps 5-6. The packs feed the home header and the ambient screensaver
+ * dashboard once on; touch sounds needs the WRITE_SETTINGS grant; the back gesture can only be
+ * enabled from Android's Accessibility settings, so that row deep-links there and shows status.
+ */
+@Composable
+private fun MoreFeaturesSection() {
+  val context = LocalContext.current
+  Spacer(Modifier.size(26.dp))
+  SectionLabel("Almanac")
+  Card {
+    CalendarPacks.AVAILABLE.forEach { pack ->
+      var on by remember { mutableStateOf(CalendarPacks.isEnabled(context, pack.id)) }
+      ToggleRow(pack.title, on) { checked ->
+        on = checked
+        CalendarPacks.setEnabled(context, pack.id, checked)
+      }
+    }
+  }
+  Spacer(Modifier.size(26.dp))
+  SectionLabel("Sound & input")
+  Card {
+    var sounds by remember { mutableStateOf(SystemSounds.touchSoundsEnabled(context)) }
+    ToggleRow("Touch sounds", sounds) { checked ->
+      if (SystemSounds.canWrite(context)) {
+        SystemSounds.setTouchSounds(context, checked)
+        sounds = SystemSounds.touchSoundsEnabled(context)
+      } else {
+        SystemSounds.requestWriteAccess(context)
+      }
+    }
+    NavRow("Back gesture", if (BackHelper.isBackServiceEnabled(context)) "On" else "Off") {
+      runCatching { context.startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)) }
+    }
+  }
 }
 
 /**

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -118,6 +118,7 @@ class PhotoFrameController(
   private lateinit var dashDate: TextView
   private lateinit var dashWeather: TextView
   private lateinit var dashEvent: TextView
+  private lateinit var dashAlmanac: TextView
   private var dashboardVisible = false
   // Weather string for the dashboard. The Face overlay fetches its own weather; this
   // small keyless fetch feeds the ambient-dashboard card so it stays self-contained.
@@ -820,6 +821,12 @@ class PhotoFrameController(
       (it.layoutParams as? LinearLayout.LayoutParams)?.topMargin = dp(10)
       col.addView(it)
     }
+    // Almanac line(s): enabled calendar packs (Irish holidays, prayer times) + a quote of the day.
+    dashAlmanac = text(20f, Color.WHITE, false).also {
+      it.gravity = Gravity.CENTER
+      (it.layoutParams as? LinearLayout.LayoutParams)?.topMargin = dp(14)
+      col.addView(it)
+    }
     return panel
   }
 
@@ -843,6 +850,21 @@ class PhotoFrameController(
     dashWeather.text = weatherText
     dashWeather.visibility = if (weatherText.isNotBlank()) View.VISIBLE else View.GONE
     dashEvent.visibility = View.GONE
+    dashAlmanac.visibility = View.GONE
+    io.execute {
+      val lines = buildList {
+        runCatching { CalendarPacks.headerLines(context) }.getOrDefault(emptyList()).forEach { add(it) }
+        val q = DailyContent.quoteOfDay()
+        add("“${q.text}”  — ${q.author}")
+      }
+      val txt = lines.joinToString("\n")
+      ui.post {
+        if (dashboardVisible && txt.isNotBlank()) {
+          dashAlmanac.text = txt
+          dashAlmanac.visibility = View.VISIBLE
+        }
+      }
+    }
     io.execute {
       val ev = runCatching {
         if (CalendarHelper.hasPermission(context)) CalendarHelper.upcoming(context).firstOrNull() else null


### PR DESCRIPTION
Steps 5–6 of `docs/design/feature-integration.md`. **On-device check wanted** — it touches the screensaver dashboard and two system-permission flows that unit tests can't cover. No new logic; every engine already existed.

## Step 5 — richer ambient dashboard
The ambient screensaver dashboard (already there, toggled by `screensaver → ambientDashboard`) showed only clock/date/weather/next-event. Adds an **almanac line** fed from the existing gated accessors:
- `CalendarPacks.headerLines()` — whatever add-on packs the user has enabled (Irish holidays, prayer times), self-gating.
- `DailyContent.quoteOfDay()` — a universal quote of the day.

Rendered via the panel's existing `text()` helper, computed off the UI thread like the calendar event.

## Step 6 (and making step 5's packs reachable)
A `MoreFeaturesSection` in the settings menu — these had **no enable UI** before:
- **Almanac**: toggles for the calendar packs (`CalendarPacks.isEnabled/setEnabled`). Turning one on surfaces it in both the home header and the ambient dashboard.
- **Sound & input**: a **Touch sounds** toggle (`SystemSounds`, requesting the `WRITE_SETTINGS` grant when needed) and a **Back gesture** row that shows on/off (`BackHelper.isBackServiceEnabled`) and deep-links to Accessibility settings (an accessibility service can't be toggled programmatically).

## Verification
- `:app:assembleDebug` + `:app:testDebugUnitTest` green (260 tests).
- On-device: the dashboard almanac line, the touch-sounds `WRITE_SETTINGS` prompt, and the back-gesture accessibility deep-link + status.

With this, the integration plan's spec steps are all addressed (step 4 was already functionally complete via the digital-clock toggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4SmhtgSd5B5sdTiV216XM)_