### PR TITLE
docs: cover the 1.60 feature set; retire CHANGELOG to a Releases pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,21 @@ The Kotlin package is flat; files are grouped by name prefix:
 
 - **Launcher / home grid:** `HomeActivity`, `UserLayout`, `QuickBar*`, `AppSwitcherActivity`
 - **Screensaver / photo frame:** `PhotoDreamService`, `PhotoFrameController`, `Screensaver*`,
-  `Face*` / `ClockFaces` / `FlipWebClockFaceView`, `DreamPolicy`, `PresenceState`, `AntiBurnIn`
+  `Face*` / `ClockFaces` / `FlipWebClockFaceView`, `DreamPolicy`, `PresenceState`, `AntiBurnIn`;
+  digital-clock face `DigitalClock*`; welcome overlay `Welcome*`; Dream selection in `SettingsGuard`
 - **Photo sources:** `LocalMedia`, `ImmichSource`, `SmbSource`, `DavSource`, `RemoteAlbum`,
   `Weather`, `CalendarFeed`
+- **Tools screen:** `ToolsActivity`, `HomeToolOverlays`, `CameraViewerActivity` / `CameraConfig`,
+  `LampActivity`, `BedtimeStoryActivity` / `Stories`, `IntercomActivity` / `LanAudio`,
+  `CountdownSettingsActivity` / `CountdownConfig`, plus the keyless helpers `Converter`, `IssPasses`,
+  `Aurora`, `PrayerTimes`
+- **Ambient & sound:** chimes `Chime*` / `ChimeConfig`; sunrise wake-light `Sunrise*` /
+  `SunriseConfig`; almanac packs `CalendarPacks` (+ `FeastDays`, `NameDays`, `IrishHolidays`,
+  `DailyContent`)
+- **Wallpaper (home background):** `WallpaperConfig`, `AmbientBackground` / `HomeBackground`,
+  `SkyColors`, `StarField`
+- **Accessibility / input:** back gesture `BackHelper`, `ImmortalBackGestureService`,
+  `SystemBackGestureService`; touch sounds `SystemSounds`
 - **App store / install:** `StoreActivity`, `StoreCatalog`, `UpdateManager`, `InstallDaemon`,
   `HeadlessInstaller`, `ApkInstallActivity`, `ApkBrowserActivity`, `InstallConfirmService`
 - **Fleet agent (on-device HTTP API):** `FleetAgentService`, `FleetHttpServer`, `FleetRoutes`,
@@ -92,7 +104,8 @@ definition drives three consumers automatically:
 2. **On-device UI** — `SettingsRenderer.SettingsList(domain, …)` renders the specs as Compose rows.
 3. **Phone remote** — the `/remote/settings` schema + the generic PWA renderer in `RemoteHtml`.
 
-The domains live in `SettingsDomains.kt`: `screensaver`, `calendar`, `immortal`, `mqtt`, `quickbar`.
+The domains live in `SettingsDomains.kt` (`SettingsDomains.all`): `screensaver`, `calendar`,
+`immortal`, `mqtt`, `quickbar`, `fleet`, `chime`, `digitalclock`, `welcome`, `sunrise`.
 
 ### Adding or changing a setting — the rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+Immortal's per-release history lives in
+**[GitHub Releases](https://github.com/starbrightlab/immortal/releases)** — that's the canonical,
+always-current source. Every release is cut by [`scripts/cut-release.sh`](docs/releasing.md), which
+writes the same notes into the GitHub Release **and** into [`version.json`](version.json) (what a
+device shows when it offers the update), so the two can't drift.
+
+This file is **no longer updated per release.** A hand-maintained changelog sitting outside that one
+command is exactly the kind of thing that drifts — and did: it stalled at 1.43 while 1.44 through
+1.52 shipped. The rest of the project designs drift out with tripwires rather than policing it by
+hand, and the changelog should be no exception.
+
+The entries below are kept as an archive of the early history. For anything from **1.44 onward**, see
+the Releases page linked above.
+
+---
+
+## Archived history (up to 1.43)
+
 ## 1.43 (2026-06-20)
 
 Screensaver gets clock faces and a lot more places to pull photos from.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,18 @@ services. Touch models and the remote-driven **Portal TV** are both supported.
   keyless built-in feed (Lorem Picsum, Unsplash-ready). Weather is keyless Open-Meteo + IP
   geolocation. It cooperates with the Portal's presence sensor so it runs as a **permanent frame**
   while someone's around (and on mains power), and on the battery-powered **Portal Go** an optional
-  "sleep when nobody's around" setting saves power. Swipe to change photos, tap to exit.
+  "sleep when nobody's around" setting saves power. Swipe to change photos, tap to exit. There's
+  also a **digital-clock** screensaver as an alternative to the photo frame, a **welcome-back**
+  greeting overlay, and an **ambient almanac** line fed by keyless on-device calendar packs
+  (Romanian name-days & Orthodox feasts, Irish holidays, prayer times).
+- **Tools** (`ToolsActivity`) — a **Tools** tile on the home grid gathers the built-in utilities:
+  **RTSP cameras**, **countdowns** (also shown as home-screen chips), a **reading lamp**,
+  **bedtime stories** read aloud, a Wi-Fi **intercom** to another Portal, **kitchen timers**,
+  **sticky/voice notes**, a **unit/currency converter**, **ISS pass** times, an **aurora outlook**,
+  and a Cloudflare **speed test**. All keyless and on-device.
+- **Ambient & sound** (`ChimeConfig` / `SunriseConfig`) — optional gentle audio cues (an hourly
+  chime, spoken time, a golden-hour tone) with a nightly quiet-hours window, and a **sunrise
+  wake-light** that eases the screen up in the morning. All off by default and configured on-device.
 - **App Store** (`StoreActivity` / `StoreCatalog`) — a hosted JSON catalog
   ([`catalog.json`](catalog.json), schema v2) rendered with app icons, search, per-app detail
   pages (author, source, website, credit), device-compatibility badges, and an "Updates" section
@@ -153,13 +164,14 @@ a Gen-1 Portal+). For apps that ship as split APKs, the Shizuku path above is th
 
 Hosted from this repo:
 
-- [`version.json`](version.json) — the self-update manifest. Bump `versionCode`/`versionName`,
-  build a signed release, and attach it as `immortal.apk` to a GitHub Release; devices update on
-  their next check. The asset **must** be named `immortal.apk` — the manifest's `apkUrl` (and the
-  store catalog) point at the stable `releases/latest/download/immortal.apk`, which 404s and breaks
-  self-update for every device if a release attaches only a versioned name. Use
-  [`scripts/publish-release.sh`](scripts/publish-release.sh) `<tag> <signed.apk>` to upload the
-  asset under both the stable and versioned names and verify the URL resolves.
+- [`version.json`](version.json) — the self-update manifest. Devices poll it and update when it
+  advertises a higher `versionCode`. Don't hand-edit it — one command cuts a release end to end:
+  [`scripts/cut-release.sh`](scripts/cut-release.sh) `<versionName> "<notes>"` bumps
+  `app/build.gradle.kts` and `version.json` in lockstep, builds and verifies the signed APK
+  (version match + same signing key as the published build), and publishes the GitHub Release with
+  the asset named **`immortal.apk`** — the stable `releases/latest/download/immortal.apk` the
+  manifest and store catalog point at. It fails fast at every gate. See
+  [docs/releasing.md](docs/releasing.md).
 - [`catalog.json`](catalog.json) — the app-store catalog. Edit and commit; clients pick it up on
   next open (a bundled copy ships as the offline fallback).
 

--- a/docs/features/ambient-sound.md
+++ b/docs/features/ambient-sound.md
@@ -1,0 +1,39 @@
+# Ambient & sound
+
+Small touches that make a Portal feel like part of the room rather than a screen on a shelf: gentle
+audio cues through the day, and a gradual wake-light in the morning. Both are **off by default** and
+configured from the [Settings](launcher.md#settings) screen.
+
+## Sounds — chimes & spoken time
+
+`ChimeConfig` / `ChimeScheduler` — the **Sounds** settings screen (`ChimeSettingsActivity`). Every
+cue is off by default; switch on only the ones you want.
+
+- **Hourly chime** — a soft tone on the hour. Volume is adjustable (default 60%).
+- **Spoken time** — the Portal says the time aloud on the hour ("It's three o'clock"), through
+  Android's text-to-speech, with a voice picker.
+- **Golden-hour tone** — a tone at sunrise and sunset, with a choice of morning or rooster sound.
+- **Ping the other room** — a doorbell used by the Wi-Fi [Intercom](tools.md); its volume is a touch
+  louder by default (85%).
+- **Quiet hours** — a nightly window that mutes every cue. This one is **on by default**
+  (22:00–08:00), so nothing chimes overnight until you say otherwise.
+
+## Sunrise wake-light
+
+`SunriseConfig` / `SunriseScheduler` — the **Wake-up light** settings screen
+(`SunriseSettingsActivity`). At the set time, the screen brightens gradually from a deep ember to
+full daylight over a ramp, optionally finishing with a soft chime — turning a bedroom Portal into a
+sunrise alarm.
+
+- **Time** and **days of the week** (default 07:00, Mon–Fri; leave the days empty for a one-shot
+  next-occurrence alarm).
+- **Ramp** — how long the brighten takes (default 20 minutes).
+- **Chime at the end** — a gentle tone when the ramp completes (default on).
+
+It re-arms itself across reboots, so it keeps working after a power blip.
+
+## See also
+
+- The screensaver's [welcome-back overlay](screensaver.md#welcome-back-overlay) and
+  [ambient almanac](screensaver.md#ambient-almanac-calendar-packs) are the other "feels alive"
+  touches, but they live on the photo frame.

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -34,7 +34,42 @@ and is fully navigable by remote on the [Portal TV](portal-tv.md).
 - **Manage** button (bottom-right) — enter Manage mode.
 - **Calls** tile — a green tile that bridges to the stock dialer/contacts for WhatsApp and
   Messenger calling.
+- **Tools** tile — opens the [Tools](tools.md) screen: cameras, timers, notes, a converter, a
+  reading lamp, an intercom, and more.
 - **Help** tile — a friendly, non-technical [walkthrough](#help-tour).
+
+Countdown events you add in [Tools → Countdowns](tools.md) also appear on the grid as chips
+(`🎂 Birthday · 12 days`).
+
+## Wallpaper
+
+The background behind the grid is a wallpaper mode you pick in Settings (`WallpaperConfig`):
+
+- **Dark** (default) and a set of **gradient** presets.
+- **Bundled photos**.
+- **Sky** — a full-screen gradient driven by the real sunrise/sunset for your location: dawn pinks,
+  midday blue, dusk orange, and a near-black night, refreshed through the day.
+- **Star field** — the actual night sky for your latitude and longitude and the current time
+  (~60 of the brightest stars, with the lines of Orion, the Big Dipper, and Cassiopeia), fading in
+  through twilight.
+- **Screensaver** — use your chosen [screensaver](screensaver.md) as the wallpaper too.
+
+## Sounds & input
+
+- **Touch sounds** — an optional soft click on taps, toggled under **More features** in Settings.
+  (For chimes and spoken time, see [Ambient & sound](ambient-sound.md).)
+- **Back gesture** — an optional accessibility service (`ImmortalBackGestureService`) that adds a
+  system-wide "go back" action in any app, and routes a back-to-home to *Immortal's* home rather
+  than the Portal's stock launcher. Enable it from **More features → Back gesture** in Settings,
+  which opens Android's Accessibility screen where you switch the Immortal service on.
+
+## Settings
+
+`ImmortalSettingsActivity` is the on-device Settings screen, and every Immortal feature is reachable
+from it — the screensaver and clock, [sounds and the wake-light](ambient-sound.md), the welcome
+overlay, wallpaper, [almanac packs](screensaver.md#ambient-almanac-calendar-packs), touch sounds,
+and the back gesture. Each setting is rendered from a single declarative registry, so the same
+control appears here and on the [phone remote](remote.md), and can never quietly drift out of sync.
 
 ## Help tour
 

--- a/docs/features/screensaver.md
+++ b/docs/features/screensaver.md
@@ -12,6 +12,22 @@ Swipe to change photos, tap to exit.
 Choose a screensaver clock face from a face picker (`FacePickerActivity`): **flip clock**,
 **big**, **bold**, or **minimal**, each with size options.
 
+## Digital-clock screensaver
+
+`DigitalClockConfig` / `DigitalClockDreamService` — an alternative screensaver that shows a large,
+customisable clock **instead of** the photo frame. Turn it on from the **Clock** settings screen
+(`ClockSettingsActivity`) and Immortal swaps the active screensaver to it automatically; a
+non-drag tap exits.
+
+- **Style** — classic, flip, bold, neon, seven-segment, or analog.
+- **Colour**, **font**, **size**, **position**, **background**, and **glow** — all pickable, with a
+  live preview. Show the date and/or seconds as you like.
+- Anti-burn-in slowly drifts the clock so a static display doesn't mark the panel.
+
+With this off, the screensaver is the [photo frame](#photo-sources) below; with it on, it's the
+clock. Everything else on this page (overnight behaviour, presence, welcome overlay) applies to
+whichever is showing.
+
 ## Photo sources
 
 Point the frame at whatever you like — most sources can be set up **from your phone** (pair the
@@ -44,3 +60,27 @@ dream/sleep lifecycle. The design notes go deep on this:
 During an overnight window the screensaver can show a **dimmed clock** instead of going fully
 dark — and a deliberate tap inside the window wakes the device for normal use, returning to
 sleep a short while after you stop interacting.
+
+## Welcome-back overlay
+
+When the screensaver starts, Immortal can show a brief **welcome-back overlay**
+(`WelcomeConfig`) — a time-of-day greeting ("Good morning", optionally with your name), the clock,
+and the date, optionally spoken aloud. It auto-dismisses after a few seconds. Turn it on with the
+**Welcome screen** toggle in the screensaver's Display settings, and tune the greeting, name, and
+timing on the **Welcome** settings screen (`WelcomeSettingsActivity`).
+
+## Ambient almanac & calendar packs
+
+The photo frame's dashboard can carry an **ambient almanac** line — a quiet daily fact fed by
+installable, keyless, on-device **calendar packs** plus a quote of the day (`CalendarPacks`,
+rendered by `PhotoFrameController`). Switch packs on per household under **More features → Almanac**
+on the [Settings](launcher.md#settings) screen (all off by default):
+
+| Pack | Adds |
+| --- | --- |
+| **Romanian name-days & Orthodox feasts** | Today's Orthodox feast and the name-days for the day. |
+| **Irish holidays** | Bank holidays and saints' days (St Patrick's, St Brigid's…). |
+| **Prayer times** | The next daily Islamic prayer time for your location. |
+
+Each pack contributes a line only when it has something for the day, and everything is computed
+on-device — no keys, no accounts.

--- a/docs/features/tools.md
+++ b/docs/features/tools.md
@@ -1,0 +1,33 @@
+# Tools
+
+`ToolsActivity` — a **Tools** tile on the home grid opens a single screen that gathers the small
+utilities Immortal ships. Some open their own full-screen Activity; the lighter ones open as an
+in-page overlay hosted on the Tools screen itself.
+
+Everything here is **keyless and on-device** — no accounts, and the couple of tools that reach the
+network use free, keyless public endpoints.
+
+## What's on the Tools screen
+
+| Tool | What it does |
+| --- | --- |
+| **Cameras** | Full-screen live view of a saved **RTSP** camera feed, played through Android's native video stack (no extra libraries). Add and name cameras with their RTSP URL; tap one to view. (`CameraViewerActivity`) |
+| **Countdowns** | Days until birthdays and events, shown as chips on the home screen (`🎂 Birthday · 12 days`). Each event has a label, emoji, and date; a year of `0` repeats every year, otherwise it's a one-off. (`CountdownSettingsActivity`) |
+| **Lamp** | Turns the panel into a full-screen warm-white light — a nightlight, reading light, or fill light. Brightness and warmth sliders, plus a red night-light mode; the screen is forced bright and kept awake. (`LampActivity`) |
+| **Bedtime story** | Public-domain children's tales in large, calm text, read aloud with Android's text-to-speech. No network. (`BedtimeStoryActivity`) |
+| **Intercom** | Talk to another Portal on your Wi-Fi — a push-to-talk intercom (or a one-way baby monitor), streamed directly between devices with no server. Needs microphone permission the first time. (`IntercomActivity`) |
+| **Timers** | Kitchen timers with a live countdown. |
+| **Leave a note** | A sticky note or a quick voice memo, left on the device for the next person. |
+| **Converter** | Units and currency. |
+| **ISS passes** | When the International Space Station next flies over your location. |
+| **Aurora outlook** | The northern-lights chance for your location. |
+| **Speed test** | Check your internet speed (via Cloudflare). |
+
+## Where things are configured
+
+- **Cameras** and **Countdowns** keep their saved list on the device (add/remove from the tool
+  itself). Countdowns you add appear as chips on the home screen as well.
+- The remaining tools have no persistent settings — you open them, use them, and leave.
+
+These are separate from the [Settings](launcher.md#settings) screen: the Tools screen is a *launcher*
+for utilities, not a settings surface.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,9 @@ keeps improving without a cable.
 | Area | What it does |
 | --- | --- |
 | [Launcher](features/launcher.md) | A fullscreen app grid with clock/date/weather, folders, an app switcher, and a Calls tile. |
-| [Screensaver](features/screensaver.md) | A photo frame with clock faces and many photo sources (your own folder, Immich, SMB, WebDAV, web pages, iCloud albums, or a keyless built-in feed). |
+| [Screensaver](features/screensaver.md) | A photo frame with clock faces and many photo sources (your own folder, Immich, SMB, WebDAV, web pages, iCloud albums, or a keyless built-in feed), plus a digital-clock face, a welcome-back overlay, and an ambient almanac. |
+| [Tools](features/tools.md) | A screen of built-in utilities — cameras, kitchen timers, notes, a converter, ISS passes, a reading lamp, a Wi-Fi intercom, and more. |
+| [Ambient & sound](features/ambient-sound.md) | Hourly chimes and spoken time, quiet hours, and a gradual sunrise wake-light. |
 | [App Store](features/app-store.md) | A hosted, community-submittable catalog that installs apps on-device, with updates and self-update. |
 | [Multi-room audio](features/multi-room-audio.md) | Synced whole-home music across Portals, with now-playing and transport controls on every device in a group. |
 | [Smart home](features/smart-home.md) | Home Assistant integration over MQTT — state and control, including the screen. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,8 @@ nav:
   - Features:
       - Launcher: features/launcher.md
       - Screensaver & photo frame: features/screensaver.md
+      - Tools: features/tools.md
+      - Ambient & sound: features/ambient-sound.md
       - App Store: features/app-store.md
       - Multi-room audio & now-playing: features/multi-room-audio.md
       - Smart home (Home Assistant / MQTT): features/smart-home.md


### PR DESCRIPTION
## What

Brings the documentation up to date with everything that landed since 1.52, ahead of cutting 1.60, and settles the CHANGELOG question from first principles.

## Feature coverage

- **New page `docs/features/tools.md`** — the Tools screen: RTSP cameras, countdowns, reading lamp, bedtime stories, Wi-Fi intercom, kitchen timers, sticky/voice notes, converter, ISS passes, aurora outlook, speed test.
- **New page `docs/features/ambient-sound.md`** — chimes, spoken time, golden-hour tone, quiet hours, and the sunrise wake-light.
- **`docs/features/screensaver.md`** — adds the digital-clock screensaver, the welcome-back overlay, and the ambient almanac / calendar packs (Romanian & Orthodox, Irish, prayer times).
- **`docs/features/launcher.md`** — adds the Tools tile, the wallpaper modes (Sky, Star field, …), a Sounds & input section (touch sounds, back-gesture service), and a Settings section describing the declarative registry.
- **`docs/index.md`** and **README** "What's in it" gain Tools and Ambient & sound.
- **`mkdocs.yml`** nav gains the two new pages.

## Drift fixes

- README "Releasing" section referenced the retired `publish-release.sh`; now points at `cut-release.sh` (the one enforced release command).
- `AGENTS.md` settings-domains list was five domains behind (`fleet`, `chime`, `digitalclock`, `welcome`, `sunrise` were missing); its "Finding code by feature" map now covers Tools, ambient/sound, wallpaper, and accessibility.

## CHANGELOG decision (from first principles)

`CHANGELOG.md` is retired to a signpost. The project designs drift out with tripwires rather than policing it by hand; a changelog maintained outside the one enforced release command (`cut-release.sh`, which writes the same notes into the GitHub Release **and** `version.json`) is precisely the artifact that drifts — and it had, stalling at 1.43 while 1.44–1.52 shipped. GitHub Releases is now the single canonical history. Pre-1.44 entries are kept as a clearly-labelled archive (non-destructive).

## Testing

`mkdocs build --strict` passes — all internal links and anchors resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4SmhtgSd5B5sdTiV216XM)_