### PR TITLE
Fix: declare WRITE_SETTINGS so the touch-sounds grant toggle works

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,12 @@
          `pm grant ... WRITE_SECURE_SETTINGS`. Harmless no-op if not granted. -->
     <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
+    <!-- Touch sounds: writes Settings.System.SOUND_EFFECTS_ENABLED. This must be
+         DECLARED for the "Allow modifying system settings" toggle to be enableable;
+         without it the grant screen shows but its switch is dead, and Settings.System
+         writes fail. The user grants it interactively (SystemSounds.requestWriteAccess). -->
+    <uses-permission android:name="android.permission.WRITE_SETTINGS"
+        tools:ignore="ProtectedPermissions" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <!-- Gesture-wave-to-wake on the screensaver (GestureCamera). Optional feature so
          camera-less models still install. -->


### PR DESCRIPTION
## Symptom
Enabling **Settings → Sound & input → Touch sounds** opens the "Allow modifying system settings" screen, but the toggle is **unclickable**. The only way users can turn touch sounds on is the adb workaround:

```
adb shell appops set com.immortal.launcher WRITE_SETTINGS allow
```

## Cause
`SystemSounds.setTouchSounds` writes `Settings.System.SOUND_EFFECTS_ENABLED`, which requires the `WRITE_SETTINGS` app-op. `requestWriteAccess()` correctly fires `ACTION_MANAGE_WRITE_SETTINGS`, but `AndroidManifest.xml` only declares `WRITE_SECURE_SETTINGS` — a *different* permission that governs `Settings.Secure`/`Settings.Global`, not `Settings.System`.

Android only enables the "Allow modifying system settings" toggle for apps that **declare** `android.permission.WRITE_SETTINGS`. Without the declaration the switch is inert and `Settings.System.canWrite()` can never become true through the UI. The `appops` workaround succeeds precisely because it sets the app-op directly, bypassing the manifest gate.

## Fix
Declare `android.permission.WRITE_SETTINGS`. The grant stays interactive/user-driven — the only change is that the existing toggle now works, so no adb is needed.