### PR TITLE
Track the latest release for Jarvis and Portal-Kasa automatically

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updated": "2026-07-01",
+  "updated": "2026-07-04",
   "note": "Portal app catalog, schema v2. All v2 fields are ADDITIVE so v1 clients keep working. Entries with source 'fdroid' resolve the current APK at install time via the F-Droid API, so they never go stale. Entries with source 'url' use a direct apkUrl (use this for your own custom Portal apps); give them a 'versionCode' (bumped per release) OR a 'versionUrl' — a JSON manifest (e.g. the app's own version.json) with a 'versionCode' field that the store reads live, so a 'releases/latest/download' app stays current with no catalog edit per release. Multi-ABI apps (e.g. VLC) ship separate per-architecture APKs on F-Droid; pin the arm64-v8a build with 'versionCode' since Portal is arm64. New in v2: iconUrl (https PNG; omit to get a monogram tile), author, homepage, submittedBy (community credit), longDescription (detail page), devices (['touch','tv'] — omit when the app runs on every Portal). minSdk drives the compatibility badge: the first-gen Portal/Portal+ and Portal TV are API 28, the 2019/2021 models are API 29.",
   "categories": [
     {
@@ -302,8 +302,8 @@
           "name": "Portal-Kasa",
           "packageName": "com.portal.kasa",
           "source": "url",
-          "apkUrl": "https://github.com/rudysev/portal-kasa/releases/download/v1.0.1/portal-kasa-v1.0.1.apk",
-          "versionCode": 2,
+          "apkUrl": "https://github.com/rudysev/portal-kasa/releases/latest/download/portal-kasa.apk",
+          "versionUrl": "https://raw.githubusercontent.com/rudysev/portal-kasa/main/version.json",
           "minSdk": 28,
           "description": "Toggle TP-Link Kasa smart plugs and bulbs on your Wi-Fi — local, no account, no cloud.",
           "longDescription": "A TP-Link Kasa controller built for the Portal: every plug and bulb on your Wi-Fi on one glanceable dashboard (green = on), with one-tap toggles and All on / All off. Control is entirely local LAN — no TP-Link account, no cloud, no sign-in; devices are discovered by UDP broadcast and switched directly over TCP. The dashboard re-syncs every ~30 seconds while open (backing off in the background), so changes made from the Kasa phone app or a physical button show up on their own. Pairs with the Jarvis assistant (also in this store) for voice control: enable \"Kasa Plugs\" under its External tools and say \"hey jarvis, turn on the coffee maker\". The Portal and the devices must be on the same Wi-Fi network.",
@@ -344,8 +344,8 @@
           "name": "Jarvis (portal-assistant)",
           "packageName": "com.portal.assistant",
           "source": "url",
-          "apkUrl": "https://github.com/rudysev/portal-assistant/releases/download/v2.1.0/portal-assistant-v2.1.0.apk",
-          "versionCode": 3,
+          "apkUrl": "https://github.com/rudysev/portal-assistant/releases/latest/download/portal-assistant.apk",
+          "versionUrl": "https://raw.githubusercontent.com/rudysev/portal-assistant/main/version.json",
           "minSdk": 28,
           "description": "Hands-free voice assistant — ask anything, control the device, open apps. BYO Gemini key.",
           "longDescription": "A conversational AI assistant built for the Portal, powered by the Gemini Live API. Talk to it in plain language and it answers out loud in a natural voice — web lookups, device control, opening apps — running as background voice with just a small orange bar over whatever's on screen, plus a live on-screen chat when the app is open. It knows the device's local time and approximate location, so questions like \"what's the weather?\" just work. Bring your own free Google Gemini API key (aistudio.google.com/apikey) — it stays on the device. Tap-to-talk works everywhere; the hands-free \"Hey Jarvis\" wake word needs the companion portal-wake app and is Gen 1 only.",


### PR DESCRIPTION
## Summary
Both apps' catalog entries were pinned to a fixed release tag and `versionCode`, so every release required a manual `catalog.json` edit — and Portal-Kasa had already drifted two releases behind.

This points `apkUrl` at the stable `releases/latest/download` asset and replaces the `versionCode` pin with a `versionUrl` manifest (`version.json` on each repo's `main`) that the store reads live — per the catalog's own schema note. The entries now stay current with **no catalog edit per release**.

## Changes
- `catalog.json` — Jarvis and Portal-Kasa entries switched to `latest/download` asset URLs + `versionUrl` manifests (5 insertions, 5 deletions).

## Verification
Verified end to end:
- Both repos now publish a stable-named asset alongside the tag-stamped one (their release scripts maintain both plus `version.json`).
- The `latest/download` URLs resolve HTTP 200.
- The manifests parse.
- `StoreCatalogTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)