### PR TITLE
provisioning: also disable the Settings RRO on Gen-1 (fixes #137)

### DIFF
--- a/provisioning/config.env
+++ b/provisioning/config.env
@@ -31,11 +31,12 @@ VERIFIER_PKG=com.facebook.appverifier
 # it can't kill the daemon). Skipped automatically on newer Portals (API >= 29),
 # which have a working dialog and don't ship this overlay. Reversible via restore.
 DISABLE_INSTALLER_OVERLAY=true
-# Overlay package(s) to disable, space separated. The framework overlay is the one
-# that breaks the installer dialog; a companion settings overlay
-# (com.facebook.aloha.rro.niu.settings) exists on some builds - only ones actually
-# present on the device are touched.
-INSTALLER_OVERLAY_PKGS="com.facebook.aloha.rro.niu.android"
+# Overlay package(s) to disable, space separated. The framework overlay
+# (com.facebook.aloha.rro.niu.android) breaks the installer dialog; the companion
+# settings overlay (com.facebook.aloha.rro.niu.settings) re-themes System Settings
+# white-on-white on some Gen-1 builds, making it unreadable (issue #137). Only
+# overlays actually present on the device are touched, and restore re-enables them.
+INSTALLER_OVERLAY_PKGS="com.facebook.aloha.rro.niu.android com.facebook.aloha.rro.niu.settings"
 
 # Which steps to perform.
 # SET_LAUNCHER replaces the SYSTEM home with our launcher (reversible via

--- a/provisioning/provision.ps1
+++ b/provisioning/provision.ps1
@@ -304,7 +304,7 @@ function Disable-InstallerOverlay {
   if ($cfg["DISABLE_INSTALLER_OVERLAY"] -eq "false") { return }
   $sdk = [int]("$(A shell getprop ro.build.version.sdk)".Trim())
   if ($sdk -ge 29) { return }  # newer Portals have a working dialog; no overlay to fix
-  Step "Fixing the on-device installer dialog (disabling Meta's white-on-white overlay)"
+  Step "Fixing Meta's white-on-white overlays (installer dialog + system settings)"
   $did = $false
   foreach ($ov in ($cfg["INSTALLER_OVERLAY_PKGS"] -split "\s+")) {
     if (-not $ov) { continue }

--- a/provisioning/provision.sh
+++ b/provisioning/provision.sh
@@ -384,7 +384,7 @@ disable_installer_overlay() {
   # Newer Portals (API >= 29) have a working installer dialog and don't ship this
   # overlay — skip them so we don't touch theming that isn't broken.
   [ "${sdk:-99}" -lt 29 ] 2>/dev/null || return
-  step "Fixing the on-device installer dialog (disabling Meta's white-on-white overlay)"
+  step "Fixing Meta's white-on-white overlays (installer dialog + system settings)"
   local did=0
   for ov in $INSTALLER_OVERLAY_PKGS; do
     # Only act on overlays actually present on this device.


### PR DESCRIPTION
## Problem

Reported in #137. After provisioning a Gen-1 Portal+ (Android 9), Immortal works, but Android **System Settings** renders white-on-white and is unreadable. The reporter traced it to the companion overlay `com.facebook.aloha.rro.niu.settings` and confirmed:

```
adb shell cmd overlay disable --user 0 com.facebook.aloha.rro.niu.settings
```

fixes it. This is the same class of issue as the installer-dialog overlay (`com.facebook.aloha.rro.niu.android`) that provisioning already disables.

## Fix

Add `com.facebook.aloha.rro.niu.settings` to the default `INSTALLER_OVERLAY_PKGS`. The existing overlay-fix path in both provisioners already:

- **presence-guards** each entry (`cmd overlay list | grep` — only overlays actually on the device are touched), so devices without it are unaffected;
- only runs on **API < 29** (Gen-1), where these overlays exist;
- **restores** by re-enabling the full list, so it stays reversible.

The user-facing step message is broadened to "Fixing Meta's white-on-white overlays (installer dialog + system settings)".

## Testing

- `bash -n provision.sh` parses; `config.env` sources with both packages.
- `provision.ps1` parses via the PowerShell AST parser and is ASCII-clean (Windows-script hard rule).
- CI's provisioning-script parse check covers both.

Closes #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4SmhtgSd5B5sdTiV216XM)_