### PR TITLE
Immich: play videos when the "Play videos" setting is on

### DIFF
--- a/app/src/main/java/com/immortal/launcher/ImmichSource.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmichSource.kt
@@ -14,9 +14,10 @@ import org.json.JSONObject
 
 /**
  * A photo source backed by a self-hosted [Immich](https://immich.app) server — the most
- * requested screensaver source. Lists image *preview* URLs for a chosen album (or the whole
- * library); the screensaver then downloads each through the shared remote path, sending the
- * same `x-api-key` header (see [authHeaders]).
+ * requested screensaver source. Lists image *preview* URLs (and, when the "Play videos" setting
+ * is on, video *playback* URLs) for a chosen album (or the whole library); the screensaver then
+ * fetches each through the shared remote path, sending the same `x-api-key` header (see
+ * [authHeaders]).
  *
  * Verified against Immich **v2.5.2** and **v3.0.1**:
  *  - auth: header `x-api-key: <key>` (no key → 401)
@@ -26,6 +27,7 @@ import org.json.JSONObject
  *    dropped the `assets` array that `GET /api/albums/{id}` used to embed, so both paths now go
  *    through search — see #135.)
  *  - image bytes:   `GET  /api/assets/{id}/thumbnail?size=preview` → JPEG sized to the screen
+ *  - video stream:  `GET  /api/assets/{id}/video/playback` → the (server-transcoded) clip
  *
  * Everything is best-effort: any failure returns null and the caller falls back to the default
  * feed, so the frame is never blank.
@@ -34,6 +36,9 @@ object ImmichSource {
 
   /** A library album, for the connection picker. */
   data class Album(val id: String, val name: String, val count: Int)
+
+  /** One playable asset: a preview-image URL, or a video-playback URL when [isVideo]. */
+  data class Media(val url: String, val isVideo: Boolean)
 
   /** Header(s) every Immich request (including image downloads) must carry. */
   fun authHeaders(apiKey: String): Map<String, String> = mapOf("x-api-key" to apiKey.trim())
@@ -48,6 +53,10 @@ object ImmichSource {
   /** The preview-image URL for an asset (sized to the screen; ~150KB JPEG). */
   fun previewUrl(base: String, assetId: String): String =
       "${normalizeBase(base)}/api/assets/$assetId/thumbnail?size=preview"
+
+  /** The streaming-playback URL for a video asset (the server transcodes as needed). */
+  fun playbackUrl(base: String, assetId: String): String =
+      "${normalizeBase(base)}/api/assets/$assetId/video/playback"
 
   /** Confirm the server is reachable and the key is valid (`GET /api/users/me` → 200). */
   fun testConnection(base: String, apiKey: String): Boolean =
@@ -69,40 +78,53 @@ object ImmichSource {
           .getOrNull()
 
   /**
-   * Image preview URLs for [albumId] (or the whole library when null/blank), capped at [cap].
-   * Images only — videos are skipped (the frame can't stream auth'd video). Null on failure.
+   * Playable media for [albumId] (or the whole library when null/blank), capped at [cap] items:
+   * preview URLs for images, playback URLs for videos when [includeVideo] is on (the "Play
+   * videos" setting — videos stream through the same auth'd remote path). Null on failure.
    */
-  fun listImageUrls(base: String, apiKey: String, albumId: String?, cap: Int = 1000): List<String>? =
+  fun listMedia(
+      base: String,
+      apiKey: String,
+      albumId: String?,
+      includeVideo: Boolean = false,
+      cap: Int = 1000,
+  ): List<Media>? =
       runCatching {
             val b = normalizeBase(base)
             val headers = authHeaders(apiKey)
-            val ids = searchImageIds(b, headers, cap, albumId?.takeIf { it.isNotBlank() })
-            ids.map { previewUrl(b, it) }
+            val assets = searchAssets(b, headers, cap, albumId?.takeIf { it.isNotBlank() }, includeVideo)
+            assets.map { (id, isVideo) ->
+              Media(if (isVideo) playbackUrl(b, id) else previewUrl(b, id), isVideo)
+            }
           }
           .getOrNull()
 
   /**
-   * Image asset ids via the paged `POST /api/search/metadata` endpoint. When [albumId] is given
-   * the search is filtered to that album (`albumIds`), otherwise it covers the whole library. This
-   * one path replaces the old album `GET /api/albums/{id}` embed, which stopped returning an
-   * `assets` array in Immich 3.0 (#135).
+   * Asset (id, isVideo) pairs via the paged `POST /api/search/metadata` endpoint. When [albumId]
+   * is given the search is filtered to that album (`albumIds`), otherwise it covers the whole
+   * library. This one path replaces the old album `GET /api/albums/{id}` embed, which stopped
+   * returning an `assets` array in Immich 3.0 (#135). Images only searches keep the server-side
+   * `type: IMAGE` filter; with [includeVideo] the type filter is dropped and IMAGE/VIDEO are
+   * accepted client-side, preserving the library's natural ordering.
    */
-  private fun searchImageIds(
+  private fun searchAssets(
       base: String,
       headers: Map<String, String>,
       cap: Int,
       albumId: String?,
-  ): List<String> {
-    val out = ArrayList<String>()
+      includeVideo: Boolean,
+  ): List<Pair<String, Boolean>> {
+    val out = ArrayList<Pair<String, Boolean>>()
     var page = 1
     while (out.size < cap) {
-      val req = JSONObject().put("type", "IMAGE").put("size", 1000).put("page", page)
+      val req = JSONObject().put("size", 1000).put("page", page)
+      if (!includeVideo) req.put("type", "IMAGE")
       if (albumId != null) req.put("albumIds", JSONArray().put(albumId))
       val body = httpPostJson("$base/api/search/metadata", headers, req.toString()) ?: break
       val assets = JSONObject(body).optJSONObject("assets") ?: break
       val items = assets.optJSONArray("items") ?: break
       if (items.length() == 0) break
-      out.addAll(imageIdsFrom(items, cap - out.size))
+      out.addAll(assetsFrom(items, cap - out.size, includeVideo))
       val next = assets.opt("nextPage")
       if (next == null || next == JSONObject.NULL) break
       page = (next as? String)?.toIntOrNull() ?: (next as? Int) ?: break
@@ -110,12 +132,19 @@ object ImmichSource {
     return out
   }
 
-  private fun imageIdsFrom(assets: JSONArray, limit: Int): List<String> {
-    val out = ArrayList<String>()
+  private fun assetsFrom(
+      assets: JSONArray,
+      limit: Int,
+      includeVideo: Boolean,
+  ): List<Pair<String, Boolean>> {
+    val out = ArrayList<Pair<String, Boolean>>()
     var i = 0
     while (i < assets.length() && out.size < limit) {
       val o = assets.getJSONObject(i)
-      if (o.optString("type") == "IMAGE") out.add(o.getString("id"))
+      when (o.optString("type")) {
+        "IMAGE" -> out.add(o.getString("id") to false)
+        "VIDEO" -> if (includeVideo) out.add(o.getString("id") to true)
+      }
       i++
     }
     return out

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -160,9 +160,13 @@ class PhotoFrameController(
   // overlapping re-fetches.
   private var remoteReresolveStreak = 0
   private var remoteReresolving = false
-  // Auth headers sent with each remote image download — empty for public shares, the
-  // x-api-key for Immich. Applied in [advanceRemote]/[downloadBitmap].
+  // Auth headers sent with each remote fetch (image download or video stream) — empty for
+  // public shares, the x-api-key for Immich. Applied in [advanceRemote]/[downloadBitmap]/
+  // [showRemoteVideo].
   private var remoteHeaders: Map<String, String> = emptyMap()
+  // The subset of [remoteUrls] that are videos (Immich with "Play videos" on); these stream
+  // through the VideoView instead of the bitmap download. See [showRemoteVideo].
+  private var remoteVideos: Set<String> = emptySet()
   // Optional custom fetcher for the remote path: when set (SMB), each "url" is fetched through
   // this instead of an HTTP download, so SMB reuses all the remote advance/tick/fallback logic.
   private var remoteFetch: ((String) -> Bitmap?)? = null
@@ -332,10 +336,14 @@ class PhotoFrameController(
       }
       is PhotoFrameSource.Immich -> {
         io.execute {
-          val urls = ImmichSource.listImageUrls(source.url, source.key, source.albumId).orEmpty()
+          val media =
+              ImmichSource.listMedia(source.url, source.key, source.albumId, source.includeVideo)
+                  .orEmpty()
           ui.post {
-            if (urls.isNotEmpty()) {
-              remoteUrls = if (source.shuffle) urls.shuffled() else urls
+            if (media.isNotEmpty()) {
+              val ordered = if (source.shuffle) media.shuffled() else media
+              remoteUrls = ordered.map { it.url }
+              remoteVideos = media.filter { it.isVideo }.mapTo(HashSet()) { it.url }
               remoteHeaders = ImmichSource.authHeaders(source.key)
               remoteMode = true
               remoteIndex = -1
@@ -1195,6 +1203,10 @@ class PhotoFrameController(
     remoteIndex = ((remoteIndex + dir) % remoteUrls.size + remoteUrls.size) % remoteUrls.size
     val url = remoteUrls[remoteIndex]
     val g = gen
+    if (url in remoteVideos) {
+      showRemoteVideo(url, g)
+      return
+    }
     stopVideo()
     io.execute {
       val fetch = remoteFetch
@@ -1218,6 +1230,49 @@ class PhotoFrameController(
         ui.postDelayed(remoteTick, intervalMs())
       }
     }
+  }
+
+  /**
+   * Stream a remote video (an Immich playback URL) through the shared [videoView]. Mirrors the
+   * local [showVideo] — muted, advance on completion, skip on error — but the URI variant carries
+   * [remoteHeaders] so the server's auth (`x-api-key`) rides along with the stream.
+   */
+  private fun showRemoteVideo(url: String, g: Int) {
+    cancelKenBurns()
+    faceRenderer.setCaption(null, null)
+    photo.setImageDrawable(null)
+    photo.visibility = View.GONE
+    videoView.visibility = View.VISIBLE
+    runCatching {
+          videoView.setOnPreparedListener { mp ->
+            mp.isLooping = false
+            runCatching { mp.setVolume(0f, 0f) } // a screensaver shouldn't blare audio
+            if (g == gen) {
+              remoteFailStreak = 0
+              remoteReresolveStreak = 0
+              videoView.start()
+            }
+          }
+          videoView.setOnCompletionListener {
+            if (g == gen) advanceRemote(+1)
+          }
+          videoView.setOnErrorListener { _, _, _ ->
+            if (g == gen) {
+              remoteFailStreak++
+              advanceRemote(+1)
+            }
+            true
+          }
+          videoView.setVideoURI(android.net.Uri.parse(url), remoteHeaders)
+          // Safety net: advance even if a clip is very long or never reports done.
+          ui.postDelayed(remoteTick, maxOf(intervalMs(), 5 * 60_000L))
+        }
+        .onFailure {
+          if (g == gen) {
+            remoteFailStreak++
+            advanceRemote(+1)
+          }
+        }
   }
 
   /**
@@ -1265,6 +1320,7 @@ class PhotoFrameController(
     localMode = false
     remoteMode = false
     remoteHeaders = emptyMap()
+    remoteVideos = emptySet()
     remoteFetch = null
     smbSource?.let { s -> io.execute { runCatching { s.close() } } }
     smbSource = null

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameSource.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameSource.kt
@@ -26,6 +26,7 @@ sealed class PhotoFrameSource {
       val url: String,
       val key: String,
       val albumId: String?,
+      val includeVideo: Boolean,
       val shuffle: Boolean,
   ) : PhotoFrameSource()
 
@@ -77,6 +78,7 @@ sealed class PhotoFrameSource {
                   url = settings.immichUrl!!,
                   key = settings.immichKey!!,
                   albumId = settings.immichAlbumId,
+                  includeVideo = settings.includeVideo,
                   shuffle = settings.shuffle,
               )
           settings.usesDav ->

--- a/app/src/test/java/com/immortal/launcher/ImmichSourceTest.kt
+++ b/app/src/test/java/com/immortal/launcher/ImmichSourceTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ImmichSourceTest {
+
+  @Test
+  fun normalizeBase_stripsTrailingSlashAndApiSuffix() {
+    assertEquals("http://immich:2283", ImmichSource.normalizeBase("http://immich:2283/"))
+    assertEquals("http://immich:2283", ImmichSource.normalizeBase(" http://immich:2283/api "))
+    assertEquals("https://photos.example", ImmichSource.normalizeBase("https://photos.example/API/"))
+  }
+
+  @Test
+  fun previewUrl_pointsAtScreenSizedThumbnail() {
+    assertEquals(
+        "http://immich:2283/api/assets/abc/thumbnail?size=preview",
+        ImmichSource.previewUrl("http://immich:2283/", "abc"))
+  }
+
+  @Test
+  fun playbackUrl_pointsAtVideoPlaybackEndpoint() {
+    assertEquals(
+        "http://immich:2283/api/assets/abc/video/playback",
+        ImmichSource.playbackUrl("http://immich:2283/", "abc"))
+  }
+
+  @Test
+  fun authHeaders_carryTrimmedApiKey() {
+    assertEquals(mapOf("x-api-key" to "secret"), ImmichSource.authHeaders(" secret "))
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/PhotoFrameSourceTest.kt
+++ b/app/src/test/java/com/immortal/launcher/PhotoFrameSourceTest.kt
@@ -44,13 +44,15 @@ class PhotoFrameSourceTest {
                 shuffle = true,
             )))
     assertEquals(
-        PhotoFrameSource.Immich("http://immich", "key", albumId = "album", shuffle = false),
+        PhotoFrameSource.Immich(
+            "http://immich", "key", albumId = "album", includeVideo = false, shuffle = false),
         PhotoFrameSource.from(
             ScreensaverConfig.Settings(
                 source = ScreensaverConfig.SOURCE_IMMICH,
                 immichUrl = "http://immich",
                 immichKey = "key",
                 immichAlbumId = "album",
+                includeVideo = false,
             )))
   }
 

--- a/docs/features/screensaver.md
+++ b/docs/features/screensaver.md
@@ -38,7 +38,7 @@ you don't type URLs and credentials on the Portal:
 | --- | --- |
 | Your own folder | Photos **and** videos from the device's own storage. EXIF rotation is honoured. |
 | iCloud shared album | Paste a shared-album link (supports Apple's newer CloudKit link format). |
-| [Immich](https://immich.app/) | A self-hosted photo library. |
+| [Immich](https://immich.app/) | A self-hosted photo library. Photos **and** videos (with "Play videos" on), from an album or the whole library. |
 | Network share (SMB) | A file server on your LAN. |
 | WebDAV | Any WebDAV server. |
 | Web page | Pull images from any web page. |


### PR DESCRIPTION
## Problem

Choosing Immich as the screensaver photo source (album or whole library) only ever showed photos — videos were skipped even with the **Play videos** setting on. The Immich source hard-filtered its metadata search to `type: "IMAGE"`, and the setting was only wired to the local-folder source.

## Changes

- **`ImmichSource`** — `listImageUrls` becomes `listMedia(..., includeVideo)`. With "Play videos" on, the `POST /api/search/metadata` request drops the server-side type filter and accepts `IMAGE`/`VIDEO` client-side (preserving library order, still album-filtered). Videos map to the streaming endpoint `GET /api/assets/{id}/video/playback`; images keep the preview thumbnail. With the setting off, the request is unchanged.
- **`PhotoFrameSource.Immich`** — carries `includeVideo` from the existing setting, same as the folder source.
- **`PhotoFrameController`** — the remote slideshow tracks which URLs are videos and streams them through the shared `VideoView` via `setVideoURI(uri, headers)`, so the `x-api-key` header rides along with the stream. Same semantics as local folder videos: muted, advance on completion, skip on error, fall back to the built-in feed after a full failure loop.
- Updated `PhotoFrameSourceTest`, added `ImmichSourceTest` for the URL/auth helpers, refreshed the Immich row in `docs/features/screensaver.md`.

## Testing

- `./gradlew :app:testDebugUnitTest` — green locally (Gradle 9.4.1, SDK platform 36, mirroring `tests.yml`).
- On-device behaviour notes: videos stream directly from the Immich server (first frame may take a moment on large clips while the server transcodes) and play muted, like folder videos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiZKi8ubqa9kmX9EGXrqGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiZKi8ubqa9kmX9EGXrqGR)_