### PR TITLE
Fix screensaver dismiss-app after handoff, silent Immich fallback, and forced gradient (#146, #103, #142, #144)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/DreamPolicy.kt
+++ b/app/src/main/java/com/immortal/launcher/DreamPolicy.kt
@@ -184,6 +184,9 @@ object DreamPolicy {
     runCatching {
       context.startActivity(
           Intent(context, PhotoFramePreviewActivity::class.java)
+              // The continuation frame IS the screensaver to the user, so a tap on it must honour
+              // the "open when dismissed" target like the dream's own tap handler (issue #146).
+              .putExtra(PhotoFramePreviewActivity.EXTRA_LAUNCH_DISMISS_APP, true)
               .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP))
     }
         .onFailure { Log.w(TAG, "frame relaunch failed", it) }

--- a/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
+++ b/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
@@ -164,14 +164,17 @@ class FaceRenderer(
     // A full-bleed clock (e.g. the Fliqlo flip clock) owns the whole frame on its own near-black
     // background, so skip the scrim and the date/battery/weather widgets — none should overlay it.
     if (!fullBleed) {
-      // Legibility scrim under the bottom cluster, matching the original frame.
-      val scrim = View(context)
-      scrim.background =
-          GradientDrawable(
-              GradientDrawable.Orientation.BOTTOM_TOP,
-              intArrayOf(0xCC000000.toInt(), 0x00000000),
-          )
-      view.addView(scrim, 0, FrameLayout.LayoutParams(MATCH, dp(320), Gravity.BOTTOM))
+      // Legibility scrim under the bottom cluster, matching the original frame. Optional since
+      // issue #144 — art-frame setups with the widgets off want the photo clean to the edge.
+      if (ScreensaverConfig.load(context).showGradient) {
+        val scrim = View(context)
+        scrim.background =
+            GradientDrawable(
+                GradientDrawable.Orientation.BOTTOM_TOP,
+                intArrayOf(0xCC000000.toInt(), 0x00000000),
+            )
+        view.addView(scrim, 0, FrameLayout.LayoutParams(MATCH, dp(320), Gravity.BOTTOM))
+      }
       buildStandaloneWidgets(face)
       // Photo caption is photo metadata, so (like the widgets) it's skipped on a full-bleed clock.
       if (face.caption.enabled) buildCaption(face.caption)

--- a/app/src/main/java/com/immortal/launcher/ImmichSource.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmichSource.kt
@@ -7,6 +7,7 @@
 
 package com.immortal.launcher
 
+import android.util.Log
 import java.net.HttpURLConnection
 import java.net.URL
 import org.json.JSONArray
@@ -30,9 +31,11 @@ import org.json.JSONObject
  *  - video stream:  `GET  /api/assets/{id}/video/playback` → the (server-transcoded) clip
  *
  * Everything is best-effort: any failure returns null and the caller falls back to the default
- * feed, so the frame is never blank.
+ * feed, so the frame is never blank — but every failure is logged under [TAG], because a silent
+ * fallback is undiagnosable from a user report (issue #142).
  */
 object ImmichSource {
+  private const val TAG = "ImmortalImmich"
 
   /** A library album, for the connection picker. */
   data class Album(val id: String, val name: String, val count: Int)
@@ -75,6 +78,7 @@ object ImmichSource {
               Album(o.getString("id"), o.optString("albumName", "Album"), o.optInt("assetCount", 0))
             }
           }
+          .onFailure { Log.w(TAG, "album list failed", it) }
           .getOrNull()
 
   /**
@@ -93,10 +97,14 @@ object ImmichSource {
             val b = normalizeBase(base)
             val headers = authHeaders(apiKey)
             val assets = searchAssets(b, headers, cap, albumId?.takeIf { it.isNotBlank() }, includeVideo)
+            if (assets.isEmpty()) {
+              Log.w(TAG, "search returned no assets (album=${albumId ?: "library"})")
+            }
             assets.map { (id, isVideo) ->
               Media(if (isVideo) playbackUrl(b, id) else previewUrl(b, id), isVideo)
             }
           }
+          .onFailure { Log.w(TAG, "media list failed (album=${albumId ?: "library"})", it) }
           .getOrNull()
 
   /**
@@ -157,7 +165,7 @@ object ImmichSource {
     c.readTimeout = 10000
     headers.forEach { (k, v) -> c.setRequestProperty(k, v) }
     return if (c.responseCode in 200..299) c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
-    else null
+    else null.also { logHttpFailure("GET", spec, c) }
   }
 
   private fun httpPostJson(spec: String, headers: Map<String, String>, json: String): String? {
@@ -170,6 +178,14 @@ object ImmichSource {
     headers.forEach { (k, v) -> c.setRequestProperty(k, v) }
     c.outputStream.use { it.write(json.toByteArray(Charsets.UTF_8)) }
     return if (c.responseCode in 200..299) c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
-    else null
+    else null.also { logHttpFailure("POST", spec, c) }
+  }
+
+  /** A rejected request is the one clue a user report can carry — keep the server's own words. */
+  private fun logHttpFailure(method: String, spec: String, c: HttpURLConnection) {
+    val detail =
+        runCatching { c.errorStream?.use { it.readBytes().toString(Charsets.UTF_8).take(300) } }
+            .getOrNull()
+    Log.w(TAG, "$method $spec -> HTTP ${c.responseCode}${detail?.let { ": $it" } ?: ""}")
   }
 }

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -350,7 +350,9 @@ class PhotoFrameController(
               remoteFailStreak = 0
               advanceRemote(+1)
             } else {
-              // Server unreachable / album empty → never leave the frame blank.
+              // Server unreachable / album empty → never leave the frame blank. Say so: the
+              // swap to the built-in feed is otherwise invisible in a user report (issue #142).
+              Log.w(TAG, "Immich gave no media (album=${source.albumId ?: "library"}); falling back to built-in feed")
               startWeb()
             }
           }

--- a/app/src/main/java/com/immortal/launcher/PhotoFramePreviewActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFramePreviewActivity.kt
@@ -14,6 +14,7 @@ import android.content.IntentFilter
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import android.view.MotionEvent
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
@@ -71,7 +72,21 @@ class PhotoFramePreviewActivity : ComponentActivity() {
     }
 
     frame = PhotoFrameController(this, showWelcome = intent.getBooleanExtra(EXTRA_SHOW_WELCOME, false))
-    frame.onExit = { finish() }
+    // Only the screensaver-continuation launch (DreamPolicy's force-wake handoff) honours the
+    // "open when dismissed" choice — to the user that frame IS the screensaver, so a tap must
+    // behave like PhotoDreamService's tap (issue #146). Deliberate on-demand starts (settings
+    // preview, face picker, header button, MQTT command) keep returning to where they came from.
+    // The night clock never launches anything — a 3am tap should just hand back, dark.
+    val launchDismissOnExit = intent.getBooleanExtra(EXTRA_LAUNCH_DISMISS_APP, false) && !nightClock
+    frame.onExit = {
+      Log.i(TAG, "onExit (tap) -> finish(), launchDismiss=$launchDismissOnExit")
+      // The user tapped the frame: they're unambiguously here. Without this the continuation
+      // frame leaves PresenceHub stuck on DREAMING (finishing an Activity fires no dream-stop),
+      // so MQTT screen/state reported "dreaming" forever after the ~2-min handoff (issue #103).
+      PresenceHub.onInteraction(this)
+      if (launchDismissOnExit) ScreensaverDismiss.launchChosenApp(this)
+      finish()
+    }
 
     if (nightClock) {
       // Bedside clock: force the screen on for the window and dim it to a soft glow. Brightness is
@@ -151,8 +166,17 @@ class PhotoFramePreviewActivity : ComponentActivity() {
   }
 
   companion object {
+    private const val TAG = "ImmortalFrame"
+
     /** When true, the launched frame shows the welcome-back overlay (presence-triggered starts). */
     const val EXTRA_SHOW_WELCOME = "show_welcome"
+
+    /**
+     * When true, a tap-to-dismiss honours the "open when dismissed" target ([ScreensaverDismiss]).
+     * Set only by [DreamPolicy]'s screensaver-continuation relaunch — on-demand previews keep the
+     * plain finish-back-to-caller behaviour.
+     */
+    const val EXTRA_LAUNCH_DISMISS_APP = "launch_dismiss_app"
 
     // A soft glow for the overnight bedside clock — dim but still legible in a dark room.
     const val NIGHT_BRIGHTNESS = 0.08f

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -145,6 +145,9 @@ object ScreensaverConfig {
       // Anti-burn-in pixel-shift: slowly drift the overlay so static content (the clock) doesn't
       // brand the panel over days. On by default; can be turned off if the motion is distracting.
       val antiBurnIn: Boolean = true,
+      // The legibility gradient under the bottom widget cluster. On by default (the original
+      // frame look); off shows the photo clean edge-to-edge (issue #144).
+      val showGradient: Boolean = true,
       // Whether to draw a clock face at all. Off = photos only (the now-playing card still follows
       // its own [showNowPlaying] switch). On by default.
       val facesEnabled: Boolean = true,
@@ -274,6 +277,7 @@ object ScreensaverConfig {
         batterySaver = p.getBoolean("battery_saver", true),
         showNowPlaying = p.getBoolean("show_now_playing", true),
         antiBurnIn = p.getBoolean("anti_burn_in", true),
+        showGradient = p.getBoolean("show_gradient", true),
         facesEnabled = p.getBoolean("faces_enabled", true),
         faceId = p.getString("face_id", "immortal-classic") ?: "immortal-classic",
         faceSizeIndex = p.getInt("face_size_index", 1),
@@ -426,6 +430,10 @@ object ScreensaverConfig {
 
   fun setAntiBurnIn(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("anti_burn_in", on).apply()
+
+  /** Show/hide the legibility gradient under the bottom widget cluster. */
+  fun setShowGradient(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("show_gradient", on).apply()
 
   /** Turn the clock face on/off (off = photos only). */
   fun setFacesEnabled(c: Context, on: Boolean) =

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -275,6 +275,14 @@ object SettingsDomains {
                       "Reduce screen burn-in",
                       get = { it.antiBurnIn },
                       set = ScreensaverConfig::setAntiBurnIn),
+                  BoolSpec(
+                      "showGradient",
+                      "Legibility gradient",
+                      get = { it.showGradient },
+                      set = ScreensaverConfig::setShowGradient,
+                      help =
+                          "Darken the bottom of the frame so the clock and widgets stay readable " +
+                              "over bright photos. Turn off to show photos clean edge-to-edge."),
                   EnumSpec(
                       "presenceMode",
                       "Power",
@@ -415,6 +423,7 @@ object SettingsDomains {
                   "includeVideo" to "Display",
                   "showNowPlaying" to "Display",
                   "antiBurnIn" to "Display",
+                  "showGradient" to "Display",
                   "feed" to "Display",
                   "ambientDashboard" to "Display",
                   "gestureWave" to "Display",


### PR DESCRIPTION
Three fixes from the issue triage, one commit each.

## 1. "Open app on dismiss" dies after the ~2-minute handoff (closes #146, most of #103)

`PhotoDreamService`'s tap handler launches the chosen dismiss target, but the `PhotoFramePreviewActivity` continuation frame — which takes over when Android force-wakes the DreamService, i.e. most of the frame's lifetime under the default ALWAYS_ON mode — dismissed with a bare `finish()`. Its tap-exit now:

- launches `ScreensaverDismiss.launchChosenApp()`, gated to the `DreamPolicy` continuation relaunch via a new `EXTRA_LAUNCH_DISMISS_APP` intent extra — deliberate on-demand starts (settings preview, face picker, welcome preview, header button, MQTT `screensaver` command) still return to their caller, and the night clock always stays dark;
- calls `PresenceHub.onInteraction()` — finishing an Activity fires no dream-stop, so the hub stayed stuck on `DREAMING` and MQTT `screen/state` never published `interactive` after the handoff (**#103**, Gen-2 report);
- logs the exit under a new `ImmortalFrame` tag (the #146 reporter hit a "no logs at all" wall here).

## 2. Immich failures fall back to the stock feed with zero trace (#142, part 1 of 2)

The whole Immich chain was `runCatching { … }.getOrNull()` with no logging, by design — which made #142 (album selection silently showing the built-in feed) undiagnosable from user reports. Non-2xx responses now log method/endpoint/status plus the first 300 chars of the server's error body under `ImmortalImmich`, and the fallback swap logs under `ImmortalPhotoFrame`. The root-cause fix for the album filter follows once the reporter's curl test confirms what the server actually returns (asked on the issue).

## 3. Legibility gradient can't be disabled (closes #144)

`FaceRenderer` drew the bottom scrim unconditionally on every non-full-bleed face, even with every widget off. New `showGradient` setting (default **on** — the original look is unchanged), wired through the settings registry so it appears on-device and on the phone remote, gates the scrim.

## Testing

- `./gradlew :app:testDebugUnitTest` green, including the settings-registry completeness tripwires picking up the new `showGradient` spec.
- On-device confirmation still wanted for #146/#103 (tap the continuation frame with an HA dismiss target set; watch `immortal/{id}/screen/state`) — the reporters of both issues have offered to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRTP7kN5WbzXFGoCWYR89s

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRTP7kN5WbzXFGoCWYR89s)_