### PR TITLE
Screensaver: honour fit/fill for videos; remote UI gains an Immich album picker

### DIFF
--- a/app/src/main/java/com/immortal/launcher/FleetScreensaver.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetScreensaver.kt
@@ -8,6 +8,7 @@
 package com.immortal.launcher
 
 import android.content.Context
+import org.json.JSONArray
 import org.json.JSONObject
 
 /**
@@ -51,6 +52,8 @@ object FleetScreensaver {
           .put("source", currentSource(s))
           .put("immichUrl", s.immichUrl ?: "")
           .put("immichKey", s.immichKey ?: "")
+          .put("immichAlbumId", s.immichAlbumId ?: "")
+          .put("immichAlbumName", s.immichAlbumName ?: "")
           .put("smbHost", s.smbHost ?: "")
           .put("smbShare", s.smbShare ?: "")
           .put("smbPath", s.smbPath ?: "")
@@ -61,6 +64,15 @@ object FleetScreensaver {
           .put("davPass", s.davPass ?: "")
           .put("webUrl", s.webUrl ?: "")
           .put("albumUrl", s.albumUrl ?: "")
+
+  /** Immich album list → wire JSON for the remote's album picker (`/remote/immich/albums`). Pure. */
+  fun albumsJson(albums: List<ImmichSource.Album>): JSONArray {
+    val arr = JSONArray()
+    albums.forEach { a ->
+      arr.put(JSONObject().put("id", a.id).put("name", a.name).put("count", a.count))
+    }
+    return arr
+  }
 
   /** The active photo-source as a Setup-form key (immich/smb/dav/web/album/default). Pure. */
   internal fun currentSource(s: ScreensaverConfig.Settings): String =
@@ -134,6 +146,14 @@ object FleetScreensaver {
       if (url.isNotBlank() && key.isNotBlank()) {
         ScreensaverConfig.setImmich(context, url, key)
         applied.add("immich")
+        // The album choice rides along with the connection (the remote's picker always sends the
+        // creds too). Only when the key is present, so a creds-only push keeps the saved album;
+        // a blank id means "whole library", so clearing stays expressible.
+        if (body.has("immichAlbumId")) {
+          ScreensaverConfig.setImmichAlbum(
+              context, body.optString("immichAlbumId"), body.optString("immichAlbumName"))
+          applied.add("immichAlbum")
+        }
       }
     }
     run {

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -667,10 +667,30 @@ class PhotoFrameController(
   }
 
   private fun applyFit() {
-    // Video letterboxes either way (VideoView limitation); images honour the choice.
+    // Video gets the same choice via [applyVideoFit], sized per-clip once its dimensions are known.
     photo.scaleType =
         if (settings.fit == ScreensaverConfig.FIT_FIT) ImageView.ScaleType.FIT_CENTER
         else ImageView.ScaleType.CENTER_CROP
+  }
+
+  /**
+   * Honour the fit setting for the shared [videoView]. VideoView always letterboxes inside its
+   * own bounds (its onMeasure shrinks to the clip's aspect even with EXACTLY specs), so "fill"
+   * can't be a scaleType like the photo layer: instead the view is sized to *cover* the screen
+   * (aspect-preserving, the video CENTER_CROP) and the parent clips the overflow. "Fit" — or an
+   * unknown clip/screen size — restores match-parent letterboxing.
+   */
+  private fun applyVideoFit(videoW: Int, videoH: Int) {
+    val lp = videoView.layoutParams as FrameLayout.LayoutParams
+    val host = videoView.parent as? View
+    val cover =
+        if (settings.fit == ScreensaverConfig.FIT_FILL)
+            videoCoverSize(videoW, videoH, host?.width ?: 0, host?.height ?: 0)
+        else null
+    lp.width = cover?.first ?: MATCH
+    lp.height = cover?.second ?: MATCH
+    lp.gravity = Gravity.CENTER
+    videoView.layoutParams = lp
   }
 
   // --- welcome-back overlay (fork) --------------------------------------------
@@ -1128,7 +1148,12 @@ class PhotoFrameController(
           videoView.setOnPreparedListener { mp ->
             mp.isLooping = false
             runCatching { mp.setVolume(0f, 0f) } // a screensaver shouldn't blare audio
-            if (g == gen) videoView.start()
+            // Some streams only report their real dimensions after prepare.
+            mp.setOnVideoSizeChangedListener { _, w, h -> if (g == gen) applyVideoFit(w, h) }
+            if (g == gen) {
+              applyVideoFit(mp.videoWidth, mp.videoHeight)
+              videoView.start()
+            }
           }
           videoView.setOnCompletionListener {
             if (g == gen) advanceLocal(+1)
@@ -1249,9 +1274,12 @@ class PhotoFrameController(
           videoView.setOnPreparedListener { mp ->
             mp.isLooping = false
             runCatching { mp.setVolume(0f, 0f) } // a screensaver shouldn't blare audio
+            // Some streams only report their real dimensions after prepare.
+            mp.setOnVideoSizeChangedListener { _, w, h -> if (g == gen) applyVideoFit(w, h) }
             if (g == gen) {
               remoteFailStreak = 0
               remoteReresolveStreak = 0
+              applyVideoFit(mp.videoWidth, mp.videoHeight)
               videoView.start()
             }
           }
@@ -1575,7 +1603,21 @@ class PhotoFrameController(
   private val MAX_RERESOLVE = 3
   private fun dp(v: Int): Int = (v * context.resources.displayMetrics.density).toInt()
 
-  private companion object {
+  internal companion object {
+    /**
+     * The view size (w × h) that makes a [videoW]×[videoH] clip cover a [screenW]×[screenH]
+     * screen with its aspect preserved — the geometry behind [applyVideoFit]'s fill mode. Null
+     * when any dimension is unknown (callers fall back to match-parent letterboxing). Clamped to
+     * at least the screen so rounding never leaves a hairline of background showing. Pure.
+     */
+    internal fun videoCoverSize(videoW: Int, videoH: Int, screenW: Int, screenH: Int): Pair<Int, Int>? {
+      if (videoW <= 0 || videoH <= 0 || screenW <= 0 || screenH <= 0) return null
+      val scale = maxOf(screenW.toDouble() / videoW, screenH.toDouble() / videoH)
+      return Pair(
+          Math.round(videoW * scale).toInt().coerceAtLeast(screenW),
+          Math.round(videoH * scale).toInt().coerceAtLeast(screenH))
+    }
+
     const val TAG = "ImmortalPhotoFrame"
     // Cap on the longest edge of any decoded photo. Full-res camera originals (tens of MP) decode
     // to bitmaps larger than the hardware Canvas can draw (~100MB), which crashes the launcher and

--- a/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
@@ -274,7 +274,7 @@ object RemoteHtml {
           <label class=pick><input type=radio name=src value=dav onclick="showSrc('dav')"> WebDAV folder</label>
           <label class=pick><input type=radio name=src value=web onclick="showSrc('web')"> Web page</label>
           <label class=pick><input type=radio name=src value=album onclick="showSrc('album')"> Shared album link</label>
-          <div class=srcf id=f_immich><input id=immichUrl placeholder="Immich URL (http://192.168.x.x:2283)"><input id=immichKey placeholder="API key"></div>
+          <div class=srcf id=f_immich><input id=immichUrl placeholder="Immich URL (http://192.168.x.x:2283)"><input id=immichKey placeholder="API key"><div class=row><select id=immichAlbum><option value="">Whole library</option></select><button onclick=loadImmichAlbums()>Load albums</button></div><div id=immichAlbumMsg class=sub style="margin:4px 0 0"></div></div>
           <div class=srcf id=f_smb><input id=smbHost placeholder="Host or IP"><input id=smbShare placeholder="Share name"><input id=smbPath placeholder="Folder path (optional)"><input id=smbUser placeholder="Username (optional)"><input id=smbPass type=password placeholder="Password (optional)"></div>
           <div class=srcf id=f_dav><input id=davUrl placeholder="WebDAV URL"><input id=davUser placeholder="Username (optional)"><input id=davPass type=password placeholder="Password (optional)"></div>
           <div class=srcf id=f_web><input id=webUrl placeholder="Web page URL"></div>
@@ -795,16 +795,43 @@ object RemoteHtml {
       var s=d.sources||{},src=s.source||'default';
       var r=document.querySelector('input[name=src][value="'+src+'"]');if(r)r.checked=true;
       setVal('immichUrl',s.immichUrl);setVal('immichKey',s.immichKey);
+      seedImmichAlbum(s.immichAlbumId,s.immichAlbumName);
       setVal('smbHost',s.smbHost);setVal('smbShare',s.smbShare);setVal('smbPath',s.smbPath);setVal('smbUser',s.smbUser);setVal('smbPass',s.smbPass);
       setVal('davUrl',s.davUrl);setVal('davUser',s.davUser);setVal('davPass',s.davPass);
       setVal('webUrl',s.webUrl);setVal('albumUrl',s.albumUrl);
       showSrc(src);
     }).catch(function(){});
   }
+  // --- Immich album picker: the <select> holds album ids; each option carries the plain album
+  // name in data-name (the label adds a photo count). seedImmichAlbum shows the saved choice
+  // without a fetch; "Load albums" pulls the server's list through the Portal (the phone often
+  // can't reach Immich directly, and the key shouldn't ride through a third box anyway).
+  function albumOption(id,name,label){var o=document.createElement('option');o.value=id;o.textContent=label||name;o.setAttribute('data-name',name);return o;}
+  function seedImmichAlbum(id,name){
+    var sel=document.getElementById('immichAlbum');sel.innerHTML='';
+    sel.appendChild(albumOption('','','Whole library'));
+    if(id)sel.appendChild(albumOption(id,name||'Saved album'));
+    sel.value=id||'';
+  }
+  function loadImmichAlbums(){
+    var msg=document.getElementById('immichAlbumMsg');msg.textContent='Loading albums…';
+    api('/remote/immich/albums',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({url:gv('immichUrl'),key:gv('immichKey')})})
+      .then(function(d){
+        if(!d||!d.ok)throw 0;
+        var sel=document.getElementById('immichAlbum'),cur=sel.value;
+        sel.innerHTML='';sel.appendChild(albumOption('','','Whole library'));
+        (d.albums||[]).forEach(function(a){sel.appendChild(albumOption(a.id,a.name,a.name+' ('+a.count+')'));});
+        sel.value=cur;if(sel.value!==cur)sel.value='';
+        msg.textContent=(d.albums&&d.albums.length)?'':'No albums on the server yet.';
+      })
+      .catch(function(){msg.textContent='Couldn\'t load albums — check the URL and API key.';});
+  }
   function saveSources(){
     var src=(document.querySelector('input[name=src]:checked')||{}).value||'default';
     var body={source:src};
-    if(src==='immich'){body.immichUrl=gv('immichUrl');body.immichKey=gv('immichKey');}
+    if(src==='immich'){body.immichUrl=gv('immichUrl');body.immichKey=gv('immichKey');
+      var sel=document.getElementById('immichAlbum'),opt=sel.options[sel.selectedIndex];
+      body.immichAlbumId=sel.value;body.immichAlbumName=sel.value?(opt&&opt.getAttribute('data-name'))||'':'';}
     else if(src==='smb'){body.smbHost=gv('smbHost');body.smbShare=gv('smbShare');body.smbPath=gv('smbPath');body.smbUser=gv('smbUser');body.smbPass=gv('smbPass');}
     else if(src==='dav'){body.davUrl=gv('davUrl');body.davUser=gv('davUser');body.davPass=gv('davPass');}
     else if(src==='web'){body.webUrl=gv('webUrl');}

--- a/app/src/main/java/com/immortal/launcher/RemoteRoutes.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteRoutes.kt
@@ -61,6 +61,7 @@ class RemoteRoutes(private val context: Context) {
         "/remote/devices" -> authed(req) { devices() }
         "/remote/roster" -> authed(req) { roster(req) }
         "/remote/sources" -> authed(req) { sources(req) }
+        "/remote/immich/albums" -> authed(req) { immichAlbums(req) }
         "/remote/settings" -> authed(req) { settings(req) }
         else -> json(404, err("not_found"))
       }
@@ -301,6 +302,24 @@ class RemoteRoutes(private val context: Context) {
         }
         else -> json(405, err("method_not_allowed"))
       }
+
+  /**
+   * List an Immich server's albums for the Setup form's album picker: POST `{"url":"…","key":"…"}`
+   * — the form's live field values, so the picker works before the connection is saved; blank
+   * fields fall back to the stored connection. Runs on the fleet server's pool thread, so the
+   * blocking fetch is fine here. 502 when the server can't be reached or rejects the key, so the
+   * form can hint at the problem instead of showing an empty list.
+   */
+  private fun immichAlbums(req: FleetHttpServer.Request): FleetHttpServer.Response {
+    if (req.method != "POST") return json(405, err("method_not_allowed"))
+    val body = parseJson(req.bodyText()) ?: return json(400, err("bad_json"))
+    val stored = ScreensaverConfig.load(context)
+    val url = body.optString("url").ifBlank { stored.immichUrl ?: "" }
+    val key = body.optString("key").ifBlank { stored.immichKey ?: "" }
+    if (url.isBlank() || key.isBlank()) return json(400, err("immich_credentials_required"))
+    val albums = ImmichSource.listAlbums(url, key) ?: return json(502, err("immich_unreachable"))
+    return json(200, ok().put("albums", FleetScreensaver.albumsJson(albums)))
+  }
 
   /**
    * Generic settings surface driven by the declarative [SettingsRegistry]. GET returns every

--- a/app/src/test/java/com/immortal/launcher/FleetScreensaverTest.kt
+++ b/app/src/test/java/com/immortal/launcher/FleetScreensaverTest.kt
@@ -87,6 +87,8 @@ class FleetScreensaverTest {
         listOf(
             "immichUrl",
             "immichKey",
+            "immichAlbumId",
+            "immichAlbumName",
             "smbHost",
             "smbShare",
             "smbPath",
@@ -112,6 +114,35 @@ class FleetScreensaverTest {
     assertEquals("immich", json.getString("source"))
     assertEquals("https://immich.example", json.getString("immichUrl"))
     assertEquals("secret-key", json.getString("immichKey"))
+  }
+
+  @Test
+  fun sourcesJson_reportsImmichAlbumChoice() {
+    val s =
+        ScreensaverConfig.Settings(
+            source = ScreensaverConfig.SOURCE_IMMICH,
+            immichUrl = "https://immich.example",
+            immichKey = "secret-key",
+            immichAlbumId = "album-1",
+            immichAlbumName = "Family")
+    val json = FleetScreensaver.sourcesJson(s)
+    assertEquals("album-1", json.getString("immichAlbumId"))
+    assertEquals("Family", json.getString("immichAlbumName"))
+  }
+
+  @Test
+  fun albumsJson_shapesPickerEntries() {
+    val json =
+        FleetScreensaver.albumsJson(
+            listOf(
+                ImmichSource.Album("a1", "Family", 120),
+                ImmichSource.Album("a2", "Holidays", 0)))
+    assertEquals(2, json.length())
+    assertEquals("a1", json.getJSONObject(0).getString("id"))
+    assertEquals("Family", json.getJSONObject(0).getString("name"))
+    assertEquals(120, json.getJSONObject(0).getInt("count"))
+    assertEquals("a2", json.getJSONObject(1).getString("id"))
+    assertEquals(0, json.getJSONObject(1).getInt("count"))
   }
 
   @Test

--- a/app/src/test/java/com/immortal/launcher/PhotoFrameControllerTest.kt
+++ b/app/src/test/java/com/immortal/launcher/PhotoFrameControllerTest.kt
@@ -1,0 +1,42 @@
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure geometry behind the screensaver's video fill mode (no Context). */
+class PhotoFrameControllerTest {
+
+  @Test
+  fun videoCoverSize_widerClipCoversByHeight() {
+    // 16:9 clip on a 4:3 screen: match the screen height, overflow horizontally.
+    val (w, h) = PhotoFrameController.videoCoverSize(1920, 1080, 1280, 960)!!
+    assertEquals(960, h)
+    assertTrue("width $w must cover 1280", w >= 1280)
+    // Aspect preserved: w/h == 1920/1080 (within rounding).
+    assertEquals(1707, w)
+  }
+
+  @Test
+  fun videoCoverSize_tallerClipCoversByWidth() {
+    // Portrait phone clip on a landscape screen: match the width, overflow vertically.
+    val (w, h) = PhotoFrameController.videoCoverSize(1080, 1920, 1920, 1080)!!
+    assertEquals(1920, w)
+    assertTrue("height $h must cover 1080", h >= 1080)
+    assertEquals(3413, h)
+  }
+
+  @Test
+  fun videoCoverSize_matchingAspectIsExactlyTheScreen() {
+    assertEquals(Pair(1920, 1080), PhotoFrameController.videoCoverSize(3840, 2160, 1920, 1080))
+  }
+
+  @Test
+  fun videoCoverSize_unknownDimensionsFallBack() {
+    // Audio-only / not-yet-reported sizes and an unlaid-out host all mean "letterbox instead".
+    assertNull(PhotoFrameController.videoCoverSize(0, 0, 1920, 1080))
+    assertNull(PhotoFrameController.videoCoverSize(1920, 1080, 0, 0))
+    assertNull(PhotoFrameController.videoCoverSize(-1, 1080, 1920, 1080))
+  }
+}

--- a/docs/features/remote.md
+++ b/docs/features/remote.md
@@ -22,7 +22,9 @@ the same always-on [fleet agent](fleet.md) that already manages the device over 
 - **App launcher grid** — every launchable app on the Portal, tap to open.
 - **Screensaver & calendar setup** — set the photo source (Immich / NAS / WebDAV / web / album /
   default feed) and the calendar feed from the phone, instead of typing URLs and credentials on the
-  Portal. (This replaced the old standalone "set up from your phone" LAN form.)
+  Portal. For Immich, "Load albums" lists the server's albums (fetched via the Portal) so you can
+  pick one — or the whole library — from the phone. (This replaced the old standalone "set up from
+  your phone" LAN form.)
 - **Multiple devices** — one remote drives every Portal on your Wi-Fi. Other Portals are discovered
   automatically (mDNS); pick one from the device switcher and pair it with its on-screen PIN. The
   phone keeps a per-device token, so a token never crosses between Portals.
@@ -143,3 +145,4 @@ secrets); the rest require `Authorization: Bearer <session-or-fleet-token>`.
 | `GET` | `/remote/devices` | this device's name + mDNS-discovered peers `[{name,host,port}]` |
 | `GET`/`POST` | `/remote/roster` | read or replace the phone's backed-up device roster `[{name,base,token}]` |
 | `GET`/`POST` | `/remote/sources` | read or set the screensaver photo source + calendar feed |
+| `POST` | `/remote/immich/albums` | `{"url":"…","key":"…"}` (blank → stored connection) → `{albums:[{id,name,count}]}` for the album picker |


### PR DESCRIPTION
Two screensaver fixes:

## Fit/fill for videos

The fit setting was only applied to the photo `ImageView`; videos always letterboxed (`applyFit()` even carried a comment calling it a VideoView limitation). Android's `VideoView` shrinks the clip to fit inside its own bounds, so fill can't be expressed as a scale type.

In fill mode the shared `VideoView` is now sized per-clip to *cover* the screen (aspect-preserving, the parent clips the overflow — the video equivalent of `CENTER_CROP`), applied once the clip's dimensions are known at prepare time and again via `onVideoSizeChanged` for streams that report late. Fit mode — or an unknown clip/screen size — keeps the old match-parent letterboxing. Applies to both local-folder videos and Immich streamed videos, which share the view. The cover geometry is a pure companion helper (`videoCoverSize`) with unit tests.

## Immich album picker on the phone remote

The remote's Setup form had Immich URL + API key fields but no way to pick an album (the on-Portal connect screen has a picker), so the remote could only set "whole library".

- New authed `POST /remote/immich/albums` endpoint: lists albums via `ImmichSource.listAlbums` using the form's live creds (falling back to the stored connection), so the fetch goes through the Portal — the phone doesn't need direct reachability to Immich and the key doesn't transit anywhere new. 502 with `immich_unreachable` when the server can't be reached, so the form can hint instead of showing an empty list.
- The Setup form gains a "Load albums" button + album dropdown ("Whole library" + each album with its photo count); the saved choice pre-fills without a fetch.
- `/remote/sources` now round-trips `immichAlbumId`/`immichAlbumName`, and `FleetScreensaver.apply` persists the album alongside the connection (blank id = whole library, so clearing is expressible). This also makes the album pushable from the fleet CLI's `/screensaver` endpoint.

Docs: `docs/features/remote.md` updated (endpoint table + setup description).

Tests: new `PhotoFrameControllerTest` (cover geometry incl. rounding/fallback edges), extended `FleetScreensaverTest` (`sourcesJson` album fields, `albumsJson` shape). Full `:app:testDebugUnitTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWncF4SGjBocNP8YToHvV3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWncF4SGjBocNP8YToHvV3)_