### PR TITLE
Frame: re-read dismiss intent on singleTask reuse (#146 regression)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/PhotoFramePreviewActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFramePreviewActivity.kt
@@ -38,6 +38,11 @@ class PhotoFramePreviewActivity : ComponentActivity() {
   private lateinit var frame: PhotoFrameController
   private var powerReceiver: BroadcastReceiver? = null
 
+  // Read from the *latest* intent (onCreate or onNewIntent), never captured in a closure:
+  // this activity is singleTask, so a relaunch while the frame is already up reuses the live
+  // instance and skips onCreate entirely (issue #146 regression).
+  private var launchDismissOnExit = false
+
   // Overnight "night clock" mode: this activity is the dimmed bedside flip clock for the window.
   private var nightClock = false
   private val nightWatch = Handler(Looper.getMainLooper())
@@ -77,7 +82,7 @@ class PhotoFramePreviewActivity : ComponentActivity() {
     // behave like PhotoDreamService's tap (issue #146). Deliberate on-demand starts (settings
     // preview, face picker, header button, MQTT command) keep returning to where they came from.
     // The night clock never launches anything — a 3am tap should just hand back, dark.
-    val launchDismissOnExit = intent.getBooleanExtra(EXTRA_LAUNCH_DISMISS_APP, false) && !nightClock
+    launchDismissOnExit = intent.getBooleanExtra(EXTRA_LAUNCH_DISMISS_APP, false) && !nightClock
     frame.onExit = {
       Log.i(TAG, "onExit (tap) -> finish(), launchDismiss=$launchDismissOnExit")
       // The user tapped the frame: they're unambiguously here. Without this the continuation
@@ -136,6 +141,17 @@ class PhotoFramePreviewActivity : ComponentActivity() {
             })
       }
     }
+  }
+
+  // singleTask relaunch onto a live frame (most commonly DreamPolicy's force-wake continuation
+  // when this instance survived under the dream) lands here, not onCreate. Re-derive the
+  // dismiss behaviour from the fresh intent — last launch wins, matching what onCreate would
+  // have decided — and log it, so a reused instance is visible in a logcat capture.
+  override fun onNewIntent(intent: Intent) {
+    super.onNewIntent(intent)
+    setIntent(intent)
+    launchDismissOnExit = intent.getBooleanExtra(EXTRA_LAUNCH_DISMISS_APP, false) && !nightClock
+    Log.i(TAG, "onNewIntent (reused instance): launchDismiss=$launchDismissOnExit")
   }
 
   private fun applyKeepScreenOn() {


### PR DESCRIPTION
Fixes the regression hazer00 reported on #146 (and the remaining symptom on #103).

## Root cause

`PhotoFramePreviewActivity` is `launchMode="singleTask"` in the manifest, so **any** relaunch onto a live instance — DreamPolicy's force-wake continuation, the MQTT `screensaver` command, the header button, settings previews, the night clock — skips `onCreate` and routes through `onNewIntent()`, which was not overridden. The fresh `EXTRA_LAUNCH_DISMISS_APP` extra was silently dropped, so the reused instance kept whatever dismiss behaviour it captured at creation. That's the "works exactly once, then breaks" pattern: only a fresh instance read the extra.

(hazer00's analysis blamed the `FLAG_ACTIVITY_SINGLE_TOP` intent flag — directionally right, but singleTask makes it broader: every launch site is affected, not just DreamPolicy's.)

## Fix

- `launchDismissOnExit` is now a field the exit closure reads at tap time, instead of a local captured in `onCreate`.
- New `onNewIntent()` override calls `setIntent()` and re-derives `launchDismissOnExit` from the fresh intent — last launch wins, the same decision `onCreate` would have made — and logs under `ImmortalFrame` so a reused instance is visible in future logcat captures.

## Why this also settles the "onExit isn't firing at all" theory

It was firing. `PresenceHub.set()` dedupes unchanged states, so `onInteraction()` on an already-`interactive` state publishes nothing over MQTT — the failing cycles never entered `dreaming`, so there was nothing to observe. The frozen `screen/state` and the wrong dismiss target were both downstream of the same dropped intent. With the reuse path fixed, the force-wake handoff (`DreamPolicy` re-publishes `dreaming` independently of the activity) followed by a tap publishes `interactive` again — the #103 symptom.

## Testing

- `./gradlew :app:assembleDebug :app:testDebugUnitTest` pass.
- On-device retest requested from hazer00 on #146 (two Portals, Gen-1 + Gen-2, reliable repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)