### PR TITLE
On-device media cache for Immich/WebDAV screensaver sources

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -119,6 +119,14 @@ dependencies {
   // render the BitMatrix to a Bitmap ourselves, no Android-specific zxing module needed.
   implementation("com.google.zxing:core:3.5.3")
 
+  // Media3 Transformer: on-device, hardware-accelerated video downscale/transcode for the
+  // screensaver media cache ([VideoTranscoder]) — turns near-original remote clips into
+  // 1200x800 derivatives the Portal stores and replays locally. -effect provides Presentation
+  // (aspect-fit resize); -common carries MediaItem etc.
+  implementation("androidx.media3:media3-transformer:1.5.1")
+  implementation("androidx.media3:media3-effect:1.5.1")
+  implementation("androidx.media3:media3-common:1.5.1")
+
   // Unit tests (pure JVM — no device/emulator). org.json provides a real
   // implementation so JSON-parsing logic can be tested off-device (the android.jar
   // stub used in unit tests otherwise throws "not mocked").

--- a/app/src/main/java/com/immortal/launcher/DavSource.kt
+++ b/app/src/main/java/com/immortal/launcher/DavSource.kt
@@ -42,16 +42,47 @@ object DavSource {
       runCatching { propfind(dir(baseUrl), authHeaders(user, pass), "0") != null }
           .getOrDefault(false)
 
+  /** One playable asset under a WebDAV folder: a file URL, plus whether it is a video. */
+  data class Media(val url: String, val isVideo: Boolean)
+
   /**
    * Image file URLs under [baseUrl] (recursing into subfolders), capped at [cap]. Null on
    * failure. The base URL is the full WebDAV folder URL (e.g.
    * `http://nas:30035/media/photos/library/`).
    */
   fun listImageUrls(baseUrl: String, user: String?, pass: String?, cap: Int = 1000): List<String>? =
+      crawl(baseUrl, user, pass, includeVideo = false, cap = cap)?.map { it.url }
+
+  /**
+   * Playable media (image URLs, plus video URLs when [includeVideo]) under [baseUrl], capped at
+   * [cap]. Videos stream through the same auth'd remote path as Immich (a plain GET with the
+   * Basic-auth header), so a WebDAV share can back a video wall — see [PhotoFrameController]'s
+   * WebDAV branch. Null on failure.
+   */
+  fun listMedia(
+      baseUrl: String,
+      user: String?,
+      pass: String?,
+      includeVideo: Boolean = false,
+      cap: Int = 1000,
+  ): List<Media>? = crawl(baseUrl, user, pass, includeVideo, cap)
+
+  /**
+   * PROPFIND-crawl [baseUrl] and its subfolders, returning image files (and, when [includeVideo],
+   * video files) as [Media]. The single crawl behind both [listImageUrls] and [listMedia]. Null on
+   * failure; best-effort throughout.
+   */
+  private fun crawl(
+      baseUrl: String,
+      user: String?,
+      pass: String?,
+      includeVideo: Boolean,
+      cap: Int,
+  ): List<Media>? =
       runCatching {
             val headers = authHeaders(user, pass)
             val origin = origin(baseUrl) ?: return null
-            val out = ArrayList<String>()
+            val out = ArrayList<Media>()
             val stack = ArrayDeque<String>()
             stack.addLast(dir(baseUrl))
             val seen = HashSet<String>()
@@ -64,8 +95,14 @@ object DavSource {
                 if (out.size >= cap) break
                 if (href.trimEnd('/') == selfPath.trimEnd('/')) continue // the folder itself
                 val full = origin + href
-                if (isCollection) stack.addLast(dir(full))
-                else if (LocalMedia.classify(href) == LocalMedia.Kind.IMAGE) out.add(full)
+                if (isCollection) {
+                  stack.addLast(dir(full))
+                } else
+                    when (LocalMedia.classify(href)) {
+                      LocalMedia.Kind.IMAGE -> out.add(Media(full, false))
+                      LocalMedia.Kind.VIDEO -> if (includeVideo) out.add(Media(full, true))
+                      else -> {}
+                    }
               }
             }
             out

--- a/app/src/main/java/com/immortal/launcher/MediaCache.kt
+++ b/app/src/main/java/com/immortal/launcher/MediaCache.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * On-device cache of screensaver media, shared by every HTTP remote source (Immich, WebDAV,
+ * shared albums). Images are stored as fetched; videos are stored as screen-sized (1200x800)
+ * H.264 derivatives produced by [VideoTranscoder]. Each Portal fills its own cache once, then
+ * plays from local storage on every subsequent loop — cutting repeat fetches (and, for video,
+ * most of the bytes) off the source server. This is the on-device answer to the video-wall
+ * problem: the server is touched once per asset, not on every advance forever.
+ *
+ * Keyed by a stable hash of the item's URL, so the same asset maps to the same file across runs
+ * and app restarts. Eviction is a size-budgeted LRU keyed on file last-modified, which is
+ * touched on every cache hit — so the working set of a looping album stays resident and only
+ * genuinely cold items are dropped.
+ *
+ * All operations are best-effort: a failure returns null/false and the caller falls back to a
+ * direct fetch, so the frame is never blank because of a cache problem.
+ */
+class MediaCache internal constructor(private val dir: File, private val budgetBytes: Long) {
+
+  constructor(
+      context: Context,
+      budgetBytes: Long,
+  ) : this(File(context.filesDir, DIR), budgetBytes)
+
+  init {
+    runCatching { dir.mkdirs() }
+  }
+
+  /** Stable SHA-1 hex of the source URL — the cache key, independent of source or session. */
+  fun key(url: String): String {
+    val h = MessageDigest.getInstance("SHA-1").digest(url.toByteArray())
+    return h.joinToString("") { "%02x".format(it) }
+  }
+
+  fun imageFile(url: String): File = File(dir, "${key(url)}.jpg")
+
+  fun videoFile(url: String): File = File(dir, "${key(url)}.mp4")
+
+  /** The cached file for [url] if present and non-empty, touched as most-recently-used; else null. */
+  fun getIfPresent(url: String, isVideo: Boolean): File? {
+    val f = if (isVideo) videoFile(url) else imageFile(url)
+    if (f.exists() && f.length() > 0L) {
+      runCatching { f.setLastModified(System.currentTimeMillis()) }
+      return f
+    }
+    return null
+  }
+
+  fun isCached(url: String, isVideo: Boolean): Boolean =
+      (if (isVideo) videoFile(url) else imageFile(url)).let { it.exists() && it.length() > 0L }
+
+  /** Store image bytes atomically, then enforce the budget. Returns the file, or null on failure. */
+  fun putImage(url: String, bytes: ByteArray): File? =
+      runCatching {
+            val f = imageFile(url)
+            writeAtomic(f, bytes)
+            enforceBudget()
+            f
+          }
+          .getOrNull()
+
+  /** A temp path beside a target file, for a transcoder/downloader to write before committing. */
+  fun tempFor(target: File): File = File(dir, ".${target.name}.tmp")
+
+  /** Atomically move a finished temp file into place as [target], then enforce the budget. */
+  fun commit(tmp: File, target: File): Boolean =
+      runCatching {
+            val ok = tmp.renameTo(target)
+            if (ok) enforceBudget()
+            ok
+          }
+          .getOrDefault(false)
+
+  private fun writeAtomic(f: File, bytes: ByteArray) {
+    val tmp = tempFor(f)
+    tmp.outputStream().use { it.write(bytes) }
+    if (!tmp.renameTo(f)) {
+      tmp.delete()
+      error("rename failed for ${f.name}")
+    }
+  }
+
+  /**
+   * Delete least-recently-used files until the total resident size is within [budgetBytes].
+   * Hidden temp files ('.'-prefixed, in-flight writes) are ignored. Synchronized so a prefetch
+   * commit and an image put don't evict against a stale total at the same time.
+   */
+  @Synchronized
+  fun enforceBudget() {
+    val files = dir.listFiles()?.filter { it.isFile && !it.name.startsWith(".") } ?: return
+    var total = files.sumOf { it.length() }
+    if (total <= budgetBytes) return
+    for (f in files.sortedBy { it.lastModified() }) {
+      if (total <= budgetBytes) break
+      val len = f.length()
+      if (runCatching { f.delete() }.getOrDefault(false)) total -= len
+    }
+  }
+
+  /** Current resident size (excludes in-flight temp files). */
+  fun sizeBytes(): Long =
+      dir.listFiles()?.filter { it.isFile && !it.name.startsWith(".") }?.sumOf { it.length() } ?: 0L
+
+  companion object {
+    const val DIR = "screensaver-media-cache"
+
+    /** Delete the whole cache directory — used to reclaim storage when the user turns caching off. */
+    fun purge(context: Context) {
+      runCatching {
+        val dir = File(context.filesDir, DIR)
+        if (dir.exists()) dir.deleteRecursively()
+      }
+    }
+
+    /** Storage always left free for the OS (updates, logs), never handed to the cache. */
+    const val HEADROOM_BYTES = 2L * 1024 * 1024 * 1024
+
+    /**
+     * A safe default budget: the user's [ceilingBytes] cap, bounded by what's actually free minus a
+     * fixed [HEADROOM_BYTES] reserve. The wall Portals are dedicated to the frame, so we let the
+     * cache use nearly all their spare space (keep-2GB) rather than only half — while a nearly-full
+     * device (free ≤ headroom) yields 0, so caching simply never fills the disk.
+     */
+    fun defaultBudget(freeBytes: Long, ceilingBytes: Long = 4L * 1024 * 1024 * 1024): Long =
+        minOf(ceilingBytes, (freeBytes - HEADROOM_BYTES).coerceAtLeast(0L))
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -171,6 +171,15 @@ class PhotoFrameController(
   // this instead of an HTTP download, so SMB reuses all the remote advance/tick/fallback logic.
   private var remoteFetch: ((String) -> Bitmap?)? = null
   private var smbSource: SmbSource? = null
+  // On-device media cache for stable-URL HTTP sources (Immich, WebDAV): images are stored as
+  // fetched, videos as 1200x800 derivatives, so each asset is pulled from the server once and
+  // then replayed from local storage on every loop. Null unless such a source is active. A
+  // background worker on [transcodeIo] warms the video cache ahead of playback. See
+  // [enableMediaCache]/[fetchRemoteImage]/[schedulePrefetch].
+  private var mediaCache: MediaCache? = null
+  private var transcoder: VideoTranscoder? = null
+  private val transcodeIo = Executors.newSingleThreadExecutor()
+  @Volatile private var prefetchRunning = false
   // Web-page source: a fullscreen WebView that owns the whole frame (the page brings its own
   // clock/widgets, so the photo layer and Immortal overlay are skipped).
   private var webView: android.webkit.WebView? = null
@@ -232,6 +241,8 @@ class PhotoFrameController(
 
   fun start() {
     settings = ScreensaverConfig.load(context)
+    // Caching off? Reclaim any space a previous "on" session left behind (best-effort, off-thread).
+    if (!settings.cacheEnabled) Thread { MediaCache.purge(context) }.start()
     val source = PhotoFrameSource.from(settings, allowWebPage = faceOverride == null)
     applyFit()
     refreshCalendar.run()
@@ -348,7 +359,9 @@ class PhotoFrameController(
               remoteMode = true
               remoteIndex = -1
               remoteFailStreak = 0
+              enableMediaCache()
               advanceRemote(+1)
+              schedulePrefetch()
             } else {
               // Server unreachable / album empty → never leave the frame blank. Say so: the
               // swap to the built-in feed is otherwise invisible in a user report (issue #142).
@@ -360,15 +373,21 @@ class PhotoFrameController(
       }
       is PhotoFrameSource.WebDav -> {
         io.execute {
-          val urls = DavSource.listImageUrls(source.url, source.user, source.pass).orEmpty()
+          val media =
+              DavSource.listMedia(source.url, source.user, source.pass, source.includeVideo)
+                  .orEmpty()
           ui.post {
-            if (urls.isNotEmpty()) {
-              remoteUrls = if (source.shuffle) urls.shuffled() else urls
+            if (media.isNotEmpty()) {
+              val ordered = if (source.shuffle) media.shuffled() else media
+              remoteUrls = ordered.map { it.url }
+              remoteVideos = ordered.filter { it.isVideo }.mapTo(HashSet()) { it.url }
               remoteHeaders = DavSource.authHeaders(source.user, source.pass)
               remoteMode = true
               remoteIndex = -1
               remoteFailStreak = 0
+              enableMediaCache()
               advanceRemote(+1)
+              schedulePrefetch()
             } else {
               startWeb()
             }
@@ -456,6 +475,7 @@ class PhotoFrameController(
     smbSource = null
     io.shutdownNow()
     metaIo.shutdownNow()
+    transcodeIo.shutdownNow()
   }
 
   // --- UI ---------------------------------------------------------------------
@@ -1085,8 +1105,10 @@ class PhotoFrameController(
   }
 
   /** Stream variant: buffers to bytes so the bounds pass can run before the real decode. */
-  private fun decodeBoundedStream(input: java.io.InputStream): Bitmap? {
-    val bytes = input.readBytes()
+  private fun decodeBoundedStream(input: java.io.InputStream): Bitmap? = decodeBoundedBytes(input.readBytes())
+
+  /** Two-pass decode of in-memory image bytes, bounded to [MAX_EDGE] (see [sampleSizeFor]). */
+  private fun decodeBoundedBytes(bytes: ByteArray): Bitmap? {
     val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
     BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
     val opts =
@@ -1231,14 +1253,20 @@ class PhotoFrameController(
     val url = remoteUrls[remoteIndex]
     val g = gen
     if (url in remoteVideos) {
-      showRemoteVideo(url, g)
+      // Prefer a cached 1200x800 derivative (plays from disk, no network). On a miss, stream the
+      // original this once and warm the cache in the background for the next loop.
+      val cached = mediaCache?.getIfPresent(url, isVideo = true)
+      if (cached != null) {
+        showRemoteVideo(android.net.Uri.fromFile(cached), emptyMap(), g)
+      } else {
+        showRemoteVideo(android.net.Uri.parse(url), remoteHeaders, g)
+        schedulePrefetch()
+      }
       return
     }
     stopVideo()
     io.execute {
-      val fetch = remoteFetch
-      val bmp =
-          runCatching { fetch?.invoke(url) ?: downloadBitmap(url, remoteHeaders) }.getOrNull()
+      val bmp = runCatching { fetchRemoteImage(url) }.getOrNull()
       ui.post {
         if (g != gen) return@post // superseded by a newer advance
         if (!remoteMode) return@post // raced with startWeb() flipping us off
@@ -1260,11 +1288,12 @@ class PhotoFrameController(
   }
 
   /**
-   * Stream a remote video (an Immich playback URL) through the shared [videoView]. Mirrors the
-   * local [showVideo] — muted, advance on completion, skip on error — but the URI variant carries
-   * [remoteHeaders] so the server's auth (`x-api-key`) rides along with the stream.
+   * Play a remote video through the shared [videoView] from [uri]: either an Immich/WebDAV
+   * playback URL (with [headers] carrying the server's auth) streamed live, or a `file://` URI
+   * for a cached 1200x800 derivative (empty headers). Mirrors the local [showVideo] — muted,
+   * advance on completion, skip on error.
    */
-  private fun showRemoteVideo(url: String, g: Int) {
+  private fun showRemoteVideo(uri: android.net.Uri, headers: Map<String, String>, g: Int) {
     cancelKenBurns()
     faceRenderer.setCaption(null, null)
     photo.setImageDrawable(null)
@@ -1293,7 +1322,7 @@ class PhotoFrameController(
             }
             true
           }
-          videoView.setVideoURI(android.net.Uri.parse(url), remoteHeaders)
+          videoView.setVideoURI(uri, headers)
           // Safety net: advance even if a clip is very long or never reports done.
           ui.postDelayed(remoteTick, maxOf(intervalMs(), 5 * 60_000L))
         }
@@ -1591,6 +1620,99 @@ class PhotoFrameController(
     c.setRequestProperty("User-Agent", USER_AGENT)
     headers.forEach { (k, v) -> c.setRequestProperty(k, v) }
     return c.inputStream.use { decodeBoundedStream(it) }
+  }
+
+  // --- on-device media cache (Immich / WebDAV) --------------------------------
+
+  /**
+   * Spin up the cache + transcoder for a stable-URL HTTP source, if the user has enabled it. The
+   * budget is the user's chosen GB cap, still bounded by free space so a small Portal is never
+   * pushed over. No-op (leaves [mediaCache] null → direct fetch) when the setting is off.
+   */
+  private fun enableMediaCache() {
+    if (mediaCache != null || !settings.cacheEnabled) return
+    val ceiling = settings.cacheBudgetGb.toLong() * 1024L * 1024L * 1024L
+    val budget = MediaCache.defaultBudget(context.filesDir.usableSpace, ceiling)
+    mediaCache = MediaCache(context, budget).also { it.enforceBudget() } // apply a lowered cap now
+    transcoder = VideoTranscoder(context)
+  }
+
+  /**
+   * Fetch a remote image, going through [mediaCache] when one is active (Immich/WebDAV): a hit
+   * decodes straight from disk with no network; a miss downloads the bytes, caches them, and
+   * decodes. SMB (a custom [remoteFetch]) and the uncached sources fall back to the direct path.
+   */
+  private fun fetchRemoteImage(url: String): Bitmap? {
+    val cache = mediaCache
+    if (cache != null && remoteFetch == null) {
+      cache.getIfPresent(url, isVideo = false)?.let { f ->
+        runCatching { decodeBoundedFile(f.path) }.getOrNull()?.let { return it }
+      }
+      val bytes = runCatching { downloadBytes(url, remoteHeaders) }.getOrNull() ?: return null
+      cache.putImage(url, bytes)
+      return decodeBoundedBytes(bytes)
+    }
+    return remoteFetch?.invoke(url) ?: downloadBitmap(url, remoteHeaders)
+  }
+
+  /** Raw bytes of an authed HTTP GET (for caching before decode). Null on failure. */
+  private fun downloadBytes(spec: String, headers: Map<String, String>): ByteArray? {
+    val c = URL(spec).openConnection() as HttpURLConnection
+    c.connectTimeout = 8000
+    c.readTimeout = 12000
+    c.instanceFollowRedirects = true
+    c.setRequestProperty("User-Agent", USER_AGENT)
+    headers.forEach { (k, v) -> c.setRequestProperty(k, v) }
+    return c.inputStream.use { it.readBytes() }
+  }
+
+  /** Stream an authed HTTP GET straight to [dst] (for the video prefetch source). */
+  private fun downloadToFile(spec: String, headers: Map<String, String>, dst: java.io.File): Boolean =
+      runCatching {
+            val c = URL(spec).openConnection() as HttpURLConnection
+            c.connectTimeout = 8000
+            c.readTimeout = 20000
+            c.instanceFollowRedirects = true
+            c.setRequestProperty("User-Agent", USER_AGENT)
+            headers.forEach { (k, v) -> c.setRequestProperty(k, v) }
+            c.inputStream.use { input -> dst.outputStream().use { input.copyTo(it) } }
+            dst.length() > 0L
+          }
+          .getOrDefault(false)
+
+  /**
+   * Background-warm the video cache: for each not-yet-cached video, pull the source once, transcode
+   * it to a 1200x800 derivative, and commit it. One clip at a time (single-thread [transcodeIo]) so
+   * a wall of Portals doesn't thrash — the first loop still streams originals; every loop after is
+   * local. Guarded by [prefetchRunning] so overlapping advances don't stack workers.
+   */
+  private fun schedulePrefetch() {
+    val cache = mediaCache ?: return
+    val tc = transcoder ?: return
+    if (prefetchRunning) return
+    prefetchRunning = true
+    transcodeIo.execute {
+      try {
+        for (url in remoteVideos.toList()) {
+          if (!remoteMode || Thread.currentThread().isInterrupted) break
+          if (cache.isCached(url, isVideo = true)) continue
+          val target = cache.videoFile(url)
+          val srcTmp = cache.tempFor(java.io.File(target.path + ".src"))
+          val outTmp = cache.tempFor(target)
+          try {
+            if (!downloadToFile(url, remoteHeaders, srcTmp)) continue
+            if (runCatching { tc.transcode(srcTmp, outTmp) }.getOrDefault(false)) {
+              cache.commit(outTmp, target)
+            }
+          } finally {
+            runCatching { srcTmp.delete() }
+            runCatching { if (outTmp.exists()) outTmp.delete() }
+          }
+        }
+      } finally {
+        prefetchRunning = false
+      }
+    }
   }
 
   private val MATCH = FrameLayout.LayoutParams.MATCH_PARENT

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameSource.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameSource.kt
@@ -34,6 +34,7 @@ sealed class PhotoFrameSource {
       val url: String,
       val user: String,
       val pass: String,
+      val includeVideo: Boolean,
       val shuffle: Boolean,
   ) : PhotoFrameSource()
 
@@ -86,6 +87,7 @@ sealed class PhotoFrameSource {
                   url = settings.davUrl!!,
                   user = settings.davUser.orEmpty(),
                   pass = settings.davPass.orEmpty(),
+                  includeVideo = settings.includeVideo,
                   shuffle = settings.shuffle,
               )
           settings.usesSmb ->

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -50,6 +50,11 @@ object ScreensaverConfig {
   const val FIT_FIT = "fit" // letterbox to show the whole image
   const val DEFAULT_INTERVAL = 30
   const val DEFAULT_ALBUM_REFRESH_MIN = 60
+  // On-device media-cache storage limit, in GB (the "Storage limit" control's range). Capped at
+  // 32 — the most any Portal ships with (Portal+ = 32 GB; the 10" units are 16 GB), and the
+  // runtime budget is further bounded by actual free space (see MediaCache.defaultBudget).
+  const val CACHE_GB_MIN = 1
+  const val CACHE_GB_MAX = 32
 
   // Which edge the calendar widget hugs. Top of that edge either way.
   const val CAL_SIDE_LEFT = "left"
@@ -125,6 +130,12 @@ object ScreensaverConfig {
       val albumRefreshMin: Int = DEFAULT_ALBUM_REFRESH_MIN,
       val shuffle: Boolean = false,
       val includeVideo: Boolean = true,
+      // On-device media cache (Immich / WebDAV sources only): download each asset once and replay
+      // it from local storage on every loop — transcoding videos to a screen-sized copy — instead
+      // of re-fetching from the server. Off by default. [cacheBudgetGb] caps the disk it may use
+      // (also bounded at runtime by free space). See MediaCache / VideoTranscoder.
+      val cacheEnabled: Boolean = false,
+      val cacheBudgetGb: Int = 4,
       // Calendar widget: a public iCalendar (.ics) feed link (Google "secret iCal"
       // address or an Apple iCloud public-calendar / webcal link) and how much of it
       // to show on the frame. Empty link = the widget is off.
@@ -267,6 +278,8 @@ object ScreensaverConfig {
             clampAlbumRefresh(p.getInt("album_refresh_min", DEFAULT_ALBUM_REFRESH_MIN)),
         shuffle = p.getBoolean("shuffle", false),
         includeVideo = p.getBoolean("include_video", true),
+        cacheEnabled = p.getBoolean("cache_enabled", false),
+        cacheBudgetGb = p.getInt("cache_budget_gb", 4).coerceIn(CACHE_GB_MIN, CACHE_GB_MAX),
         calendarUrl = p.getString("calendar_url", null),
         calendarRange = CalendarFeed.clampRange(p.getString("calendar_range", CalendarFeed.RANGE_DAY)),
         calendarEnabled = p.getBoolean("calendar_enabled", true),
@@ -421,6 +434,12 @@ object ScreensaverConfig {
 
   fun setIncludeVideo(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("include_video", on).apply()
+
+  fun setCacheEnabled(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("cache_enabled", on).apply()
+
+  fun setCacheBudgetGb(c: Context, gb: Int) =
+      prefs(c).edit().putInt("cache_budget_gb", gb.coerceIn(CACHE_GB_MIN, CACHE_GB_MAX)).apply()
 
   fun setBatterySaver(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("battery_saver", on).apply()

--- a/app/src/main/java/com/immortal/launcher/VideoTranscoder.kt
+++ b/app/src/main/java/com/immortal/launcher/VideoTranscoder.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.net.Uri
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.effect.Presentation
+import androidx.media3.transformer.Composition
+import androidx.media3.transformer.DefaultEncoderFactory
+import androidx.media3.transformer.EditedMediaItem
+import androidx.media3.transformer.Effects
+import androidx.media3.transformer.ExportException
+import androidx.media3.transformer.ExportResult
+import androidx.media3.transformer.Transformer
+import androidx.media3.transformer.VideoEncoderSettings
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Downscales a local video to a screen-sized (default 1200x800) muted H.264 clip, using the
+ * Portal's hardware encoder via Media3 [Transformer]. This is the on-device half of the video
+ * wall's storage story: [MediaCache] hands a fetched source here once, and every later loop
+ * replays the small derivative from disk instead of re-streaming the near-original from the
+ * server.
+ *
+ * [transcode] is **blocking** — it runs the export on a private [HandlerThread] (Transformer
+ * requires a Looper on the thread it's created on and posts its callbacks there) and waits for
+ * completion, so callers drive it from a background executor. Best-effort: any export error
+ * returns false and the caller keeps streaming the original, so a codec quirk on one clip never
+ * breaks playback.
+ */
+@OptIn(UnstableApi::class)
+class VideoTranscoder(
+    private val context: Context,
+    private val maxWidth: Int = 1200,
+    private val maxHeight: Int = 800,
+    // 1.2 Mbps at <1MP is a good quality/size point and keeps more of a large album resident on a
+    // storage-tight Portal (16 GB units). Bump it if fidelity matters more than coverage.
+    private val bitrate: Int = 1_200_000,
+) {
+  /** Transcode [src] into [dst] (overwritten). Returns true only on a complete, non-empty export. */
+  fun transcode(src: File, dst: File): Boolean {
+    if (!src.exists() || src.length() == 0L) return false
+    val thread = HandlerThread("wall-transcode")
+    thread.start()
+    val handler = Handler(thread.looper)
+    val latch = CountDownLatch(1)
+    val ok = AtomicBoolean(false)
+    handler.post {
+      runCatching {
+            val transformer =
+                Transformer.Builder(context)
+                    .setEncoderFactory(
+                        DefaultEncoderFactory.Builder(context)
+                            .setRequestedVideoEncoderSettings(
+                                VideoEncoderSettings.Builder().setBitrate(bitrate).build())
+                            .build())
+                    .addListener(
+                        object : Transformer.Listener {
+                          override fun onCompleted(composition: Composition, result: ExportResult) {
+                            ok.set(true)
+                            latch.countDown()
+                          }
+
+                          override fun onError(
+                              composition: Composition,
+                              result: ExportResult,
+                              exception: ExportException,
+                          ) {
+                            Log.w(TAG, "transcode failed for ${src.name}", exception)
+                            ok.set(false)
+                            latch.countDown()
+                          }
+                        })
+                    .build()
+            // Aspect-preserving fit inside the box (portrait clips end up <=maxWidth wide,
+            // landscape <=maxHeight tall) — the screensaver's fit/fill handles the letterbox.
+            val edited =
+                EditedMediaItem.Builder(MediaItem.fromUri(Uri.fromFile(src)))
+                    .setRemoveAudio(true) // a screensaver plays muted; drop the whole track
+                    .setEffects(
+                        Effects(
+                            /* audioProcessors= */ emptyList(),
+                            listOf(
+                                Presentation.createForWidthAndHeight(
+                                    maxWidth, maxHeight, Presentation.LAYOUT_SCALE_TO_FIT))))
+                    .build()
+            transformer.start(edited, dst.absolutePath)
+          }
+          .onFailure {
+            Log.w(TAG, "transcode setup failed for ${src.name}", it)
+            latch.countDown()
+          }
+    }
+    latch.await()
+    runCatching { thread.quitSafely() }
+    return ok.get() && dst.exists() && dst.length() > 0L
+  }
+
+  private companion object {
+    const val TAG = "ImmortalTranscode"
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -255,6 +255,33 @@ object SettingsDomains {
                       "Play videos",
                       get = { it.includeVideo },
                       set = ScreensaverConfig::setIncludeVideo),
+                  // On-device cache: only meaningful for a network source that re-fetches the same
+                  // assets every loop (Immich / WebDAV). Hidden for a local folder or the built-in
+                  // feed, where there's nothing to save a round-trip on.
+                  BoolSpec(
+                      "cacheEnabled",
+                      "Store media on this device",
+                      get = { it.cacheEnabled },
+                      set = ScreensaverConfig::setCacheEnabled,
+                      help =
+                          "Downloads each photo and video from your server once, then plays it from " +
+                              "this device on every loop instead of fetching it again. Videos are " +
+                              "shrunk to fit the screen. The frame loads faster and your server does " +
+                              "far less work; it uses some of this device's storage.",
+                      visible = { _, s -> s.usesImmich || s.usesDav }),
+                  IntSpec(
+                      "cacheBudgetGb",
+                      "Storage limit",
+                      get = { it.cacheBudgetGb },
+                      set = ScreensaverConfig::setCacheBudgetGb,
+                      min = ScreensaverConfig.CACHE_GB_MIN,
+                      max = ScreensaverConfig.CACHE_GB_MAX,
+                      step = 1,
+                      format = { "$it GB" },
+                      help =
+                          "The most storage the saved copies may use. When it fills up, the items " +
+                              "shown longest ago are removed first. Also limited by free space.",
+                      visible = { _, s -> (s.usesImmich || s.usesDav) && s.cacheEnabled }),
                   BoolSpec(
                       "batterySaver",
                       "Sleep on battery when nobody's around",

--- a/app/src/test/java/com/immortal/launcher/MediaCacheTest.kt
+++ b/app/src/test/java/com/immortal/launcher/MediaCacheTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class MediaCacheTest {
+  @get:Rule val tmp = TemporaryFolder()
+
+  private fun cache(budget: Long) = MediaCache(File(tmp.root, "cache"), budget)
+
+  /** Write a cache file directly (bypassing putImage's auto-enforce) with an exact size + mtime,
+   *  so eviction-ordering tests can control LRU age deterministically. */
+  private fun seed(c: MediaCache, url: String, isVideo: Boolean, size: Int, mtime: Long) {
+    val f = if (isVideo) c.videoFile(url) else c.imageFile(url)
+    f.outputStream().use { it.write(ByteArray(size)) }
+    f.setLastModified(mtime)
+  }
+
+  @Test
+  fun key_isStableAndUrlDistinct() {
+    val c = cache(Long.MAX_VALUE)
+    assertEquals(c.key("http://a/1"), c.key("http://a/1"))
+    assertTrue(c.key("http://a/1") != c.key("http://a/2"))
+  }
+
+  @Test
+  fun imageAndVideo_keySameUrlToDifferentFiles() {
+    val c = cache(Long.MAX_VALUE)
+    val url = "http://immich/api/assets/x/thumbnail?size=preview"
+    assertTrue(c.imageFile(url).name.endsWith(".jpg"))
+    assertTrue(c.videoFile(url).name.endsWith(".mp4"))
+    assertTrue(c.imageFile(url).name != c.videoFile(url).name)
+  }
+
+  @Test
+  fun putImage_thenGetIfPresent_roundTrips() {
+    val c = cache(Long.MAX_VALUE)
+    val url = "http://host/pic"
+    assertNull(c.getIfPresent(url, isVideo = false))
+    val f = c.putImage(url, ByteArray(1234) { 7 })
+    assertNotNull(f)
+    val hit = c.getIfPresent(url, isVideo = false)
+    assertNotNull(hit)
+    assertEquals(1234L, hit!!.length())
+    assertTrue(c.isCached(url, isVideo = false))
+  }
+
+  @Test
+  fun getIfPresent_ignoresEmptyFile() {
+    val c = cache(Long.MAX_VALUE)
+    val url = "http://host/empty"
+    c.imageFile(url).createNewFile() // zero-length
+    assertNull(c.getIfPresent(url, isVideo = false))
+  }
+
+  @Test
+  fun enforceBudget_evictsLeastRecentlyUsedFirst() {
+    val c = cache(budget = 2_500L) // holds ~2 of the 1000-byte entries
+    seed(c, "u1", isVideo = false, size = 1000, mtime = 1_000L) // oldest
+    seed(c, "u2", isVideo = false, size = 1000, mtime = 1_001L)
+    seed(c, "u3", isVideo = false, size = 1000, mtime = 1_002L) // newest
+    // Budget forces one eviction; u1 (oldest) must go, u2/u3 stay.
+    c.enforceBudget()
+    assertFalse("oldest evicted", c.isCached("u1", isVideo = false))
+    assertTrue(c.isCached("u2", isVideo = false))
+    assertTrue(c.isCached("u3", isVideo = false))
+    assertTrue(c.sizeBytes() <= 2_500L)
+  }
+
+  @Test
+  fun getIfPresent_touchProtectsFromEviction() {
+    val c = cache(budget = 2_500L)
+    seed(c, "a", isVideo = false, size = 1000, mtime = 1_000L) // oldest
+    seed(c, "b", isVideo = false, size = 1000, mtime = 1_001L)
+    seed(c, "c", isVideo = false, size = 1000, mtime = 1_002L)
+    // Touch the oldest so it becomes most-recently-used; the next-oldest ('b') should be evicted.
+    assertNotNull(c.getIfPresent("a", isVideo = false))
+    c.enforceBudget()
+    assertTrue("touched survives", c.isCached("a", isVideo = false))
+    assertFalse("next-oldest evicted", c.isCached("b", isVideo = false))
+  }
+
+  @Test
+  fun commit_movesTempIntoPlace() {
+    val c = cache(Long.MAX_VALUE)
+    val target = c.videoFile("http://host/clip")
+    val tmpFile = c.tempFor(target)
+    tmpFile.outputStream().use { it.write(ByteArray(5000)) }
+    assertTrue(c.commit(tmpFile, target))
+    assertTrue(c.isCached("http://host/clip", isVideo = true))
+    assertFalse(tmpFile.exists())
+  }
+
+  @Test
+  fun defaultBudget_capsAndReservesHeadroom() {
+    val gb = 1024L * 1024 * 1024
+    // Plenty free → capped at the ceiling (default 4 GB).
+    assertEquals(4 * gb, MediaCache.defaultBudget(100 * gb))
+    // Free space is the binding limit → free minus the 2 GB headroom (8 GB free, 32 GB cap → 6 GB).
+    assertEquals(6 * gb, MediaCache.defaultBudget(8 * gb, ceilingBytes = 32 * gb))
+    // Nearly-full device (free <= headroom) → 0, so caching never fills the disk.
+    assertEquals(0L, MediaCache.defaultBudget(1 * gb, ceilingBytes = 32 * gb))
+  }
+}

--- a/scripts/immich_audit.py
+++ b/scripts/immich_audit.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Starbright Lab.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Immich screensaver compression + load audit.
+
+Answers the two questions the launcher's Immich source raises for a video wall:
+  1. What is the real compression ratio between originals and the *optimized*
+     variants the screensaver actually fetches (preview JPEG for photos,
+     /video/playback for videos)?
+  2. How much would an on-device cache save, and how much is the wall pulling
+     from Immich today with no cache?
+
+It hits the SAME endpoints the app does (see app/.../ImmichSource.kt):
+  - POST /api/search/metadata      enumerate an album (or the whole library)
+  - GET  /api/assets/{id}          original size via exifInfo.fileSizeInByte
+  - GET  /api/assets/{id}/thumbnail?size=preview   the photo bytes served
+  - GET  /api/assets/{id}/video/playback           the video bytes served
+
+Optimized sizes are read from the response Content-Length header WITHOUT
+downloading the bodies, so the audit itself is light on the server.
+
+Your URL and API key stay on your machine. Prefer the environment variables so
+the key never lands in your shell history:
+
+    export IMMICH_URL=https://immich.example.lan
+    export IMMICH_API_KEY=xxxxxxxx
+    python3 scripts/immich_audit.py --album "Wall Videos"
+
+Flags:
+    --url URL            Immich base URL      (or env IMMICH_URL)
+    --key KEY            API key              (or env IMMICH_API_KEY)
+    --album NAME|ID      Scope to one album; omit for the whole library
+    --sample N           Assets measured per type for the size estimate (default 60)
+    --interval SEC       Slideshow dwell per item, for the load estimate (default 30)
+    --portals N          Portals looping this album, for the load estimate (default 8)
+    --insecure           Skip TLS verification (self-signed home certs)
+"""
+
+import argparse
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+
+TIMEOUT = 20
+
+
+def die(msg):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def human(n):
+    """Bytes -> human string (KB/MB/GB, base 1024)."""
+    if n is None:
+        return "unknown"
+    x = float(n)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if x < 1024 or unit == "TB":
+            return f"{x:.1f} {unit}" if unit != "B" else f"{int(x)} B"
+        x /= 1024
+
+
+class Immich:
+    def __init__(self, base, key, insecure):
+        self.base = base.rstrip("/")
+        if self.base.lower().endswith("/api"):
+            self.base = self.base[:-4]
+        self.key = key.strip()
+        self.ctx = ssl._create_unverified_context() if insecure else None
+
+    def _open(self, path, method="GET", body=None):
+        url = f"{self.base}{path}"
+        headers = {"x-api-key": self.key, "Accept": "application/json"}
+        data = None
+        if body is not None:
+            data = json.dumps(body).encode()
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        return urllib.request.urlopen(req, timeout=TIMEOUT, context=self.ctx)
+
+    def get_json(self, path, method="GET", body=None):
+        with self._open(path, method, body) as r:
+            return json.load(r)
+
+    def content_length(self, path):
+        """Length of what this endpoint would serve, read from the header only.
+
+        Opens the stream, reads Content-Length, and closes before pulling the
+        body -- so we learn the served size without downloading the asset.
+        Returns (bytes_or_None, note).
+        """
+        try:
+            r = self._open(path)
+        except urllib.error.HTTPError as e:
+            return None, f"HTTP {e.code}"
+        except Exception as e:  # noqa: BLE001 - best-effort probe
+            return None, str(e)[:40]
+        try:
+            cl = r.headers.get("Content-Length")
+            return (int(cl), "") if cl is not None else (None, "no Content-Length")
+        finally:
+            r.close()
+
+    def resolve_album(self, name_or_id):
+        albums = self.get_json("/api/albums")
+        for a in albums:
+            if a.get("id") == name_or_id:
+                return a["id"], a.get("albumName", name_or_id), a.get("assetCount")
+        lowered = name_or_id.lower()
+        for a in albums:
+            if a.get("albumName", "").lower() == lowered:
+                return a["id"], a["albumName"], a.get("assetCount")
+        die(
+            f"album {name_or_id!r} not found. Available: "
+            + ", ".join(sorted(a.get("albumName", "?") for a in albums))
+        )
+
+    def enumerate_assets(self, album_id):
+        """All (id, type) in the album (or whole library when album_id is None)."""
+        out = []
+        page = 1
+        while True:
+            body = {"size": 1000, "page": page}
+            if album_id:
+                body["albumIds"] = [album_id]
+            resp = self.get_json("/api/search/metadata", method="POST", body=body)
+            assets = resp.get("assets") or {}
+            items = assets.get("items") or []
+            if not items:
+                break
+            out.extend((it["id"], it.get("type")) for it in items)
+            nxt = assets.get("nextPage")
+            if not nxt:
+                break
+            try:
+                page = int(nxt)
+            except (TypeError, ValueError):
+                break
+        return out
+
+    def asset_meta(self, asset_id):
+        """(original_bytes, duration_seconds) from the asset detail. None on failure."""
+        try:
+            a = self.get_json(f"/api/assets/{asset_id}")
+        except Exception:  # noqa: BLE001
+            return None, None
+        exif = a.get("exifInfo") or {}
+        return exif.get("fileSizeInByte"), parse_duration(a.get("duration"))
+
+
+def parse_duration(s):
+    """Immich duration string 'H:MM:SS.ffffff' -> seconds (float). None if absent."""
+    if not s:
+        return None
+    try:
+        h, m, sec = s.split(":")
+        return int(h) * 3600 + int(m) * 60 + float(sec)
+    except (ValueError, AttributeError):
+        return None
+
+
+def evenly_sampled(items, n):
+    """Deterministic stride sample of up to n items across the list."""
+    if n <= 0 or len(items) <= n:
+        return list(items)
+    step = len(items) / n
+    return [items[int(i * step)] for i in range(n)]
+
+
+def measure(client, ids, is_video, sample_n):
+    """Return per-asset (original, optimized, note, duration) for a sample of ids."""
+    sample = evenly_sampled(ids, sample_n)
+    rows = []
+    for i, aid in enumerate(sample, 1):
+        orig, dur = client.asset_meta(aid)
+        if is_video:
+            opt, note = client.content_length(f"/api/assets/{aid}/video/playback")
+        else:
+            opt, note = client.content_length(
+                f"/api/assets/{aid}/thumbnail?size=preview"
+            )
+        rows.append((orig, opt, note, dur))
+        kind = "video" if is_video else "photo"
+        extra = f"  {dur:.0f}s" if (is_video and dur) else ""
+        print(
+            f"  {kind} {i}/{len(sample)}  original={human(orig):>10}  "
+            f"served={human(opt):>10}{extra}  {note}",
+            file=sys.stderr,
+        )
+    return rows
+
+
+def summarize(rows):
+    """Averages over rows with both sizes known: (avg_orig, avg_opt, n, avg_dur)."""
+    good = [(o, p, d) for (o, p, _, d) in rows if o and p]
+    if not good:
+        return None
+    avg_o = sum(o for o, _, _ in good) / len(good)
+    avg_p = sum(p for _, p, _ in good) / len(good)
+    durs = [d for _, _, d in good if d]
+    avg_d = sum(durs) / len(durs) if durs else None
+    return avg_o, avg_p, len(good), avg_d
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Immich screensaver compression + load audit")
+    ap.add_argument("--url", default=os.environ.get("IMMICH_URL"))
+    ap.add_argument("--key", default=os.environ.get("IMMICH_API_KEY"))
+    ap.add_argument("--album")
+    ap.add_argument("--sample", type=int, default=60)
+    ap.add_argument("--interval", type=float, default=30)
+    ap.add_argument("--portals", type=int, default=8)
+    ap.add_argument(
+        "--target-mbps",
+        type=float,
+        default=1.5,
+        help="bitrate for the predicted 1200x800 derivative (default 1.5)",
+    )
+    ap.add_argument("--insecure", action="store_true")
+    args = ap.parse_args()
+
+    if not args.url:
+        die("no Immich URL (pass --url or set IMMICH_URL)")
+    if not args.key:
+        die("no API key (pass --key or set IMMICH_API_KEY)")
+
+    client = Immich(args.url, args.key, args.insecure)
+
+    # Connectivity + auth check, mirroring the app's testConnection.
+    try:
+        client.get_json("/api/users/me")
+    except Exception as e:  # noqa: BLE001
+        die(f"cannot reach Immich or key rejected: {e}")
+
+    album_id = None
+    scope = "whole library"
+    if args.album:
+        album_id, album_name, _ = client.resolve_album(args.album)
+        scope = f"album {album_name!r}"
+
+    print(f"Enumerating {scope} ...", file=sys.stderr)
+    assets = client.enumerate_assets(album_id)
+    photos = [aid for (aid, t) in assets if t == "IMAGE"]
+    videos = [aid for (aid, t) in assets if t == "VIDEO"]
+    print(
+        f"Found {len(assets)} assets: {len(photos)} photos, {len(videos)} videos.\n"
+        f"Sampling up to {args.sample} of each for sizes ...",
+        file=sys.stderr,
+    )
+
+    photo_rows = measure(client, photos, False, args.sample) if photos else []
+    video_rows = measure(client, videos, True, args.sample) if videos else []
+
+    p = summarize(photo_rows)
+    v = summarize(video_rows)
+
+    # Video transcode-policy tell: served size ~= original means /video/playback
+    # is handing back the ORIGINAL (no transcode) -- the heaviest case for a wall.
+    untranscoded = sum(
+        1 for (o, s, _, _) in video_rows if o and s and s >= o * 0.95
+    )
+    measured_videos = sum(1 for (o, s, _, _) in video_rows if o and s)
+
+    line = "=" * 64
+    print(f"\n{line}\nImmich screensaver audit -- {scope}\n{line}")
+
+    def block(label, count, summ):
+        if not summ:
+            print(f"\n{label}: {count} assets (no size sample available)")
+            return 0.0
+        avg_o, avg_p, n, _ = summ
+        ratio = avg_o / avg_p if avg_p else 0
+        total_opt = avg_p * count
+        total_orig = avg_o * count
+        print(
+            f"\n{label}: {count} assets  (sized from {n})\n"
+            f"  avg original : {human(avg_o)}\n"
+            f"  avg served   : {human(avg_p)}\n"
+            f"  ratio        : {ratio:.1f}x smaller\n"
+            f"  album served total (= cache footprint) : {human(total_opt)}\n"
+            f"  album original total                   : {human(total_orig)}"
+        )
+        return total_opt
+
+    photo_cache = block("PHOTOS", len(photos), p)
+    video_cache = block("VIDEOS", len(videos), v)
+
+    if measured_videos:
+        print(
+            f"\nVideo transcode check: {untranscoded}/{measured_videos} sampled "
+            f"videos are served at ~original size."
+        )
+        if untranscoded:
+            print(
+                "  -> /video/playback is streaming ORIGINAL bytes for those. If you\n"
+                "     expected transcodes, check Immich Admin > Video Transcoding\n"
+                "     (target resolution / transcode policy)."
+            )
+
+    # What a purpose-built 1200x800 derivative would cost. Duration is unchanged by
+    # re-encoding, so predicted size = target_bitrate * duration. This is the number
+    # that decides whether an on-device cache actually fits.
+    if v and v[3]:
+        avg_dur = v[3]
+        served_mbps = (v[1] * 8) / avg_dur / 1e6
+        deriv_avg = args.target_mbps * 1e6 / 8 * avg_dur  # bytes per clip
+        deriv_total = deriv_avg * len(videos)
+        print(
+            f"\n{line}\nDERIVATIVE PREDICTION (purpose-built for 1200x800)\n"
+            f"  avg clip duration        : {avg_dur:.0f}s\n"
+            f"  current served bitrate    : {served_mbps:.1f} Mbps  (for a <1MP screen!)\n"
+            f"  target                    : 1200x800 H.264 @ {args.target_mbps:g} Mbps\n"
+            f"  predicted avg size        : {human(deriv_avg)}  "
+            f"({v[1] / deriv_avg:.0f}x smaller than served)\n"
+            f"  predicted album footprint : {human(deriv_total)}  "
+            f"(vs {human(video_cache)} served today)"
+        )
+
+    total_cache = photo_cache + video_cache
+    print(f"\n{line}\nCACHE FOOTPRINT (per portal, if it holds the whole album)")
+    print(f"  serving Immich's current output : {human(total_cache)}")
+    if v and v[3]:
+        deriv_total = args.target_mbps * 1e6 / 8 * v[3] * len(videos)
+        print(f"  serving 1200x800 derivatives    : {human(deriv_total + photo_cache)}")
+
+    # Current no-cache load: every dwell fetches one asset, on every portal, forever.
+    # Weight the average served size by the real photo/video mix -- a video-heavy
+    # wall pulls far more than a naive two-type average would suggest.
+    if args.interval > 0 and (p or v):
+        served_bytes = (p[1] * len(photos) if p else 0) + (v[1] * len(videos) if v else 0)
+        served_count = (len(photos) if p else 0) + (len(videos) if v else 0)
+        avg_served = served_bytes / served_count if served_count else 0
+        fetches_per_day_per_portal = 86400 / args.interval
+        bytes_day = avg_served * fetches_per_day_per_portal * args.portals
+        print(
+            f"\nCURRENT LOAD (no cache): {args.portals} portals, {args.interval:g}s dwell"
+        )
+        print(
+            f"  ~{fetches_per_day_per_portal:,.0f} fetches/portal/day "
+            f"x {args.portals} portals\n"
+            f"  ~{human(bytes_day)}/day pulled from Immich, every day, forever\n"
+            f"  With a cache: each asset fetched once per portal, then served locally."
+        )
+    print(line)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

An opt-in, per-device media cache for the screensaver's network sources. Each Portal fetches a remote asset **once** and replays it locally on every loop, instead of re-pulling near-original video from the server on every advance.

Motivation: an audit of a video-wall Immich album (`scripts/immich_audit.py`) found Immich's `/video/playback` serves ~64 MB/clip (only 1.5× vs original) to fill a sub-1MP panel — ~1.4 TB/day pulled across an 8-Portal wall with no cache.

## Changes

- **`MediaCache`** — SHA-1(url)-keyed disk cache under `filesDir`; images stored as fetched, videos as 1200×800 derivatives; size-budgeted LRU (touch-on-hit); budget = `min(user limit, free − 2 GB headroom)`. Unit-tested.
- **`VideoTranscoder`** — Media3 Transformer on the Portal's hardware `MediaCodec`, aspect-fit to 1200×800 @ 1.2 Mbps, audio dropped. No codecs bundled.
- **WebDAV video** — `DavSource.listMedia` + controller wiring; WebDAV was image-only (would have made a WebDAV wall photos-only). SMB stays image-only by design (VideoView can't play `smb://`).
- **`PhotoFrameController`** — cache-through image fetch, cache-or-stream video playback, background prefetch worker warms the video cache.
- **Settings** — "Store media on this device" (off by default) + "Storage limit" (1–32 GB, default 4), shown only for Immich/WebDAV. Purges on disable; enforces a lowered budget on start.

## Testing

- Full unit suite green (incl. the `SettingsDomain` completeness tripwire and `MediaCacheTest`).
- `assembleDebug` builds (~21 MB APK, no bundled native codecs).
- ⚠️ **Not verifiable in CI:** the hardware transcode + cache-hit playback need a real Portal (MediaCodec doesn't exist in JVM tests). To smoke-test on-device: enable the toggle with an Immich album, loop once, confirm the second pass plays instantly and `filesDir/screensaver-media-cache` fills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)