### PR TITLE
Refactor date formatting to fully support global locales natively

### DIFF
--- a/app/src/main/java/com/immortal/launcher/DateFormatter.kt
+++ b/app/src/main/java/com/immortal/launcher/DateFormatter.kt
@@ -1,0 +1,28 @@
+package com.immortal.launcher
+
+import android.text.format.DateFormat
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object DateFormatter {
+    /**
+     * Formats a date using a localized pattern based on the provided skeleton.
+     * Capitalizes the first letter if the locale naturally produces a lowercase start
+     * (which is common in French and some other languages for days/months).
+     *
+     * Example skeletons: "EEEMMMd" -> "EEE, MMM d" (US) or "EEE d MMM" (FR)
+     * "EEEEMMMMd" -> "EEEE, MMMM d" (US) or "EEEE d MMMM" (FR)
+     */
+    fun format(date: Date, skeleton: String, locale: Locale = Locale.getDefault()): String {
+        val pattern = DateFormat.getBestDateTimePattern(locale, skeleton)
+        val raw = SimpleDateFormat(pattern, locale).format(date)
+        
+        // Capitalize the first letter of each word (Title Case) for a premium UI look.
+        // This universally solves issues in locales (like French or Spanish) where 
+        // days and months are normally lowercase, without hardcoding country rules.
+        return raw.split(" ").joinToString(" ") { word ->
+            word.replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
+        }
+    }
+}

--- a/app/src/main/java/com/immortal/launcher/DigitalClockView.kt
+++ b/app/src/main/java/com/immortal/launcher/DigitalClockView.kt
@@ -170,7 +170,7 @@ object DigitalClockView {
       controller.flipMinute?.text = cal.get(Calendar.MINUTE).toString().padStart(2, '0')
       controller.flipSecond?.text = cal.get(Calendar.SECOND).toString().padStart(2, '0')
     }
-    controller.dateText?.text = java.text.SimpleDateFormat("EEEE, MMMM d", java.util.Locale.getDefault()).format(now)
+    controller.dateText?.text = DateFormatter.format(now, "EEEEMMMMd")
   }
 
   private fun buildDateView(context: Context, settings: DigitalClockConfig.Settings, color: Int): TextView {

--- a/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
+++ b/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
@@ -530,7 +530,7 @@ class FaceRenderer(
           clockFace?.update(now, blinkOn)
           if (face.clock.showDate)
               dateView?.text =
-                  SimpleDateFormat(face.clock.dateFormat.pattern(), Locale.getDefault()).format(now)
+                  face.clock.dateFormat.format(now)
           val (pct, charging) = batteryInfo()
           val hasBattery = pct >= 0
           batteryView?.text = if (hasBattery) (if (charging) "$pct% ⚡" else "$pct%") else ""

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -1502,7 +1502,7 @@ private fun HeaderBar(onScreensaver: () -> Unit) {
         }
       }
       Text(
-          SimpleDateFormat("EEEE, MMMM d", Locale.getDefault()).format(now),
+          DateFormatter.format(now, "EEEEMMMMd"),
           color = Color(0xFFDADADA),
           fontSize = 18.sp,
           modifier = Modifier.padding(top = 4.dp),

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -682,7 +682,7 @@ class PhotoFrameController(
     return when (dayKey(millis)) {
       today -> "Today"
       tomorrow -> "Tomorrow"
-      else -> SimpleDateFormat("EEE, MMM d", Locale.getDefault()).format(Date(millis))
+      else -> DateFormatter.format(Date(millis), "EEEMMMd")
     }
   }
 
@@ -769,7 +769,7 @@ class PhotoFrameController(
 
     if (welcomeCfg.showDate) {
       val dateView = text(welcomeCfg.dateSize, welcomeCfg.dateColor, false)
-      dateView.text = SimpleDateFormat("EEEE, MMM d", Locale.getDefault()).format(Date())
+      dateView.text = DateFormatter.format(Date(), "EEEEMMMd")
       dateView.gravity = Gravity.CENTER
       dateView.maxLines = 1
       val dateLp = LinearLayout.LayoutParams(
@@ -896,7 +896,7 @@ class PhotoFrameController(
     val now = Date()
     val clockPattern = if (ImmortalSettings.use24HourClock(context)) "H:mm" else "h:mm"
     dashClock.text = SimpleDateFormat(clockPattern, Locale.getDefault()).format(now)
-    dashDate.text = SimpleDateFormat("EEEE, MMMM d", Locale.getDefault()).format(now)
+    dashDate.text = DateFormatter.format(now, "EEEEMMMMd")
     dashWeather.text = weatherText
     dashWeather.visibility = if (weatherText.isNotBlank()) View.VISIBLE else View.GONE
     dashEvent.visibility = View.GONE

--- a/app/src/main/java/com/immortal/launcher/ScreensaverFace.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverFace.kt
@@ -199,15 +199,14 @@ enum class DateFormat {
   NUMERIC_MDY,
   ISO;
 
-  /** The SimpleDateFormat pattern for this format. SHORT matches the original overlay. */
-  fun pattern(): String =
+  fun format(date: java.util.Date): String =
       when (this) {
-        SHORT -> "EEE, MMM d"
-        LONG -> "EEEE, MMMM d"
-        WRITTEN -> "EEEE, MMMM d, yyyy"
-        NUMERIC_DMY -> "dd/MM/yyyy"
-        NUMERIC_MDY -> "MM/dd/yyyy"
-        ISO -> "yyyy-MM-dd"
+        SHORT -> DateFormatter.format(date, "EEEMMMd")
+        LONG -> DateFormatter.format(date, "EEEEMMMMd")
+        WRITTEN -> DateFormatter.format(date, "yEEEEMMMMd")
+        NUMERIC_DMY -> java.text.SimpleDateFormat("dd/MM/yyyy", java.util.Locale.getDefault()).format(date)
+        NUMERIC_MDY -> java.text.SimpleDateFormat("MM/dd/yyyy", java.util.Locale.getDefault()).format(date)
+        ISO -> java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.getDefault()).format(date)
       }
 
   companion object {


### PR DESCRIPTION
**Description**
This PR refactors the hardcoded date formats (like "EEEE, MMMM d") across the launcher to use Android's native android.text.format.DateFormat.getBestDateTimePattern.

**Why?**
The previous approach heavily relied on English capitalization defaults and didn't display nicely in other languages (like French, Spanish, etc.) where days and months are natively lowercase.
Instead of hardcoding if statements for specific locales, I've introduced a DateFormatter utility that :
- Properly resolves the best localized format dynamically (using getBestDateTimePattern).
- Universally applies "Title Case" to the formatted string by splitting it and capitalizing the first letter of each word.

**Result**
A much more premium UI look that perfectly handles dates in all languages without relying on country-specific rules.

**Testing**
Successfully compiled and tested on the device.