### PR TITLE
Media cache: fix aspect, self-heal, and churn defects from the #153 review

### DIFF
--- a/app/src/main/java/com/immortal/launcher/MediaCache.kt
+++ b/app/src/main/java/com/immortal/launcher/MediaCache.kt
@@ -36,6 +36,13 @@ class MediaCache internal constructor(private val dir: File, private val budgetB
 
   init {
     runCatching { dir.mkdirs() }
+    // Sweep temp files stranded by a process death mid-download/transcode. They're '.'-prefixed,
+    // so the budget never counts them — without this sweep a crashy stretch could quietly fill
+    // the disk with invisible half-downloaded sources (~100-200 MB each). Any live temp belongs
+    // to a previous controller instance, and only one screensaver runs at a time.
+    runCatching {
+      dir.listFiles()?.filter { it.isFile && it.name.startsWith(".") }?.forEach { it.delete() }
+    }
   }
 
   /** Stable SHA-1 hex of the source URL — the cache key, independent of source or session. */
@@ -112,6 +119,14 @@ class MediaCache internal constructor(private val dir: File, private val budgetB
   /** Current resident size (excludes in-flight temp files). */
   fun sizeBytes(): Long =
       dir.listFiles()?.filter { it.isFile && !it.name.startsWith(".") }?.sumOf { it.length() } ?: 0L
+
+  /**
+   * Whether the cache has meaningful room left (under ~90% of budget). The prefetch worker stops
+   * here rather than transcoding clips whose commit would just evict warmer entries — on an album
+   * bigger than the budget, filling past this line turns the cache into a treadmill (every add
+   * evicts something the slideshow still wants, so the server keeps getting re-hit forever).
+   */
+  fun hasRoom(): Boolean = sizeBytes() < budgetBytes - budgetBytes / 10
 
   companion object {
     const val DIR = "screensaver-media-cache"

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -180,6 +180,10 @@ class PhotoFrameController(
   private var transcoder: VideoTranscoder? = null
   private val transcodeIo = Executors.newSingleThreadExecutor()
   @Volatile private var prefetchRunning = false
+  // Set when a prefetch pass finds the cache out of room, so later misses don't spawn a worker
+  // (and log) just to rediscover that every ~30s. Cleared when a corrupt entry is deleted (space
+  // freed); resets with the controller each dream session.
+  @Volatile private var prefetchFull = false
   // Web-page source: a fullscreen WebView that owns the whole frame (the page brings its own
   // clock/widgets, so the photo layer and Immortal overlay are skipped).
   private var webView: android.webkit.WebView? = null
@@ -1253,11 +1257,11 @@ class PhotoFrameController(
     val url = remoteUrls[remoteIndex]
     val g = gen
     if (url in remoteVideos) {
-      // Prefer a cached 1200x800 derivative (plays from disk, no network). On a miss, stream the
-      // original this once and warm the cache in the background for the next loop.
+      // Prefer a cached screen-sized derivative (plays from disk, no network). On a miss, stream
+      // the original this once and warm the cache in the background for the next loop.
       val cached = mediaCache?.getIfPresent(url, isVideo = true)
       if (cached != null) {
-        showRemoteVideo(android.net.Uri.fromFile(cached), emptyMap(), g)
+        showRemoteVideo(android.net.Uri.fromFile(cached), emptyMap(), g, cachedFile = cached)
       } else {
         showRemoteVideo(android.net.Uri.parse(url), remoteHeaders, g)
         schedulePrefetch()
@@ -1290,10 +1294,27 @@ class PhotoFrameController(
   /**
    * Play a remote video through the shared [videoView] from [uri]: either an Immich/WebDAV
    * playback URL (with [headers] carrying the server's auth) streamed live, or a `file://` URI
-   * for a cached 1200x800 derivative (empty headers). Mirrors the local [showVideo] — muted,
-   * advance on completion, skip on error.
+   * for a cached screen-sized derivative (empty headers, [cachedFile] set). Mirrors the local
+   * [showVideo] — muted, advance on completion, skip on error.
+   *
+   * A playback error on a *cached* file deletes it: a truncated or codec-incompatible derivative
+   * would otherwise fail every loop forever — and because the cache-hit lookup touches the file's
+   * LRU stamp, eviction would actually protect the corrupt entry. Deleting it makes the next
+   * encounter stream the original and re-transcode, so the slot self-heals like the image path.
    */
-  private fun showRemoteVideo(uri: android.net.Uri, headers: Map<String, String>, g: Int) {
+  private fun showRemoteVideo(
+      uri: android.net.Uri,
+      headers: Map<String, String>,
+      g: Int,
+      cachedFile: java.io.File? = null,
+  ) {
+    fun dropCorruptCache() {
+      cachedFile?.let { f ->
+        Log.w(TAG, "cached video failed to play; deleting for re-fetch: ${f.name}")
+        runCatching { f.delete() }
+        prefetchFull = false // space freed; let the prefetch worker re-warm this slot
+      }
+    }
     cancelKenBurns()
     faceRenderer.setCaption(null, null)
     photo.setImageDrawable(null)
@@ -1316,6 +1337,7 @@ class PhotoFrameController(
             if (g == gen) advanceRemote(+1)
           }
           videoView.setOnErrorListener { _, _, _ ->
+            dropCorruptCache()
             if (g == gen) {
               remoteFailStreak++
               advanceRemote(+1)
@@ -1327,6 +1349,7 @@ class PhotoFrameController(
           ui.postDelayed(remoteTick, maxOf(intervalMs(), 5 * 60_000L))
         }
         .onFailure {
+          dropCorruptCache()
           if (g == gen) {
             remoteFailStreak++
             advanceRemote(+1)
@@ -1627,14 +1650,22 @@ class PhotoFrameController(
   /**
    * Spin up the cache + transcoder for a stable-URL HTTP source, if the user has enabled it. The
    * budget is the user's chosen GB cap, still bounded by free space so a small Portal is never
-   * pushed over. No-op (leaves [mediaCache] null → direct fetch) when the setting is off.
+   * pushed over. No-op (leaves [mediaCache] null → direct fetch) when the setting is off, or when
+   * the disk is so full the budget is negligible — enabling then would just churn (every write
+   * immediately evicted) without ever helping.
    */
   private fun enableMediaCache() {
     if (mediaCache != null || !settings.cacheEnabled) return
     val ceiling = settings.cacheBudgetGb.toLong() * 1024L * 1024L * 1024L
-    val budget = MediaCache.defaultBudget(context.filesDir.usableSpace, ceiling)
+    val free = context.filesDir.usableSpace
+    val budget = MediaCache.defaultBudget(free, ceiling)
+    if (budget < MIN_CACHE_BUDGET_BYTES) {
+      Log.w(TAG, "media cache enabled but disk too full (free=${free / MB}MB -> budget=${budget / MB}MB); not caching")
+      return
+    }
     mediaCache = MediaCache(context, budget).also { it.enforceBudget() } // apply a lowered cap now
     transcoder = VideoTranscoder(context)
+    Log.i(TAG, "media cache on: budget=${budget / MB}MB (cap=${settings.cacheBudgetGb}GB, free=${free / MB}MB)")
   }
 
   /**
@@ -1681,38 +1712,72 @@ class PhotoFrameController(
           .getOrDefault(false)
 
   /**
-   * Background-warm the video cache: for each not-yet-cached video, pull the source once, transcode
-   * it to a 1200x800 derivative, and commit it. One clip at a time (single-thread [transcodeIo]) so
-   * a wall of Portals doesn't thrash — the first loop still streams originals; every loop after is
-   * local. Guarded by [prefetchRunning] so overlapping advances don't stack workers.
+   * Background-warm the video cache: for each not-yet-cached video, pull the source once,
+   * transcode it to a screen-sized derivative, and commit it. One clip at a time (single-thread
+   * [transcodeIo]) so a wall of Portals doesn't thrash — the first loop still streams originals;
+   * every loop after is local. Guarded by [prefetchRunning] so overlapping advances don't stack
+   * workers.
+   *
+   * Warms in *playlist order from the current position* ([prefetchOrder]) so the clips about to
+   * be shown are cached first, and **stops when the cache runs out of room** ([MediaCache.hasRoom])
+   * — on an album bigger than the budget, pressing on would evict warm entries to add cold ones,
+   * turning the cache into a treadmill that re-hits the server forever.
    */
   private fun schedulePrefetch() {
     val cache = mediaCache ?: return
     val tc = transcoder ?: return
-    if (prefetchRunning) return
+    if (prefetchRunning || prefetchFull) return
+    // Snapshot playlist order + headers on the UI thread (both are mutated here only).
+    val queue = prefetchOrder(remoteUrls, remoteVideos, remoteIndex)
+    if (queue.isEmpty()) return
+    val headers = remoteHeaders
     prefetchRunning = true
-    transcodeIo.execute {
-      try {
-        for (url in remoteVideos.toList()) {
-          if (!remoteMode || Thread.currentThread().isInterrupted) break
-          if (cache.isCached(url, isVideo = true)) continue
-          val target = cache.videoFile(url)
-          val srcTmp = cache.tempFor(java.io.File(target.path + ".src"))
-          val outTmp = cache.tempFor(target)
-          try {
-            if (!downloadToFile(url, remoteHeaders, srcTmp)) continue
-            if (runCatching { tc.transcode(srcTmp, outTmp) }.getOrDefault(false)) {
-              cache.commit(outTmp, target)
+    // execute can only reject after stop() shut the executor down; reset the guard and move on.
+    runCatching {
+          transcodeIo.execute {
+            var built = 0
+            var failed = 0
+            try {
+              for (url in queue) {
+                if (!remoteMode || Thread.currentThread().isInterrupted) break
+                if (!cache.hasRoom()) {
+                  prefetchFull = true
+                  Log.i(TAG, "prefetch: cache full at ${cache.sizeBytes() / MB}MB; stopping (album larger than budget)")
+                  break
+                }
+                if (cache.isCached(url, isVideo = true)) continue
+                val target = cache.videoFile(url)
+                val srcTmp = cache.tempFor(java.io.File(target.path + ".src"))
+                val outTmp = cache.tempFor(target)
+                try {
+                  if (!downloadToFile(url, headers, srcTmp)) {
+                    failed++
+                    Log.w(TAG, "prefetch: download failed for $url")
+                    continue
+                  }
+                  if (runCatching { tc.transcode(srcTmp, outTmp) }.getOrDefault(false) &&
+                      cache.commit(outTmp, target)) {
+                    built++
+                    Log.i(
+                        TAG,
+                        "prefetch: cached ${target.name} (${srcTmp.length() / MB}MB -> ${target.length() / MB}MB)")
+                  } else {
+                    failed++ // transcode already logged its own reason under ImmortalTranscode
+                  }
+                } finally {
+                  runCatching { srcTmp.delete() }
+                  runCatching { if (outTmp.exists()) outTmp.delete() }
+                }
+              }
+            } finally {
+              prefetchRunning = false
+              if (built + failed > 0) {
+                Log.i(TAG, "prefetch pass done: $built cached, $failed failed, cache=${cache.sizeBytes() / MB}MB")
+              }
             }
-          } finally {
-            runCatching { srcTmp.delete() }
-            runCatching { if (outTmp.exists()) outTmp.delete() }
           }
         }
-      } finally {
-        prefetchRunning = false
-      }
-    }
+        .onFailure { prefetchRunning = false }
   }
 
   private val MATCH = FrameLayout.LayoutParams.MATCH_PARENT
@@ -1741,6 +1806,25 @@ class PhotoFrameController(
     }
 
     const val TAG = "ImmortalPhotoFrame"
+    const val MB = 1024L * 1024L
+    // Below this computed budget the cache isn't worth enabling: every write would evict
+    // something at least as warm, so it would only add churn. See [enableMediaCache].
+    const val MIN_CACHE_BUDGET_BYTES = 256L * 1024L * 1024L
+
+    /**
+     * The video URLs from [urls] in playlist order starting *after* [currentIndex] (wrapping),
+     * i.e. the order the slideshow will actually want them — so the prefetch worker warms the
+     * near future first, not a HashSet's arbitrary order. Skips the currently-playing index
+     * (it's already streaming; downloading it again in parallel would double the bandwidth).
+     * Tolerates currentIndex = -1 (nothing shown yet -> playlist order from the top). Pure.
+     */
+    internal fun prefetchOrder(urls: List<String>, videos: Set<String>, currentIndex: Int): List<String> {
+      if (urls.isEmpty() || videos.isEmpty()) return emptyList()
+      val start = if (currentIndex in urls.indices) currentIndex + 1 else 0
+      return (0 until urls.size - if (currentIndex in urls.indices) 1 else 0)
+          .map { urls[(start + it) % urls.size] }
+          .filter { it in videos }
+    }
     // Cap on the longest edge of any decoded photo. Full-res camera originals (tens of MP) decode
     // to bitmaps larger than the hardware Canvas can draw (~100MB), which crashes the launcher and
     // makes Android drop its default-home role. The largest Portal panel is 1920px; 2560 leaves

--- a/app/src/main/java/com/immortal/launcher/VideoTranscoder.kt
+++ b/app/src/main/java/com/immortal/launcher/VideoTranscoder.kt
@@ -8,6 +8,7 @@
 package com.immortal.launcher
 
 import android.content.Context
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Handler
 import android.os.HandlerThread
@@ -26,20 +27,30 @@ import androidx.media3.transformer.Transformer
 import androidx.media3.transformer.VideoEncoderSettings
 import java.io.File
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Downscales a local video to a screen-sized (default 1200x800) muted H.264 clip, using the
- * Portal's hardware encoder via Media3 [Transformer]. This is the on-device half of the video
- * wall's storage story: [MediaCache] hands a fetched source here once, and every later loop
- * replays the small derivative from disk instead of re-streaming the near-original from the
- * server.
+ * Downscales a local video to a screen-sized muted H.264 clip, using the Portal's hardware
+ * encoder via Media3 [Transformer]. This is the on-device half of the video wall's storage
+ * story: [MediaCache] hands a fetched source here once, and every later loop replays the small
+ * derivative from disk instead of re-streaming the near-original from the server.
+ *
+ * The output is sized to the source's own aspect ratio, fitted inside [maxWidth]x[maxHeight]
+ * ([fitWithin]) — **never** to the box itself. `Presentation.createForWidthAndHeight` always
+ * emits exactly the requested frame and pads any aspect mismatch with black bars; sizing the
+ * request to the source's aspect means there is nothing to pad. Baking bars in would be wrong
+ * twice over: a portrait clip's derivative would carry pillarbox bars the screensaver's fill
+ * mode could no longer crop away (the derivative's aspect *is* the screen's), and every padded
+ * pixel wastes bitrate. Small sources are never upscaled. If the source can't be probed, the
+ * aspect-preserving `createForHeight` keeps the fallback bar-free too.
  *
  * [transcode] is **blocking** — it runs the export on a private [HandlerThread] (Transformer
- * requires a Looper on the thread it's created on and posts its callbacks there) and waits for
- * completion, so callers drive it from a background executor. Best-effort: any export error
- * returns false and the caller keeps streaming the original, so a codec quirk on one clip never
- * breaks playback.
+ * requires a Looper thread and posts its callbacks there) and waits for completion, bounded by
+ * [timeoutMinutes]: a hung codec is cancelled and reported as failure rather than stalling the
+ * caller's worker forever. Best-effort: any error returns false and the caller keeps streaming
+ * the original, so a codec quirk on one clip never breaks playback.
  */
 @OptIn(UnstableApi::class)
 class VideoTranscoder(
@@ -49,15 +60,18 @@ class VideoTranscoder(
     // 1.2 Mbps at <1MP is a good quality/size point and keeps more of a large album resident on a
     // storage-tight Portal (16 GB units). Bump it if fidelity matters more than coverage.
     private val bitrate: Int = 1_200_000,
+    private val timeoutMinutes: Long = 10,
 ) {
   /** Transcode [src] into [dst] (overwritten). Returns true only on a complete, non-empty export. */
   fun transcode(src: File, dst: File): Boolean {
     if (!src.exists() || src.length() == 0L) return false
+    val presentation = presentationFor(src)
     val thread = HandlerThread("wall-transcode")
     thread.start()
     val handler = Handler(thread.looper)
     val latch = CountDownLatch(1)
     val ok = AtomicBoolean(false)
+    val transformerRef = AtomicReference<Transformer?>()
     handler.post {
       runCatching {
             val transformer =
@@ -85,17 +99,11 @@ class VideoTranscoder(
                           }
                         })
                     .build()
-            // Aspect-preserving fit inside the box (portrait clips end up <=maxWidth wide,
-            // landscape <=maxHeight tall) — the screensaver's fit/fill handles the letterbox.
+            transformerRef.set(transformer)
             val edited =
                 EditedMediaItem.Builder(MediaItem.fromUri(Uri.fromFile(src)))
                     .setRemoveAudio(true) // a screensaver plays muted; drop the whole track
-                    .setEffects(
-                        Effects(
-                            /* audioProcessors= */ emptyList(),
-                            listOf(
-                                Presentation.createForWidthAndHeight(
-                                    maxWidth, maxHeight, Presentation.LAYOUT_SCALE_TO_FIT))))
+                    .setEffects(Effects(/* audioProcessors= */ emptyList(), listOf(presentation)))
                     .build()
             transformer.start(edited, dst.absolutePath)
           }
@@ -104,12 +112,69 @@ class VideoTranscoder(
             latch.countDown()
           }
     }
-    latch.await()
+    val finished = runCatching { latch.await(timeoutMinutes, TimeUnit.MINUTES) }.getOrDefault(false)
+    if (!finished) {
+      // Hung or over-long export: cancel on the transformer's own thread so the codec is
+      // released, and report failure. Without this one bad clip would stall the prefetch
+      // worker (and leak this thread) forever.
+      Log.w(TAG, "transcode timed out after ${timeoutMinutes}m for ${src.name}; cancelling")
+      handler.post { runCatching { transformerRef.get()?.cancel() } }
+      ok.set(false)
+    }
     runCatching { thread.quitSafely() }
     return ok.get() && dst.exists() && dst.length() > 0L
   }
 
-  private companion object {
+  /**
+   * The aspect-exact presentation for [src]: its displayed (rotation-applied) dimensions fitted
+   * inside the target box. Probe failure falls back to `createForHeight`, which also preserves
+   * the source aspect — never to a fixed box that would bake in bars.
+   */
+  private fun presentationFor(src: File): Presentation {
+    val size = probeDisplaySize(src)?.let { (w, h) -> fitWithin(w, h, maxWidth, maxHeight) }
+    return if (size != null)
+        Presentation.createForWidthAndHeight(size.first, size.second, Presentation.LAYOUT_SCALE_TO_FIT)
+    else Presentation.createForHeight(maxHeight)
+  }
+
+  /** The source's displayed (rotation-applied) width x height, or null if unprobeable. */
+  private fun probeDisplaySize(src: File): Pair<Int, Int>? {
+    val r = MediaMetadataRetriever()
+    try {
+      r.setDataSource(src.path)
+      val w =
+          r.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull()
+              ?: return null
+      val h =
+          r.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull()
+              ?: return null
+      val rot =
+          r.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)?.toIntOrNull() ?: 0
+      // A 90/270 rotation flag means the stored frame displays sideways: the Transformer
+      // pipeline auto-rotates it upright, so the *displayed* dimensions are the swapped ones.
+      return if (rot % 180 != 0) Pair(h, w) else Pair(w, h)
+    } catch (e: Exception) {
+      Log.w(TAG, "could not probe ${src.name}; falling back to height-fit", e)
+      return null
+    } finally {
+      runCatching { r.release() }
+    }
+  }
+
+  internal companion object {
     const val TAG = "ImmortalTranscode"
+
+    /**
+     * Fit [srcW]x[srcH] inside [maxW]x[maxH]: aspect-preserving, never upscaling, floored to
+     * even dimensions (hardware H.264 encoders reject odd sizes). Null when any input is
+     * non-positive or the result would collapse below 2px. Pure.
+     */
+    internal fun fitWithin(srcW: Int, srcH: Int, maxW: Int, maxH: Int): Pair<Int, Int>? {
+      if (srcW <= 0 || srcH <= 0 || maxW <= 0 || maxH <= 0) return null
+      val scale = minOf(maxW.toDouble() / srcW, maxH.toDouble() / srcH, 1.0)
+      val w = ((srcW * scale).toInt() / 2) * 2
+      val h = ((srcH * scale).toInt() / 2) * 2
+      return if (w >= 2 && h >= 2) Pair(w, h) else null
+    }
   }
 }

--- a/app/src/test/java/com/immortal/launcher/MediaCacheTest.kt
+++ b/app/src/test/java/com/immortal/launcher/MediaCacheTest.kt
@@ -106,6 +106,33 @@ class MediaCacheTest {
   }
 
   @Test
+  fun init_sweepsStrandedTempFiles() {
+    // A process death mid-download strands hidden temp files the budget can't see. A fresh
+    // cache instance must reap them — and must not touch real entries.
+    val dir = File(tmp.root, "cache").apply { mkdirs() }
+    File(dir, ".abc.mp4.src.tmp").outputStream().use { it.write(ByteArray(500)) }
+    File(dir, ".def.mp4.tmp").outputStream().use { it.write(ByteArray(500)) }
+    val real = File(dir, "0123456789abcdef.mp4")
+    real.outputStream().use { it.write(ByteArray(500)) }
+
+    val c = MediaCache(dir, Long.MAX_VALUE)
+    assertFalse(File(dir, ".abc.mp4.src.tmp").exists())
+    assertFalse(File(dir, ".def.mp4.tmp").exists())
+    assertTrue("real entries survive the sweep", real.exists())
+    assertEquals(500L, c.sizeBytes())
+  }
+
+  @Test
+  fun hasRoom_stopsShortOfTheBudget() {
+    val c = cache(budget = 10_000L) // room threshold = 9,000
+    assertTrue(c.hasRoom())
+    seed(c, "a", isVideo = true, size = 8_000, mtime = 1_000L)
+    assertTrue("8000 < 9000", c.hasRoom())
+    seed(c, "b", isVideo = true, size = 1_500, mtime = 1_001L)
+    assertFalse("9500 >= 9000", c.hasRoom())
+  }
+
+  @Test
   fun defaultBudget_capsAndReservesHeadroom() {
     val gb = 1024L * 1024 * 1024
     // Plenty free → capped at the ceiling (default 4 GB).

--- a/app/src/test/java/com/immortal/launcher/PhotoFrameControllerTest.kt
+++ b/app/src/test/java/com/immortal/launcher/PhotoFrameControllerTest.kt
@@ -39,4 +39,32 @@ class PhotoFrameControllerTest {
     assertNull(PhotoFrameController.videoCoverSize(1920, 1080, 0, 0))
     assertNull(PhotoFrameController.videoCoverSize(-1, 1080, 1920, 1080))
   }
+
+  // --- prefetchOrder: what the cache-warming worker downloads, and in what order ---
+
+  private val urls = listOf("p0", "v1", "p2", "v3", "v4")
+  private val videos = setOf("v1", "v3", "v4")
+
+  @Test
+  fun prefetchOrder_startsAfterCurrentAndWraps() {
+    // Playing index 2 ("p2"): the playlist continues v3, v4, p0, v1 — videos only.
+    assertEquals(listOf("v3", "v4", "v1"), PhotoFrameController.prefetchOrder(urls, videos, 2))
+  }
+
+  @Test
+  fun prefetchOrder_skipsTheCurrentlyPlayingVideo() {
+    // Playing v1: it's already streaming; downloading it again would double the bandwidth.
+    assertEquals(listOf("v3", "v4"), PhotoFrameController.prefetchOrder(urls, videos, 1))
+  }
+
+  @Test
+  fun prefetchOrder_beforeFirstAdvanceUsesPlaylistOrder() {
+    assertEquals(listOf("v1", "v3", "v4"), PhotoFrameController.prefetchOrder(urls, videos, -1))
+  }
+
+  @Test
+  fun prefetchOrder_emptyInputs() {
+    assertEquals(emptyList<String>(), PhotoFrameController.prefetchOrder(emptyList(), videos, 0))
+    assertEquals(emptyList<String>(), PhotoFrameController.prefetchOrder(urls, emptySet(), 0))
+  }
 }

--- a/app/src/test/java/com/immortal/launcher/VideoTranscoderTest.kt
+++ b/app/src/test/java/com/immortal/launcher/VideoTranscoderTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure geometry behind the transcoder's output sizing. This math is what keeps black bars out of
+ * cached derivatives: the Presentation is sized to the *source's* aspect (fitted in the box), so
+ * there is never a mismatch to pad. See the PR-#153 review finding.
+ */
+class VideoTranscoderTest {
+
+  @Test
+  fun fitWithin_landscape4kFitsByWidth() {
+    // 16:9 into a 3:2 box: width binds. 3840x2160 * (1200/3840) = 1200x675 -> 674 (even floor).
+    assertEquals(Pair(1200, 674), VideoTranscoder.fitWithin(3840, 2160, 1200, 800))
+  }
+
+  @Test
+  fun fitWithin_portraitPhoneFitsByHeight() {
+    // 9:16 into a 3:2 box: height binds. 1080x1920 * (800/1920) = 450x800 — no pillarbox baked in.
+    assertEquals(Pair(450, 800), VideoTranscoder.fitWithin(1080, 1920, 1200, 800))
+  }
+
+  @Test
+  fun fitWithin_matchingAspectFillsTheBoxExactly() {
+    assertEquals(Pair(1200, 800), VideoTranscoder.fitWithin(2400, 1600, 1200, 800))
+  }
+
+  @Test
+  fun fitWithin_neverUpscalesASmallSource() {
+    // 640x360 is already smaller than the box: keep it, don't inflate the file.
+    assertEquals(Pair(640, 360), VideoTranscoder.fitWithin(640, 360, 1200, 800))
+  }
+
+  @Test
+  fun fitWithin_flooredToEvenDimensions() {
+    // 1279x721 scaled by 800/721 -> width 1418... capped: scale = min(1200/1279, 800/721, 1).
+    // 1200/1279 = 0.9382 -> 1200 x 676.4 -> 1200x676; both even.
+    val (w, h) = VideoTranscoder.fitWithin(1279, 721, 1200, 800)!!
+    assertEquals(0, w % 2)
+    assertEquals(0, h % 2)
+    assertEquals(Pair(1200, 676), Pair(w, h))
+  }
+
+  @Test
+  fun fitWithin_rejectsDegenerateInput() {
+    assertNull(VideoTranscoder.fitWithin(0, 1080, 1200, 800))
+    assertNull(VideoTranscoder.fitWithin(1920, -1, 1200, 800))
+    assertNull(VideoTranscoder.fitWithin(1920, 1080, 0, 800))
+    // A pathological 1xN source collapses below 2px wide -> null rather than an invalid encode.
+    assertNull(VideoTranscoder.fitWithin(1, 4000, 1200, 800))
+  }
+}


### PR DESCRIPTION
Follow-up to #153, fixing all six findings from its post-merge review before the cache gets its first real run on a wall.

## High-severity fixes

1. **Black bars baked into cached video** — `Presentation.createForWidthAndHeight(1200, 800, …)` always emits exactly that frame and pads aspect mismatches with black bars, so every cached portrait clip played back pillarboxed — and fill mode couldn't crop the bars away (the derivative's aspect *is* the screen's). Now each derivative is sized to the **source's** aspect fitted inside 1200×800: probed via `MediaMetadataRetriever` (rotation-aware), never upscaled, floored to even dims (`fitWithin`, tested). Probe failure falls back to `createForHeight` — also bar-free.
2. **Corrupt derivative poisoned its slot forever** — playback error on a cached file now deletes it, so the slot re-streams and re-transcodes (self-heals like the image path). Previously the cache-hit LRU touch actively *protected* the corrupt entry from eviction while it failed every loop.
3. **Prefetch churn on an oversized album** — the worker now warms in playlist order from the current position (`prefetchOrder`, tested) and **stops at ~90% budget** (`MediaCache.hasRoom`) instead of transcoding the whole album through the LRU forever. A sticky `prefetchFull` flag stops later misses re-spawning the worker.

## Medium-severity fixes

4. **Transcode hang** — 10-minute timeout + `Transformer.cancel()`; a hung codec no longer stalls the prefetch worker and leaks its HandlerThread permanently.
5. **Stranded temp files** — `MediaCache` init sweeps `.`-prefixed temps left by a process death (invisible to the budget, ~100–200 MB each, previously unbounded). Near-zero budgets (<256 MB) skip enabling the cache instead of churning.
6. **Zero observability** — cache enablement (budget/free), per-clip prefetch results with sizes, pass summaries, and corrupt-entry deletions now logged under the existing TAG, per the project's no-silent-fallback principle (#142).

## Testing

- New: `VideoTranscoderTest` (fit geometry), `prefetchOrder` cases, temp-sweep + `hasRoom` cases.
- Full unit suite green; `assembleDebug` builds.
- On-device behavior (hardware transcode, cache-hit playback) still needs the wall smoke test — that was always device-only; these fixes remove the defects that would have confounded it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)