### PR TITLE
Fix Calls handoff: prefer stock-launcher deep link over Back-press burst

### DIFF
--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -173,8 +173,9 @@ private data class PendingWidgetAdd(
     val provider: WidgetProviderEntry,
 )
 
-/** Calls→stock-home bridge: how many system Back presses reach Meta's launcher, and the gap
- *  between them (verified on the Portal TV — 5 presses lands on the stock launcher's Apps tab). */
+/** Portal-TV (ripleyhome) fallback for [launchStockHome]: how many system Back presses to reach
+ *  Meta's launcher, and the gap between them. Best-effort — on some Portal TVs the burst lands on
+ *  the previously-used app instead (issue #91), and it's untestable from here. */
 private const val STOCK_HOME_BACK_PRESSES = 5
 private const val STOCK_HOME_BACK_INTERVAL_MS = 300L
 private const val HOME_APP_WIDGET_HOST_ID = 0x4611
@@ -290,7 +291,13 @@ class HomeActivity : ComponentActivity() {
    * launcher's `portal://launcher/home` VIEW deep link instead resumes its
    * interactive Home tab directly — the Contacts/Favorites calling surface — and we
    * mark a bridge in flight so [DreamPolicy] doesn't claw the frame back during the
-   * transition.
+   * transition. (Launching Contacts directly is rejected as an untrusted caller, so the
+   * hand-off must go through the launcher.)
+   *
+   * Path order: the deep link is primary on touchscreen Portals. The accessibility
+   * Back-press burst is only a Portal-TV (ripleyhome) fallback for when the deep link
+   * doesn't resolve — on a touchscreen Portal a system BACK from Immortal (itself the
+   * home activity) never surfaces the stock launcher, so the burst can't be primary there.
    */
   private fun launchStockHome() {
     // Suppress the screensaver-relaunch race while the stock home comes forward, and
@@ -300,15 +307,6 @@ class HomeActivity : ComponentActivity() {
     // kills our process also see the bridge and return SUPPRESSED (not REDREAM).
     DreamPolicy.markBridge(this)
 
-    // Preferred path: a short burst of system Back presses reliably surfaces Meta's stock
-    // launcher (verified on the Portal TV) — unlike the portal:// deep link or a HOME launch,
-    // which cold-start ripleyhome's idle dream and bounce the user. Needs our accessibility
-    // service (baseline-enabled on provisioned devices); falls back to the deep link otherwise.
-    if (RemoteInput.available()) {
-      RemoteInput.backRepeat(STOCK_HOME_BACK_PRESSES, STOCK_HOME_BACK_INTERVAL_MS)
-      return
-    }
-
     fun fire(intent: Intent): Boolean =
         runCatching {
               startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
@@ -316,15 +314,24 @@ class HomeActivity : ComponentActivity() {
             }
             .getOrDefault(false)
 
-    // 1) Deep-link straight to the touchscreen stock launcher's Home tab.
+    // 1) Touchscreen Portals (Portal / Portal+ / Go / Mini): deep-link into the stock launcher's
+    //    Home tab. Needs the stock launcher enabled — provisioning leaves it so. Gate on
+    //    resolveActivity: launching an explicit-but-DISABLED component does NOT throw, so an
+    //    unguarded fire() would return true and swallow the tap (Calls silently no-ops) instead of
+    //    falling through. Resolving first means a disabled launcher drops to the fallbacks below.
     val deepLink =
         Intent(Intent.ACTION_VIEW, Uri.parse("portal://launcher/home"))
             .setPackage("com.facebook.alohaapps.launcher")
-    if (fire(deepLink)) return
+    if (packageManager.resolveActivity(deepLink, 0) != null && fire(deepLink)) return
 
-    // 2) Fallback for models without the portal:// deep link (e.g. the Portal TV's
-    //    ripleyhome): this device's real stock HOME, excluding ourselves and the
-    //    system fallback homes.
+    // 2) Portal TV (ripleyhome): no portal:// deep link, so the VIEW above didn't resolve. Surface
+    //    its stock launcher with a Back-press burst through the accessibility service.
+    if (RemoteInput.available()) {
+      RemoteInput.backRepeat(STOCK_HOME_BACK_PRESSES, STOCK_HOME_BACK_INTERVAL_MS)
+      return
+    }
+
+    // 3) Last resort: this device's real stock HOME, excluding ourselves and the fallback homes.
     val stock =
         packageManager
             .queryIntentActivities(


### PR DESCRIPTION
## Problem

The home-grid **Calls** tile broke on touchscreen Portals: it flashed and bounced back to the Immortal launcher, or — once the accessibility service was connected — did nothing.

## Root cause

`HomeActivity.launchStockHome()` fired a system **Back-press burst first** (whenever `BarWatchService` was connected), falling back to the `portal://launcher/home` deep link only otherwise. On a touchscreen Portal a system BACK from Immortal — itself the home activity, with an empty back stack — never surfaces the stock launcher; it pops to whatever task sits behind us. So Calls either bounced or landed on the wrong app.

The deep link (which hands off to Meta's trusted stock launcher — the only caller allowed to open the gated Contacts/calling surface) is the path that worked before the burst was wedged ahead of it.

## Fix

Reorder `launchStockHome`:
1. **Deep link** `portal://launcher/home` — primary on touchscreen Portals. Guarded on `resolveActivity` before firing: launching an explicit-but-**disabled** component does not throw, so an unguarded `startActivity` returns "success" and swallows the tap (Calls silently no-ops). Resolving first means a disabled stock launcher drops through to the fallbacks instead of dead-ending here.
2. **Back-press burst** — Portal-TV (`ripleyhome`) fallback for when the deep link doesn't resolve.
3. **HOME-query** — last resort.

## Verification (Gen-1 Portal+ Android 9; Gen-2 Portal Android 10)

**Gen-1 Portal+ (Android 9)** — both the debug and release-id (`com.immortal.launcher`, provisioning permissions granted) builds:

- Old path logged `-> back-press path (5x BACK)` → landed on a stale Chrome task.
- Direct Contacts launch → rejected: `ContactsMainActivity launched by untrusted caller` (confirms the launcher hand-off is required).
- **Fixed:** `-> deep-link portal://launcher/home fired=true` → resumes `com.facebook.alohaapps.launcher/…home.touch.HomeActivity` (the calling surface) and **stays** (checked t+2/4/6s), no rejection.

**Gen-2 Portal (Android 10)** — debug build (`com.immortal.launcher`, provisioning permissions granted):

- Reproduced issue #160 ("Calls does nothing"). Root cause on this unit: the stock launcher `com.facebook.alohaapps.launcher` was **disabled**, so `portal://launcher/home` resolved to no activity. `startActivity` still dispatched (`START … dat=portal://launcher/home … pkg=com.facebook.alohaapps.launcher`) but the system silently dropped it, and pre-fix the unguarded `fire()` returned true → no fallback ran → foreground stayed on Immortal.
- Re-enabling the launcher (`pm enable com.facebook.alohaapps.launcher`): the deep link resolves to `…home.touch.HomeActivity`, tapping Calls lands there and **stays** (t+1/3/6s), no rejection.
- With the `resolveActivity` guard: a disabled launcher now falls through to the fallbacks instead of swallowing the tap at step 1.

Unit suite (`:app:testDebugUnitTest`) green.

## Notes / out of scope

- **Portal TV (#91):** left on the untestable Back-press fallback, which reportedly lands on the last-used app there. Not addressed here (no Portal TV to test on).
- The stock launcher (`com.facebook.alohaapps.launcher`) must be **enabled** for the hand-off to resolve; provisioning leaves it enabled. It was seen **disabled** in the field on a Gen-2 unit — the guard makes Calls degrade gracefully instead of silently no-op'ing, but the launcher still has to be enabled to actually reach the calling surface. (Follow-up option: have provisioning re-enable it so a re-provision self-heals.)

Fixes #160. Refs #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
