### PR TITLE
Feature/digital world clock

### DIFF
--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -2777,10 +2777,12 @@ private fun ImmortalDigitalWorldClockWidget(modifier: Modifier = Modifier) {
   LaunchedEffect(Unit) {
     while (true) {
       now = Date()
-      delay(1000)
+      val millisUntilNextMinute = (60_000L - (System.currentTimeMillis() % 60_000L)).coerceAtLeast(1000L)
+      delay(millisUntilNextMinute)
     }
   }
   val activeZones = remember(zones) { zones.take(4) }
+  val minuteBucket = now.time / 60_000L
 
   ImmortalWidgetShell(
       title = com.immortal.launcher.i18n.I18n.translate("Digital World Clock", userLang),
@@ -2799,7 +2801,7 @@ private fun ImmortalDigitalWorldClockWidget(modifier: Modifier = Modifier) {
               modifier = itemModifier,
               horizontalAlignment = Alignment.CenterHorizontally,
           ) {
-            val timeText = remember(zone, now, use24Hour) {
+            val timeText = remember(zone, minuteBucket, use24Hour) {
               val fmt = SimpleDateFormat(if (use24Hour) "HH:mm" else "h:mm a", Locale.getDefault())
               fmt.timeZone = TimeZone.getTimeZone(zone)
               fmt.format(now)
@@ -2807,7 +2809,8 @@ private fun ImmortalDigitalWorldClockWidget(modifier: Modifier = Modifier) {
             val mainFontSize = when (activeZones.size) {
               1 -> if (use24Hour) 34.sp else 28.sp
               2 -> if (use24Hour) 24.sp else 20.sp
-              else -> if (use24Hour) 20.sp else 15.sp
+              3 -> if (use24Hour) 18.sp else 14.sp
+              else -> if (use24Hour) 16.sp else 13.sp
             }
             val labelFontSize = if (activeZones.size == 1) 15.sp else 12.sp
             val offsetFontSize = if (activeZones.size == 1) 12.sp else 10.sp
@@ -2818,6 +2821,7 @@ private fun ImmortalDigitalWorldClockWidget(modifier: Modifier = Modifier) {
                 fontSize = mainFontSize,
                 fontWeight = FontWeight.Bold,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
             Spacer(Modifier.size(4.dp))
             Text(
@@ -3205,8 +3209,8 @@ private fun CustomWidgetGlyph(kind: String) {
       when (kind) {
         HomeWidgetStore.KIND_WEATHER -> "☁"
         HomeWidgetStore.KIND_WORLD_CLOCK -> "◷"
-        HomeWidgetStore.KIND_WORLD_CLOCK_DIGITAL -> "⏱"
-        HomeWidgetStore.KIND_TIMERS -> "⌛"
+        HomeWidgetStore.KIND_WORLD_CLOCK_DIGITAL -> "🕒"
+        HomeWidgetStore.KIND_TIMERS -> "⏱"
         else -> "+"
       }
   Text(emoji, color = Color.White, fontSize = 28.sp, fontWeight = FontWeight.SemiBold)

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -1368,6 +1368,7 @@ private fun customWidgetLabel(kind: String): String =
     when (kind) {
       HomeWidgetStore.KIND_WEATHER -> "Weather"
       HomeWidgetStore.KIND_WORLD_CLOCK -> "World Clock"
+      HomeWidgetStore.KIND_WORLD_CLOCK_DIGITAL -> "Digital World Clock"
       HomeWidgetStore.KIND_TIMERS -> "Timers"
       else -> "Widget"
     }
@@ -2568,6 +2569,7 @@ private fun ImmortalWidgetContent(widget: HomeWidgetStore.HomeWidget, modifier: 
   when (widget.kind) {
     HomeWidgetStore.KIND_WEATHER -> ImmortalWeatherWidget(modifier)
     HomeWidgetStore.KIND_WORLD_CLOCK -> ImmortalWorldClockWidget(modifier)
+    HomeWidgetStore.KIND_WORLD_CLOCK_DIGITAL -> ImmortalDigitalWorldClockWidget(modifier)
     HomeWidgetStore.KIND_TIMERS -> ImmortalTimersWidget(modifier)
     else -> UnknownImmortalWidget(widget.kind, modifier)
   }
@@ -2724,6 +2726,73 @@ private fun ImmortalWorldClockWidget(modifier: Modifier = Modifier) {
         ) {
           AnalogClock(zone, now, Modifier.fillMaxWidth().aspectRatio(1f))
           Spacer(Modifier.size(6.dp))
+          Text(
+              worldClockLabel(zone),
+              color = Color.White,
+              fontSize = 12.sp,
+              fontWeight = FontWeight.Medium,
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis,
+          )
+          Text(worldClockOffset(zone, now), color = Color(0xFF9A9A9A), fontSize = 10.sp, maxLines = 1)
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun ImmortalDigitalWorldClockWidget(modifier: Modifier = Modifier) {
+  val context = androidx.compose.ui.platform.LocalContext.current
+  val userLang = ImmortalSettings.load(context).language
+  var zones by remember { mutableStateOf(ImmortalSettings.worldClockZones(context)) }
+  var use24Hour by remember { mutableStateOf(ImmortalSettings.use24HourClock(context)) }
+  val lifecycleOwner = LocalLifecycleOwner.current
+  DisposableEffect(lifecycleOwner) {
+    val obs = LifecycleEventObserver { _, e ->
+      if (e == Lifecycle.Event.ON_RESUME) {
+        zones = ImmortalSettings.worldClockZones(context)
+        use24Hour = ImmortalSettings.use24HourClock(context)
+      }
+    }
+    lifecycleOwner.lifecycle.addObserver(obs)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+  }
+  var now by remember { mutableStateOf(Date()) }
+  LaunchedEffect(Unit) {
+    while (true) {
+      now = Date()
+      delay(1000)
+    }
+  }
+  ImmortalWidgetShell(
+      title = com.immortal.launcher.i18n.I18n.translate("Digital World Clock", userLang),
+      accent = Color(0xFFFF9500),
+      modifier = modifier,
+  ) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+      zones.take(4).forEach { zone ->
+        Column(
+            modifier = Modifier.weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+          val timeText = remember(zone, now, use24Hour) {
+            val fmt = SimpleDateFormat(if (use24Hour) "HH:mm" else "h:mm a", Locale.getDefault())
+            fmt.timeZone = TimeZone.getTimeZone(zone)
+            fmt.format(now)
+          }
+          Text(
+              timeText,
+              color = Color.White,
+              fontSize = if (use24Hour) 20.sp else 15.sp,
+              fontWeight = FontWeight.Bold,
+              maxLines = 1,
+          )
+          Spacer(Modifier.size(4.dp))
           Text(
               worldClockLabel(zone),
               color = Color.White,
@@ -3108,7 +3177,8 @@ private fun CustomWidgetGlyph(kind: String) {
       when (kind) {
         HomeWidgetStore.KIND_WEATHER -> "☁"
         HomeWidgetStore.KIND_WORLD_CLOCK -> "◷"
-        HomeWidgetStore.KIND_TIMERS -> "⏱"
+        HomeWidgetStore.KIND_WORLD_CLOCK_DIGITAL -> "⏱"
+        HomeWidgetStore.KIND_TIMERS -> "⌛"
         else -> "+"
       }
   Text(emoji, color = Color.White, fontSize = 28.sp, fontWeight = FontWeight.SemiBold)
@@ -3355,6 +3425,15 @@ private fun loadWidgetProviders(context: Context, tileDp: Dp): List<WidgetProvid
               spanX = 2,
               spanY = 2,
               customKind = HomeWidgetStore.KIND_WORLD_CLOCK,
+          ),
+          WidgetProviderEntry(
+              label = "Digital World Clock",
+              packageLabel = "Immortal",
+              icon = null,
+              info = null,
+              spanX = 2,
+              spanY = 2,
+              customKind = HomeWidgetStore.KIND_WORLD_CLOCK_DIGITAL,
           ),
           WidgetProviderEntry(
               label = "Timers",

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -2713,28 +2713,43 @@ private fun ImmortalWorldClockWidget(modifier: Modifier = Modifier) {
       delay(1000)
     }
   }
+  val activeZones = remember(zones) { zones.take(4) }
+
   ImmortalWidgetShell(title = "World Clock", accent = Color(0xFFFFC857), modifier = modifier) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-        verticalAlignment = Alignment.Top,
-    ) {
-      zones.take(4).forEach { zone ->
-        Column(
-            modifier = Modifier.weight(1f),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-          AnalogClock(zone, now, Modifier.fillMaxWidth().aspectRatio(1f))
-          Spacer(Modifier.size(6.dp))
-          Text(
-              worldClockLabel(zone),
-              color = Color.White,
-              fontSize = 12.sp,
-              fontWeight = FontWeight.Medium,
-              maxLines = 1,
-              overflow = TextOverflow.Ellipsis,
-          )
-          Text(worldClockOffset(zone, now), color = Color(0xFF9A9A9A), fontSize = 10.sp, maxLines = 1)
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = if (activeZones.size <= 2) Arrangement.SpaceEvenly else Arrangement.spacedBy(10.dp),
+          verticalAlignment = Alignment.CenterVertically,
+      ) {
+        activeZones.forEach { zone ->
+          val itemModifier = if (activeZones.size <= 2) Modifier.widthIn(max = 140.dp) else Modifier.weight(1f)
+          val clockModifier = when (activeZones.size) {
+            1 -> Modifier.size(92.dp)
+            2 -> Modifier.size(76.dp)
+            else -> Modifier.fillMaxWidth().aspectRatio(1f)
+          }
+          Column(
+              modifier = itemModifier,
+              horizontalAlignment = Alignment.CenterHorizontally,
+          ) {
+            AnalogClock(zone, now, clockModifier)
+            Spacer(Modifier.size(6.dp))
+            Text(
+                worldClockLabel(zone),
+                color = Color.White,
+                fontSize = if (activeZones.size == 1) 14.sp else 12.sp,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                worldClockOffset(zone, now),
+                color = Color(0xFF9A9A9A),
+                fontSize = if (activeZones.size == 1) 12.sp else 10.sp,
+                maxLines = 1,
+            )
+          }
         }
       }
     }
@@ -2765,43 +2780,56 @@ private fun ImmortalDigitalWorldClockWidget(modifier: Modifier = Modifier) {
       delay(1000)
     }
   }
+  val activeZones = remember(zones) { zones.take(4) }
+
   ImmortalWidgetShell(
       title = com.immortal.launcher.i18n.I18n.translate("Digital World Clock", userLang),
       accent = Color(0xFFFF9500),
       modifier = modifier,
   ) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-      zones.take(4).forEach { zone ->
-        Column(
-            modifier = Modifier.weight(1f),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-          val timeText = remember(zone, now, use24Hour) {
-            val fmt = SimpleDateFormat(if (use24Hour) "HH:mm" else "h:mm a", Locale.getDefault())
-            fmt.timeZone = TimeZone.getTimeZone(zone)
-            fmt.format(now)
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = if (activeZones.size <= 2) Arrangement.SpaceEvenly else Arrangement.spacedBy(10.dp),
+          verticalAlignment = Alignment.CenterVertically,
+      ) {
+        activeZones.forEach { zone ->
+          val itemModifier = if (activeZones.size <= 2) Modifier.widthIn(max = 160.dp) else Modifier.weight(1f)
+          Column(
+              modifier = itemModifier,
+              horizontalAlignment = Alignment.CenterHorizontally,
+          ) {
+            val timeText = remember(zone, now, use24Hour) {
+              val fmt = SimpleDateFormat(if (use24Hour) "HH:mm" else "h:mm a", Locale.getDefault())
+              fmt.timeZone = TimeZone.getTimeZone(zone)
+              fmt.format(now)
+            }
+            val mainFontSize = when (activeZones.size) {
+              1 -> if (use24Hour) 34.sp else 28.sp
+              2 -> if (use24Hour) 24.sp else 20.sp
+              else -> if (use24Hour) 20.sp else 15.sp
+            }
+            val labelFontSize = if (activeZones.size == 1) 15.sp else 12.sp
+            val offsetFontSize = if (activeZones.size == 1) 12.sp else 10.sp
+
+            Text(
+                timeText,
+                color = Color.White,
+                fontSize = mainFontSize,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+            )
+            Spacer(Modifier.size(4.dp))
+            Text(
+                worldClockLabel(zone),
+                color = Color(0xFFE0E0E0),
+                fontSize = labelFontSize,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(worldClockOffset(zone, now), color = Color(0xFF9A9A9A), fontSize = offsetFontSize, maxLines = 1)
           }
-          Text(
-              timeText,
-              color = Color.White,
-              fontSize = if (use24Hour) 20.sp else 15.sp,
-              fontWeight = FontWeight.Bold,
-              maxLines = 1,
-          )
-          Spacer(Modifier.size(4.dp))
-          Text(
-              worldClockLabel(zone),
-              color = Color.White,
-              fontSize = 12.sp,
-              fontWeight = FontWeight.Medium,
-              maxLines = 1,
-              overflow = TextOverflow.Ellipsis,
-          )
-          Text(worldClockOffset(zone, now), color = Color(0xFF9A9A9A), fontSize = 10.sp, maxLines = 1)
         }
       }
     }

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -2759,7 +2759,6 @@ private fun ImmortalWorldClockWidget(modifier: Modifier = Modifier) {
 @Composable
 private fun ImmortalDigitalWorldClockWidget(modifier: Modifier = Modifier) {
   val context = androidx.compose.ui.platform.LocalContext.current
-  val userLang = ImmortalSettings.load(context).language
   var zones by remember { mutableStateOf(ImmortalSettings.worldClockZones(context)) }
   var use24Hour by remember { mutableStateOf(ImmortalSettings.use24HourClock(context)) }
   val lifecycleOwner = LocalLifecycleOwner.current
@@ -2785,7 +2784,7 @@ private fun ImmortalDigitalWorldClockWidget(modifier: Modifier = Modifier) {
   val minuteBucket = now.time / 60_000L
 
   ImmortalWidgetShell(
-      title = com.immortal.launcher.i18n.I18n.translate("Digital World Clock", userLang),
+      title = "Digital World Clock",
       accent = Color(0xFFFF9500),
       modifier = modifier,
   ) {

--- a/app/src/main/java/com/immortal/launcher/HomeWidgetStore.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeWidgetStore.kt
@@ -41,6 +41,7 @@ object HomeWidgetStore {
   const val KIND_APP_WIDGET = "appwidget"
   const val KIND_WEATHER = "weather"
   const val KIND_WORLD_CLOCK = "world_clock"
+  const val KIND_WORLD_CLOCK_DIGITAL = "world_clock_digital"
   const val KIND_TIMERS = "timers"
 
   const val DEFAULT_SPAN_X = 2


### PR DESCRIPTION
Adds a standalone Digital World Clock widget and makes the existing Analog World Clock widget responsive.

### Changes

#### 1. New Digital World Clock Widget
- **Digital time layout**: Shows time in bold digital format for 1 to 4 configured time zones.
- **Minute-boundary tick**: Calculates exact millis until the next minute mark instead of running a 1-second polling loop.
- **Responsive font scaling**: Automatically adapts time and city label font sizes based on active zone count (1–4 zones) to avoid clipping.
- **24-hour support**: Respects the user's 12h/24h clock preference.

#### 2. Analog World Clock Improvements
- **Responsive sizing**: Re-layouts items responsively when showing 1 or 2 zones (`SpaceEvenly` + constrained max-width) instead of stretching fixed weights across the card.
- **Centered layout**: Wraps content in a centered `Box` to prevent awkward alignment when fewer than 4 zones are active.

#### 3. Standalone Integration
- Registered cleanly in `HomeWidgetStore.kt` and `HomeActivity.kt` with its own glyph (`🕒`).
- Completely decoupled from i18n branches.

> **Note on the offset line**: this branch currently retains and scales `worldClockOffset`, but [#203](https://github.com/starbrightlab/immortal/pull/203) removes it from the widget entirely. I'll follow that decision on rebase rather than reintroduce it, so both faces stay consistent.