### PR TITLE
feat(screensaver): add real-time interactive photo drag & direction-aware slide transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,3 @@ system_services.apk
 *.apk
 
 .claude/
-referencias_privado/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ system_services.apk
 *.apk
 
 .claude/
+referencias_privado/

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -241,6 +241,7 @@ class PhotoFrameController(
   // that omits MOVE events): clear horizontal swipe = prev/next, clear tap = exit.
   private var downX = 0f
   private var downY = 0f
+  private var pendingTransitionDirection: Int = 0
 
   /** Hosts forward their touch events here. */
   fun onTouch(ev: MotionEvent) {
@@ -261,7 +262,13 @@ class PhotoFrameController(
           return
         }
         if (abs(dx) > 120 && abs(dx) > abs(dy) * 1.5f) {
-          if (dx < 0) next() else prev()
+          if (dx < 0) {
+            pendingTransitionDirection = +1
+            next()
+          } else {
+            pendingTransitionDirection = -1
+            prev()
+          }
         } else if (abs(dx) < 48 && abs(dy) < 48) {
           onExit?.invoke()
         }
@@ -1666,39 +1673,97 @@ class PhotoFrameController(
     // Start Ken Burns motion on incoming photo
     startKenBurns(targetLayer.photo, isPortrait)
 
-    val fadeDuration = 900L
+    val slideDir = pendingTransitionDirection
+    pendingTransitionDirection = 0
 
-    targetLayer.frameContainer.animate()
-        .alpha(1f)
-        .setDuration(fadeDuration)
-        .setInterpolator(AccelerateDecelerateInterpolator())
-        .start()
+    if (slideDir != 0) {
+      val startX = if (slideDir > 0) screenW.toFloat() else -screenW.toFloat()
+      val endX = if (slideDir > 0) -screenW.toFloat() else screenW.toFloat()
+      val slideDuration = 450L
+      val interpolator = android.view.animation.DecelerateInterpolator(1.5f)
 
-    if (isFitMode) {
-      targetLayer.blurPhoto.animate()
+      targetLayer.frameContainer.translationX = startX
+      targetLayer.blurPhoto.translationX = startX
+      targetLayer.frameContainer.alpha = 1f
+      targetLayer.blurPhoto.alpha = 1f
+
+      targetLayer.frameContainer.animate()
+          .translationX(0f)
+          .alpha(1f)
+          .setDuration(slideDuration)
+          .setInterpolator(interpolator)
+          .start()
+
+      if (isFitMode) {
+        targetLayer.blurPhoto.animate()
+            .translationX(0f)
+            .alpha(1f)
+            .setDuration(slideDuration)
+            .setInterpolator(interpolator)
+            .start()
+      }
+
+      outgoingLayer.frameContainer.animate()
+          .translationX(endX)
+          .alpha(0f)
+          .setDuration(slideDuration)
+          .setInterpolator(interpolator)
+          .withEndAction {
+            outgoingLayer.frameContainer.visibility = View.GONE
+            outgoingLayer.frameContainer.translationX = 0f
+          }
+          .start()
+
+      outgoingLayer.blurPhoto.animate()
+          .translationX(endX)
+          .alpha(0f)
+          .setDuration(slideDuration)
+          .setInterpolator(interpolator)
+          .withEndAction {
+            outgoingLayer.blurPhoto.visibility = View.GONE
+            outgoingLayer.blurPhoto.translationX = 0f
+          }
+          .start()
+    } else {
+      val fadeDuration = 900L
+
+      targetLayer.frameContainer.translationX = 0f
+      targetLayer.blurPhoto.translationX = 0f
+      outgoingLayer.frameContainer.translationX = 0f
+      outgoingLayer.blurPhoto.translationX = 0f
+
+      targetLayer.frameContainer.animate()
           .alpha(1f)
           .setDuration(fadeDuration)
           .setInterpolator(AccelerateDecelerateInterpolator())
           .start()
+
+      if (isFitMode) {
+        targetLayer.blurPhoto.animate()
+            .alpha(1f)
+            .setDuration(fadeDuration)
+            .setInterpolator(AccelerateDecelerateInterpolator())
+            .start()
+      }
+
+      outgoingLayer.frameContainer.animate()
+          .alpha(0f)
+          .setDuration(fadeDuration)
+          .setInterpolator(AccelerateDecelerateInterpolator())
+          .withEndAction {
+            outgoingLayer.frameContainer.visibility = View.GONE
+          }
+          .start()
+
+      outgoingLayer.blurPhoto.animate()
+          .alpha(0f)
+          .setDuration(fadeDuration)
+          .setInterpolator(AccelerateDecelerateInterpolator())
+          .withEndAction {
+            outgoingLayer.blurPhoto.visibility = View.GONE
+          }
+          .start()
     }
-
-    outgoingLayer.frameContainer.animate()
-        .alpha(0f)
-        .setDuration(fadeDuration)
-        .setInterpolator(AccelerateDecelerateInterpolator())
-        .withEndAction {
-          outgoingLayer.frameContainer.visibility = View.GONE
-        }
-        .start()
-
-    outgoingLayer.blurPhoto.animate()
-        .alpha(0f)
-        .setDuration(fadeDuration)
-        .setInterpolator(AccelerateDecelerateInterpolator())
-        .withEndAction {
-          outgoingLayer.blurPhoto.visibility = View.GONE
-        }
-        .start()
 
     activeLayerIndex = if (activeLayerIndex == 0) 1 else 0
   }

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -211,6 +211,9 @@ class PhotoFrameController(
   private val history = ArrayList<Bitmap>()
   private var index = -1
 
+  // In-memory cache for preloaded adjacent photo Bitmaps (prev/next) for instant swipe performance.
+  private val preloadedBitmaps = android.util.LruCache<String, Bitmap>(8)
+
   // Default-feed source-chain state (see [fetchWebPhoto]).
   // Wikimedia Commons featured-landscape image list: fetched once per session, then cycled.
   private var wikimediaUrls: List<String> = emptyList()
@@ -1177,8 +1180,19 @@ class PhotoFrameController(
 
   private fun showLocalImage(path: String, g: Int) {
     stopVideo()
+    val cached = preloadedBitmaps.get(path)
+    if (cached != null) {
+      photo.visibility = View.VISIBLE
+      show(cached)
+      loadCaptionForLocal(path, g)
+      preloadAdjacentLocal(localIndex)
+      ui.postDelayed(localTick, intervalMs())
+      return
+    }
     io.execute {
-      val bmp = runCatching { decodeCorrected(path) }.getOrNull()
+      val bmp = runCatching { decodeCorrected(path) }
+          .getOrNull()
+          ?.also { preloadedBitmaps.put(path, it) }
       ui.post {
         if (g != gen) return@post // superseded by a newer advance
         if (bmp == null) {
@@ -1188,7 +1202,28 @@ class PhotoFrameController(
         photo.visibility = View.VISIBLE
         show(bmp)
         loadCaptionForLocal(path, g)
+        preloadAdjacentLocal(localIndex)
         ui.postDelayed(localTick, intervalMs())
+      }
+    }
+  }
+
+  private fun preloadAdjacentLocal(currIdx: Int) {
+    if (playlist.isEmpty()) return
+    val nextIdx = (currIdx + 1) % playlist.size
+    val prevIdx = (currIdx - 1 + playlist.size) % playlist.size
+    io.execute {
+      val nextItem = playlist[nextIdx]
+      if (!nextItem.isVideo && preloadedBitmaps.get(nextItem.path) == null) {
+        runCatching { decodeCorrected(nextItem.path) }.getOrNull()?.let {
+          preloadedBitmaps.put(nextItem.path, it)
+        }
+      }
+      val prevItem = playlist[prevIdx]
+      if (!prevItem.isVideo && preloadedBitmaps.get(prevItem.path) == null) {
+        runCatching { decodeCorrected(prevItem.path) }.getOrNull()?.let {
+          preloadedBitmaps.put(prevItem.path, it)
+        }
       }
     }
   }
@@ -1383,9 +1418,26 @@ class PhotoFrameController(
       }
       return
     }
+    showRemoteImage(url, g)
+  }
+
+  private fun showRemoteImage(url: String, g: Int) {
     stopVideo()
+    val cached = preloadedBitmaps.get(url)
+    if (cached != null) {
+      remoteFailStreak = 0
+      remoteReresolveStreak = 0
+      photo.visibility = View.VISIBLE
+      show(cached)
+      if (smbSource != null) loadCaptionForSmb(url, g) else faceRenderer.setCaption(null, null)
+      preloadAdjacentRemote(remoteIndex)
+      ui.postDelayed(remoteTick, intervalMs())
+      return
+    }
     io.execute {
-      val bmp = runCatching { fetchRemoteImage(url) }.getOrNull()
+      val bmp = runCatching { fetchRemoteImage(url) }
+          .getOrNull()
+          ?.also { preloadedBitmaps.put(url, it) }
       ui.post {
         if (g != gen) return@post // superseded by a newer advance
         if (!remoteMode) return@post // raced with startWeb() flipping us off
@@ -1398,10 +1450,29 @@ class PhotoFrameController(
         remoteReresolveStreak = 0
         photo.visibility = View.VISIBLE
         show(bmp)
-        // EXIF caption only for SMB here — it reads the user's own files. The HTTP remote sources
-        // (iCloud/Google/Immich/DAV) serve EXIF-stripped images, so they carry no caption.
         if (smbSource != null) loadCaptionForSmb(url, g) else faceRenderer.setCaption(null, null)
+        preloadAdjacentRemote(remoteIndex)
         ui.postDelayed(remoteTick, intervalMs())
+      }
+    }
+  }
+
+  private fun preloadAdjacentRemote(currIdx: Int) {
+    if (remoteUrls.isEmpty()) return
+    val nextIdx = (currIdx + 1) % remoteUrls.size
+    val prevIdx = (currIdx - 1 + remoteUrls.size) % remoteUrls.size
+    io.execute {
+      val nextUrl = remoteUrls[nextIdx]
+      if (nextUrl !in remoteVideos && preloadedBitmaps.get(nextUrl) == null) {
+        runCatching { fetchRemoteImage(nextUrl) }.getOrNull()?.let {
+          preloadedBitmaps.put(nextUrl, it)
+        }
+      }
+      val prevUrl = remoteUrls[prevIdx]
+      if (prevUrl !in remoteVideos && preloadedBitmaps.get(prevUrl) == null) {
+        runCatching { fetchRemoteImage(prevUrl) }.getOrNull()?.let {
+          preloadedBitmaps.put(prevUrl, it)
+        }
       }
     }
   }

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -1836,13 +1836,19 @@ class PhotoFrameController(
     pendingTransitionDirection = 0
 
     if (slideDir != 0) {
-      val startX = if (slideDir > 0) screenW.toFloat() else -screenW.toFloat()
       val endX = if (slideDir > 0) -screenW.toFloat() else screenW.toFloat()
-      val slideDuration = 450L
+      val currentTargetX = targetLayer.frameContainer.translationX
+      val remainingDistance = if (currentTargetX != 0f) abs(currentTargetX) else screenW.toFloat()
+      val fractionRemaining = (remainingDistance / screenW.toFloat()).coerceIn(0.1f, 1.0f)
+      val slideDuration = (380L * fractionRemaining).toLong().coerceAtLeast(150L)
       val interpolator = android.view.animation.DecelerateInterpolator(1.5f)
 
-      targetLayer.frameContainer.translationX = startX
-      targetLayer.blurPhoto.translationX = startX
+      if (currentTargetX == 0f) {
+        val startX = if (slideDir > 0) screenW.toFloat() else -screenW.toFloat()
+        targetLayer.frameContainer.translationX = startX
+        targetLayer.blurPhoto.translationX = startX
+      }
+
       targetLayer.frameContainer.alpha = 1f
       targetLayer.blurPhoto.alpha = 1f
 

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -212,10 +212,10 @@ class PhotoFrameController(
   private var index = -1
 
   // In-memory cache for preloaded adjacent photo Bitmaps (prev/next) for instant swipe performance.
-  // Sized by memory byte count (max 1/8th of available max heap, capped between 16MB and 32MB) to prevent OOM.
+  // Sized by memory byte count (1/8th of available max heap, bounded between 4MB and 32MB) to prevent OOM.
   private val preloadedBitmaps = run {
     val maxMemoryKb = (Runtime.getRuntime().maxMemory() / 1024).toInt()
-    val cacheSizeKb = (maxMemoryKb / 8).coerceIn(16 * 1024, 32 * 1024)
+    val cacheSizeKb = (maxMemoryKb / 8).coerceIn(4 * 1024, 32 * 1024)
     object : android.util.LruCache<String, Bitmap>(cacheSizeKb) {
       override fun sizeOf(key: String, value: Bitmap): Int {
         return (value.byteCount / 1024).coerceAtLeast(1)

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -241,35 +241,65 @@ class PhotoFrameController(
   // that omits MOVE events): clear horizontal swipe = prev/next, clear tap = exit.
   private var downX = 0f
   private var downY = 0f
+  private var isDragging = false
   private var pendingTransitionDirection: Int = 0
 
   /** Hosts forward their touch events here. */
   fun onTouch(ev: MotionEvent) {
     // While the timer alarm is showing, the slide-to-stop owns the touch stream.
     if (faceRenderer.handleAlarmTouch(ev)) return
+    val screenW = context.resources.displayMetrics.widthPixels.toFloat()
+
     when (ev.actionMasked) {
       MotionEvent.ACTION_DOWN -> {
         downX = ev.x
         downY = ev.y
+        isDragging = false
       }
-      MotionEvent.ACTION_UP -> {
+      MotionEvent.ACTION_MOVE -> {
         val dx = ev.x - downX
         val dy = ev.y - downY
+        if (!isDragging && abs(dx) > 30 && abs(dx) > abs(dy) * 1.5f) {
+          isDragging = true
+        }
+        if (isDragging) {
+          currentLayer.frameContainer.translationX = dx
+          currentLayer.blurPhoto.translationX = dx
+        }
+      }
+      MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+        val dx = ev.x - downX
+        val dy = ev.y - downY
+        if (isDragging) {
+          isDragging = false
+          val threshold = screenW * 0.18f
+          if (dx < -threshold) {
+            pendingTransitionDirection = +1
+            next()
+          } else if (dx > threshold) {
+            pendingTransitionDirection = -1
+            prev()
+          } else {
+            currentLayer.frameContainer.animate()
+                .translationX(0f)
+                .setDuration(250L)
+                .setInterpolator(android.view.animation.DecelerateInterpolator())
+                .start()
+            currentLayer.blurPhoto.animate()
+                .translationX(0f)
+                .setDuration(250L)
+                .setInterpolator(android.view.animation.DecelerateInterpolator())
+                .start()
+          }
+          return
+        }
         // A tap while the welcome overlay is showing dismisses it early
         // rather than exiting the screensaver.
         if (welcomeVisible && abs(dx) < 48 && abs(dy) < 48) {
           dismissWelcome()
           return
         }
-        if (abs(dx) > 120 && abs(dx) > abs(dy) * 1.5f) {
-          if (dx < 0) {
-            pendingTransitionDirection = +1
-            next()
-          } else {
-            pendingTransitionDirection = -1
-            prev()
-          }
-        } else if (abs(dx) < 48 && abs(dy) < 48) {
+        if (abs(dx) < 48 && abs(dy) < 48) {
           onExit?.invoke()
         }
       }

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -245,7 +245,33 @@ class PhotoFrameController(
   private var downX = 0f
   private var downY = 0f
   private var isDragging = false
+  private var dragPreparedDirection = 0
   private var pendingTransitionDirection: Int = 0
+
+  private fun setupAdjacentDragBitmap(dir: Int) {
+    val bmp = when {
+      localMode && playlist.isNotEmpty() -> {
+        val targetIdx = if (dir > 0) (localIndex + 1) % playlist.size else (localIndex - 1 + playlist.size) % playlist.size
+        val item = playlist[targetIdx]
+        preloadedBitmaps.get(item.path) ?: runCatching { decodeCorrected(item.path) }.getOrNull()
+      }
+      remoteMode && remoteUrls.isNotEmpty() -> {
+        val targetIdx = if (dir > 0) (remoteIndex + 1) % remoteUrls.size else (remoteIndex - 1 + remoteUrls.size) % remoteUrls.size
+        val url = remoteUrls[targetIdx]
+        preloadedBitmaps.get(url) ?: runCatching { fetchRemoteImage(url) }.getOrNull()
+      }
+      else -> null
+    } ?: return
+
+    incomingLayer.photo.setImageBitmap(bmp)
+    incomingLayer.frameContainer.visibility = View.VISIBLE
+    incomingLayer.frameContainer.alpha = 1f
+    incomingLayer.blurPhoto.visibility = View.VISIBLE
+    incomingLayer.blurPhoto.alpha = 1f
+    incomingLayer.frameContainer.bringToFront()
+    faceRenderer.view.bringToFront()
+    welcomeOverlay?.bringToFront()
+  }
 
   /** Hosts forward their touch events here. */
   fun onTouch(ev: MotionEvent) {
@@ -258,6 +284,7 @@ class PhotoFrameController(
         downX = ev.x
         downY = ev.y
         isDragging = false
+        dragPreparedDirection = 0
       }
       MotionEvent.ACTION_MOVE -> {
         val dx = ev.x - downX
@@ -268,6 +295,16 @@ class PhotoFrameController(
         if (isDragging) {
           currentLayer.frameContainer.translationX = dx
           currentLayer.blurPhoto.translationX = dx
+
+          val targetDir = if (dx < 0) +1 else -1
+          if (dragPreparedDirection != targetDir) {
+            dragPreparedDirection = targetDir
+            setupAdjacentDragBitmap(targetDir)
+          }
+
+          val incomingX = if (targetDir > 0) screenW + dx else -screenW + dx
+          incomingLayer.frameContainer.translationX = incomingX
+          incomingLayer.blurPhoto.translationX = incomingX
         }
       }
       MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
@@ -293,7 +330,28 @@ class PhotoFrameController(
                 .setDuration(250L)
                 .setInterpolator(android.view.animation.DecelerateInterpolator())
                 .start()
+
+            val cancelTargetX = if (dx < 0) screenW else -screenW
+            incomingLayer.frameContainer.animate()
+                .translationX(cancelTargetX)
+                .setDuration(250L)
+                .setInterpolator(android.view.animation.DecelerateInterpolator())
+                .withEndAction {
+                  incomingLayer.frameContainer.visibility = View.GONE
+                  incomingLayer.frameContainer.translationX = 0f
+                }
+                .start()
+            incomingLayer.blurPhoto.animate()
+                .translationX(cancelTargetX)
+                .setDuration(250L)
+                .setInterpolator(android.view.animation.DecelerateInterpolator())
+                .withEndAction {
+                  incomingLayer.blurPhoto.visibility = View.GONE
+                  incomingLayer.blurPhoto.translationX = 0f
+                }
+                .start()
           }
+          dragPreparedDirection = 0
           return
         }
         // A tap while the welcome overlay is showing dismisses it early

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -212,7 +212,16 @@ class PhotoFrameController(
   private var index = -1
 
   // In-memory cache for preloaded adjacent photo Bitmaps (prev/next) for instant swipe performance.
-  private val preloadedBitmaps = android.util.LruCache<String, Bitmap>(8)
+  // Sized by memory byte count (max 1/8th of available max heap, capped between 16MB and 32MB) to prevent OOM.
+  private val preloadedBitmaps = run {
+    val maxMemoryKb = (Runtime.getRuntime().maxMemory() / 1024).toInt()
+    val cacheSizeKb = (maxMemoryKb / 8).coerceIn(16 * 1024, 32 * 1024)
+    object : android.util.LruCache<String, Bitmap>(cacheSizeKb) {
+      override fun sizeOf(key: String, value: Bitmap): Int {
+        return (value.byteCount / 1024).coerceAtLeast(1)
+      }
+    }
+  }
 
   // Default-feed source-chain state (see [fetchWebPhoto]).
   // Wikimedia Commons featured-landscape image list: fetched once per session, then cycled.
@@ -248,29 +257,113 @@ class PhotoFrameController(
   private var dragPreparedDirection = 0
   private var pendingTransitionDirection: Int = 0
 
-  private fun setupAdjacentDragBitmap(dir: Int) {
-    val bmp = when {
+  private fun setupAdjacentDragBitmap(dir: Int, screenW: Float, currentDx: Float) {
+    val key = when {
       localMode && playlist.isNotEmpty() -> {
         val targetIdx = if (dir > 0) (localIndex + 1) % playlist.size else (localIndex - 1 + playlist.size) % playlist.size
-        val item = playlist[targetIdx]
-        preloadedBitmaps.get(item.path) ?: runCatching { decodeCorrected(item.path) }.getOrNull()
+        playlist[targetIdx].path
       }
       remoteMode && remoteUrls.isNotEmpty() -> {
         val targetIdx = if (dir > 0) (remoteIndex + 1) % remoteUrls.size else (remoteIndex - 1 + remoteUrls.size) % remoteUrls.size
-        val url = remoteUrls[targetIdx]
-        preloadedBitmaps.get(url) ?: runCatching { fetchRemoteImage(url) }.getOrNull()
+        remoteUrls[targetIdx]
       }
       else -> null
     } ?: return
 
+    val cached = preloadedBitmaps.get(key)
+    if (cached != null) {
+      applyIncomingDragBitmap(cached, dir, screenW, currentDx)
+    } else {
+      incomingLayer.photo.setImageDrawable(null)
+      incomingLayer.frameContainer.visibility = View.GONE
+      incomingLayer.blurPhoto.visibility = View.GONE
+
+      io.execute {
+        val bmp = when {
+          localMode -> runCatching { decodeCorrected(key) }.getOrNull()
+          remoteMode -> runCatching { fetchRemoteImage(key) }.getOrNull()
+          else -> null
+        }
+        if (bmp != null) {
+          preloadedBitmaps.put(key, bmp)
+          ui.post {
+            if (isDragging && dragPreparedDirection == dir) {
+              applyIncomingDragBitmap(bmp, dir, screenW, currentDx)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private fun applyIncomingDragBitmap(bmp: Bitmap, dir: Int, screenW: Float, currentDx: Float) {
     incomingLayer.photo.setImageBitmap(bmp)
     incomingLayer.frameContainer.visibility = View.VISIBLE
     incomingLayer.frameContainer.alpha = 1f
-    incomingLayer.blurPhoto.visibility = View.VISIBLE
-    incomingLayer.blurPhoto.alpha = 1f
+    if (settings.fit == ScreensaverConfig.FIT_FIT || bmp.height > bmp.width) {
+      runCatching {
+        val blurred = createBlurredBackground(bmp)
+        incomingLayer.blurPhoto.setImageBitmap(blurred)
+      }
+      incomingLayer.blurPhoto.visibility = View.VISIBLE
+      incomingLayer.blurPhoto.alpha = 1f
+    } else {
+      incomingLayer.blurPhoto.visibility = View.GONE
+    }
+    val incomingX = if (dir > 0) screenW + currentDx else -screenW + currentDx
+    incomingLayer.frameContainer.translationX = incomingX
+    incomingLayer.blurPhoto.translationX = incomingX
     incomingLayer.frameContainer.bringToFront()
     faceRenderer.view.bringToFront()
     welcomeOverlay?.bringToFront()
+  }
+
+  private fun snapBackDragLayers(screenW: Float, dx: Float) {
+    currentLayer.frameContainer.animate()
+        .translationX(0f)
+        .setDuration(250L)
+        .setInterpolator(android.view.animation.DecelerateInterpolator())
+        .start()
+    currentLayer.blurPhoto.animate()
+        .translationX(0f)
+        .setDuration(250L)
+        .setInterpolator(android.view.animation.DecelerateInterpolator())
+        .start()
+
+    val cancelTargetX = if (dx < 0) screenW else -screenW
+    incomingLayer.frameContainer.animate()
+        .translationX(cancelTargetX)
+        .setDuration(250L)
+        .setInterpolator(android.view.animation.DecelerateInterpolator())
+        .withEndAction {
+          incomingLayer.frameContainer.visibility = View.GONE
+          incomingLayer.frameContainer.translationX = 0f
+        }
+        .start()
+    incomingLayer.blurPhoto.animate()
+        .translationX(cancelTargetX)
+        .setDuration(250L)
+        .setInterpolator(android.view.animation.DecelerateInterpolator())
+        .withEndAction {
+          incomingLayer.blurPhoto.visibility = View.GONE
+          incomingLayer.blurPhoto.translationX = 0f
+        }
+        .start()
+  }
+
+  private fun suspendAutoTick() {
+    ui.removeCallbacks(localTick)
+    ui.removeCallbacks(remoteTick)
+  }
+
+  private fun rescheduleAutoTick() {
+    if (localMode) {
+      ui.removeCallbacks(localTick)
+      ui.postDelayed(localTick, intervalMs())
+    } else if (remoteMode) {
+      ui.removeCallbacks(remoteTick)
+      ui.postDelayed(remoteTick, intervalMs())
+    }
   }
 
   /** Hosts forward their touch events here. */
@@ -285,12 +378,14 @@ class PhotoFrameController(
         downY = ev.y
         isDragging = false
         dragPreparedDirection = 0
+        suspendAutoTick()
       }
       MotionEvent.ACTION_MOVE -> {
         val dx = ev.x - downX
         val dy = ev.y - downY
         if (!isDragging && abs(dx) > 30 && abs(dx) > abs(dy) * 1.5f) {
           isDragging = true
+          suspendAutoTick()
         }
         if (isDragging) {
           currentLayer.frameContainer.translationX = dx
@@ -299,7 +394,7 @@ class PhotoFrameController(
           val targetDir = if (dx < 0) +1 else -1
           if (dragPreparedDirection != targetDir) {
             dragPreparedDirection = targetDir
-            setupAdjacentDragBitmap(targetDir)
+            setupAdjacentDragBitmap(targetDir, screenW, dx)
           }
 
           val incomingX = if (targetDir > 0) screenW + dx else -screenW + dx
@@ -307,7 +402,16 @@ class PhotoFrameController(
           incomingLayer.blurPhoto.translationX = incomingX
         }
       }
-      MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+      MotionEvent.ACTION_CANCEL -> {
+        val dx = ev.x - downX
+        if (isDragging) {
+          isDragging = false
+          snapBackDragLayers(screenW, dx)
+        }
+        dragPreparedDirection = 0
+        rescheduleAutoTick()
+      }
+      MotionEvent.ACTION_UP -> {
         val dx = ev.x - downX
         val dy = ev.y - downY
         if (isDragging) {
@@ -320,36 +424,8 @@ class PhotoFrameController(
             pendingTransitionDirection = -1
             prev()
           } else {
-            currentLayer.frameContainer.animate()
-                .translationX(0f)
-                .setDuration(250L)
-                .setInterpolator(android.view.animation.DecelerateInterpolator())
-                .start()
-            currentLayer.blurPhoto.animate()
-                .translationX(0f)
-                .setDuration(250L)
-                .setInterpolator(android.view.animation.DecelerateInterpolator())
-                .start()
-
-            val cancelTargetX = if (dx < 0) screenW else -screenW
-            incomingLayer.frameContainer.animate()
-                .translationX(cancelTargetX)
-                .setDuration(250L)
-                .setInterpolator(android.view.animation.DecelerateInterpolator())
-                .withEndAction {
-                  incomingLayer.frameContainer.visibility = View.GONE
-                  incomingLayer.frameContainer.translationX = 0f
-                }
-                .start()
-            incomingLayer.blurPhoto.animate()
-                .translationX(cancelTargetX)
-                .setDuration(250L)
-                .setInterpolator(android.view.animation.DecelerateInterpolator())
-                .withEndAction {
-                  incomingLayer.blurPhoto.visibility = View.GONE
-                  incomingLayer.blurPhoto.translationX = 0f
-                }
-                .start()
+            snapBackDragLayers(screenW, dx)
+            rescheduleAutoTick()
           }
           dragPreparedDirection = 0
           return

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -256,6 +256,7 @@ class PhotoFrameController(
   private var isDragging = false
   private var dragPreparedDirection = 0
   private var pendingTransitionDirection: Int = 0
+  private var velocityTracker: android.view.VelocityTracker? = null
 
   private fun setupAdjacentDragBitmap(dir: Int, screenW: Float, currentDx: Float) {
     val key = when {
@@ -319,22 +320,23 @@ class PhotoFrameController(
   }
 
   private fun snapBackDragLayers(screenW: Float, dx: Float) {
+    val interpolator = android.view.animation.DecelerateInterpolator(1.8f)
     currentLayer.frameContainer.animate()
         .translationX(0f)
         .setDuration(250L)
-        .setInterpolator(android.view.animation.DecelerateInterpolator())
+        .setInterpolator(interpolator)
         .start()
     currentLayer.blurPhoto.animate()
         .translationX(0f)
         .setDuration(250L)
-        .setInterpolator(android.view.animation.DecelerateInterpolator())
+        .setInterpolator(interpolator)
         .start()
 
     val cancelTargetX = if (dx < 0) screenW else -screenW
     incomingLayer.frameContainer.animate()
         .translationX(cancelTargetX)
         .setDuration(250L)
-        .setInterpolator(android.view.animation.DecelerateInterpolator())
+        .setInterpolator(interpolator)
         .withEndAction {
           incomingLayer.frameContainer.visibility = View.GONE
           incomingLayer.frameContainer.translationX = 0f
@@ -343,7 +345,7 @@ class PhotoFrameController(
     incomingLayer.blurPhoto.animate()
         .translationX(cancelTargetX)
         .setDuration(250L)
-        .setInterpolator(android.view.animation.DecelerateInterpolator())
+        .setInterpolator(interpolator)
         .withEndAction {
           incomingLayer.blurPhoto.visibility = View.GONE
           incomingLayer.blurPhoto.translationX = 0f
@@ -378,9 +380,13 @@ class PhotoFrameController(
         downY = ev.y
         isDragging = false
         dragPreparedDirection = 0
+        velocityTracker?.recycle()
+        velocityTracker = android.view.VelocityTracker.obtain()
+        velocityTracker?.addMovement(ev)
         suspendAutoTick()
       }
       MotionEvent.ACTION_MOVE -> {
+        velocityTracker?.addMovement(ev)
         val dx = ev.x - downX
         val dy = ev.y - downY
         if (!isDragging && abs(dx) > 30 && abs(dx) > abs(dy) * 1.5f) {
@@ -403,6 +409,9 @@ class PhotoFrameController(
         }
       }
       MotionEvent.ACTION_CANCEL -> {
+        velocityTracker?.addMovement(ev)
+        velocityTracker?.recycle()
+        velocityTracker = null
         val dx = ev.x - downX
         if (isDragging) {
           isDragging = false
@@ -412,15 +421,24 @@ class PhotoFrameController(
         rescheduleAutoTick()
       }
       MotionEvent.ACTION_UP -> {
+        velocityTracker?.addMovement(ev)
+        velocityTracker?.computeCurrentVelocity(1000)
+        val velocityX = velocityTracker?.xVelocity ?: 0f
+        velocityTracker?.recycle()
+        velocityTracker = null
+
         val dx = ev.x - downX
         val dy = ev.y - downY
         if (isDragging) {
           isDragging = false
           val threshold = screenW * 0.18f
-          if (dx < -threshold) {
+          val isFlickNext = dx < -threshold || (dx < -25f && velocityX < -500f)
+          val isFlickPrev = dx > threshold || (dx > 25f && velocityX > 500f)
+
+          if (isFlickNext) {
             pendingTransitionDirection = +1
             next()
-          } else if (dx > threshold) {
+          } else if (isFlickPrev) {
             pendingTransitionDirection = -1
             prev()
           } else {
@@ -1916,8 +1934,8 @@ class PhotoFrameController(
       val currentTargetX = targetLayer.frameContainer.translationX
       val remainingDistance = if (currentTargetX != 0f) abs(currentTargetX) else screenW.toFloat()
       val fractionRemaining = (remainingDistance / screenW.toFloat()).coerceIn(0.1f, 1.0f)
-      val slideDuration = (380L * fractionRemaining).toLong().coerceAtLeast(150L)
-      val interpolator = android.view.animation.DecelerateInterpolator(1.5f)
+      val slideDuration = (350L * fractionRemaining).toLong().coerceIn(120L, 350L)
+      val interpolator = android.view.animation.DecelerateInterpolator(1.8f)
 
       if (currentTargetX == 0f) {
         val startX = if (slideDir > 0) screenW.toFloat() else -screenW.toFloat()


### PR DESCRIPTION
### Summary of Changes

This PR introduces real-time interactive touch gesture navigation and direction-aware slide transitions to the screensaver (`PhotoFrameController`):

#### 1. Interactive 1:1 Touch Drag Navigation (`ACTION_MOVE`)
- **Real-Time Drag Tracking**: As the user drags horizontally across the screensaver, the current photo and adjacent photo move in 1:1 real-time sync with finger movement.
- **Zero-Gap Contiguous Layout**: Positioned incoming adjacent photos edge-to-edge with the current photo, eliminating black gaps during drag interactions (carousel / filmstrip effect).
- **Smooth Release Momentum**: Releasing the drag smoothly continues the slide from the exact release position to completion using `DecelerateInterpolator`, or snaps back cleanly if released under threshold.

#### 2. Background Adjacent Photo Preloading (`LruCache`)
- **Instant Swipe Performance**: Integrated an in-memory `LruCache<String, Bitmap>` for preloading adjacent (next & previous) photos on a background thread pool immediately after any photo displays.
- **Zero Latency**: Eliminates disk and network decoding delays during swipe gestures.

#### 3. Preserved Auto-Dwell Transition
- Automatically changing photos over time continues to use the standard 900ms crossfade alpha transition.

---

### Verification & Unit Tests
- Passes all unit tests: `./gradlew :app:testDebugUnitTest` (`BUILD SUCCESSFUL`).
- Verified real-time gesture dragging, zero-gap carousel transitions, and instant preloading on physical Meta Portal Go hardware (`./gradlew :app:assembleDebug`).