### PR TITLE
Fix #158: show the photo frame over a secure keyguard on wake

### DIFF
--- a/app/src/main/java/com/immortal/launcher/PhotoFramePreviewActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFramePreviewActivity.kt
@@ -11,6 +11,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -75,6 +76,11 @@ class PhotoFramePreviewActivity : ComponentActivity() {
       finish()
       return
     }
+
+    // Render the frame *over* a secure keyguard so a presence/motion wake lands on the slideshow
+    // (or the night clock), the stock pre-Immortal behaviour, instead of the PIN pad (issue #158).
+    // Placed after the overnight-dark early-return above so it never fights the night blanking.
+    showOverKeyguard()
 
     frame = PhotoFrameController(this, showWelcome = intent.getBooleanExtra(EXTRA_SHOW_WELCOME, false))
     // Only the screensaver-continuation launch (DreamPolicy's force-wake handoff) honours the
@@ -152,6 +158,25 @@ class PhotoFramePreviewActivity : ComponentActivity() {
     setIntent(intent)
     launchDismissOnExit = intent.getBooleanExtra(EXTRA_LAUNCH_DISMISS_APP, false) && !nightClock
     Log.i(TAG, "onNewIntent (reused instance): launchDismiss=$launchDismissOnExit")
+  }
+
+  /**
+   * Show the frame over a secure keyguard and turn the panel on for it, so a presence/motion wake
+   * surfaces the slideshow rather than the lock screen (issue #158). Mirrors [WakeLightActivity]'s
+   * show-over-lock flags but deliberately OMITS FLAG_DISMISS_KEYGUARD: the keyguard stays armed
+   * underneath, so a Portal in a public space still requires the PIN to actually *use* the device —
+   * finishing this frame on a tap falls back to the keyguard-protected launcher, which prompts the
+   * PIN on interaction. No-op on devices without a secure lock set.
+   */
+  private fun showOverKeyguard() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+      setShowWhenLocked(true)
+      setTurnScreenOn(true)
+    } else {
+      window.addFlags(
+          WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+              WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON)
+    }
   }
 
   private fun applyKeepScreenOn() {


### PR DESCRIPTION
## Problem (issue #158)

On a Portal with a secure lock (PIN) set, a presence/motion wake lands **directly on the PIN pad** instead of the photo slideshow. Expected (stock, pre-Immortal) behaviour: motion wake → slideshow shows; only a **touch** should prompt the PIN.

## Root cause

"Screen Lock PIN" is the OS keyguard, not an Immortal feature. None of the screensaver surfaces are marked show-when-locked, so on wake the secure keyguard is raised on top of the frame. The only surface in the app that shows over the lock today is `WakeLightActivity` (the sunrise alarm).

## Fix

Mark `PhotoFramePreviewActivity` — the permanent frame for the default `ALWAYS_ON` installs, and the surface that takes over after `DreamPolicy`'s ~2-min force-wake handoff — `setShowWhenLocked(true)` + `setTurnScreenOn(true)`, mirroring `WakeLightActivity` **but deliberately omitting `FLAG_DISMISS_KEYGUARD`**. The keyguard stays armed underneath, so:

- **Motion wake → slideshow** renders over the lock.
- **Tap to interact →** the frame finishes back to the keyguard-protected launcher, which prompts the PIN.

Placed after the overnight-dark early-return so it never fights the night blanking (issue #154). No-op on devices without a secure lock set.

## Known gap (documented, not addressed here)

The initial ~2-minute `PhotoDreamService` window can't render over a secure keyguard — a `DreamService` always draws *behind* it. Fully covering the "cold motion wake" instant would require routing the presence wake to this activity instead of the dream; that's a larger, `DreamPolicy`-level follow-up. This PR covers the dominant long-lived frame.

## Testing

- `./gradlew :app:compileDebugKotlin` — clean.
- ⚠️ **Needs on-device verification** on a Portal with a secure lock set (keyguard interaction on this frozen firmware can't be exercised off-device). Draft until then. Suggested checks: (1) motion wake shows the slideshow over the lock; (2) a tap surfaces the PIN and, after unlock, lands on the launcher / the "open when dismissed" target; (3) no regression for users **without** a lock; (4) overnight dark window still stays dark.

Fixes #158.