### PR TITLE
Fix Google Photos pagination & high-res portraits (closes #155)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -14,6 +14,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.graphics.Matrix
+import android.graphics.PorterDuff
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.os.Handler
@@ -24,6 +25,7 @@ import android.util.Log
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
+import android.view.ViewOutlineProvider
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.FrameLayout
 import android.widget.ImageView
@@ -81,7 +83,23 @@ class PhotoFrameController(
   private val metaIo = Executors.newSingleThreadExecutor()
   private val ui = Handler(Looper.getMainLooper())
 
-  private lateinit var photo: ImageView
+  private class PhotoLayer(
+      val blurPhoto: ImageView,
+      val frameContainer: FrameLayout,
+      val photo: ImageView
+  )
+
+  private lateinit var layerA: PhotoLayer
+  private lateinit var layerB: PhotoLayer
+  private var activeLayerIndex = 0
+
+  private val currentLayer: PhotoLayer get() = if (this::layerA.isInitialized) (if (activeLayerIndex == 0) layerA else layerB) else PhotoLayer(ImageView(context), FrameLayout(context), ImageView(context))
+  private val incomingLayer: PhotoLayer get() = if (this::layerA.isInitialized) (if (activeLayerIndex == 0) layerB else layerA) else PhotoLayer(ImageView(context), FrameLayout(context), ImageView(context))
+
+  private val photo: ImageView get() = currentLayer.photo
+  private val blurPhoto: ImageView get() = currentLayer.blurPhoto
+  private val photoFrameContainer: FrameLayout get() = currentLayer.frameContainer
+
   private lateinit var videoView: VideoView
 
   // tvOS-style slow zoom/pan ("Ken Burns") on the photo layer. Runs over the dwell time and is
@@ -489,9 +507,45 @@ class PhotoFrameController(
     val root = FrameLayout(context)
     root.setBackgroundColor(Color.BLACK)
 
-    photo = ImageView(context)
-    photo.scaleType = ImageView.ScaleType.CENTER_CROP
-    root.addView(photo, FrameLayout.LayoutParams(MATCH, MATCH))
+    val blurPhotoA = ImageView(context).apply {
+      scaleType = ImageView.ScaleType.CENTER_CROP
+      setColorFilter(Color.argb(45, 0, 0, 0), PorterDuff.Mode.DARKEN)
+    }
+    val frameA = FrameLayout(context).apply {
+      outlineProvider = ViewOutlineProvider.BOUNDS
+      clipToOutline = true
+      clipChildren = true
+      clipToPadding = true
+    }
+    val photoA = ImageView(context).apply { scaleType = ImageView.ScaleType.CENTER_CROP }
+    val photoLpA = FrameLayout.LayoutParams(MATCH, MATCH, Gravity.CENTER).apply {
+      setMargins(-4, 0, -4, 0)
+    }
+    frameA.addView(photoA, photoLpA)
+
+    val blurPhotoB = ImageView(context).apply {
+      scaleType = ImageView.ScaleType.CENTER_CROP
+      setColorFilter(Color.argb(45, 0, 0, 0), PorterDuff.Mode.DARKEN)
+    }
+    val frameB = FrameLayout(context).apply {
+      outlineProvider = ViewOutlineProvider.BOUNDS
+      clipToOutline = true
+      clipChildren = true
+      clipToPadding = true
+    }
+    val photoB = ImageView(context).apply { scaleType = ImageView.ScaleType.CENTER_CROP }
+    val photoLpB = FrameLayout.LayoutParams(MATCH, MATCH, Gravity.CENTER).apply {
+      setMargins(-4, 0, -4, 0)
+    }
+    frameB.addView(photoB, photoLpB)
+
+    layerA = PhotoLayer(blurPhotoA, frameA, photoA)
+    layerB = PhotoLayer(blurPhotoB, frameB, photoB)
+
+    root.addView(blurPhotoA, FrameLayout.LayoutParams(MATCH, MATCH))
+    root.addView(frameA, FrameLayout.LayoutParams(MATCH, MATCH, Gravity.CENTER))
+    root.addView(blurPhotoB, FrameLayout.LayoutParams(MATCH, MATCH))
+    root.addView(frameB, FrameLayout.LayoutParams(MATCH, MATCH, Gravity.CENTER))
 
     videoView = VideoView(context)
     videoView.visibility = View.GONE
@@ -692,9 +746,11 @@ class PhotoFrameController(
 
   private fun applyFit() {
     // Video gets the same choice via [applyVideoFit], sized per-clip once its dimensions are known.
+    val isFit = settings.fit == ScreensaverConfig.FIT_FIT
     photo.scaleType =
-        if (settings.fit == ScreensaverConfig.FIT_FIT) ImageView.ScaleType.FIT_CENTER
+        if (isFit) ImageView.ScaleType.FIT_CENTER
         else ImageView.ScaleType.CENTER_CROP
+    blurPhoto.visibility = if (isFit) View.VISIBLE else View.GONE
   }
 
   /**
@@ -1169,6 +1225,8 @@ class PhotoFrameController(
     faceRenderer.setCaption(null, null)
     photo.setImageDrawable(null)
     photo.visibility = View.GONE
+    blurPhoto.setImageDrawable(null)
+    blurPhoto.visibility = View.GONE
     videoView.visibility = View.VISIBLE
     runCatching {
           videoView.setOnPreparedListener { mp ->
@@ -1319,6 +1377,8 @@ class PhotoFrameController(
     faceRenderer.setCaption(null, null)
     photo.setImageDrawable(null)
     photo.visibility = View.GONE
+    blurPhoto.setImageDrawable(null)
+    blurPhoto.visibility = View.GONE
     videoView.visibility = View.VISIBLE
     runCatching {
           videoView.setOnPreparedListener { mp ->
@@ -1482,62 +1542,157 @@ class PhotoFrameController(
   }
 
   private fun show(bmp: Bitmap) {
-    // The caption belongs to whichever photo is incoming; hide it now and let the per-source
-    // metadata load re-show it (web/CDN photos never re-show it — they carry no EXIF).
     faceRenderer.setCaption(null, null)
-    photo
-        .animate()
-        .alpha(0.15f)
-        .setDuration(220)
+
+    val targetLayer = incomingLayer
+    val outgoingLayer = currentLayer
+
+    val isRawPortrait = bmp.height > bmp.width
+
+    // Optionally crop vertical (portrait) photos by ~20% (10% top, 10% bottom) if setting is enabled
+    val displayBmp = if (isRawPortrait && settings.cropVertical) {
+      runCatching {
+        val cropPct = 0.20f
+        val cropPixels = (bmp.height * cropPct / 2f).toInt()
+        val croppedH = maxOf(1, bmp.height - cropPixels * 2)
+        Bitmap.createBitmap(bmp, 0, cropPixels, bmp.width, croppedH)
+      }.getOrDefault(bmp)
+    } else {
+      bmp
+    }
+
+    val isPortrait = displayBmp.height > displayBmp.width
+    val isFitMode = isPortrait || settings.fit == ScreensaverConfig.FIT_FIT
+
+    val containerLp = targetLayer.frameContainer.layoutParams as FrameLayout.LayoutParams
+    val displayMetrics = context.resources.displayMetrics
+    val screenW = displayMetrics.widthPixels
+    val screenH = displayMetrics.heightPixels
+
+    if (isFitMode) {
+      val imgRatio = displayBmp.width.toFloat() / displayBmp.height.toFloat()
+      val screenRatio = screenW.toFloat() / screenH.toFloat()
+
+      if (imgRatio < screenRatio) {
+        val calcW = Math.round(screenH * imgRatio)
+        val evenW = if (calcW % 2 != 0) calcW + 1 else calcW
+        containerLp.height = screenH
+        containerLp.width = maxOf(2, evenW)
+      } else {
+        val calcH = Math.round(screenW / imgRatio)
+        val evenH = if (calcH % 2 != 0) calcH + 1 else calcH
+        containerLp.width = screenW
+        containerLp.height = maxOf(2, evenH)
+      }
+      containerLp.gravity = Gravity.CENTER
+      targetLayer.frameContainer.layoutParams = containerLp
+
+      runCatching {
+        val blurred = createBlurredBackground(displayBmp)
+        targetLayer.blurPhoto.setImageBitmap(blurred)
+      }
+    } else {
+      containerLp.width = MATCH
+      containerLp.height = MATCH
+      containerLp.gravity = Gravity.CENTER
+      targetLayer.frameContainer.layoutParams = containerLp
+    }
+
+    targetLayer.photo.setImageBitmap(displayBmp)
+
+    // Prepare incoming layer at 0 alpha and bring to front
+    targetLayer.blurPhoto.alpha = 0f
+    targetLayer.blurPhoto.visibility = if (isFitMode) View.VISIBLE else View.GONE
+
+    targetLayer.frameContainer.alpha = 0f
+    targetLayer.frameContainer.visibility = View.VISIBLE
+
+    targetLayer.blurPhoto.bringToFront()
+    targetLayer.frameContainer.bringToFront()
+
+    // Keep UI components above photo layers
+    if (this::videoView.isInitialized) videoView.bringToFront()
+    faceRenderer.view.bringToFront()
+    dashboardPanel?.bringToFront()
+    welcomeOverlay?.bringToFront()
+
+    // Start Ken Burns motion on incoming photo
+    startKenBurns(targetLayer.photo, isPortrait)
+
+    val fadeDuration = 900L
+
+    targetLayer.frameContainer.animate()
+        .alpha(1f)
+        .setDuration(fadeDuration)
+        .setInterpolator(AccelerateDecelerateInterpolator())
+        .start()
+
+    if (isFitMode) {
+      targetLayer.blurPhoto.animate()
+          .alpha(1f)
+          .setDuration(fadeDuration)
+          .setInterpolator(AccelerateDecelerateInterpolator())
+          .start()
+    }
+
+    outgoingLayer.frameContainer.animate()
+        .alpha(0f)
+        .setDuration(fadeDuration)
+        .setInterpolator(AccelerateDecelerateInterpolator())
         .withEndAction {
-          photo.setImageBitmap(bmp)
-          startKenBurns()
-          photo.animate().alpha(1f).setDuration(420).start()
+          outgoingLayer.frameContainer.visibility = View.GONE
         }
         .start()
+
+    outgoingLayer.blurPhoto.animate()
+        .alpha(0f)
+        .setDuration(fadeDuration)
+        .setInterpolator(AccelerateDecelerateInterpolator())
+        .withEndAction {
+          outgoingLayer.blurPhoto.visibility = View.GONE
+        }
+        .start()
+
+    activeLayerIndex = if (activeLayerIndex == 0) 1 else 0
   }
 
   /**
-   * Apply a slow tvOS-style zoom/pan to the current photo over the dwell time. Cancelled and
-   * restarted on each advance. Only in fill mode: in fit/letterbox mode the user asked to see the
-   * whole frame, so cropping into it with a zoom would defeat that. A little overscan (scale
-   * [BIG]) gives pan styles room to move without ever exposing the black background.
+   * Apply a subtle tvOS-style zoom/pan to the frontal photo over the dwell time.
    */
-  private fun startKenBurns() {
+  private fun startKenBurns(targetPhoto: ImageView = currentLayer.photo, isPortrait: Boolean = false) {
     kenBurns?.cancel()
-    // Reset to identity first so a cancelled mid-animation transform never lingers on the new shot.
-    photo.scaleX = 1f
-    photo.scaleY = 1f
-    photo.translationX = 0f
-    photo.translationY = 0f
-    if (settings.fit != ScreensaverConfig.FIT_FILL) return
-    val w = (if (photo.width > 0) photo.width else context.resources.displayMetrics.widthPixels)
-    val h = (if (photo.height > 0) photo.height else context.resources.displayMetrics.heightPixels)
-    photo.pivotX = w / 2f
-    photo.pivotY = h / 2f
-    val pan = (BIG - 1f) / 2f // max translation fraction that stays within the overscan at scale BIG
+    val minScale = 1.006f
+    targetPhoto.scaleX = minScale
+    targetPhoto.scaleY = minScale
+    targetPhoto.translationX = 0f
+    targetPhoto.translationY = 0f
+
+    val zoomScale = if (isPortrait) 1.15f else 1.08f
+    val w = (if (targetPhoto.width > 0) targetPhoto.width else context.resources.displayMetrics.widthPixels)
+    val h = (if (targetPhoto.height > 0) targetPhoto.height else context.resources.displayMetrics.heightPixels)
+    targetPhoto.pivotX = w / 2f
+    targetPhoto.pivotY = h / 2f
+    val pan = (zoomScale - minScale) / 2f
     val set = AnimatorSet()
     when ((kenBurnsStyle++ % 4 + 4) % 4) {
-      0 -> // slow zoom in
-      set.playTogether(
-          ObjectAnimator.ofFloat(photo, View.SCALE_X, 1f, BIG),
-          ObjectAnimator.ofFloat(photo, View.SCALE_Y, 1f, BIG))
-      1 -> // slow zoom out
-      set.playTogether(
-          ObjectAnimator.ofFloat(photo, View.SCALE_X, BIG, 1f),
-          ObjectAnimator.ofFloat(photo, View.SCALE_Y, BIG, 1f))
-      2 -> { // pan down (hold the zoom so the edges stay covered)
-        photo.scaleX = BIG
-        photo.scaleY = BIG
-        set.playTogether(ObjectAnimator.ofFloat(photo, View.TRANSLATION_Y, pan * h, -pan * h))
+      0 -> set.playTogether(
+          ObjectAnimator.ofFloat(targetPhoto, View.SCALE_X, minScale, zoomScale),
+          ObjectAnimator.ofFloat(targetPhoto, View.SCALE_Y, minScale, zoomScale))
+      1 -> set.playTogether(
+          ObjectAnimator.ofFloat(targetPhoto, View.SCALE_X, zoomScale, minScale),
+          ObjectAnimator.ofFloat(targetPhoto, View.SCALE_Y, zoomScale, minScale))
+      2 -> {
+        targetPhoto.scaleX = zoomScale
+        targetPhoto.scaleY = zoomScale
+        set.playTogether(ObjectAnimator.ofFloat(targetPhoto, View.TRANSLATION_Y, pan * h, -pan * h))
       }
-      else -> { // pan up
-        photo.scaleX = BIG
-        photo.scaleY = BIG
-        set.playTogether(ObjectAnimator.ofFloat(photo, View.TRANSLATION_Y, -pan * h, pan * h))
+      else -> {
+        targetPhoto.scaleX = zoomScale
+        targetPhoto.scaleY = zoomScale
+        set.playTogether(ObjectAnimator.ofFloat(targetPhoto, View.TRANSLATION_Y, -pan * h, pan * h))
       }
     }
-    set.duration = intervalMs() + 1200L // outlast the dwell so the motion never visibly stalls
+    set.duration = intervalMs() + 1200L
     set.interpolator = AccelerateDecelerateInterpolator()
     set.start()
     kenBurns = set
@@ -1546,12 +1701,104 @@ class PhotoFrameController(
   private fun cancelKenBurns() {
     kenBurns?.cancel()
     kenBurns = null
-    if (this::photo.isInitialized) {
-      photo.scaleX = 1f
-      photo.scaleY = 1f
-      photo.translationX = 0f
-      photo.translationY = 0f
+    val minScale = 1.006f
+    if (this::layerA.isInitialized) {
+      layerA.photo.scaleX = minScale
+      layerA.photo.scaleY = minScale
+      layerA.photo.translationX = 0f
+      layerA.photo.translationY = 0f
     }
+    if (this::layerB.isInitialized) {
+      layerB.photo.scaleX = minScale
+      layerB.photo.scaleY = minScale
+      layerB.photo.translationX = 0f
+      layerB.photo.translationY = 0f
+    }
+  }
+
+  /**
+   * Create a smooth, high-definition blurred background version of the bitmap
+   * preserving aspect ratio without distortion or pixelation.
+   */
+  private fun createBlurredBackground(src: Bitmap): Bitmap {
+    val maxDim = maxOf(64, maxOf(src.width, src.height) / 2)
+    val (tw, th) = if (src.width >= src.height) {
+      maxDim to maxOf(1, (maxDim * src.height) / src.width)
+    } else {
+      maxOf(1, (maxDim * src.width) / src.height) to maxDim
+    }
+    val scaled = Bitmap.createScaledBitmap(src, tw, th, true)
+    return applyBoxBlur(scaled, 4)
+  }
+
+  private fun applyBoxBlur(bitmap: Bitmap, radius: Int): Bitmap {
+    val w = bitmap.width
+    val h = bitmap.height
+    if (w <= 0 || h <= 0) return bitmap
+    val pixels = IntArray(w * h)
+    bitmap.getPixels(pixels, 0, w, 0, 0, w, h)
+
+    val out = IntArray(w * h)
+    val r = IntArray(w * h)
+    val g = IntArray(w * h)
+    val b = IntArray(w * h)
+
+    val count = radius * 2 + 1
+
+    // Horizontal sliding window
+    for (y in 0 until h) {
+      var rsum = 0
+      var gsum = 0
+      var bsum = 0
+      val row = y * w
+      for (i in -radius..radius) {
+        val px = pixels[row + minOf(w - 1, maxOf(0, i))]
+        rsum += (px shr 16) and 0xff
+        gsum += (px shr 8) and 0xff
+        bsum += px and 0xff
+      }
+      for (x in 0 until w) {
+        r[row + x] = rsum / count
+        g[row + x] = gsum / count
+        b[row + x] = bsum / count
+        val oldPx = pixels[row + maxOf(0, x - radius)]
+        val newPx = pixels[row + minOf(w - 1, x + radius + 1)]
+        rsum += ((newPx shr 16) and 0xff) - ((oldPx shr 16) and 0xff)
+        gsum += ((newPx shr 8) and 0xff) - ((oldPx shr 8) and 0xff)
+        bsum += (newPx and 0xff) - (oldPx and 0xff)
+      }
+    }
+
+    // Vertical sliding window
+    for (x in 0 until w) {
+      var rsum = 0
+      var gsum = 0
+      var bsum = 0
+      for (i in -radius..radius) {
+        val py = minOf(h - 1, maxOf(0, i))
+        val idx = py * w + x
+        rsum += r[idx]
+        gsum += g[idx]
+        bsum += b[idx]
+      }
+      for (y in 0 until h) {
+        val idx = y * w + x
+        val cr = rsum / count
+        val cg = gsum / count
+        val cb = bsum / count
+        out[idx] = (0xff shl 24) or (cr shl 16) or (cg shl 8) or cb
+        val oldIdx = maxOf(0, y - radius) * w + x
+        val newIdx = minOf(h - 1, y + radius + 1) * w + x
+        rsum += r[newIdx] - r[oldIdx]
+        gsum += g[newIdx] - g[oldIdx]
+        bsum += b[newIdx] - b[oldIdx]
+      }
+    }
+
+    val blurred = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+    blurred.setPixels(out, 0, w, 0, 0, w, h)
+    bitmap.recycle()
+    return blurred
   }
 
   // --- default-feed sources (tried in turn by [fetchWebPhoto]) ----------------

--- a/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
@@ -368,17 +368,75 @@ object RemoteAlbum {
     val raw = LH3_REGEX.findAll(html).map { it.value }.toList()
     if (raw.isEmpty()) return Album(null, emptyList())
 
-    // Strip the size suffix so we can ask Google for a screen-sized variant, and
-    // skip avatar-service URLs (`/a/` and `/a-/`) — those embed on every share page
-    // as the owner's profile picture and would otherwise lead the slideshow.
-    val sizeSuffix = "=w${screenW}-h${screenH}-no"
+    // Target the maximum screen dimension so both landscape and portrait photos render
+    // crisp without downscaling portrait photos to low resolution inside a bounding box.
+    val maxDim = maxOf(screenW, screenH)
+    val sizeSuffix = "=w${maxDim}-h${maxDim}-no"
     val seen = LinkedHashSet<String>()
     raw.forEach { u ->
       if (isGoogleAvatarUrl(u)) return@forEach
       val stripped = u.substringBefore('=')
       seen.add(stripped + sizeSuffix)
     }
+
+    // Crawl pagination tokens if the Google Photos album contains more photos than page 1.
+    val albumKey = extractGoogleAlbumKey(finalUrl, html)
+    var token = extractGoogleContinuationToken(html)
+    var page = 0
+    val maxPages = 100 // Cap to 100 pages (~10,000 photos) for memory/network safety
+
+    while (!token.isNullOrBlank() && !albumKey.isNullOrBlank() && page < maxPages) {
+      val rpcBody = fetchGoogleBatchRpc(albumKey, token) ?: break
+      val prevSize = seen.size
+      LH3_REGEX.findAll(rpcBody).forEach { m ->
+        val u = m.value
+        if (!isGoogleAvatarUrl(u)) {
+          val stripped = u.substringBefore('=')
+          seen.add(stripped + sizeSuffix)
+        }
+      }
+      val nextToken = extractGoogleContinuationToken(rpcBody)
+      if (nextToken == token || seen.size == prevSize) {
+        break
+      }
+      token = nextToken
+      page++
+    }
+
     return Album(extractGoogleTitle(html), seen.toList())
+  }
+
+  internal fun extractGoogleAlbumKey(url: String, html: String): String? {
+    val mUrl = Regex("""photos\.google\.com/share/([A-Za-z0-9_\-]+)""", RegexOption.IGNORE_CASE).find(url)
+    if (mUrl != null) return mUrl.groupValues[1]
+    val mHtml = Regex("""["'](AF1Qa1[A-Za-z0-9_\-]+)["']""").find(html)
+    return mHtml?.groupValues?.get(1)
+  }
+
+  internal fun extractGoogleContinuationToken(text: String): String? {
+    val m = Regex("""["'](C[A-Za-z0-9_\-]{30,})["']""").find(text)
+    return m?.groupValues?.get(1)
+  }
+
+  private fun fetchGoogleBatchRpc(albumKey: String, token: String): String? {
+    val spec = "https://photos.google.com/_/PhotosUi/data/batched/ds:1?rpcids=snAcAc&_reqid=1000&rt=c"
+    val reqData = """[[["snAcAc","[\"$albumKey\",\"$token\"]",null,"1"]]]"""
+    val body = "f.req=" + URLEncoder.encode(reqData, "UTF-8")
+    return postForm(spec, body)
+  }
+
+  private fun postForm(spec: String, body: String): String? {
+    val c = URL(spec).openConnection() as HttpURLConnection
+    c.connectTimeout = 8000
+    c.readTimeout = 10000
+    c.requestMethod = "POST"
+    c.doOutput = true
+    c.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
+    c.setRequestProperty("User-Agent", USER_AGENT)
+    return runCatching {
+      c.outputStream.use { it.write(body.toByteArray(Charsets.UTF_8)) }
+      c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
+    }.getOrNull()
   }
 
   internal fun isGoogleAvatarUrl(url: String): Boolean {

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -213,6 +213,8 @@ object ScreensaverConfig {
       // dashboard path to deep-link to (e.g. "today-home/security"), and "" opens the
       // user's default dashboard. Only offered when an HA app is installed.
       val dismissHaDashboard: String? = null,
+      // Crop vertical (portrait) photos by ~20% (top & bottom) so they look less tall/panoramic.
+      val cropVertical: Boolean = false,
   ) {
     /** True when the idle screen-off timeout is active. */
     val idleSleepOn: Boolean
@@ -313,8 +315,12 @@ object ScreensaverConfig {
         welcomeEnabled = p.getBoolean("welcome_enabled", true),
         dismissAppComponent = p.getString("dismiss_app_component", null),
         dismissHaDashboard = p.getString("dismiss_ha_dashboard", null),
+        cropVertical = p.getBoolean("crop_vertical", false),
     )
   }
+
+  fun setCropVertical(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("crop_vertical", on).apply()
 
   fun setSoundscape(c: Context, s: String) = prefs(c).edit().putString("soundscape", s).apply()
 

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -255,6 +255,12 @@ object SettingsDomains {
                       "Play videos",
                       get = { it.includeVideo },
                       set = ScreensaverConfig::setIncludeVideo),
+                  BoolSpec(
+                      "cropVertical",
+                      "Crop vertical photos (~20%)",
+                      get = { it.cropVertical },
+                      set = ScreensaverConfig::setCropVertical,
+                      help = "Trims ~20% off the top and bottom of portrait photos so they look less tall and narrow."),
                   // On-device cache: only meaningful for a network source that re-fetches the same
                   // assets every loop (Immich / WebDAV). Hidden for a local folder or the built-in
                   // feed, where there's nothing to save a round-trip on.

--- a/app/src/test/java/com/immortal/launcher/RemoteAlbumTest.kt
+++ b/app/src/test/java/com/immortal/launcher/RemoteAlbumTest.kt
@@ -180,4 +180,20 @@ class RemoteAlbumTest {
             """.trimIndent())
     assertEquals("big", RemoteAlbum.pickBestDerivative(derivs, 1920, 1080))
   }
+
+  @Test
+  fun extractGoogleAlbumKey_parsesUrlAndHtml() {
+    val url = "https://photos.google.com/share/AF1Qa1b2c3d_Key456?key=SampleKey"
+    assertEquals("AF1Qa1b2c3d_Key456", RemoteAlbum.extractGoogleAlbumKey(url, ""))
+
+    val html = """var data = ["AF1Qa1b2c3d_KeyFromHtml"];"""
+    assertEquals("AF1Qa1b2c3d_KeyFromHtml", RemoteAlbum.extractGoogleAlbumKey("https://photos.app.goo.gl/short", html))
+  }
+
+  @Test
+  fun extractGoogleContinuationToken_findsLongToken() {
+    val sampleText = """AF_initDataCallback({key: 'ds:1', data: [["photo1"], "CAESa0FBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB"]});"""
+    val token = RemoteAlbum.extractGoogleContinuationToken(sampleText)
+    assertTrue(token != null && token.startsWith("CAESa"))
+  }
 }


### PR DESCRIPTION
Cherry-picks @miguelsg29's Google Photos fix (`8a31dec`, originally in #164) onto a clean branch off `main`, **decoupled from the Spanish i18n sweep** so it can land on its own. Authorship preserved.

## What it does (closes #155)
- **Pagination:** crawls the Google Photos shared-album `batchexecute` RPC (`extractGoogleAlbumKey` / `extractGoogleContinuationToken` / `fetchGoogleBatchRpc` in `RemoteAlbum.kt`) so albums with >30 photos load beyond the initial HTML chunk (hard-capped at 100 pages / 10k photos).
- **High-res portraits:** CDN suffix `=w{maxDim}-h{maxDim}-no` at max screen dimension; aspect-preserving background blur, dual-layer crossfade, clipped Ken-Burns frame, and an opt-in `cropVertical` toggle (added as a `BoolSpec`, tripwire-clean).

## Review notes (from deep review)
- **Fails safe:** every new path returns page-1 results or falls back to the built-in feed on error, so it can't regress today's behaviour.
- ⚠️ **Pagination is best-effort:** the continuation-token regex leans on undocumented Google internals and may not match the real cursor for every album, so the "~30-photo cap" symptom *could* persist in the field for some albums and will rot if Google changes their payload. The high-res/portrait half is solid. Worth confirming against a real >30-photo album before we consider #155 fully closed.
- **Nit (not blocking):** the box blur runs on the main thread per portrait/fit transition (`PhotoFrameController.kt:1591`) — a per-transition hitch on the Portal CPU; ideally moved to the `io` executor in a follow-up.

## Testing
- `./gradlew :app:compileDebugKotlin` + `RemoteAlbumTest` — green. (The new tests cover the key/token extractors against fixtures; they don't exercise a real Google payload.)

Closes #155. Original work by @miguelsg29 (split out of #164).