### PR TITLE
Fleet agent: don't let a dropped connection kill the launcher

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,6 +96,12 @@ android {
     targetCompatibility = JavaVersion.VERSION_11
   }
   buildFeatures { compose = true }
+  testOptions {
+    // Let unit tests exercise code that logs: the android.jar stub used off-device throws
+    // "not mocked" for android.util.Log, which would otherwise put every logging path
+    // (e.g. FleetHttpServer's connection-error handling) out of reach of a JVM test.
+    unitTests.isReturnDefaultValues = true
+  }
 }
 
 dependencies {

--- a/app/src/main/java/com/immortal/launcher/FleetHttpServer.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetHttpServer.kt
@@ -9,11 +9,13 @@ package com.immortal.launcher
 
 import android.util.Log
 import java.io.ByteArrayOutputStream
+import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
+import java.net.SocketTimeoutException
 import java.net.URLDecoder
 import java.util.concurrent.Executors
 
@@ -36,7 +38,10 @@ class FleetHttpServer(
     private val port: Int,
     private val handler: (Request) -> Response,
 ) {
-  private val pool = Executors.newFixedThreadPool(4)
+  // Browsers fan out to ~6 parallel connections per host, and `Connection: close`
+  // means every asset and poll costs a fresh one — keep enough threads for a phone
+  // remote loading the page without queueing behind itself.
+  private val pool = Executors.newFixedThreadPool(8)
   @Volatile private var server: ServerSocket? = null
   @Volatile private var running = false
   private var acceptThread: Thread? = null
@@ -182,8 +187,29 @@ class FleetHttpServer(
                 if (running) Log.w(TAG, "accept failed", it)
                 return
               }
-      runCatching { pool.execute { serve(socket) } }
+      runCatching { pool.execute { serveSafely(socket) } }
           .onFailure { runCatching { socket.close() } }
+    }
+  }
+
+  /**
+   * A connection's failure must never leave the pool thread. Browsers open speculative
+   * connections they may never write to (and drop live ones when a tab closes), so a
+   * read here can time out or reset; a checked IOException thrown out of a pool
+   * Runnable reaches the thread's uncaught handler wrapped in [java.lang.Error] and
+   * takes the whole launcher down with it. Log and drop the connection instead.
+   */
+  private fun serveSafely(socket: Socket) {
+    try {
+      serve(socket)
+    } catch (e: SocketTimeoutException) {
+      Log.d(TAG, "idle connection timed out: ${e.message}")
+    } catch (e: IOException) {
+      Log.d(TAG, "connection dropped: ${e.message}")
+    } catch (t: Throwable) {
+      Log.w(TAG, "connection handler failed", t)
+    } finally {
+      runCatching { socket.close() }
     }
   }
 
@@ -195,7 +221,10 @@ class FleetHttpServer(
         Log.w(TAG, "rejecting non-LAN peer ${it.inetAddress?.hostAddress}")
         return
       }
-      it.soTimeout = 30_000
+      // Short fuse while waiting for a request line: a browser preconnect that never
+      // writes would otherwise pin one of the pool's few threads for the full body
+      // timeout, and enough of them make the agent unreachable from the phone remote.
+      it.soTimeout = HEAD_TIMEOUT_MS
       val input = it.getInputStream()
       val out = it.getOutputStream()
       val head = readHead(input)
@@ -211,6 +240,8 @@ class FleetHttpServer(
         runCatching { writeResponse(out, Response.preflight()) }
         return
       }
+      // A real request is in flight now — give the body (uploads) the longer budget.
+      it.soTimeout = BODY_TIMEOUT_MS
       val len = head.headers["content-length"]?.toIntOrNull()?.coerceAtLeast(0) ?: 0
       val req = Request(head.method, head.path, head.query, head.headers, input, len)
       // Honour Expect: 100-continue (curl sends it for larger uploads) so the
@@ -256,6 +287,8 @@ class FleetHttpServer(
   internal companion object {
     private const val TAG = "ImmortalFleet"
     private const val MAX_HEAD_BYTES = 64 * 1024
+    private const val HEAD_TIMEOUT_MS = 10_000
+    private const val BODY_TIMEOUT_MS = 30_000
     private const val CRLF_CRLF = 0x0D0A0D0A
 
     /** Parse the request line + headers (text up to and including the blank line). */

--- a/app/src/test/java/com/immortal/launcher/FleetHttpServerSocketTest.kt
+++ b/app/src/test/java/com/immortal/launcher/FleetHttpServerSocketTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Drives a real [FleetHttpServer] over loopback. Guards the connection-level failure
+ * handling: a phone browser opens speculative connections and abandons them, and a
+ * socket error from one of those must not escape its pool thread — that reached the
+ * uncaught handler as `java.lang.Error` and took the whole launcher down.
+ */
+class FleetHttpServerSocketTest {
+
+  private fun freePort(): Int = ServerSocket(0).use { it.localPort }
+
+  private fun serverOn(port: Int, handler: (FleetHttpServer.Request) -> FleetHttpServer.Response) =
+      FleetHttpServer(port, handler).apply { start() }
+
+  private fun connect(port: Int): Socket =
+      Socket().apply {
+        connect(InetSocketAddress(InetAddress.getByName("127.0.0.1"), port), 2_000)
+        soTimeout = 5_000
+      }
+
+  /** Send [text] verbatim over a fresh connection; returns the status line. */
+  private fun raw(port: Int, text: String): String =
+      connect(port).use { s ->
+        s.getOutputStream().apply {
+          write(text.toByteArray(Charsets.US_ASCII))
+          flush()
+        }
+        s.getInputStream().bufferedReader().readLine()
+      }
+
+  /** Send one well-formed request line over a fresh connection; returns the status line. */
+  private fun request(port: Int, line: String): String =
+      raw(port, "$line HTTP/1.1\r\nHost: portal\r\n\r\n")
+
+  private fun ok(port: Int) = request(port, "GET /info")
+
+  @Test
+  fun connectionResetDoesNotEscapeThePoolThread_andTheServerKeepsServing() {
+    val caught = mutableListOf<Throwable>()
+    val previous = Thread.getDefaultUncaughtExceptionHandler()
+    Thread.setDefaultUncaughtExceptionHandler { _, t -> synchronized(caught) { caught.add(t) } }
+    val port = freePort()
+    val server = serverOn(port) { FleetHttpServer.Response(200, """{"ok":true}""") }
+    try {
+      // SO_LINGER 0 makes close() send an RST, so the server's header read fails the same
+      // way an abandoned browser connection does — without waiting out the read timeout.
+      repeat(3) {
+        Socket().apply {
+          connect(InetSocketAddress(InetAddress.getByName("127.0.0.1"), port), 2_000)
+          setSoLinger(true, 0)
+          close()
+        }
+      }
+      // The pool must still answer — proof no worker died and the pool wasn't poisoned.
+      assertEquals("HTTP/1.1 200 OK", ok(port))
+      synchronized(caught) { assertTrue("uncaught: $caught", caught.isEmpty()) }
+    } finally {
+      server.stop()
+      Thread.setDefaultUncaughtExceptionHandler(previous)
+    }
+  }
+
+  @Test
+  fun malformedRequestGetsA400AndTheServerSurvives() {
+    val port = freePort()
+    val server = serverOn(port) { FleetHttpServer.Response(200, """{"ok":true}""") }
+    try {
+      // One token where a method + target belong — parseHead rejects it.
+      assertTrue(raw(port, "garbage\r\nHost: portal\r\n\r\n").startsWith("HTTP/1.1 400"))
+      assertEquals("HTTP/1.1 200 OK", ok(port))
+    } finally {
+      server.stop()
+    }
+  }
+
+  @Test
+  fun optionsPreflightIsAnsweredBeforeTheHandlerRuns() {
+    val port = freePort()
+    var handled = 0
+    val server =
+        serverOn(port) {
+          handled++
+          FleetHttpServer.Response(200, """{"ok":true}""")
+        }
+    try {
+      assertTrue(request(port, "OPTIONS /info").startsWith("HTTP/1.1 204"))
+      assertEquals(0, handled)
+      assertEquals("HTTP/1.1 200 OK", ok(port))
+      assertEquals(1, handled)
+    } finally {
+      server.stop()
+    }
+  }
+
+  @Test
+  fun aThrowingHandlerBecomesA500RatherThanACrash() {
+    val port = freePort()
+    val server = serverOn(port) { error("boom") }
+    try {
+      assertTrue(request(port, "GET /info").startsWith("HTTP/1.1 500"))
+    } finally {
+      server.stop()
+    }
+  }
+
+  @Test
+  fun stopClosesTheListeningPort() {
+    val port = freePort()
+    val server = serverOn(port) { FleetHttpServer.Response(200, """{"ok":true}""") }
+    assertEquals("HTTP/1.1 200 OK", ok(port))
+    server.stop()
+    assertNotNull(
+        "expected connect to fail after stop()",
+        runCatching { connect(port).close() }.exceptionOrNull(),
+    )
+  }
+}


### PR DESCRIPTION
## What

Loading the phone remote page crashed the launcher. `FleetHttpServer` ran each connection directly as a pool task:

```kotlin
pool.execute { serve(socket) }
```

Browsers preconnect speculatively and abandon connections when a tab is backgrounded, so `readHead()` blocked until the 30s `soTimeout` and threw `SocketTimeoutException`. A checked exception escaping a `Runnable` gets wrapped by `ThreadPoolExecutor.runWorker` into `java.lang.Error`, which reaches the thread's uncaught handler:

```
FATAL EXCEPTION: pool-2-thread-2
java.lang.Error: java.net.SocketTimeoutException: Read timed out
    at com.immortal.launcher.FleetHttpServer.readHead(FleetHttpServer.kt:239)
    at com.immortal.launcher.FleetHttpServer.serve(FleetHttpServer.kt:201)
```

`CrashGuard` then recovered the process, so turning on "remote — control from phone" and opening the page from a phone browser bounced the launcher. Every other failure path in the file was already inside `runCatching`; the header read was the one hole.

## Changes

- **`serveSafely()`** wraps `serve()` — timeouts and resets log at debug, anything else warns, and the socket is always closed. A dead connection can no longer take the process down.
- **Split the read timeout**: 10s while waiting for a request line, 30s once a real request is in flight (uploads keep the long budget). An abandoned connection previously pinned a pool thread for the full 30s.
- **Pool 4 → 8**: with `Connection: close`, every asset and poll costs a fresh connection and browsers fan out ~6 in parallel, so the remote page could queue behind itself.

## Testing

`FleetHttpServerSocketTest` drives a real loopback server: reset connections stay off the uncaught handler and the pool keeps serving, plus coverage for preflight, a malformed request, a throwing handler, and `stop()`. Full suite passes (298 tests).

The unit-test change to `app/build.gradle.kts` (`unitTests.isReturnDefaultValues`) is needed because the off-device `android.util.Log` stub throws "not mocked", which put every logging path out of reach of a JVM test. No test regressions.

**Verified on a Portal 10" gen2 (Android 10)** with the `dev` build: held idle connections open past the header timeout, and the same exception now surfaces as

```
D ImmortalFleet: idle connection timed out: Read timed out
```

with the PID unchanged and the next request answered normally. The phone remote is usable end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)