### PR TITLE
Integrate AirPlay 2 receiver into the launcher

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Install compile SDK
         run: yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" >/dev/null || true
 
+      # The :airplay module declares an externalNativeBuild, and AGP resolves the NDK while
+      # CONFIGURING it — before any task runs — so a missing NDK fails the build with "NDK is not
+      # installed" even for a pure-JVM test task. Nothing native is actually compiled here: no
+      # CMake task appears in :app:testDebugUnitTest's graph (verified), which is why CMake itself
+      # isn't installed. Keep the version in step with ndkVersion in airplay/build.gradle.kts.
+      - name: Install NDK (:airplay configures against it)
+        run: yes | sdkmanager "ndk;27.0.12077973" >/dev/null || true
+
       - name: Run unit tests
         run: ./gradlew :app:testDebugUnitTest --no-daemon
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,15 @@
 .cxx
 local.properties
 
+# :airplay (AirPlay receiver) build output. Its four native submodules under
+# airplay/src/main/cpp/third_party/ ARE tracked, as gitlinks — see .gitmodules.
+/airplay/build/
+
+# Editor swap files. Not just tidiness: sync-upstream.sh refuses to run while anything
+# under airplay/ is dirty, and a stray .swp there blocks a sync with nothing to commit.
+.*.sw?
+*~
+
 # MkDocs build output (the docs site is built and deployed by CI, not committed).
 /site
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,21 @@
+# Same four dependencies at the same commits as upstream, re-rooted under airplay/ because the
+# native stack lives in its own Gradle module here. Pins are tracked in airplay/UPSTREAM.md.
+#
+# UxPlay in particular must stay a real checkout: the applyUxplayPatches Gradle task runs
+# `git -C .../UxPlay checkout -- <files>` then `git apply` against it at CMake-configure time.
+[submodule "airplay/src/main/cpp/third_party/UxPlay"]
+	path = airplay/src/main/cpp/third_party/UxPlay
+	url = https://github.com/FDH2/UxPlay.git
+	shallow = true
+[submodule "airplay/src/main/cpp/third_party/libplist"]
+	path = airplay/src/main/cpp/third_party/libplist
+	url = https://github.com/libimobiledevice/libplist.git
+	shallow = true
+[submodule "airplay/src/main/cpp/third_party/openssl-cmake"]
+	path = airplay/src/main/cpp/third_party/openssl-cmake
+	url = https://github.com/viaduck/openssl-cmake.git
+	shallow = true
+[submodule "airplay/src/main/cpp/third_party/ffmpeg"]
+	path = airplay/src/main/cpp/third_party/ffmpeg
+	url = https://github.com/FFmpeg/FFmpeg.git
+	shallow = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,11 @@ release.
 ## Repository layout
 
 ```
-app/                         The Android app (single module)
+app/                         The Android app
+airplay/                     AirPlay 2 receiver library module — VENDORED, read airplay/UPSTREAM.md
+  src/main/cpp/              native stack (UxPlay + OpenSSL + libplist + FFmpeg), 4 git submodules
+  src/main/kotlin/io/github/jqssun/airplay/   upstream's code — do NOT rename this package
+  src/main/kotlin/com/immortal/airplay/       the host-facing facade; the only part that's ours
   src/main/java/com/immortal/launcher/   ~99 Kotlin files, flat package, grouped by name prefix
   src/main/assets/           bundled catalog.json fallback, clock faces, fonts, fallback photos
   src/main/res/              Compose theme lives in .../launcher/ui/theme/
@@ -105,7 +109,7 @@ definition drives three consumers automatically:
 3. **Phone remote** — the `/remote/settings` schema + the generic PWA renderer in `RemoteHtml`.
 
 The domains live in `SettingsDomains.kt` (`SettingsDomains.all`): `screensaver`, `calendar`,
-`immortal`, `mqtt`, `quickbar`, `fleet`, `chime`, `digitalclock`, `welcome`, `sunrise`.
+`immortal`, `mqtt`, `quickbar`, `fleet`, `chime`, `digitalclock`, `welcome`, `sunrise`, `airplay`.
 
 ### Adding or changing a setting — the rules
 

--- a/airplay/UPSTREAM.md
+++ b/airplay/UPSTREAM.md
@@ -1,0 +1,157 @@
+# `:airplay` — vendored from android-airplay-server
+
+This module is the portable AirPlay receiver: the native stack (UxPlay + OpenSSL + libplist +
+FFmpeg via JNI), the protocol/renderer Kotlin, and the foreground service that drives them. It is
+copied **verbatim** into Immortal; `:app` in this repo is only a thin UI shell around it.
+
+Upstream: <https://github.com/jqssun/android-airplay-server> (GPL-3.0)
+
+| | |
+|---|---|
+| Pinned at | `b9a590fc06dba94c3cc225ac68b2e997cfed00f4` ("feat: sanitize", 2026-07-21) |
+| Previous pin | `9600431` ("size", 2026-06-27) — the original fork point |
+
+## The point of this file
+
+The first fork of this project renamed the Kotlin package (`io.github.jqssun.airplay` →
+`com.portal.receiver`) across 21 files and patched the JNI symbol prefix in `native_bridge.cpp`.
+That made every upstream sync a manual merge. **That rename has been reverted.** The vendored tree
+is now byte-identical to upstream apart from the two local patches listed below, so
+`sync-upstream.sh` produces a diff you can actually read.
+
+**Do not rename the vendored package, and do not touch the JNI symbol prefix.** The native→Java
+callbacks resolve by name off the passed object, so `Java_io_github_jqssun_airplay_bridge_NativeBridge_*`
+in `native_bridge.cpp` must keep matching `bridge/NativeBridge.kt`'s package, or the library fails
+to load with `UnsatisfiedLinkError`.
+
+## The vendor line
+
+Everything below `src/main/cpp/` and these Kotlin packages is upstream's, unmodified but for the
+two `LOCAL PATCH` sites in the section after this one:
+
+| Vendored verbatim | Why |
+|---|---|
+| `src/main/cpp/**` (incl. `patches/`, `cmake/`, 4 submodules) | all of it — this is where upstream's protocol work lands, bar one `LOCAL PATCH` in `android_raop_callbacks.c` (below) |
+| `bridge/` | JNI surface; coupled to `native_bridge.cpp` |
+| `renderer/` | MediaCodec video, Oboe audio, HLS video player |
+| `audio/` | DACP control, DMAP parsing, track info |
+| `discovery/` | mDNS/NSD registration |
+| `download/` | video downloader |
+| `service/AirPlayService.kt` | the `RaopCallbackHandler` implementation + native lifecycle |
+| `Prefs.kt`, `Display.kt` | configuration keys and panel geometry the service reads |
+
+**Derived from upstream, not copied** — `sync-upstream.sh` cannot rsync these and prints a reminder
+to check them by hand:
+
+| File | Relationship to upstream |
+|---|---|
+| `viewmodel/DebugModels.kt` | `AudioDebug` / `DebugInfo` lifted out of upstream's `MainViewModel.kt`, which we do not vendor. `AudioDebug`'s field list **is** the decode layout for the packed buffer `nativeServerAudioDebug` fills and `renderer/AudioRenderer` unpacks — a reordered or added field upstream moves the synced reader but not this record. Diff it on every sync. |
+| `res/values/strings.xml` | the seven strings the module resolves through `R`; upstream keeps them in the app's full `strings.xml`. Check the `notification_*` / `download_*` entries and their format args. |
+
+Not vendored — upstream's UI shell, which each host app replaces with its own:
+`MainActivity`, `ui/**`, `viewmodel/MainViewModel.kt`, `AirPlayApp`, `BootReceiver`.
+
+Ours, and the only files in this module with host opinions:
+`com/immortal/airplay/AirPlayHost.kt` (and the facade alongside it). Not upstream's, so changes
+here are not patches and cost nothing at sync time. One is worth knowing about:
+
+- **`AirPlayEngine.reconfigure` restarts via `start()`, not `service.startServer(name)`.** The
+  latter calls `startForegroundService` and then `startForeground` *in that order*, so the start
+  request it files is answered before it is delivered and nothing answers it afterwards. Following
+  `stopServer()` (which has just called `stopForeground` + `stopSelf`) the platform kills the whole
+  process five seconds later — `RemoteServiceException: Context.startForegroundService() did not
+  then call Service.startForeground()` — and the receiver is left down and unadvertised. Observed
+  on a gen-2 Portal, reproducibly, on every settings change. `start()` sends `ACTION_START_SERVER`,
+  which `onStartCommand` answers with `promoteToForeground()`. If a future sync changes
+  `startServer`'s foreground handling, re-check this.
+
+### Local patches against upstream
+
+Two concerns, all sites marked `LOCAL PATCH`:
+
+- **`service/AirPlayService.kt`, two call sites.** `launchMainActivity()` and
+  `_buildMediaNotification()` hard-reference `MainActivity`. They now go through
+  `AirPlayHost.surfaceActivity`, so each host supplies its own surface Activity — portal-receiver
+  registers `MainActivity`, Immortal registers `AirPlayActivity`. A null value suppresses the
+  launch, which is what an audio-only host wants.
+
+- **`cpp/android_raop_callbacks.c`, `_get_env` and the block above it.** Upstream attaches RAOP's
+  internal pthreads to the JVM and never detaches them, so every thread the library retires — one
+  per sender disconnect and per server restart — exits attached, leaking its ART Thread, its
+  `java.lang.Thread` peer (a live GC root) and its local-ref table, and aborting the process on
+  runtimes that enforce the JNI contract. A `pthread` TLS destructor now detaches on thread exit,
+  clearing any pending exception first (detach dispatches one to the uncaught handler, which kills
+  the process). This is the one place `cpp/` is not upstream's; `sync-upstream.sh` rsyncs that tree
+  with `--delete`, so re-apply it after every sync.
+
+Everything else that differs from a plain upstream checkout is *packaging*, not source:
+
+- Kotlin split across two Gradle modules (upstream is single-module).
+- `res/values/strings.xml` here holds only the seven strings the module's own sources resolve
+  through `R`; the rest stayed with the UI shell.
+- Hilt/KSP dropped (upstream uses it for one `AndroidViewModel`; a stock `by viewModels()` replaces
+  it). This keeps an annotation processor out of Immortal.
+- Toolchain is the workspace standard (AGP 9.2.1 / Gradle 9.4.1 / Java 11), not upstream's
+  AGP 8.9.2 / Kotlin 2.1.0 / Java 17 — the module has to compile inside Immortal.
+- `OPENSSL_USE_STATIC_LIBS=ON` and the CMake build filtered to `arm64-v8a`. Both are cache flips in
+  `build.gradle.kts`, not edits inside `third_party/`.
+
+## Submodules
+
+Upstream tracks its native dependencies as shallow submodules and applies its UxPlay fixes as
+patch files at configure time (`applyUxplayPatches` in `build.gradle.kts`). **That task shells out
+to `git -C third_party/UxPlay`, so UxPlay has to be a real checkout** — the earlier fork's
+plain-vendored copy could not work with it. All four are therefore submodules here too, pinned to
+upstream's exact commits:
+
+| Submodule | Pin | Licence |
+|---|---|---|
+| `UxPlay` | `21eef8d` | GPL-3.0 overall; `lib/` mostly LGPL-2.1+, `lib/playfair/` and `lib/crypto.c` GPL-3.0, `lib/llhttp` and `lib/srp.c` MIT |
+| `libplist` | `f41b1ea` | LGPL-2.1 |
+| `openssl-cmake` | `4edd36a` | builds OpenSSL 3.4.4, Apache-2.0 |
+| `ffmpeg` | `38b8833` | LGPL-2.1+; built minimal and static (`--disable-all --enable-decoder=alac`) |
+
+## Deliberately not taken from upstream
+
+Upstream's app-shell features — Immortal and portal-receiver each implement their own UI, so these
+are skipped on purpose rather than missed: `theme`, `feat: player controls`, `feat: run in
+background`, `feat: auto restart`, `keep screen on`, `advertise`, `music`, `download` UI,
+`feat: sanitize` (a build variant).
+
+Note the earlier plan to skip `feat: ffmpeg alac decoder` was **reversed**. Upstream's FFmpeg is a
+minimal static build (ALAC decoder only, no network, no asm), and commit `f4fa5c5` moved the whole
+audio path into native C++ and deleted the Apple ALAC decoder along with `nativeAlacInit/Decode/
+Destroy`. Software ALAC at HEAD is FFmpeg-only, and Portal has no hardware `audio/alac` decoder, so
+that is the live path. Skipping it would have meant forking the highest-churn native files.
+
+## Syncing
+
+```bash
+airplay/sync-upstream.sh              # sync to upstream main
+airplay/sync-upstream.sh <ref>        # or a specific tag/commit
+```
+
+It fetches, copies the tracked paths over the vendored tree, and prints the diff. Review it, re-apply
+the two `LOCAL PATCH` sites if they were clobbered, update the pins above, then build and re-verify
+on hardware — **both** a gen-1 and a gen-2 Portal.
+
+Both have now been exercised at this pin (through the standalone `portal-receiver` shell): gen-2
+Portal 10" (`omni`, Android 10 / API 29) and gen-1 Portal+ (`aloha`, Android 9 / API 28). Audio
+(Spotify), YouTube mirroring, and the mirroring → AirPlay-video handover all work on both; gen-1 was
+the better of the two, holding the video session across a YouTube ad where gen-2 needed a reconnect.
+
+If that diff ever comes back large and noisy, the vendor line above is drawn in the wrong place.
+Fix the line rather than living with the merge.
+
+## Open upstream work worth revisiting
+
+Not taken yet, listed so a future sync knows what to look for:
+
+- **PR #22** — robust video session-end detection (watchdog timers for senders that abandon a
+  session without signalling). Directly useful: it is how a host knows to dismiss its surface.
+- **PR #21** — return to the previous app when casting ends.
+- **PR #15** — AirPlay video live.
+- **Issue #36** — control the initial volume. Matters on a speaker-first device like Portal, where
+  a session currently starts at maximum.
+- **PR #20** (Android TV D-pad focus) and **Issue #26** (manual dark-mode toggle) are app-shell
+  only and do not apply to either host.

--- a/airplay/build.gradle.kts
+++ b/airplay/build.gradle.kts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// TODO(licensing): the native library links GPL-3.0 code that is NOT optional —
+// cpp/third_party/UxPlay/lib/playfair/ (the FairPlay handshake) and lib/crypto.c — alongside
+// LGPL-2.1+ UxPlay lib/, MIT llhttp/srp and LGPL FFmpeg. Any APK that bundles this module is
+// therefore GPL-3.0 as a whole. Immortal is MIT and self-updates publicly, so DO NOT cut an
+// Immortal release containing :airplay until that is resolved. Dev/debug builds only.
+
+plugins {
+    // AGP 9 bundles Kotlin; only the Compose compiler plugin is applied on top.
+    alias(libs.plugins.android.library)
+}
+
+android {
+    namespace = "io.github.jqssun.airplay"
+    compileSdk = 36
+    ndkVersion = "27.0.12077973"
+
+    defaultConfig {
+        // Matches Immortal, so the module drops in unchanged. The native engine is gated at
+        // runtime (AirPlayEngine.isSupported), not by the manifest, so a lower minSdk costs
+        // nothing: Portal gen-1 is API 28 and gen-2 is API 29. Oboe uses AAudio from API 27,
+        // which is every Portal — the OpenSL ES fallback path is never taken here.
+        minSdk = 24
+
+        // Travels with the module into any host, so a minified build cannot strip the JNI bridge.
+        consumerProguardFiles("consumer-rules.pro")
+
+        externalNativeBuild {
+            cmake {
+                // Must stay c++_shared, as upstream has it: Oboe ships as a shared liboboe.so built
+                // against c++_shared (see its prefab abi.json), and it exposes a C++ API, so a
+                // static STL here would mean two libc++ copies exchanging C++ objects. Prefab
+                // refuses to configure at all in that case ("User is using a static STL but library
+                // requires a shared STL"), which is the right call. The cost is libc++_shared.so
+                // (~1.3 MB) in the APK; the OpenSSL change below is where the real saving is.
+                arguments += "-DANDROID_STL=c++_shared"
+                arguments += "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
+                // Static OpenSSL: openssl-cmake already exposes this (third_party/openssl-cmake/
+                // CMakeLists.txt), so it is a cache flip rather than a patch. The linker then keeps
+                // only what UxPlay references and libcrypto.so leaves the APK entirely (it was
+                // 5.9 MB of the debug build).
+                arguments += "-DOPENSSL_USE_STATIC_LIBS=ON"
+
+                // Every Portal is arm64 (gen-1/gen-2 Snapdragon, Portal TV Amlogic). Filtering the
+                // CMake build rather than ndk.abiFilters is deliberate: it leaves a host app's own
+                // ABI guard untouched — Immortal keeps its arm64-v8a + armeabi-v7a filter — while
+                // still building the native library exactly once.
+                abiFilters += "arm64-v8a"
+            }
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+        }
+    }
+
+    buildTypes {
+        // Matches the app's variant of the same name so :app:assembleSanitize gets a sanitized
+        // native library rather than silently falling back to the plain debug one. CMakeLists.txt
+        // already defines the SANITIZE option; this is what turns it on.
+        create("sanitize") {
+            initWith(getByName("debug"))
+            externalNativeBuild {
+                cmake { arguments += "-DSANITIZE=ON" }
+            }
+        }
+    }
+
+    buildFeatures {
+        // Oboe ships as a prefab AAR; CMakeLists resolves it with find_package(oboe REQUIRED CONFIG).
+        prefab = true
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+// Upstream keeps its UxPlay fixes as patch files applied to the submodule at configure time rather
+// than as commits on a fork. Vendored verbatim, including this task — it is why UxPlay has to stay
+// a real git checkout (the task runs `git checkout --` then `git apply` inside it).
+tasks.register("applyUxplayPatches") {
+    doLast {
+        fun git(vararg args: String): String {
+            val proc = ProcessBuilder("git", "-C", "$projectDir/src/main/cpp/third_party/UxPlay", *args)
+                .redirectErrorStream(true).start()
+            val out = proc.inputStream.bufferedReader().readText()
+            check(proc.waitFor() == 0) { "git ${args.joinToString(" ")} failed:\n$out" }
+            return out
+        }
+        val patches = file("src/main/cpp/patches/UxPlay").listFiles { f -> f.extension == "patch" }!!.sorted()
+        val touched = patches.flatMap { git("apply", "--numstat", it.path).trim().lines() }
+            .map { it.substringAfterLast("\t") }.distinct()
+        git("checkout", "--", *touched.toTypedArray())
+        patches.forEach { git("apply", it.path) }
+    }
+}
+
+tasks.configureEach {
+    if (name.startsWith("configureCMake")) dependsOn("applyUxplayPatches")
+}
+
+dependencies {
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.service)
+    implementation(libs.androidx.media)
+    implementation(libs.kotlinx.coroutines)
+
+    // AirPlay "video" mode (the sender hands over an HLS URL instead of mirroring), the DACP
+    // player, and the video downloader are all upstream features that render through media3.
+    implementation(libs.media3.exoplayer)
+    implementation(libs.media3.exoplayer.hls)
+    implementation(libs.media3.transformer) // download/VideoDownloader remuxes the HLS stream
+
+    // Low-latency audio output. On Portal this resolves to AAudio (API 28/29 >= 27).
+    implementation(libs.oboe)
+}

--- a/airplay/consumer-rules.pro
+++ b/airplay/consumer-rules.pro
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 Starbright Lab.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Consumer rules: applied to whatever app bundles this module, so the JNI contract survives R8 in
+# ANY host — not just this repo's shell. These used to live only in app/proguard-rules.pro, which
+# does not travel when the module is copied into Immortal; a minified host would then load the .so
+# fine and get a null jmethodID for every native->Java callback (black screen, no audio).
+#
+# The native side resolves these by NAME via GetMethodID (see cpp/android_raop_callbacks.c and
+# cpp/log_sink.h), so renaming or stripping any of them breaks the bridge silently.
+
+# Callback interfaces invoked from native code, and their implementors (AirPlayService).
+-keep class io.github.jqssun.airplay.bridge.RaopCallbackHandler { *; }
+-keep class * implements io.github.jqssun.airplay.bridge.RaopCallbackHandler { *; }
+-keep class io.github.jqssun.airplay.bridge.LogListener { *; }
+-keep class * implements io.github.jqssun.airplay.bridge.LogListener { *; }
+
+# The JNI surface itself: method names must match the Java_io_github_jqssun_airplay_bridge_
+# NativeBridge_* symbols exported by native_bridge.cpp.
+-keep class io.github.jqssun.airplay.bridge.NativeBridge { *; }

--- a/airplay/src/main/AndroidManifest.xml
+++ b/airplay/src/main/AndroidManifest.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) 2026 Starbright Lab.
+     This source code is licensed under the MIT license found in the
+     LICENSE file in the root directory of this source tree. -->
+<!--
+  Everything the AirPlay receiver needs to run, declared by the module itself so any host app
+  (portal-receiver here, Immortal next) gets it through manifest merging without restating it.
+
+  Deliberately NOT declared here, because they are host policy rather than module requirements:
+    - SYSTEM_ALERT_WINDOW           the host decides whether to raise a surface over other apps
+    - RECEIVE_BOOT_COMPLETED        the host owns its own boot receiver
+    - android:usesCleartextTraffic  an <application> attribute; AirPlay video streams HLS over
+                                    plain http from the native httpd, so a host that wants the
+                                    video path must set it (portal-receiver and Immortal both do)
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <!-- mDNS/NSD does not receive on Android 9/10 without a held multicast lock. -->
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application>
+        <service
+            android:name="io.github.jqssun.airplay.service.AirPlayService"
+            android:foregroundServiceType="connectedDevice|mediaPlayback"
+            android:exported="false" />
+    </application>
+
+</manifest>

--- a/airplay/src/main/cpp/CMakeLists.txt
+++ b/airplay/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,159 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(airplay_native C CXX)
+
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffile-prefix-map=${CMAKE_SOURCE_DIR}=. -ffile-prefix-map=${CMAKE_BINARY_DIR}=. -ffile-prefix-map=${ANDROID_NDK}=.")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffile-prefix-map=${CMAKE_SOURCE_DIR}=. -ffile-prefix-map=${CMAKE_BINARY_DIR}=. -ffile-prefix-map=${ANDROID_NDK}=.")
+
+set(UXPLAY_LIB third_party/UxPlay/lib)
+
+# ---------- OpenSSL (built from source via openssl-cmake) ----------
+set(BUILD_OPENSSL ON CACHE BOOL "" FORCE)
+set(OPENSSL_BUILD_VERSION "3.4.4" CACHE STRING "" FORCE)
+set(CROSS_ANDROID ON CACHE BOOL "" FORCE)
+string(REGEX MATCH "[0-9]+" AIRPLAY_ANDROID_API "${ANDROID_PLATFORM}")
+set(OPENSSL_PARAMS "-D__ANDROID_API__=${AIRPLAY_ANDROID_API}" CACHE STRING "" FORCE)
+set(FORWARD_ANDROID_NDK_ROOT "${ANDROID_NDK}" CACHE STRING "" FORCE) # CI
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+add_subdirectory(third_party/openssl-cmake)
+
+# ---------- Sanitizers (opt-in via -DSANITIZE=ON) ----------
+# OpenSSL uninstrumented; HWASan is arm64-only
+option(SANITIZE "Enable UBSan (and HWASan on arm64) for the native code" OFF)
+if(SANITIZE)
+    set(SANITIZE_CFLAGS -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize=vptr)
+    set(SANITIZE_LDFLAGS -fsanitize=undefined)
+    if(ANDROID_ABI STREQUAL "arm64-v8a")
+        list(APPEND SANITIZE_CFLAGS -fsanitize=hwaddress)
+        list(APPEND SANITIZE_LDFLAGS -fsanitize=hwaddress)
+    endif()
+    add_compile_options(${SANITIZE_CFLAGS})
+    add_link_options(${SANITIZE_LDFLAGS})
+endif()
+
+# ---------- Oboe (low-latency audio output, via prefab AAR) ----------
+find_package(oboe REQUIRED CONFIG)
+
+# ---------- ffmpeg (software ALAC decoder) ----------
+include(BuildFFmpeg)
+
+# ---------- libplist (built from submodule source) ----------
+set(PLIST_SRC third_party/libplist/src)
+set(PLIST_CNARY third_party/libplist/libcnary)
+
+add_library(plist STATIC
+    ${PLIST_SRC}/base64.c
+    ${PLIST_SRC}/bplist.c
+    ${PLIST_SRC}/bytearray.c
+    ${PLIST_SRC}/hashtable.c
+    ${PLIST_SRC}/jplist.c
+    ${PLIST_SRC}/jsmn.c
+    ${PLIST_SRC}/oplist.c
+    ${PLIST_SRC}/out-default.c
+    ${PLIST_SRC}/out-limd.c
+    ${PLIST_SRC}/out-plutil.c
+    ${PLIST_SRC}/plist.c
+    ${PLIST_SRC}/ptrarray.c
+    ${PLIST_SRC}/time64.c
+    ${PLIST_SRC}/xplist.c
+    ${PLIST_CNARY}/cnary.c
+    ${PLIST_CNARY}/node.c
+    ${PLIST_CNARY}/node_list.c
+)
+target_include_directories(plist
+    PUBLIC third_party/libplist/include
+    PRIVATE ${PLIST_SRC} ${PLIST_CNARY}/include
+)
+target_compile_definitions(plist PRIVATE
+    _GNU_SOURCE
+    HAVE_STRNDUP
+    PACKAGE_VERSION="2.6.0"
+)
+
+# ---------- llhttp (embedded in UxPlay) ----------
+add_library(llhttp STATIC
+    ${UXPLAY_LIB}/llhttp/api.c
+    ${UXPLAY_LIB}/llhttp/http.c
+    ${UXPLAY_LIB}/llhttp/llhttp.c
+)
+target_include_directories(llhttp PUBLIC ${UXPLAY_LIB}/llhttp)
+
+# ---------- playfair (embedded in UxPlay) ----------
+add_library(playfair STATIC
+    ${UXPLAY_LIB}/playfair/hand_garble.c
+    ${UXPLAY_LIB}/playfair/modified_md5.c
+    ${UXPLAY_LIB}/playfair/omg_hax.c
+    ${UXPLAY_LIB}/playfair/playfair.c
+    ${UXPLAY_LIB}/playfair/sap_hash.c
+)
+target_include_directories(playfair PUBLIC ${UXPLAY_LIB}/playfair)
+
+# ---------- UxPlay core (all .c except dnssd.c, replaced by our shim) ----------
+set(AIRPLAY_SOURCES
+    ${UXPLAY_LIB}/airplay_video.c
+    ${UXPLAY_LIB}/byteutils.c
+    ${UXPLAY_LIB}/compat.c
+    ${UXPLAY_LIB}/crypto.c
+    ${UXPLAY_LIB}/fairplay_playfair.c
+    ${UXPLAY_LIB}/http_request.c
+    ${UXPLAY_LIB}/http_response.c
+    ${UXPLAY_LIB}/httpd.c
+    ${UXPLAY_LIB}/logger.c
+    ${UXPLAY_LIB}/mirror_buffer.c
+    ${UXPLAY_LIB}/netutils.c
+    ${UXPLAY_LIB}/pairing.c
+    ${UXPLAY_LIB}/raop.c
+    ${UXPLAY_LIB}/raop_buffer.c
+    ${UXPLAY_LIB}/raop_ntp.c
+    ${UXPLAY_LIB}/raop_rtp.c
+    ${UXPLAY_LIB}/raop_rtp_mirror.c
+    ${UXPLAY_LIB}/srp.c
+    ${UXPLAY_LIB}/utils.c
+)
+
+# ---------- Android JNI bridge + dnssd shim ----------
+set(BRIDGE_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/android_dnssd_shim.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/android_raop_callbacks.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/native_bridge.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/audio_engine.cpp
+)
+
+# ---------- Final shared library ----------
+add_library(airplay_native SHARED
+    ${AIRPLAY_SOURCES}
+    ${BRIDGE_SOURCES}
+)
+add_dependencies(airplay_native ffmpeg_ep)
+
+target_include_directories(airplay_native PRIVATE
+    ${UXPLAY_LIB}
+    ${UXPLAY_LIB}/llhttp
+    ${UXPLAY_LIB}/playfair
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_compile_definitions(airplay_native PRIVATE
+    ANDROID
+    __STDC_CONSTANT_MACROS
+    PLIST_210
+    TARGET_RT_LITTLE_ENDIAN=1
+)
+
+target_link_options(airplay_native PRIVATE "-Wl,--build-id=none")
+
+target_link_libraries(airplay_native
+    llhttp
+    playfair
+    crypto
+    plist
+    oboe::oboe
+    ffmpeg::avcodec
+    mediandk
+    m
+    log
+    android
+)

--- a/airplay/src/main/cpp/android_dnssd_shim.c
+++ b/airplay/src/main/cpp/android_dnssd_shim.c
@@ -1,0 +1,349 @@
+/*
+ * Android dnssd shim -- implements dnssd.h API without dns_sd.h.
+ * Stores TXT records as key=value maps in memory.
+ * Actual mDNS registration is done in Kotlin via NsdManager.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+
+#include "dnssd.h"
+#include "dnssdint.h"
+#include "global.h"
+#include "utils.h"
+
+#define MAX_DEVICEID 18
+#define MAX_SERVNAME 256
+#define MAX_TXT_ENTRIES 32
+#define MAX_TXT_KEY 32
+#define MAX_TXT_VAL 128
+
+typedef struct {
+    char key[MAX_TXT_KEY];
+    char val[MAX_TXT_VAL];
+} txt_entry_t;
+
+typedef struct {
+    txt_entry_t entries[MAX_TXT_ENTRIES];
+    int count;
+    int registered;
+} txt_record_t;
+
+struct dnssd_s {
+    txt_record_t raop_record;
+    txt_record_t airplay_record;
+
+    char *name;
+    int name_len;
+
+    char *hw_addr;
+    int hw_addr_len;
+
+    char *pk;
+
+    uint32_t features1;
+    uint32_t features2;
+
+    unsigned char pin_pw;
+
+    char codec_cn[16]; /* dynamic "cn" value, e.g. "0,1,2,3" */
+
+    char raop_servname[MAX_SERVNAME];
+    unsigned short raop_port;
+    unsigned short airplay_port;
+};
+
+static void _txt_set(txt_record_t *rec, const char *key, const char *val) {
+    for (int i = 0; i < rec->count; i++) {
+        if (strcmp(rec->entries[i].key, key) == 0) {
+            strncpy(rec->entries[i].val, val, MAX_TXT_VAL - 1);
+            return;
+        }
+    }
+    if (rec->count < MAX_TXT_ENTRIES) {
+        strncpy(rec->entries[rec->count].key, key, MAX_TXT_KEY - 1);
+        strncpy(rec->entries[rec->count].val, val, MAX_TXT_VAL - 1);
+        rec->count++;
+    }
+}
+
+dnssd_t *
+dnssd_init(const char *name, int name_len, const char *hw_addr, int hw_addr_len, int *error, unsigned char pin_pw)
+{
+    if (error) *error = DNSSD_ERROR_NOERROR;
+
+    dnssd_t *dnssd = (dnssd_t *)calloc(1, sizeof(dnssd_t));
+    if (!dnssd) {
+        if (error) *error = DNSSD_ERROR_OUTOFMEM;
+        return NULL;
+    }
+
+    dnssd->pin_pw = pin_pw;
+    strncpy(dnssd->codec_cn, RAOP_CN, sizeof(dnssd->codec_cn) - 1);
+
+    char *end = NULL;
+    unsigned long features = strtoul(FEATURES_1, &end, 16);
+    if (!end || (features & 0xFFFFFFFF) != features) {
+        free(dnssd);
+        if (error) *error = DNSSD_ERROR_BADFEATURES;
+        return NULL;
+    }
+    dnssd->features1 = (uint32_t)features;
+
+    features = strtoul(FEATURES_2, &end, 16);
+    if (!end || (features & 0xFFFFFFFF) != features) {
+        free(dnssd);
+        if (error) *error = DNSSD_ERROR_BADFEATURES;
+        return NULL;
+    }
+    dnssd->features2 = (uint32_t)features;
+
+    dnssd->name_len = name_len;
+    dnssd->name = calloc(1, name_len + 1);
+    if (!dnssd->name) {
+        free(dnssd);
+        if (error) *error = DNSSD_ERROR_OUTOFMEM;
+        return NULL;
+    }
+    memcpy(dnssd->name, name, name_len);
+
+    dnssd->hw_addr_len = hw_addr_len;
+    dnssd->hw_addr = calloc(1, hw_addr_len);
+    if (!dnssd->hw_addr) {
+        free(dnssd->name);
+        free(dnssd);
+        if (error) *error = DNSSD_ERROR_OUTOFMEM;
+        return NULL;
+    }
+    memcpy(dnssd->hw_addr, hw_addr, hw_addr_len);
+
+    return dnssd;
+}
+
+void
+dnssd_destroy(dnssd_t *dnssd)
+{
+    if (dnssd) {
+        free(dnssd->name);
+        free(dnssd->hw_addr);
+        free(dnssd);
+    }
+}
+
+int
+dnssd_register_raop(dnssd_t *dnssd, unsigned short port)
+{
+    char features[22] = {0};
+    assert(dnssd);
+
+    dnssd->raop_port = port;
+    snprintf(features, sizeof(features), "0x%X,0x%X", dnssd->features1, dnssd->features2);
+
+    txt_record_t *rec = &dnssd->raop_record;
+    rec->count = 0;
+
+    _txt_set(rec, "ch", RAOP_CH);
+    _txt_set(rec, "cn", dnssd->codec_cn);
+    _txt_set(rec, "da", RAOP_DA);
+    _txt_set(rec, "et", RAOP_ET);
+    _txt_set(rec, "vv", RAOP_VV);
+    _txt_set(rec, "ft", features);
+    _txt_set(rec, "am", GLOBAL_MODEL);
+    _txt_set(rec, "md", RAOP_MD);
+    _txt_set(rec, "rhd", RAOP_RHD);
+
+    switch (dnssd->pin_pw) {
+    case 2:
+    case 3:
+        _txt_set(rec, "pw", "true");
+        _txt_set(rec, "sf", "0x84");
+        break;
+    case 1:
+        _txt_set(rec, "pw", "true");
+        _txt_set(rec, "sf", "0x8c");
+        break;
+    default:
+        _txt_set(rec, "pw", "false");
+        _txt_set(rec, "sf", RAOP_SF);
+        break;
+    }
+
+    _txt_set(rec, "sr", RAOP_SR);
+    _txt_set(rec, "ss", RAOP_SS);
+    _txt_set(rec, "sv", RAOP_SV);
+    _txt_set(rec, "tp", RAOP_TP);
+    _txt_set(rec, "txtvers", RAOP_TXTVERS);
+    _txt_set(rec, "vs", RAOP_VS);
+    _txt_set(rec, "vn", RAOP_VN);
+    if (dnssd->pk) {
+        _txt_set(rec, "pk", dnssd->pk);
+    }
+
+    /* Build service name: HW@Name */
+    if (utils_hwaddr_raop(dnssd->raop_servname, sizeof(dnssd->raop_servname),
+                          dnssd->hw_addr, dnssd->hw_addr_len) < 0) {
+        return -1;
+    }
+    strncat(dnssd->raop_servname, "@", sizeof(dnssd->raop_servname) - strlen(dnssd->raop_servname) - 1);
+    strncat(dnssd->raop_servname, dnssd->name, sizeof(dnssd->raop_servname) - strlen(dnssd->raop_servname) - 1);
+
+    rec->registered = 1;
+    return 0; /* success -- actual mDNS registration done in Kotlin */
+}
+
+int
+dnssd_register_airplay(dnssd_t *dnssd, unsigned short port)
+{
+    char device_id[3 * MAX_HWADDR_LEN];
+    char features[22] = {0};
+    assert(dnssd);
+
+    dnssd->airplay_port = port;
+    snprintf(features, sizeof(features), "0x%X,0x%X", dnssd->features1, dnssd->features2);
+
+    if (utils_hwaddr_airplay(device_id, sizeof(device_id), dnssd->hw_addr, dnssd->hw_addr_len) < 0) {
+        return -1;
+    }
+
+    txt_record_t *rec = &dnssd->airplay_record;
+    rec->count = 0;
+
+    _txt_set(rec, "deviceid", device_id);
+    _txt_set(rec, "features", features);
+
+    switch (dnssd->pin_pw) {
+    case 1:
+    case 2:
+    case 3:
+        _txt_set(rec, "pw", "true");
+        break;
+    default:
+        _txt_set(rec, "pw", "false");
+        break;
+    }
+    _txt_set(rec, "flags", "0x4");
+    _txt_set(rec, "model", GLOBAL_MODEL);
+    if (dnssd->pk) {
+        _txt_set(rec, "pk", dnssd->pk);
+    }
+    _txt_set(rec, "pi", AIRPLAY_PI);
+    _txt_set(rec, "srcvers", AIRPLAY_SRCVERS);
+    _txt_set(rec, "vv", AIRPLAY_VV);
+
+    rec->registered = 1;
+    return 0;
+}
+
+void dnssd_unregister_raop(dnssd_t *dnssd) {
+    assert(dnssd);
+    dnssd->raop_record.registered = 0;
+}
+
+void dnssd_unregister_airplay(dnssd_t *dnssd) {
+    assert(dnssd);
+    dnssd->airplay_record.registered = 0;
+}
+
+const char *dnssd_get_raop_txt(dnssd_t *dnssd, int *length) {
+    /* Not used on Android -- TXT records retrieved via android_dnssd_* helpers */
+    if (length) *length = 0;
+    return NULL;
+}
+
+const char *dnssd_get_airplay_txt(dnssd_t *dnssd, int *length) {
+    if (length) *length = 0;
+    return NULL;
+}
+
+const char *dnssd_get_name(dnssd_t *dnssd, int *length) {
+    *length = dnssd->name_len;
+    return dnssd->name;
+}
+
+const char *dnssd_get_hw_addr(dnssd_t *dnssd, int *length) {
+    *length = dnssd->hw_addr_len;
+    return dnssd->hw_addr;
+}
+
+uint64_t dnssd_get_airplay_features(dnssd_t *dnssd) {
+    uint64_t features = ((uint64_t)dnssd->features2) << 32;
+    features += (uint64_t)dnssd->features1;
+    return features;
+}
+
+void dnssd_set_pk(dnssd_t *dnssd, char *pk_str) {
+    dnssd->pk = pk_str;
+}
+
+void dnssd_set_airplay_features(dnssd_t *dnssd, int bit, int val) {
+    uint32_t mask = 0;
+    uint32_t *features = 0;
+    if (bit < 0 || bit > 63) return;
+    if (val < 0 || val > 1) return;
+    if (bit >= 32) {
+        mask = 0x1 << (bit - 32);
+        features = &(dnssd->features2);
+    } else {
+        mask = 0x1 << bit;
+        features = &(dnssd->features1);
+    }
+    if (val) {
+        *features = *features | mask;
+    } else {
+        *features = *features & ~mask;
+    }
+}
+
+/* --- Android-specific accessors for JNI layer --- */
+
+int android_dnssd_get_raop_txt_count(dnssd_t *dnssd) {
+    return dnssd->raop_record.count;
+}
+
+const char *android_dnssd_get_raop_txt_key(dnssd_t *dnssd, int index) {
+    if (index < 0 || index >= dnssd->raop_record.count) return NULL;
+    return dnssd->raop_record.entries[index].key;
+}
+
+const char *android_dnssd_get_raop_txt_val(dnssd_t *dnssd, int index) {
+    if (index < 0 || index >= dnssd->raop_record.count) return NULL;
+    return dnssd->raop_record.entries[index].val;
+}
+
+int android_dnssd_get_airplay_txt_count(dnssd_t *dnssd) {
+    return dnssd->airplay_record.count;
+}
+
+const char *android_dnssd_get_airplay_txt_key(dnssd_t *dnssd, int index) {
+    if (index < 0 || index >= dnssd->airplay_record.count) return NULL;
+    return dnssd->airplay_record.entries[index].key;
+}
+
+const char *android_dnssd_get_airplay_txt_val(dnssd_t *dnssd, int index) {
+    if (index < 0 || index >= dnssd->airplay_record.count) return NULL;
+    return dnssd->airplay_record.entries[index].val;
+}
+
+void android_dnssd_set_codecs(dnssd_t *dnssd, int alac, int aac) {
+    /* Build cn string: 0=PCM (always), 1=ALAC, 2=AAC, 3=AAC-ELD */
+    char buf[16];
+    int pos = 0;
+    pos += snprintf(buf + pos, sizeof(buf) - pos, "0");
+    if (alac) pos += snprintf(buf + pos, sizeof(buf) - pos, ",1");
+    if (aac) pos += snprintf(buf + pos, sizeof(buf) - pos, ",2,3");
+    strncpy(dnssd->codec_cn, buf, sizeof(dnssd->codec_cn) - 1);
+}
+
+const char *android_dnssd_get_raop_servname(dnssd_t *dnssd) {
+    return dnssd->raop_servname;
+}
+
+unsigned short android_dnssd_get_raop_port(dnssd_t *dnssd) {
+    return dnssd->raop_port;
+}
+
+unsigned short android_dnssd_get_airplay_port(dnssd_t *dnssd) {
+    return dnssd->airplay_port;
+}

--- a/airplay/src/main/cpp/android_dnssd_shim.h
+++ b/airplay/src/main/cpp/android_dnssd_shim.h
@@ -1,0 +1,27 @@
+#ifndef ANDROID_DNSSD_SHIM_H
+#define ANDROID_DNSSD_SHIM_H
+
+#include "dnssd.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int android_dnssd_get_raop_txt_count(dnssd_t *dnssd);
+const char *android_dnssd_get_raop_txt_key(dnssd_t *dnssd, int index);
+const char *android_dnssd_get_raop_txt_val(dnssd_t *dnssd, int index);
+
+int android_dnssd_get_airplay_txt_count(dnssd_t *dnssd);
+const char *android_dnssd_get_airplay_txt_key(dnssd_t *dnssd, int index);
+const char *android_dnssd_get_airplay_txt_val(dnssd_t *dnssd, int index);
+
+void android_dnssd_set_codecs(dnssd_t *dnssd, int alac, int aac);
+const char *android_dnssd_get_raop_servname(dnssd_t *dnssd);
+unsigned short android_dnssd_get_raop_port(dnssd_t *dnssd);
+unsigned short android_dnssd_get_airplay_port(dnssd_t *dnssd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/airplay/src/main/cpp/android_raop_callbacks.c
+++ b/airplay/src/main/cpp/android_raop_callbacks.c
@@ -1,0 +1,452 @@
+/*
+ * Implements raop_callbacks_t by forwarding to Java/Kotlin via JNI.
+ * All callbacks fire from RAOP's internal pthreads, so we AttachCurrentThread.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <errno.h>
+#include <android/log.h>
+#include "android_raop_callbacks.h"
+#include "audio_engine.h"
+
+#define TAG "AirPlayNative"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)
+
+/* LOCAL PATCH (the only one under cpp/): upstream attaches RAOP's threads and never detaches them.
+   Everything from here to the end of _get_env is ours — sync-upstream.sh rsyncs this tree verbatim,
+   so re-apply it after a sync. See airplay/UPSTREAM.md.
+
+   Detaching at the end of each callback would cost an attach per video frame, so a thread stays
+   attached for its lifetime and this destructor detaches it when it exits. RAOP retires its threads
+   on every sender disconnect and every server restart, and each one that exits still attached leaks
+   its ART Thread, its java.lang.Thread peer (a live GC root) and its local-ref table — and on
+   runtimes that police the JNI contract, aborts the process outright. */
+static pthread_key_t _detach_key;
+static pthread_once_t _detach_key_once = PTHREAD_ONCE_INIT;
+static int _detach_key_ready = 0;
+
+static void _detach_on_thread_exit(void *jvm) {
+    JavaVM *vm = (JavaVM *)jvm;
+    JNIEnv *env = NULL;
+    if (!vm) return;
+    /* A pending exception at detach is dispatched to the thread's uncaught-exception handler, which
+       on Android kills the process. Callbacks leave exceptions for the next _get_env to clear, so
+       the last callback on this thread may well have left one. */
+    if ((*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_6) == JNI_OK && (*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+    }
+    (*vm)->DetachCurrentThread(vm);
+}
+
+static void _make_detach_key(void) {
+    _detach_key_ready = pthread_key_create(&_detach_key, _detach_on_thread_exit) == 0;
+    if (!_detach_key_ready) LOGE("pthread_key_create failed: AirPlay callbacks disabled");
+}
+
+static JNIEnv *_get_env(android_callback_ctx_t *ctx) {
+    JNIEnv *env = NULL;
+    int status = (*ctx->jvm)->GetEnv(ctx->jvm, (void **)&env, JNI_VERSION_1_6);
+    if (status == JNI_EDETACHED) {
+        /* No detach hook means no attach: leaking a thread per session is worse than a dead
+           callback, and every caller already handles a NULL env. */
+        pthread_once(&_detach_key_once, _make_detach_key);
+        if (!_detach_key_ready) return NULL;
+        if ((*ctx->jvm)->AttachCurrentThread(ctx->jvm, &env, NULL) != JNI_OK) {
+            LOGE("AttachCurrentThread failed");
+            return NULL;
+        }
+        if (pthread_setspecific(_detach_key, ctx->jvm) != 0) {
+            /* Undo the attach rather than keep a thread the destructor will never see. */
+            LOGE("pthread_setspecific failed");
+            (*ctx->jvm)->DetachCurrentThread(ctx->jvm);
+            return NULL;
+        }
+    }
+    /* A thread GetEnv already finds attached is either one of ours from an earlier callback (so
+       already registered) or the JVM's own, which must never be detached here. */
+    /* Clear any pending exception from a previous callback on this thread,
+       otherwise JNI calls like NewByteArray will fatally abort. */
+    if (env && (*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+    }
+    return env;
+}
+
+void android_callbacks_init(android_callback_ctx_t *ctx, JNIEnv *env, jobject callback_obj) {
+    (*env)->GetJavaVM(env, &ctx->jvm);
+    ctx->callback_obj = (*env)->NewGlobalRef(env, callback_obj);
+    ctx->h265_enabled = 1;
+    ctx->require_pin = 0;
+    ctx->registered_count = 0;
+    ctx->audio_engine = NULL;
+    memset(ctx->registered_keys, 0, sizeof(ctx->registered_keys));
+
+    pthread_mutex_init(&ctx->playback_info_lock, NULL);
+    pthread_cond_init(&ctx->play_ready_cond, NULL);
+    ctx->play_ready = 0;
+    ctx->playback_position = 0.0;
+    /* -1.0 is the video finished sentinel, reserved for _video_stop */
+    ctx->playback_duration = 0.0;
+    ctx->playback_rate = 0.0f;
+    ctx->playback_ready = 0;
+
+    jclass cls = (*env)->GetObjectClass(env, callback_obj);
+    ctx->on_video_data = (*env)->GetMethodID(env, cls, "onVideoData", "([BJZ)V");
+    ctx->on_audio_format = (*env)->GetMethodID(env, cls, "onAudioFormat", "(IIZ)V");
+    ctx->on_video_size = (*env)->GetMethodID(env, cls, "onVideoSize", "(FFFF)V");
+    ctx->on_volume_change = (*env)->GetMethodID(env, cls, "onVolumeChange", "(F)V");
+    ctx->on_conn_init = (*env)->GetMethodID(env, cls, "onConnectionInit", "()V");
+    ctx->on_conn_destroy = (*env)->GetMethodID(env, cls, "onConnectionDestroy", "()V");
+    ctx->on_conn_reset = (*env)->GetMethodID(env, cls, "onConnectionReset", "(I)V");
+    ctx->on_display_pin = (*env)->GetMethodID(env, cls, "onDisplayPin", "(Ljava/lang/String;)V");
+    ctx->on_metadata = (*env)->GetMethodID(env, cls, "onMetadata", "([B)V");
+    ctx->on_coverart = (*env)->GetMethodID(env, cls, "onCoverArt", "([B)V");
+    ctx->on_progress = (*env)->GetMethodID(env, cls, "onProgress", "(JJJ)V");
+    ctx->on_dacp_id = (*env)->GetMethodID(env, cls, "onDacpId", "(Ljava/lang/String;Ljava/lang/String;)V");
+    ctx->on_audio_only = (*env)->GetMethodID(env, cls, "onAudioOnly", "(Z)V");
+    ctx->on_video_play = (*env)->GetMethodID(env, cls, "onVideoPlay", "(Ljava/lang/String;F)V");
+    ctx->on_video_scrub = (*env)->GetMethodID(env, cls, "onVideoScrub", "(F)V");
+    ctx->on_video_rate = (*env)->GetMethodID(env, cls, "onVideoRate", "(F)V");
+    ctx->on_video_stop = (*env)->GetMethodID(env, cls, "onVideoStop", "()V");
+    ctx->on_video_session_poll = (*env)->GetMethodID(env, cls, "onVideoSessionPoll", "()V");
+    (*env)->DeleteLocalRef(env, cls);
+}
+
+void android_callbacks_destroy(android_callback_ctx_t *ctx, JNIEnv *env) {
+    if (ctx->callback_obj) {
+        (*env)->DeleteGlobalRef(env, ctx->callback_obj);
+        ctx->callback_obj = NULL;
+    }
+    for (int i = 0; i < ctx->registered_count; i++) {
+        free(ctx->registered_keys[i]);
+        ctx->registered_keys[i] = NULL;
+    }
+    ctx->registered_count = 0;
+    pthread_cond_destroy(&ctx->play_ready_cond);
+    pthread_mutex_destroy(&ctx->playback_info_lock);
+}
+
+void android_callbacks_update_playback_info(android_callback_ctx_t *ctx, double position,
+                                             double duration, float rate, int ready) {
+    pthread_mutex_lock(&ctx->playback_info_lock);
+    ctx->playback_position = position;
+    ctx->playback_duration = duration;
+    ctx->playback_rate = rate;
+    ctx->playback_ready = ready;
+    if (ready && !ctx->play_ready) {
+        ctx->play_ready = 1;
+        pthread_cond_signal(&ctx->play_ready_cond);
+    }
+    pthread_mutex_unlock(&ctx->playback_info_lock);
+}
+
+/* --- RAOP callback implementations --- */
+
+static void _audio_process(void *cls, raop_ntp_t *ntp, audio_decode_struct *data) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    if (!ctx->audio_engine || !data->data || data->data_len <= 0) return;
+    audio_engine_decode(ctx->audio_engine, data->data, data->data_len,
+                        (int)data->ct, (int64_t)data->ntp_time_local);
+}
+
+static void _video_process(void *cls, raop_ntp_t *ntp, video_decode_struct *data) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env || !data->data || data->data_len <= 0) return;
+
+    jbyteArray arr = (*env)->NewByteArray(env, data->data_len);
+    (*env)->SetByteArrayRegion(env, arr, 0, data->data_len, (jbyte *)data->data);
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_video_data,
+                           arr, (jlong)data->ntp_time_local, (jboolean)data->is_h265);
+    (*env)->DeleteLocalRef(env, arr);
+}
+
+static void _conn_init(void *cls) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    /* fires for every connection including the player's own hls fetches: clear only a stale sentinel */
+    pthread_mutex_lock(&ctx->playback_info_lock);
+    if (ctx->playback_duration == -1.0) {
+        ctx->playback_position = 0.0;
+        ctx->playback_duration = 0.0;
+        ctx->playback_rate = 0.0f;
+        ctx->playback_ready = 0;
+    }
+    pthread_mutex_unlock(&ctx->playback_info_lock);
+    JNIEnv *env = _get_env(ctx);
+    if (!env) return;
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_conn_init);
+}
+
+static void _conn_destroy(void *cls) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env) return;
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_conn_destroy);
+}
+
+static void _conn_reset(void *cls, int reason) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env) return;
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_conn_reset, (jint)reason);
+}
+
+static void _audio_set_volume(void *cls, float volume) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env) return;
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_volume_change, (jfloat)volume);
+}
+
+static void _audio_get_format(void *cls, unsigned char *ct, unsigned short *spf,
+                               bool *usingScreen, bool *isMedia, uint64_t *audioFormat) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env) return;
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_audio_format,
+                           (jint)*ct, (jint)*spf, (jboolean)*usingScreen);
+}
+
+static void _video_report_size(void *cls, float *w_src, float *h_src, float *w, float *h) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env) return;
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_video_size,
+                           (jfloat)*w_src, (jfloat)*h_src, (jfloat)*w, (jfloat)*h);
+}
+
+static void _display_pin(void *cls, char *pin) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    
+    /* certain senders trigger pair-pin-start even when we advertise no auth */
+    if (!ctx->require_pin) return;
+
+    JNIEnv *env = _get_env(ctx);
+    if (!env) return;
+    jstring jpin = (*env)->NewStringUTF(env, pin);
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_display_pin, jpin);
+    (*env)->DeleteLocalRef(env, jpin);
+}
+
+/* Stubs for less critical callbacks */
+static void _noop(void *cls) { (void)cls; }
+static void _noop_teardown(void *cls, bool *a, bool *b) { (void)cls; (void)a; (void)b; }
+static void _video_pause(void *cls) { LOGI("video_pause"); }
+static void _video_resume(void *cls) { LOGI("video_resume"); }
+static void _conn_feedback(void *cls) { (void)cls; }
+static void _video_stop(void *cls);
+static void _video_reset(void *cls, reset_type_t t) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    LOGI("video_reset %d", t);
+    if (t == RESET_TYPE_HLS_SHUTDOWN || t == RESET_TYPE_HLS_EOS) {
+        _video_stop(cls);
+    }
+    if (t == RESET_TYPE_HLS_CONN_CLOSED) {
+        /* abandoned only if paused and ready: rate alone is also 0 while buffering */
+        pthread_mutex_lock(&ctx->playback_info_lock);
+        int paused = ctx->playback_ready && ctx->playback_rate <= 0.0f;
+        pthread_mutex_unlock(&ctx->playback_info_lock);
+        if (paused) {
+            _video_stop(cls);
+        }
+    }
+    if (t == RESET_TYPE_HLS_SHUTDOWN && ctx->raop) {
+        raop_remove_hls_connections(ctx->raop);
+    }
+}
+static void _audio_flush(void *cls) { LOGI("audio_flush"); }
+static void _video_flush(void *cls) { LOGI("video_flush"); }
+static double _audio_set_client_volume(void *cls) { return 0.0; }
+static void _audio_set_metadata(void *cls, const void *buf, int len) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env || !buf || len <= 0) return;
+    jbyteArray arr = (*env)->NewByteArray(env, len);
+    (*env)->SetByteArrayRegion(env, arr, 0, len, (jbyte *)buf);
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_metadata, arr);
+    (*env)->DeleteLocalRef(env, arr);
+}
+
+static void _audio_set_coverart(void *cls, const void *buf, int len) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env || !buf || len <= 0) return;
+    jbyteArray arr = (*env)->NewByteArray(env, len);
+    (*env)->SetByteArrayRegion(env, arr, 0, len, (jbyte *)buf);
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_coverart, arr);
+    (*env)->DeleteLocalRef(env, arr);
+}
+
+static void _audio_remote_control_id(void *cls, const char *dacp_id, const char *active_remote) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env) return;
+    jstring jdacp = (*env)->NewStringUTF(env, dacp_id ? dacp_id : "");
+    jstring jremote = (*env)->NewStringUTF(env, active_remote ? active_remote : "");
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_dacp_id, jdacp, jremote);
+    (*env)->DeleteLocalRef(env, jdacp);
+    (*env)->DeleteLocalRef(env, jremote);
+}
+
+static void _audio_set_progress(void *cls, uint32_t *start, uint32_t *curr, uint32_t *end) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env || !start || !curr || !end) return;
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_progress,
+                           (jlong)*start, (jlong)*curr, (jlong)*end);
+}
+
+static void _mirror_video_running(void *cls, bool running) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env) return;
+    LOGI("mirror running: %d", running);
+    /* audio-only = mirror NOT running */
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_audio_only, (jboolean)!running);
+}
+static void _register_client(void *cls, const char *device_id, const char *pk_str, const char *name) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    (void)device_id; (void)name;
+    if (ctx->registered_count >= 16) return;
+    for (int i = 0; i < ctx->registered_count; i++) {
+        if (ctx->registered_keys[i] && strcmp(ctx->registered_keys[i], pk_str) == 0) return;
+    }
+    ctx->registered_keys[ctx->registered_count++] = strdup(pk_str);
+    LOGI("registered client pk (slot %d)", ctx->registered_count);
+}
+
+static bool _check_register(void *cls, const char *pk_str) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    for (int i = 0; i < ctx->registered_count; i++) {
+        if (ctx->registered_keys[i] && strcmp(ctx->registered_keys[i], pk_str) == 0) return true;
+    }
+    return false;
+}
+
+/* --- AirPlay Video (HLS) playback callbacks --- */
+
+static void _video_play(void *cls, const char *location, const float start_position) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    LOGI("video_play: %s @ %.2fs", location ? location : "(null)", start_position);
+    pthread_mutex_lock(&ctx->playback_info_lock);
+    ctx->play_ready = 0;
+    pthread_mutex_unlock(&ctx->playback_info_lock);
+    android_callbacks_update_playback_info(ctx, start_position, 0.0, 0.0f, 0);
+    JNIEnv *env = _get_env(ctx);
+    if (!env || !location) return;
+    jstring jloc = (*env)->NewStringUTF(env, location);
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_video_play, jloc, (jfloat)start_position);
+    (*env)->DeleteLocalRef(env, jloc);
+    /* self-driven senders (macOS) latch their scrubber timeline at /play; hold the response
+       until the player reports ready so that read must carry the real duration */
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec += 10; // hold for max 10s
+    pthread_mutex_lock(&ctx->playback_info_lock);
+    while (!ctx->play_ready) {
+        if (pthread_cond_timedwait(&ctx->play_ready_cond, &ctx->playback_info_lock, &ts) == ETIMEDOUT) break;
+    }
+    pthread_mutex_unlock(&ctx->playback_info_lock);
+}
+
+static void _video_scrub(void *cls, const float position) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env) return;
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_video_scrub, (jfloat)position);
+}
+
+static void _video_rate(void *cls, const float rate) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    JNIEnv *env = _get_env(ctx);
+    if (!env) return;
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_video_rate, (jfloat)rate);
+}
+
+static void _video_stop(void *cls) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    android_callbacks_update_playback_info(ctx, 0.0, -1.0, 0.0f, 0);
+    JNIEnv *env = _get_env(ctx);
+    if (!env) return;
+    (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_video_stop);
+}
+
+/* httpd thread: reads the kotlin-pushed snapshot, never calls into the player */
+static void _video_acquire_playback_info(void *cls, playback_info_t *info) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    pthread_mutex_lock(&ctx->playback_info_lock);
+    info->position = ctx->playback_position;
+    info->duration = ctx->playback_duration;
+    info->rate = ctx->playback_rate;
+    info->ready_to_play = ctx->playback_ready;
+    info->playback_buffer_empty = false;
+    info->playback_buffer_full = true;
+    info->playback_likely_to_keep_up = true;
+    info->seek_start = 0.0;
+    info->seek_duration = ctx->playback_duration > 0.0 ? ctx->playback_duration : 0.0;
+    pthread_mutex_unlock(&ctx->playback_info_lock);
+    /* polls are the earliest video-channel signal, starting ~1s before /play */
+    JNIEnv *env = _get_env(ctx);
+    if (env) {
+        (*env)->CallVoidMethod(env, ctx->callback_obj, ctx->on_video_session_poll);
+    }
+}
+
+static float _video_playlist_remove(void *cls) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    pthread_mutex_lock(&ctx->playback_info_lock);
+    double position = ctx->playback_position;
+    pthread_mutex_unlock(&ctx->playback_info_lock);
+    return (float) position;
+}
+
+static int _video_set_codec(void *cls, video_codec_t codec) {
+    android_callback_ctx_t *ctx = (android_callback_ctx_t *)cls;
+    LOGI("video_set_codec: %d (h265_enabled=%d)", codec, ctx->h265_enabled);
+    if (codec == VIDEO_CODEC_H265 && !ctx->h265_enabled) return -1;
+    return 0;
+}
+
+void android_callbacks_fill(raop_callbacks_t *cbs, android_callback_ctx_t *ctx) {
+    memset(cbs, 0, sizeof(raop_callbacks_t));
+    cbs->cls = ctx;
+
+    cbs->audio_process = _audio_process;
+    cbs->video_process = _video_process;
+    cbs->video_pause = _video_pause;
+    cbs->video_resume = _video_resume;
+    cbs->conn_feedback = _conn_feedback;
+    cbs->conn_reset = _conn_reset;
+    cbs->video_reset = _video_reset;
+    cbs->conn_init = _conn_init;
+    cbs->conn_destroy = _conn_destroy;
+    cbs->conn_teardown = _noop_teardown;
+    cbs->audio_flush = _audio_flush;
+    cbs->video_flush = _video_flush;
+    cbs->audio_set_client_volume = _audio_set_client_volume;
+    cbs->audio_set_volume = _audio_set_volume;
+    cbs->audio_set_metadata = _audio_set_metadata;
+    cbs->audio_set_coverart = _audio_set_coverart;
+    cbs->audio_remote_control_id = _audio_remote_control_id;
+    cbs->audio_set_progress = _audio_set_progress;
+    cbs->audio_get_format = _audio_get_format;
+    cbs->video_report_size = _video_report_size;
+    cbs->mirror_video_running = _mirror_video_running;
+    cbs->display_pin = _display_pin;
+    cbs->video_set_codec = _video_set_codec;
+    cbs->on_video_play = _video_play;
+    cbs->on_video_scrub = _video_scrub;
+    cbs->on_video_rate = _video_rate;
+    cbs->on_video_stop = _video_stop;
+    cbs->on_video_acquire_playback_info = _video_acquire_playback_info;
+    cbs->on_video_playlist_remove = _video_playlist_remove;
+    if (ctx->require_pin) {
+        cbs->check_register = _check_register;
+        cbs->register_client = _register_client;
+    }
+}

--- a/airplay/src/main/cpp/android_raop_callbacks.h
+++ b/airplay/src/main/cpp/android_raop_callbacks.h
@@ -1,0 +1,62 @@
+#ifndef ANDROID_RAOP_CALLBACKS_H
+#define ANDROID_RAOP_CALLBACKS_H
+
+#include <jni.h>
+#include <pthread.h>
+#include "raop.h"
+#include "audio_engine.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    JavaVM *jvm;
+    jobject callback_obj;
+    raop_t *raop;
+    jmethodID on_video_data;
+    jmethodID on_audio_format;
+    jmethodID on_video_size;
+    jmethodID on_volume_change;
+    jmethodID on_conn_init;
+    jmethodID on_conn_destroy;
+    jmethodID on_conn_reset;
+    jmethodID on_display_pin;
+    jmethodID on_metadata;
+    jmethodID on_coverart;
+    jmethodID on_progress;
+    jmethodID on_dacp_id;
+    jmethodID on_audio_only;
+    jmethodID on_video_play;
+    jmethodID on_video_scrub;
+    jmethodID on_video_rate;
+    jmethodID on_video_stop;
+    jmethodID on_video_session_poll;
+    int h265_enabled;
+    int require_pin;
+    char *registered_keys[16];
+    int registered_count;
+    /* playback info snapshot pushed by kotlin, read on the native httpd thread */
+    pthread_mutex_t playback_info_lock;
+    double playback_position;
+    double playback_duration;
+    float playback_rate;
+    int playback_ready;
+    /* holds the /play response until the player is ready, so self-driven senders (macOS)
+       establish their timeline after the real duration is known, not at duration 0 */
+    pthread_cond_t play_ready_cond;
+    int play_ready;
+    AudioEngine *audio_engine;
+} android_callback_ctx_t;
+
+void android_callbacks_init(android_callback_ctx_t *ctx, JNIEnv *env, jobject callback_obj);
+void android_callbacks_destroy(android_callback_ctx_t *ctx, JNIEnv *env);
+void android_callbacks_fill(raop_callbacks_t *cbs, android_callback_ctx_t *ctx);
+void android_callbacks_update_playback_info(android_callback_ctx_t *ctx, double position,
+                                             double duration, float rate, int ready);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/airplay/src/main/cpp/audio_decoder.h
+++ b/airplay/src/main/cpp/audio_decoder.h
@@ -1,0 +1,447 @@
+#ifndef AUDIO_DECODER_H
+#define AUDIO_DECODER_H
+
+#include <android/log.h>
+#include <media/NdkMediaCodec.h>
+#include <media/NdkMediaFormat.h>
+#include <atomic>
+#include <climits>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavutil/channel_layout.h>
+#include <libavutil/log.h>
+#include <libavutil/mem.h>
+#include <libavutil/samplefmt.h>
+}
+
+#include "audio_time.h"
+#include "log_sink.h"
+#include "timeline_buffer.h"
+
+static constexpr int CT_ALAC = 2, CT_AAC_LC = 4, CT_AAC_ELD = 8;
+
+class LatencyReporter {
+public:
+    LatencyReporter(const char *name, LogSink &log) : mName(name), mLog(log) {}
+
+    // no concurrent callers
+    void record(int64_t ns) {
+        if (mN == 0 || ns < mMinNs) mMinNs = ns;
+        if (ns > mMaxNs) mMaxNs = ns;
+        mSumNs += ns;
+        if (++mN >= UPDATE_FREQ) {
+            const int32_t meanUs = (int32_t)(mSumNs / mN / 1000);
+            mMeanUs.store(meanUs, std::memory_order_relaxed);
+            mMaxUs.store((int32_t)(mMaxNs / 1000), std::memory_order_relaxed);
+            if (mLogging.load(std::memory_order_relaxed)) {
+                mLog.info("%s latency: n=%lld min=%.2fms mean=%.2fms max=%.2fms (held=%zu)",
+                          mName, (long long)mN, mMinNs / 1e6, meanUs / 1000.0, mMaxNs / 1e6,
+                          mHeld.load(std::memory_order_relaxed));
+            }
+            mN = 0; mSumNs = 0; mMinNs = 0; mMaxNs = 0;
+        }
+    }
+
+    // # of operations currently in flight
+    void setHeld(size_t n) { mHeld.store(n, std::memory_order_relaxed); }
+
+    void setEnableLogging(bool on) { mLogging.store(on, std::memory_order_relaxed); }
+
+    // packed: nests into AudioDebugData with fixed layout
+    struct __attribute__((packed)) Debug {
+        int32_t meanUs, maxUs;  // latency in us
+        uint16_t held;          // operations in flight
+    };
+    Debug debugInfo() const {
+        Debug d{};
+        d.meanUs = mMeanUs.load(std::memory_order_relaxed);
+        d.maxUs = mMaxUs.load(std::memory_order_relaxed);
+        d.held = (uint16_t)mHeld.load(std::memory_order_relaxed);
+        return d;
+    }
+
+private:
+    static constexpr int64_t UPDATE_FREQ = 200;
+
+    const char *mName;
+    LogSink &mLog;                                       // not owned
+    std::atomic<bool> mLogging{false};
+    int64_t mN = 0, mSumNs = 0, mMinNs = 0, mMaxNs = 0;  // producer-thread accumulators
+    std::atomic<int32_t> mMeanUs{0}, mMaxUs{0};
+    std::atomic<size_t> mHeld{0};
+};
+
+// https://stackoverflow.com/a/44095383
+/*
+ * SPSC queue to measure AMediaCodec decode latency: MediaCodec can't carry side data
+ * across decode, so track queue times ourselves
+ */
+struct LatencyProbe {
+    struct Entry { int64_t ptsUs; int64_t queueNs; };
+    static constexpr uint64_t CAP = 64;
+    Entry mBuf[CAP] = {};
+    std::atomic<uint64_t> mWrite{0};
+    std::atomic<uint64_t> mRead{0};
+
+    // call before feeding frame into MediaCodec
+    void record(int64_t ptsUs, int64_t queueNs) {
+        const uint64_t w = mWrite.load(std::memory_order_relaxed);
+        mBuf[w % CAP] = {ptsUs, queueNs};
+        mWrite.store(w + 1, std::memory_order_release);
+    }
+
+    // call after frame comes back; latency ns for ptsUs, or -1 if not recorded
+    int64_t match(int64_t ptsUs, int64_t nowNs) {
+        uint64_t r = mRead.load(std::memory_order_relaxed);
+        const uint64_t w = mWrite.load(std::memory_order_acquire);
+        for (; r < w; r++) {
+            if (mBuf[r % CAP].ptsUs == ptsUs) {
+                const int64_t lat = nowNs - mBuf[r % CAP].queueNs;
+                mRead.store(r + 1, std::memory_order_release);
+                return lat;
+            }
+        }
+        return -1;
+    }
+
+    size_t inFlight() const {
+        return (size_t)(mWrite.load(std::memory_order_relaxed) -
+                        mRead.load(std::memory_order_relaxed));
+    }
+};
+
+// decodes one encoded airplay audio packet and pushes PCM onto the timeline
+class Decoder {
+public:
+    virtual ~Decoder() = default;
+    // called on RAOP receive thread; returns false = non-critical decode error
+    virtual bool decode(const uint8_t *data, size_t len, int64_t ptsNs) = 0;
+};
+
+// 24-byte ALACSpecificConfig "magic cookie" (big-endian)
+static inline void buildAlacMagicCookie(uint8_t out[24], int sampleRate, int channels, int spf) {
+    const int frameLength = spf;
+    const int bitDepth = 16, pb = 40, mb = 10, kb = 14;
+    out[0] = (frameLength >> 24) & 0xFF;
+    out[1] = (frameLength >> 16) & 0xFF;
+    out[2] = (frameLength >> 8) & 0xFF;
+    out[3] = frameLength & 0xFF;
+    out[4] = 0;                /* compatibleVersion */
+    out[5] = (uint8_t)bitDepth;
+    out[6] = (uint8_t)pb;
+    out[7] = (uint8_t)mb;
+    out[8] = (uint8_t)kb;
+    out[9] = (uint8_t)channels;
+    out[10] = 0; out[11] = 0xFF; /* maxRun = 255 (big-endian) */
+    out[12] = out[13] = out[14] = out[15] = 0; /* maxFrameBytes */
+    out[16] = out[17] = out[18] = out[19] = 0; /* avgBitRate */
+    out[20] = (sampleRate >> 24) & 0xFF;
+    out[21] = (sampleRate >> 16) & 0xFF;
+    out[22] = (sampleRate >> 8) & 0xFF;
+    out[23] = sampleRate & 0xFF;
+}
+
+// cookie wrapped in its atom: size (4) + 'alac' + version/flags (4) + ALACSpecificConfig
+static inline void buildAlacAtomCookie(uint8_t out[36], int sampleRate, int channels, int spf) {
+    static const uint8_t hdr[12] = {0x00, 0x00, 0x00, 0x24, 'a', 'l', 'a', 'c', 0, 0, 0, 0};
+    memcpy(out, hdr, sizeof(hdr));
+    buildAlacMagicCookie(out + 12, sampleRate, channels, spf);
+}
+
+// AMediaCodec decoder; output dequeued on separate thread, shaves ~10ms latency
+class MediaCodecDecoder : public Decoder {
+public:
+    // takes ownership of already-created+started codec
+    MediaCodecDecoder(AMediaCodec *codec, TimelineBuffer &timeline, LatencyReporter &lat)
+        : mCodec(codec), mTimeline(timeline), mLat(lat) {
+        mDrainRun.store(true, std::memory_order_relaxed);
+        mDrainThread = std::thread(&MediaCodecDecoder::drainLoop, this);
+    }
+
+    ~MediaCodecDecoder() override {
+        // stop drain thread before touching the codec it reads from
+        if (mDrainThread.joinable()) {
+            mDrainRun.store(false, std::memory_order_relaxed);
+            mDrainThread.join();
+        }
+        if (mCodec) { AMediaCodec_stop(mCodec); AMediaCodec_delete(mCodec); }
+    }
+
+    bool decode(const uint8_t *data, size_t len, int64_t ptsNs) override {
+        ssize_t ii = AMediaCodec_dequeueInputBuffer(mCodec, 5000);
+        if (ii < 0) return false;
+        size_t cap = 0;
+        uint8_t *in = AMediaCodec_getInputBuffer(mCodec, (size_t)ii, &cap);
+        if (!in) return false;
+        const size_t n = len < cap ? len : cap;
+        memcpy(in, data, n);
+        mProbe.record((int64_t)(ptsNs / 1000), monoNs());
+        // still queue packets that are too large, but truncate them and report as error
+        return AMediaCodec_queueInputBuffer(mCodec, (size_t)ii, 0, n, (uint64_t)(ptsNs / 1000), 0) ==
+                   AMEDIA_OK && n == len;
+    }
+
+private:
+    static constexpr int64_t DRAIN_TIMEOUT_US = 20000;
+
+    void drainLoop() {
+        AMediaCodecBufferInfo info;
+        while (mDrainRun.load(std::memory_order_relaxed)) {
+            ssize_t oi = AMediaCodec_dequeueOutputBuffer(mCodec, &info, DRAIN_TIMEOUT_US);
+            if (oi < 0) continue;  // timeout / format / buffers changed
+            size_t osz = 0;
+            uint8_t *out = AMediaCodec_getOutputBuffer(mCodec, (size_t)oi, &osz);
+            if (out && info.size > 0) {
+                mTimeline.write((const int16_t *)(out + info.offset),
+                                (size_t)info.size / sizeof(int16_t),  // bytes -> samples
+                                (int64_t)info.presentationTimeUs * 1000);
+            }
+            const int64_t nowNs = monoNs();
+            AMediaCodec_releaseOutputBuffer(mCodec, (size_t)oi, false);
+            const int64_t lat = mProbe.match((int64_t)info.presentationTimeUs, nowNs);
+            if (lat >= 0) mLat.record(lat);
+            mLat.setHeld(mProbe.inFlight());
+        }
+    }
+
+    AMediaCodec *mCodec;                  // owned
+    TimelineBuffer &mTimeline;            // not owned
+    LatencyReporter &mLat;                // not owned
+    LatencyProbe mProbe;
+    std::thread mDrainThread;
+    std::atomic<bool> mDrainRun{false};   // drain thread stop signal
+};
+
+// route ffmpeg warnings/errors to logcat
+static inline void installFfmpegLogcat() {
+    static std::once_flag once;
+    std::call_once(once, [] {
+        av_log_set_level(AV_LOG_WARNING);
+        av_log_set_callback([](void *, int level, const char *fmt, va_list vl) {
+            if (level > av_log_get_level()) return;
+            __android_log_vprint(level <= AV_LOG_ERROR ? ANDROID_LOG_ERROR : ANDROID_LOG_WARN,
+                                 "ffmpeg", fmt, vl);
+        });
+    });
+}
+
+// software ALAC via ffmpeg libavcodec; synchronous, decodes on caller's thread
+class FfmpegAlacDecoder : public Decoder {
+public:
+    // returns nullptr if codec can't be created/opened
+    static std::unique_ptr<FfmpegAlacDecoder> make(int sampleRate, int channels, int spf,
+                                                   TimelineBuffer &timeline, LatencyReporter &lat,
+                                                   LogSink &log) {
+        installFfmpegLogcat();
+        auto dec = std::unique_ptr<FfmpegAlacDecoder>(new FfmpegAlacDecoder(timeline, lat, log));
+        if (!dec->init(sampleRate, channels, spf)) return nullptr;
+        return dec;
+    }
+
+    ~FfmpegAlacDecoder() override {
+        if (mFrame) av_frame_free(&mFrame);
+        if (mPkt) av_packet_free(&mPkt);
+        if (mCtx) avcodec_free_context(&mCtx);
+    }
+
+    bool decode(const uint8_t *data, size_t len, int64_t ptsNs) override {
+        if (len == 0 || len > INT_MAX - AV_INPUT_BUFFER_PADDING_SIZE) return false;
+        const int64_t t0 = monoNs();
+
+        if (mPkt->size < (int)len) {
+            if (av_grow_packet(mPkt, (int)len - mPkt->size) < 0) return false;
+        } else {
+            av_shrink_packet(mPkt, (int)len);
+        }
+        memcpy(mPkt->data, data, len);
+
+        if (avcodec_send_packet(mCtx, mPkt) < 0) return false;
+
+        int64_t pts = ptsNs;
+        // the current libavcodec ALAC decoder always produces exactly 1 output
+        // frame for each input packet, this loop is only for completeness
+        while (avcodec_receive_frame(mCtx, mFrame) == 0) {
+            const int n = mFrame->nb_samples;
+            if (n <= 0) continue;
+            if (mFrame->format == AV_SAMPLE_FMT_S16) {
+                // this branch is not used as current libavcodec decoder cannot produce AV_SAMPLE_FMT_S16
+                mTimeline.write((const int16_t *)mFrame->data[0], (size_t)n * mChannels, pts);
+            } else if (mFrame->format == AV_SAMPLE_FMT_S16P) {
+                // timeline expects packed/interleaved (AV_SAMPLE_FMT_S16), decoder gives planar
+                if (mPcm.size() < (size_t)n * mChannels) mPcm.resize((size_t)n * mChannels);
+                for (int c = 0; c < mChannels; c++) {
+                    const int16_t *p = (const int16_t *)mFrame->data[c];
+                    for (int i = 0; i < n; i++) mPcm[(size_t)i * mChannels + c] = p[i];
+                }
+                mTimeline.write(mPcm.data(), (size_t)n * mChannels, pts);
+            } else {
+                mLog.error("ffmpeg ALAC: unsupported sample format %d", mFrame->format);
+                return false;
+            }
+            pts += (int64_t)n * NS_PER_SEC / mCtx->sample_rate;
+        }
+
+        mLat.record(monoNs() - t0);
+        mLat.setHeld(0);
+        return true;
+    }
+
+private:
+    FfmpegAlacDecoder(TimelineBuffer &timeline, LatencyReporter &lat, LogSink &log)
+        : mTimeline(timeline), mLat(lat), mLog(log) {}
+
+    bool init(int sampleRate, int channels, int spf) {
+        const AVCodec *codec = avcodec_find_decoder(AV_CODEC_ID_ALAC);
+        if (!codec) { mLog.error("ffmpeg ALAC decoder not compiled in"); return false; }
+        mCtx = avcodec_alloc_context3(codec);
+        if (!mCtx) return false;
+
+        // decoder expects atom + magic cookie via extradata
+        // extradata must be alloced with av_malloc* and have AV_INPUT_BUFFER_PADDING_SIZE of
+        // 0-padding at the end
+        mCtx->extradata = (uint8_t *)av_mallocz(36 + AV_INPUT_BUFFER_PADDING_SIZE);
+        if (!mCtx->extradata) return false;
+        buildAlacAtomCookie(mCtx->extradata, sampleRate, channels, spf);
+        mCtx->extradata_size = 36;
+
+        mCtx->sample_rate = sampleRate;
+        av_channel_layout_default(&mCtx->ch_layout, channels);
+        mCtx->thread_count = 1;
+
+        if (avcodec_open2(mCtx, codec, nullptr) < 0) {
+            mLog.error("ffmpeg ALAC open failed (rate=%d ch=%d spf=%d)", sampleRate, channels, spf);
+            return false;
+        }
+
+        mPkt = av_packet_alloc();
+        mFrame = av_frame_alloc();
+        if (!mPkt || !mFrame) return false;
+        // alloc packet buffer, sized for largest possible ALAC packet ("escape" frame + 8-byte header).
+        if (av_new_packet(mPkt, spf * channels * (int)sizeof(int16_t) + 8) < 0) return false;
+        mChannels = channels;
+        mPcm.resize((size_t)spf * channels);
+        return true;
+    }
+
+    AVCodecContext *mCtx = nullptr;  // owned
+    AVPacket *mPkt = nullptr;        // owned
+    AVFrame *mFrame = nullptr;       // owned
+    std::vector<int16_t> mPcm;       // interleave scratch
+    TimelineBuffer &mTimeline;
+    LatencyReporter &mLat;
+    LogSink &mLog;
+    int mChannels;
+};
+
+// ---- decoder factories ----
+// create + configure + start AMediaCodec for `mime` with `fmt` (consumes fmt); tries
+// `preferName` first if set, falls back to platform default; nullptr if none start
+static inline AMediaCodec *startCodec(const char *mime, const char *preferName, AMediaFormat *fmt,
+                                      LogSink &log) {
+    AMediaCodec *codec = preferName ? AMediaCodec_createCodecByName(preferName) : nullptr;
+    bool ok = codec &&
+              AMediaCodec_configure(codec, fmt, nullptr, nullptr, 0) == AMEDIA_OK &&
+              AMediaCodec_start(codec) == AMEDIA_OK;
+    if (ok) {
+        log.info("%s decoder started (%s)", mime, preferName);
+    } else {
+        if (codec) { AMediaCodec_delete(codec); codec = nullptr; }
+        codec = AMediaCodec_createDecoderByType(mime);
+        ok = codec &&
+             AMediaCodec_configure(codec, fmt, nullptr, nullptr, 0) == AMEDIA_OK &&
+             AMediaCodec_start(codec) == AMEDIA_OK;
+        if (ok) log.info("%s decoder started (default)", mime);
+    }
+    AMediaFormat_delete(fmt);
+    if (!ok && codec) { AMediaCodec_delete(codec); codec = nullptr; }
+    return ok ? codec : nullptr;
+}
+
+// default AAC decoder runs sandboxed on newer devices; sandbox IPC costs ~15-30ms
+// (Pixel 10), so request the in-process AAC decoder when available
+static constexpr const char *AAC_INPROC_DECODER = "c2.android.inproc.aac.decoder";
+
+// priority=0 requests realtime scheduling; low-latency=1 minimizes decoder buffering
+static inline void setSchedulingHints(AMediaFormat *fmt, bool realtimePriority, bool lowLatency) {
+    if (realtimePriority) AMediaFormat_setInt32(fmt, "priority", 0);
+    if (lowLatency) AMediaFormat_setInt32(fmt, "low-latency", 1);
+}
+
+static inline AMediaCodec *startAacCodec(int ct, int spf, int sampleRate, int channels, LogSink &log,
+                                         bool realtimePriority, bool lowLatency) {
+    uint8_t csd[4]; size_t csdLen; int profile;
+    if (ct == CT_AAC_ELD) {
+        // AAC-ELD AudioSpecificConfig: AOT=39, 44100, stereo, then ELDSpecificConfig whose
+        // first bit is frameLengthFlag (byte2 bit3): 1 = 480 samples/frame (0x50), 0 = 512 (0x40)
+        profile = 39; csd[0] = 0xF8; csd[1] = 0xE8;
+        csd[2] = (spf == 512) ? 0x40 : 0x50; csd[3] = 0x00; csdLen = 4;
+    } else if (ct == CT_AAC_LC) {
+        // AAC-LC AudioSpecificConfig: AOT=2, 44100, stereo, then GASpecificConfig whose
+        // first bit is frameLengthFlag (byte1 bit5): 0 = 1024 samples/frame (0x10), 1 = 960 (0x14)
+        profile = 2; csd[0] = 0x12;
+        csd[1] = (spf == 960) ? 0x14 : 0x10; csdLen = 2;
+    } else {
+        log.error("Unknown audio ct=%d", ct); return nullptr;
+    }
+    AMediaFormat *fmt = AMediaFormat_new();
+    AMediaFormat_setString(fmt, "mime", "audio/mp4a-latm");
+    AMediaFormat_setInt32(fmt, "sample-rate", sampleRate);
+    AMediaFormat_setInt32(fmt, "channel-count", channels);
+    AMediaFormat_setInt32(fmt, "aac-profile", profile);
+    AMediaFormat_setInt32(fmt, "is-adts", 0);
+    setSchedulingHints(fmt, realtimePriority, lowLatency);
+    AMediaFormat_setBuffer(fmt, "csd-0", csd, csdLen);
+    return startCodec("audio/mp4a-latm", AAC_INPROC_DECODER, fmt, log);
+}
+
+static inline AMediaCodec *startAlacHwCodec(int sampleRate, int channels, int spf, LogSink &log,
+                                            bool realtimePriority, bool lowLatency) {
+    AMediaFormat *fmt = AMediaFormat_new();
+    AMediaFormat_setString(fmt, "mime", "audio/alac");
+    AMediaFormat_setInt32(fmt, "sample-rate", sampleRate);
+    AMediaFormat_setInt32(fmt, "channel-count", channels);
+    setSchedulingHints(fmt, realtimePriority, lowLatency);
+    uint8_t csd[36];
+    buildAlacAtomCookie(csd, sampleRate, channels, spf);
+    AMediaFormat_setBuffer(fmt, "csd-0", csd, sizeof(csd));
+    return startCodec("audio/alac", nullptr, fmt, log);
+}
+
+static inline std::unique_ptr<Decoder> makeDecoder(int ct, int spf, int sampleRate, int channels,
+                                                   TimelineBuffer &timeline, LatencyReporter &lat,
+                                                   LogSink &log, bool forceSwAlac,
+                                                   bool realtimePriority, bool lowLatency) {
+    if (ct == CT_ALAC) {
+        if (!forceSwAlac) {
+            if (AMediaCodec *codec = startAlacHwCodec(sampleRate, channels, spf, log,
+                                                      realtimePriority, lowLatency)) {
+                log.info("ALAC: hardware decoder");
+                return std::make_unique<MediaCodecDecoder>(codec, timeline, lat);
+            }
+        }
+        if (auto sw = FfmpegAlacDecoder::make(sampleRate, channels, spf, timeline, lat, log)) {
+            log.info("ALAC: software decoder (ffmpeg)%s", forceSwAlac ? " (forced)" : "");
+            return sw;
+        }
+        log.error("ALAC init failed (hw and sw)");
+        return nullptr;
+    }
+    if (AMediaCodec *codec = startAacCodec(ct, spf, sampleRate, channels, log,
+                                           realtimePriority, lowLatency)) {
+        return std::make_unique<MediaCodecDecoder>(codec, timeline, lat);
+    }
+    log.error("AAC codec init failed (ct=%d)", ct);
+    return nullptr;
+}
+
+#endif  // AUDIO_DECODER_H

--- a/airplay/src/main/cpp/audio_engine.cpp
+++ b/airplay/src/main/cpp/audio_engine.cpp
@@ -1,0 +1,275 @@
+/*
+ * Native low-latency audio pipeline for the airplay receiver, three layers:
+ *   decoding (AAC/ALAC) -> timing/jitter buffer (spike absorption + PTS sync) -> PCM output
+ */
+
+#include <jni.h>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "audio_engine.h"
+#include "audio_decoder.h"
+#include "audio_output.h"
+#include "log_sink.h"
+#include "timeline_buffer.h"
+
+/*
+ * debug metrics copied out to Java each overlay poll (see copyDebug). MUST BE PACKED,
+ * including nested structs: Java reader (AudioRenderer.audioDebug) mirrors this exact
+ * byte layout
+ */
+struct __attribute__((packed)) AudioDebugData {
+    TimelineBuffer::Debug timeline;
+    LatencyReporter::Debug decode;
+    AudioOutput::Debug output;
+    int32_t decodeErrors;  // cumulative packets Decoder::decode() reported as failed
+};
+
+struct AudioConfig {
+    const int staticCushionMs;   // 0 = adaptive tuner
+    const int percentilePct;     // adaptive tuner target percentile
+    const int oboeBufferFrames;  // 0 = auto, two bursts in low-latency mode, oboe default in power save
+    const bool forceSwAlac;      // embedded ffmpeg software ALAC even when HW available
+    const bool realtimePriority; // decoder: request realtime priority
+    const bool lowLatency;       // low-latency decoder + oboe low-latency output
+    const bool benchmarkLog;     // periodically log decoder stats
+};
+
+struct CodecFormat {
+    int spf = 0;  // samples/frame; 0 = not yet announced (decoder uses built-in default)
+    bool operator==(const CodecFormat &o) const { return spf == o.spf; }
+    bool operator!=(const CodecFormat &o) const { return !(*this == o); }
+};
+
+struct AudioEngine {
+    AudioEngine(std::shared_ptr<LogSink> log, int sampleRate, int channels)
+        : mLog(std::move(log)), mSampleRate(sampleRate), mChannels(channels) {
+        mQueued[ctIndex(CT_ALAC)].store(CodecFormat{352}, std::memory_order_relaxed);
+        mQueued[ctIndex(CT_AAC_LC)].store(CodecFormat{1024}, std::memory_order_relaxed);
+        mQueued[ctIndex(CT_AAC_ELD)].store(CodecFormat{480}, std::memory_order_relaxed);
+    }
+
+    ~AudioEngine() {
+        delete mPending.load(std::memory_order_relaxed);
+    }
+
+    bool configure(const AudioConfig &cfg) {
+        std::lock_guard<std::mutex> lk(mRebuildLock);
+        if (!mApplied) {
+            initInternals(cfg);
+            return true;
+        }
+        // engine may be in use: decode() applies the queued config
+        delete mPending.exchange(new AudioConfig(cfg), std::memory_order_release);
+        return true;
+    }
+
+    bool start() {
+        std::lock_guard<std::mutex> lk(mRebuildLock);
+        mRunning = true;
+        if (mOutput && !mOutputActive) {
+            mTimeline->flushAndReprime();
+            mOutputActive = mOutput->start();
+        }
+        return mOutputActive;
+    }
+
+    void pause() {
+        std::lock_guard<std::mutex> lk(mRebuildLock);
+        mRunning = false;
+        if (mOutput && mOutputActive) {
+            mOutput->stop();
+            mOutputActive = false;
+        }
+    }
+
+    // touches decoder: must not run concurrently with decode()
+    void stop() {
+        if (mOutput) mOutput->stop();
+        mOutputActive = false;
+        mDecoder = {};
+    }
+
+    void setVolume(float v) {
+        std::lock_guard<std::mutex> lk(mRebuildLock);
+        mVolume = v;
+        if (mOutput) mOutput->setVolume(v);
+    }
+
+    void onFormat(int ct, int spf) {
+        const int i = ctIndex(ct);
+        if (i < 0 || spf <= 0) return;
+        mQueued[i].store(CodecFormat{spf}, std::memory_order_release);
+    }
+
+    bool copyDebug(void *dst, size_t dstLen) {
+        if (dstLen < sizeof(AudioDebugData)) return false;
+        {
+            // never block: return stale data if lock in use
+            std::unique_lock<std::mutex> lk(mRebuildLock, std::try_to_lock);
+            if (lk.owns_lock() && mOutput) {
+                mDebug.timeline = mTimeline->debugInfo();
+                mDebug.decode = mDecLatency.debugInfo();
+                mDebug.output = mOutput->debugInfo();
+                mDebug.decodeErrors = mDecodeErrors.load(std::memory_order_relaxed);
+            }
+        }
+        memcpy(dst, &mDebug, sizeof(mDebug));
+        return true;
+    }
+
+    // touches decoder: must not run concurrently with stop()
+    void decode(const uint8_t *data, size_t len, int ct, int64_t ptsNs) {
+        if (!mTimeline) return;
+        if (mPending.load(std::memory_order_relaxed)) {
+            if (AudioConfig *raw = mPending.exchange(nullptr, std::memory_order_acquire)) {
+                std::unique_ptr<AudioConfig> c(raw);
+                mDecoder = {};
+                std::lock_guard<std::mutex> lk(mRebuildLock);
+                if (mOutputActive) mOutput->stop();
+                mOutput.reset();
+                initInternals(*c);
+                mOutputActive = mRunning ? mOutput->start() : false;
+            }
+        }
+
+        const int ci = ctIndex(ct);
+        const CodecFormat wantConfig = ci >= 0 ? mQueued[ci].load(std::memory_order_acquire) : CodecFormat{};
+        // transient codec-service failure does not mute entire session
+        const bool changed = ct != mDecoder.ct || wantConfig != mDecoder.format;
+        if (changed || (!mDecoder.decoder && monoNs() >= mRetryAtNs)) {
+            mDecoder = {}; // release old decoder first to free resources
+            mDecoder = {ct, wantConfig,
+                        makeDecoder(ct, wantConfig.spf, mSampleRate, mChannels, *mTimeline,
+                                    mDecLatency, *mLog, mApplied->forceSwAlac,
+                                    mApplied->realtimePriority, mApplied->lowLatency)};
+            mRetryAtNs = mDecoder.decoder ? 0 : monoNs() + DECODER_RETRY_NS;
+            // codec switch is definitely a discontinuity
+            mTimeline->reanchorTracker();
+        }
+        if (mDecoder.decoder && !mDecoder.decoder->decode(data, len, ptsNs))
+            mDecodeErrors.fetch_add(1, std::memory_order_relaxed);
+    }
+
+private:
+    static int ctIndex(int ct) {
+        switch (ct) {
+            case CT_ALAC:    return 0;
+            case CT_AAC_LC:  return 1;
+            case CT_AAC_ELD: return 2;
+            default:         return -1;
+        }
+    }
+
+    void initInternals(const AudioConfig &cfg) {
+        mDecLatency.setEnableLogging(cfg.benchmarkLog);
+        mTimeline = std::make_shared<TimelineBuffer>(mSampleRate, mChannels,
+                                                     cfg.staticCushionMs, cfg.percentilePct);
+        mOutput = AudioOutput::create(mSampleRate, mChannels, cfg.oboeBufferFrames,
+                                      cfg.lowLatency, mTimeline, mLog);
+        mOutput->setVolume(mVolume);  // carry current level across rebuild
+        mApplied = std::make_unique<AudioConfig>(cfg);
+    }
+
+    const int mSampleRate;
+    const int mChannels;
+    std::unique_ptr<AudioConfig> mApplied;
+    std::shared_ptr<LogSink> mLog;
+
+    // thread safety: decode thread reads mTimeline/mOutput unguarded (nothing else writes them outside teardown) and writes them under mRebuildLock
+    // all other threads read them under mRebuildLock; mDecoder is decode-thread-only
+    // teardown stop() requires caller to guarantee no in-flight or future decode() calls
+
+    std::mutex mRebuildLock;
+    std::shared_ptr<TimelineBuffer> mTimeline; // guarded by mRebuildLock
+    std::shared_ptr<AudioOutput> mOutput;      // guarded by mRebuildLock
+    bool mRunning = false;                     // requested output state, guarded by mRebuildLock
+    bool mOutputActive = false;                // actual output state, guarded by mRebuildLock
+    float mVolume = 1.0f;                      // last-set output level, guarded by mRebuildLock
+
+    LatencyReporter mDecLatency{"decode", *mLog};
+    // decoder + codec/config it was built with
+    // ct == -1: not initialized; ct != -1 && decoder == nullptr: build for ct failed
+    struct CreatedDecoder {
+        int ct = -1;
+        CodecFormat format;
+        std::unique_ptr<Decoder> decoder;
+    };
+    CreatedDecoder mDecoder;
+    static constexpr int64_t DECODER_RETRY_NS = 1'000'000'000LL;
+    int64_t mRetryAtNs = 0;  // earliest retry of failed decoder
+
+    // wanted config per codec, keyed by ctIndex
+    static constexpr int NUM_CT = 3;
+    std::atomic<CodecFormat> mQueued[NUM_CT] = {};
+
+    // pending config change, applied on next decode()
+    std::atomic<AudioConfig *> mPending{nullptr};
+
+    AudioDebugData mDebug{};
+    std::atomic<int32_t> mDecodeErrors{0};
+};
+
+AudioEngine *audio_engine_create(std::shared_ptr<LogSink> log, int sampleRate, int channels) {
+    if (!log) return nullptr;
+    return new AudioEngine(std::move(log), sampleRate, channels);
+}
+
+
+
+extern "C" {
+
+void audio_engine_set_default_stream_values(int sampleRate, int framesPerBurst) {
+    // configures oboe's OpenSL ES backend for pre-AAudio devices
+    if (sampleRate > 0) oboe::DefaultStreamValues::SampleRate = sampleRate;
+    if (framesPerBurst > 0) oboe::DefaultStreamValues::FramesPerBurst = framesPerBurst;
+}
+
+bool audio_engine_configure(AudioEngine *engine, int cushionMs, int percentilePct,
+                            int oboeBufferFrames, bool forceSwAlac, bool realtimePriority,
+                            bool lowLatency, bool benchmarkLog) {
+    if (!engine) return false;
+    return engine->configure({cushionMs, percentilePct, oboeBufferFrames, forceSwAlac,
+                              realtimePriority, lowLatency, benchmarkLog});
+}
+
+void audio_engine_set_volume(AudioEngine *engine, float volume) {
+    if (engine) engine->setVolume(volume);
+}
+
+void audio_engine_on_format(AudioEngine *engine, int ct, int spf) {
+    if (engine) engine->onFormat(ct, spf);
+}
+
+bool audio_engine_start(AudioEngine *engine) {
+    return engine && engine->start();
+}
+
+void audio_engine_pause(AudioEngine *engine) {
+    if (engine) engine->pause();
+}
+
+bool audio_engine_get_debug(AudioEngine *engine, void *dst, size_t dstLen) {
+    if (!engine || !dst) return false;
+    return engine->copyDebug(dst, dstLen);
+}
+
+void audio_engine_destroy(AudioEngine *engine) {
+    if (!engine) return;
+    engine->stop();
+    delete engine;
+}
+
+// decode straight from RAOP audio callback, no JNI crossing
+void audio_engine_decode(AudioEngine *engine, const uint8_t *data, int len, int ct, int64_t pts_ns) {
+    if (engine && data && len > 0) {
+        engine->decode(data, (size_t)len, ct, pts_ns);
+    }
+}
+
+}

--- a/airplay/src/main/cpp/audio_engine.h
+++ b/airplay/src/main/cpp/audio_engine.h
@@ -1,0 +1,61 @@
+#ifndef AUDIO_ENGINE_H
+#define AUDIO_ENGINE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* native audio engine: decodes, buffers and outputs audio; config can change while active */
+typedef struct AudioEngine AudioEngine;
+
+/* native -> UI log channel, opaque here (C++ type) */
+typedef struct LogSink LogSink;
+
+/* report device's native output sample rate + frames-per-burst (from AudioManager) to
+ * oboe. its OpenSL ES backend (pre-AAudio devices) can't discover these itself and
+ * needs them to size low-latency buffers; unused by AAudio backend. global, call before
+ * creating engine.
+ * see: https://github.com/google/oboe/blob/main/docs/GettingStarted.md#obtaining-optimal-latency */
+void audio_engine_set_default_stream_values(int sampleRate, int framesPerBurst);
+
+/* change engine config; any thread */
+bool audio_engine_configure(AudioEngine *engine, int cushionMs, int percentilePct,
+                            int oboeBufferFrames, bool forceSwAlac, bool realtimePriority,
+                            bool lowLatency, bool benchmarkLog);
+
+/* output volume, linear gain */
+void audio_engine_set_volume(AudioEngine *engine, float volume);
+
+/* sender is switching audio formats */
+void audio_engine_on_format(AudioEngine *engine, int ct, int spf);
+
+/* begin or resume playout; false if stream fails to open; idempotent */
+bool audio_engine_start(AudioEngine *engine);
+
+/* pause playout, releases audio output devices while paused; idempotent */
+void audio_engine_pause(AudioEngine *engine);
+
+/* refresh + copy packed debug struct into dst; false if engine NULL or dstLen too small */
+bool audio_engine_get_debug(AudioEngine *engine, void *dst, size_t dstLen);
+
+/* stop + destroy engine; no concurrent or later audio_engine_decode calls allowed */
+void audio_engine_destroy(AudioEngine *engine);
+
+/* decode + play one encoded airplay packet; not concurrent with audio_engine_destroy */
+void audio_engine_decode(AudioEngine *engine, const uint8_t *data, int len, int ct, int64_t pts_ns);
+
+#ifdef __cplusplus
+}
+
+#include <memory>
+
+/* create engine; handle or NULL */
+extern "C++" AudioEngine *audio_engine_create(std::shared_ptr<LogSink> log, int sampleRate,
+                                              int channels);
+#endif
+
+#endif  // AUDIO_ENGINE_H

--- a/airplay/src/main/cpp/audio_output.h
+++ b/airplay/src/main/cpp/audio_output.h
@@ -1,0 +1,199 @@
+#ifndef AUDIO_OUTPUT_H
+#define AUDIO_OUTPUT_H
+
+#include <oboe/Oboe.h>
+#include <atomic>
+#include <memory>
+#include <mutex>
+
+#include "log_sink.h"
+#include "timeline_buffer.h"
+
+class AudioOutput;
+
+// https://github.com/google/oboe/wiki/TechNote_HowToAvoidCrashes#avoid-deleting-objects-that-are-used-by-callbacks
+/*
+ * oboe data/error callbacks. oboe can invoke these even after stop()/close():
+ * this object owns refs to everything the callbacks touch: a late callback can never
+ * reach freed state. holds only weak_ptr to AudioOutput to break the ownership cycles
+ * AudioOutput -> OboeCallbacks -> AudioOutput and
+ * AudioOutput -> oboe::AudioStream -> OboeCallbacks -> AudioOutput
+ */
+class OboeCallbacks : public oboe::AudioStreamDataCallback,
+                      public oboe::AudioStreamErrorCallback {
+public:
+    OboeCallbacks(std::shared_ptr<TimelineBuffer> timeline, std::shared_ptr<LogSink> log,
+                  int channels)
+        : mTimeline(std::move(timeline)), mLog(std::move(log)), mChannels(channels) {}
+
+    void setVolume(float v) { mVolume.store(v, std::memory_order_relaxed); }
+
+    oboe::DataCallbackResult onAudioReady(oboe::AudioStream *, void *audioData,
+                                          int32_t numFrames) override {
+        auto *out = static_cast<int16_t *>(audioData);
+        mTimeline->read(out, numFrames);
+
+        const float vol = mVolume.load(std::memory_order_relaxed);
+        if (vol < 0.999f) {
+            const size_t n = (size_t)numFrames * mChannels;
+            for (size_t i = 0; i < n; i++) out[i] = (int16_t)(out[i] * vol);
+        }
+        return oboe::DataCallbackResult::Continue;
+    }
+
+    void onErrorAfterClose(oboe::AudioStream *, oboe::Result error) override;  // needs AudioOutput
+
+private:
+    friend class AudioOutput;
+
+    std::shared_ptr<TimelineBuffer> mTimeline;
+    std::shared_ptr<LogSink> mLog;
+    const int mChannels;
+    std::atomic<float> mVolume{1.0f};
+    std::weak_ptr<AudioOutput> mOwner;
+};
+
+/*
+ * low-latency audio output via oboe (AAudio or OpenSL ES). data callback pulls PCM from
+ * TimelineBuffer and applies volume; transparently handles device-loss errors
+ * (e.g. BT/headset change)
+ */
+class AudioOutput {
+public:
+    static std::shared_ptr<AudioOutput> create(int sampleRate, int channels, int oboeBufferFrames,
+                                               bool lowLatency,
+                                               std::shared_ptr<TimelineBuffer> timeline,
+                                               std::shared_ptr<LogSink> log) {
+        auto out = std::make_shared<AudioOutput>(sampleRate, channels, oboeBufferFrames,
+                                                 lowLatency, std::move(timeline), std::move(log));
+        out->mCallbacks->mOwner = out;
+        return out;
+    }
+
+    AudioOutput(int sampleRate, int channels, int oboeBufferFrames, bool lowLatency,
+                std::shared_ptr<TimelineBuffer> timeline, std::shared_ptr<LogSink> log)
+        : mSampleRate(sampleRate), mChannels(channels), mOboeBufferFrames(oboeBufferFrames),
+          mLowLatency(lowLatency), mTimeline(std::move(timeline)), mLog(std::move(log)),
+          mCallbacks(std::make_shared<OboeCallbacks>(mTimeline, mLog, channels)) {}
+
+    ~AudioOutput() { stop(); }
+
+    bool start() {
+        std::lock_guard<std::mutex> lk(mLock);
+        mClosing.store(false);
+        if (!openLocked()) return false;
+        if (mStream->requestStart() != oboe::Result::OK) {
+            mStream->close();
+            mStream.reset();
+            return false;
+        }
+        return true;
+    }
+
+    void stop() {
+        std::lock_guard<std::mutex> lk(mLock);
+        mClosing.store(true);
+        if (mStream) {
+            mStream->stop();
+            mStream->close();
+            mStream.reset();
+        }
+    }
+
+    void setVolume(float v) { mCallbacks->setVolume(v); }
+
+    // packed: nests into AudioDebugData with fixed layout
+    struct __attribute__((packed)) Debug {
+        int32_t xrun;  // cumulative
+    };
+    Debug debugInfo() {
+        std::unique_lock<std::mutex> lk(mLock, std::try_to_lock);
+        if (lk.owns_lock() && mStream) {
+            auto r = mStream->getXRunCount();
+            if (r) mLastXrun = r.value();
+        }
+        return Debug{mLastXrun};
+    }
+
+private:
+    friend class OboeCallbacks;
+
+    // oboe error thread, on device loss: reopen and restart unless tearing down
+    void reopenAfterError() {
+        std::lock_guard<std::mutex> lk(mLock);
+        if (mClosing.load()) return;
+        mStream.reset();
+        mTimeline->reprime();
+        if (openLocked()) mStream->requestStart();
+    }
+
+    bool openLocked() {  // caller holds mLock
+        // see: https://developer.android.com/games/sdk/oboe/low-latency-audio
+        oboe::AudioStreamBuilder b;
+        b.setDirection(oboe::Direction::Output)
+            ->setSharingMode(oboe::SharingMode::Shared)
+            ->setFormat(oboe::AudioFormat::I16)
+            ->setChannelCount(mChannels)
+            ->setSampleRate(mSampleRate)
+            ->setSampleRateConversionQuality(oboe::SampleRateConversionQuality::Medium)
+            ->setContentType(oboe::ContentType::Music)
+            ->setDataCallback(mCallbacks)
+            ->setErrorCallback(mCallbacks);
+        if (mLowLatency) {
+            // game use case may enable extra latency optimizations
+            b.setPerformanceMode(oboe::PerformanceMode::LowLatency)->setUsage(oboe::Usage::Game);
+        } else {
+            // media use case may have better quality and lower power
+            b.setPerformanceMode(oboe::PerformanceMode::PowerSaving)->setUsage(oboe::Usage::Media);
+        }
+        oboe::Result r = b.openStream(mStream);
+        if (r != oboe::Result::OK) {
+            mLog->error("Failed to open Oboe stream: %s", oboe::convertToText(r));
+            return false;
+        }
+        if (mOboeBufferFrames > 0) {
+            mStream->setBufferSizeInFrames(mOboeBufferFrames);
+        } else if (mLowLatency) {
+            // smallest reasonable buffer in low-latency mode
+            mStream->setBufferSizeInFrames(mStream->getFramesPerBurst() * 2);
+        }
+
+        // log what we actually got: oboe may clamp the buffer, fall back to a
+        // higher-latency API, or deny the low-latency path
+        const bool aaudio = mStream->getAudioApi() == oboe::AudioApi::AAudio;
+        const char *api = aaudio ? "AAudio"
+                        : mStream->getAudioApi() == oboe::AudioApi::OpenSLES ? "OpenSLES" : "?";
+        const bool lowLatency = mStream->getPerformanceMode() == oboe::PerformanceMode::LowLatency;
+        const bool mmap = aaudio && oboe::OboeExtensions::isMMapUsed(mStream.get());
+        mLog->info("Oboe out: %s%s, mmap=%s, buffer=%d/%d frames, burst=%d, %d Hz",
+                  api, lowLatency ? " (low-latency)" : "", mmap ? "yes" : "no",
+                  mStream->getBufferSizeInFrames(), mStream->getBufferCapacityInFrames(),
+                  mStream->getFramesPerBurst(), mStream->getSampleRate());
+        // adaptive tuner needs final buffer size
+        mTimeline->noteOutputBufferFrames(mStream->getBufferSizeInFrames());
+        return true;
+    }
+
+    const int mSampleRate;
+    const int mChannels;
+
+    const int mOboeBufferFrames;
+    const bool mLowLatency;
+
+    std::shared_ptr<TimelineBuffer> mTimeline;
+    std::shared_ptr<LogSink> mLog;
+    std::atomic<bool> mClosing{false};
+    std::shared_ptr<OboeCallbacks> mCallbacks;
+    std::shared_ptr<oboe::AudioStream> mStream;
+    std::mutex mLock;                    // guards open/close
+    int32_t mLastXrun = 0;               // debug-poll thread only
+};
+
+inline void OboeCallbacks::onErrorAfterClose(oboe::AudioStream *, oboe::Result error) {
+    // device disconnect (e.g. BT/headset change): oboe already closed the stream, ask
+    // AudioOutput to reopen
+    mLog->error("Oboe stream error: %s - reopening", oboe::convertToText(error));
+    if (auto owner = mOwner.lock()) owner->reopenAfterError();
+}
+
+#endif  // AUDIO_OUTPUT_H

--- a/airplay/src/main/cpp/audio_time.h
+++ b/airplay/src/main/cpp/audio_time.h
@@ -1,0 +1,15 @@
+#ifndef AUDIO_TIME_H
+#define AUDIO_TIME_H
+
+#include <cstdint>
+#include <ctime>
+
+static constexpr int64_t NS_PER_SEC = 1000000000LL;
+
+static inline int64_t monoNs() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t)ts.tv_sec * NS_PER_SEC + ts.tv_nsec;
+}
+
+#endif  // AUDIO_TIME_H

--- a/airplay/src/main/cpp/cmake/BuildFFmpeg.cmake
+++ b/airplay/src/main/cpp/cmake/BuildFFmpeg.cmake
@@ -1,0 +1,78 @@
+# build minimal static ffmpeg (libavcodec + libavutil + ALAC decoder) and expose under ffmpeg::avcodec and ffmpeg::avutil
+
+include(ExternalProject)
+include(ProcessorCount)
+
+if(ANDROID_ABI STREQUAL "arm64-v8a")
+    set(_ffmpeg_arch aarch64)
+    set(_ffmpeg_triple aarch64-linux-android)
+elseif(ANDROID_ABI STREQUAL "armeabi-v7a")
+    set(_ffmpeg_arch arm)
+    set(_ffmpeg_triple armv7a-linux-androideabi)
+    set(_ffmpeg_cpu --cpu=armv7-a)
+elseif(ANDROID_ABI STREQUAL "x86_64")
+    set(_ffmpeg_arch x86_64)
+    set(_ffmpeg_triple x86_64-linux-android)
+elseif(ANDROID_ABI STREQUAL "x86")
+    set(_ffmpeg_arch x86)
+    set(_ffmpeg_triple i686-linux-android)
+else()
+    message(FATAL_ERROR "BuildFFmpeg: unhandled ABI ${ANDROID_ABI}")
+endif()
+
+# NDK's per-API clang wrappers live next to the generic clang driver
+get_filename_component(_ffmpeg_tc "${CMAKE_C_COMPILER}" DIRECTORY)
+
+ProcessorCount(_ffmpeg_jobs)
+if(_ffmpeg_jobs EQUAL 0)
+    set(_ffmpeg_jobs 4)
+endif()
+
+set(FFMPEG_INSTALL ${CMAKE_BINARY_DIR}/ffmpeg)
+
+# instrument ffmpeg with the same sanitizers; built with --disable-asm
+set(_ffmpeg_sanitize "")
+if(SANITIZE)
+    string(REPLACE ";" " " _ff_scflags "${SANITIZE_CFLAGS}")
+    string(REPLACE ";" " " _ff_sldflags "${SANITIZE_LDFLAGS}")
+    set(_ffmpeg_sanitize "--extra-cflags=${_ff_scflags}" "--extra-ldflags=${_ff_sldflags}")
+endif()
+
+ExternalProject_Add(ffmpeg_ep
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/ffmpeg
+    DOWNLOAD_COMMAND ""
+    PREFIX ${CMAKE_BINARY_DIR}/ffmpeg-ep
+    INSTALL_DIR ${FFMPEG_INSTALL}
+    CONFIGURE_COMMAND <SOURCE_DIR>/configure
+        --prefix=<INSTALL_DIR>
+        --target-os=android --arch=${_ffmpeg_arch} ${_ffmpeg_cpu} --enable-cross-compile
+        --cc=${_ffmpeg_tc}/${_ffmpeg_triple}${AIRPLAY_ANDROID_API}-clang
+        --cxx=${_ffmpeg_tc}/${_ffmpeg_triple}${AIRPLAY_ANDROID_API}-clang++
+        --ar=${_ffmpeg_tc}/llvm-ar --nm=${_ffmpeg_tc}/llvm-nm
+        --ranlib=${_ffmpeg_tc}/llvm-ranlib --strip=${_ffmpeg_tc}/llvm-strip
+        --sysroot=${CMAKE_SYSROOT}
+        --enable-pic --disable-asm --disable-x86asm
+        --disable-all --disable-debug --disable-network --disable-autodetect
+        --enable-avcodec --enable-decoder=alac --enable-static --disable-shared
+        ${_ffmpeg_sanitize}
+    BUILD_COMMAND make -j${_ffmpeg_jobs}
+    INSTALL_COMMAND make install
+    BUILD_BYPRODUCTS ${FFMPEG_INSTALL}/lib/libavcodec.a ${FFMPEG_INSTALL}/lib/libavutil.a
+    LOG_CONFIGURE TRUE
+    LOG_BUILD TRUE
+    LOG_INSTALL TRUE
+)
+
+file(MAKE_DIRECTORY ${FFMPEG_INSTALL}/include)
+
+add_library(ffmpeg::avutil STATIC IMPORTED)
+set_target_properties(ffmpeg::avutil PROPERTIES
+    IMPORTED_LOCATION ${FFMPEG_INSTALL}/lib/libavutil.a
+    INTERFACE_INCLUDE_DIRECTORIES ${FFMPEG_INSTALL}/include
+)
+add_library(ffmpeg::avcodec STATIC IMPORTED)
+set_target_properties(ffmpeg::avcodec PROPERTIES
+    IMPORTED_LOCATION ${FFMPEG_INSTALL}/lib/libavcodec.a
+    INTERFACE_INCLUDE_DIRECTORIES ${FFMPEG_INSTALL}/include
+    INTERFACE_LINK_LIBRARIES ffmpeg::avutil
+)

--- a/airplay/src/main/cpp/cmake/PatchOpenSSL.cmake
+++ b/airplay/src/main/cpp/cmake/PatchOpenSSL.cmake
@@ -1,0 +1,5 @@
+set(OPENSSL_PATCH_COMMAND PATCH_COMMAND
+    ${CMAKE_COMMAND}
+    -DTARGET=util/mkbuildinf.pl
+    -P ${CMAKE_CURRENT_LIST_DIR}/scrub_mkbuildinf.cmake
+)

--- a/airplay/src/main/cpp/cmake/scrub_mkbuildinf.cmake
+++ b/airplay/src/main/cpp/cmake/scrub_mkbuildinf.cmake
@@ -1,0 +1,8 @@
+file(READ "${TARGET}" _c)
+if(NOT _c MATCHES "ffile-prefix-map")
+    string(REPLACE
+        "my $cflags = join(' ', @ARGV);"
+        "my $cflags = join(' ', @ARGV);\n$cflags =~ s/-ffile-prefix-map=\\S+\\s*//g;"
+        _c "${_c}")
+    file(WRITE "${TARGET}" "${_c}")
+endif()

--- a/airplay/src/main/cpp/log_sink.h
+++ b/airplay/src/main/cpp/log_sink.h
@@ -1,0 +1,75 @@
+#ifndef LOG_SINK_H
+#define LOG_SINK_H
+
+#include <android/log.h>
+#include <jni.h>
+#include <cstdarg>
+#include <cstdio>
+
+#define LOG_SINK_TAG "AirPlayNative"
+
+/*
+ * log sink writing to both app log UI and logcat. any thread may emit, but emitting can
+ * be slow (JNI call)
+ */
+class LogSink {
+public:
+    // bind to Kotlin handler with `void onLog(String)` (bridge.LogListener)
+    void bind(JNIEnv *env, jobject handler) {
+        env->GetJavaVM(&mVm);
+        mObj = env->NewGlobalRef(handler);
+        jclass cls = env->GetObjectClass(handler);
+        mMethod = cls ? env->GetMethodID(cls, "onLog", "(Ljava/lang/String;)V") : nullptr;
+        if (cls) env->DeleteLocalRef(cls);
+    }
+
+    // releases handler global ref; thread safe
+    ~LogSink() {
+        if (!mVm || !mObj) return;
+        JNIEnv *env = nullptr;
+        bool attached = false;
+        if (mVm->GetEnv((void **)&env, JNI_VERSION_1_6) == JNI_EDETACHED) {
+            if (mVm->AttachCurrentThread(&env, nullptr) != JNI_OK) return;
+            attached = true;
+        }
+        env->DeleteGlobalRef(mObj);
+        if (attached) mVm->DetachCurrentThread();
+    }
+
+    // log level only affects logcat, UI ignores it
+    void info(const char *fmt, ...)  __attribute__((format(printf, 2, 3))) {
+        va_list ap; va_start(ap, fmt); vemit(ANDROID_LOG_INFO, fmt, ap); va_end(ap);
+    }
+    void warn(const char *fmt, ...)  __attribute__((format(printf, 2, 3))) {
+        va_list ap; va_start(ap, fmt); vemit(ANDROID_LOG_WARN, fmt, ap); va_end(ap);
+    }
+    void error(const char *fmt, ...) __attribute__((format(printf, 2, 3))) {
+        va_list ap; va_start(ap, fmt); vemit(ANDROID_LOG_ERROR, fmt, ap); va_end(ap);
+    }
+
+private:
+    void vemit(int prio, const char *fmt, va_list ap) {
+        char buf[256];
+        vsnprintf(buf, sizeof(buf), fmt, ap);
+        __android_log_print(prio, LOG_SINK_TAG, "%s", buf);
+        if (!mVm || !mObj || !mMethod) return;
+
+        JNIEnv *env = nullptr;
+        bool attached = false;
+        if (mVm->GetEnv((void **)&env, JNI_VERSION_1_6) == JNI_EDETACHED) {
+            if (mVm->AttachCurrentThread(&env, nullptr) != JNI_OK) return;
+            attached = true;
+        }
+        jstring s = env->NewStringUTF(buf);
+        env->CallVoidMethod(mObj, mMethod, s);
+        if (env->ExceptionCheck()) { env->ExceptionDescribe(); env->ExceptionClear(); }
+        env->DeleteLocalRef(s);
+        if (attached) mVm->DetachCurrentThread();
+    }
+
+    JavaVM *mVm = nullptr;
+    jobject mObj = nullptr;      // global ref to JNI handler
+    jmethodID mMethod = nullptr; // onLog(String)
+};
+
+#endif  // LOG_SINK_H

--- a/airplay/src/main/cpp/native_bridge.cpp
+++ b/airplay/src/main/cpp/native_bridge.cpp
@@ -1,0 +1,409 @@
+/*
+ * JNI bridge between Kotlin NativeBridge and the C RAOP library.
+ */
+
+#include <jni.h>
+#include <string.h>
+#include <stdlib.h>
+#include <memory>
+#include <android/log.h>
+
+extern "C" {
+#include "raop.h"
+#include "dnssd.h"
+#include "logger.h"
+#include "pairing.h"
+#include "android_raop_callbacks.h"
+#include "android_dnssd_shim.h"
+}
+
+#include "audio_engine.h"
+#include "log_sink.h"
+
+#define TAG "AirPlayNative"
+#define LOGI(...) __android_log_print(ANDROID_LOG_INFO, TAG, __VA_ARGS__)
+#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, TAG, __VA_ARGS__)
+
+/* Holds all native state for one server instance */
+typedef struct {
+    raop_t *raop;
+    dnssd_t *dnssd;
+    android_callback_ctx_t cb_ctx;
+    raop_callbacks_t callbacks;
+    char hw_addr[6];
+    std::shared_ptr<LogSink> log;
+} server_ctx_t;
+
+static void _log_callback(void *cls, int level, const char *msg) {
+    int prio = ANDROID_LOG_DEBUG;
+    if (level >= 5) prio = ANDROID_LOG_ERROR;
+    else if (level >= 4) prio = ANDROID_LOG_WARN;
+    else if (level >= 3) prio = ANDROID_LOG_INFO;
+    __android_log_print(prio, TAG, "%s", msg);
+}
+
+extern "C"
+JNIEXPORT jlong JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeInit(
+        JNIEnv *env, jobject thiz,
+        jobject callback, jbyteArray hwAddr, jstring name, jstring keyFile,
+        jboolean nohold, jboolean requirePin) {
+
+    server_ctx_t *ctx = new server_ctx_t();
+
+    jsize hw_len = env->GetArrayLength(hwAddr);
+    if (hw_len > 6) hw_len = 6;
+    env->GetByteArrayRegion(hwAddr, 0, hw_len, (jbyte *)ctx->hw_addr);
+
+    android_callbacks_init(&ctx->cb_ctx, env, callback);
+    ctx->cb_ctx.require_pin = requirePin ? 1 : 0;
+    android_callbacks_fill(&ctx->callbacks, &ctx->cb_ctx);
+
+    ctx->raop = raop_init(&ctx->callbacks);
+    if (!ctx->raop) {
+        LOGE("raop_init failed");
+        android_callbacks_destroy(&ctx->cb_ctx, env);
+        delete ctx;
+        return 0;
+    }
+    ctx->cb_ctx.raop = ctx->raop;
+
+    raop_set_log_level(ctx->raop, LOGGER_ERR);
+    raop_set_log_callback(ctx->raop, _log_callback, NULL);
+
+    const char *keyfile_c = env->GetStringUTFChars(keyFile, NULL);
+    const char *name_c = env->GetStringUTFChars(name, NULL);
+
+    char device_id[18];
+    snprintf(device_id, sizeof(device_id), "%02X:%02X:%02X:%02X:%02X:%02X",
+             (unsigned char)ctx->hw_addr[0], (unsigned char)ctx->hw_addr[1],
+             (unsigned char)ctx->hw_addr[2], (unsigned char)ctx->hw_addr[3],
+             (unsigned char)ctx->hw_addr[4], (unsigned char)ctx->hw_addr[5]);
+
+    int ret = raop_init2(ctx->raop, nohold ? 1 : 0, device_id, keyfile_c);
+    if (ret < 0) {
+        LOGE("raop_init2 failed: %d", ret);
+    }
+
+    if (requirePin) {
+        /* avoid UxPlay's random-PIN retry path: use one random PIN for this server run */
+        int pin = random_pin();
+        if (pin < 0) {
+            LOGE("Failed to generate random pin");
+            pin = 1234;
+        }
+        raop_set_plist(ctx->raop, "pin", pin + 10000);
+    }
+
+    /* shim dnssd_init only builds txt records; kotlin does the actual nsd registration */
+    int dns_err = 0;
+    unsigned char pin_pw = requirePin ? 1 : 0;
+    ctx->dnssd = dnssd_init(name_c, (int)strlen(name_c), ctx->hw_addr, 6, &dns_err, pin_pw);
+    if (!ctx->dnssd) {
+        LOGE("dnssd_init failed: %d", dns_err);
+    } else {
+        raop_set_dnssd(ctx->raop, ctx->dnssd);
+    }
+
+    env->ReleaseStringUTFChars(keyFile, keyfile_c);
+    env->ReleaseStringUTFChars(name, name_c);
+
+    ctx->log = std::make_shared<LogSink>();
+    ctx->log->bind(env, callback);
+
+    ctx->cb_ctx.audio_engine = audio_engine_create(ctx->log, 44100, 2);
+
+    return (jlong)(intptr_t)ctx;
+}
+
+extern "C"
+JNIEXPORT jint JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeStart(
+        JNIEnv *env, jobject thiz, jlong handle, jint requestedPort) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->raop) return -1;
+
+    unsigned short port = (unsigned short)(requestedPort > 0 ? requestedPort : 7000);
+    int ret = raop_start_httpd(ctx->raop, &port);
+    if (ret < 0) {
+        LOGE("raop_start_httpd failed: %d", ret);
+        return -1;
+    }
+    /* raop_start_httpd doesn't record the bound port; without this the hls
+       proxy urls are built with port 0 */
+    raop_set_port(ctx->raop, port);
+
+    LOGI("AirPlay server started on port %d", port);
+
+    /* Register dnssd records (stored in shim, Kotlin reads them) */
+    if (ctx->dnssd) {
+        dnssd_register_raop(ctx->dnssd, port);
+        dnssd_register_airplay(ctx->dnssd, port);
+    }
+
+    return (jint)port;
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeStop(
+        JNIEnv *env, jobject thiz, jlong handle) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->raop) return;
+
+    raop_stop_httpd(ctx->raop);
+    LOGI("AirPlay server stopped");
+
+    if (ctx->dnssd) {
+        dnssd_unregister_raop(ctx->dnssd);
+        dnssd_unregister_airplay(ctx->dnssd);
+    }
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeDestroy(
+        JNIEnv *env, jobject thiz, jlong handle) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx) return;
+
+    if (ctx->raop) {
+        raop_destroy(ctx->raop);
+        ctx->raop = NULL;
+    }
+    // engine teardown safe: raop_destroy() already ran, no decode() calls in flight
+    AudioEngine *engine = ctx->cb_ctx.audio_engine;
+    ctx->cb_ctx.audio_engine = NULL;
+    if (engine) audio_engine_destroy(engine);
+    if (ctx->dnssd) {
+        dnssd_destroy(ctx->dnssd);
+        ctx->dnssd = NULL;
+    }
+    android_callbacks_destroy(&ctx->cb_ctx, env);
+    delete ctx;
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeSetDisplaySize(
+        JNIEnv *env, jobject thiz, jlong handle, jint w, jint h, jint fps) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->raop) return;
+
+    raop_set_plist(ctx->raop, "width", w);
+    raop_set_plist(ctx->raop, "height", h);
+    raop_set_plist(ctx->raop, "refreshRate", fps);
+}
+
+/* Returns a HashMap<String, String> of TXT records */
+static jobject _build_txt_map(JNIEnv *env, dnssd_t *dnssd, int is_raop) {
+    jclass mapClass = env->FindClass("java/util/HashMap");
+    jmethodID mapInit = env->GetMethodID(mapClass, "<init>", "()V");
+    jmethodID mapPut = env->GetMethodID(mapClass, "put",
+        "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+    jobject map = env->NewObject(mapClass, mapInit);
+
+    int count = is_raop ? android_dnssd_get_raop_txt_count(dnssd)
+                        : android_dnssd_get_airplay_txt_count(dnssd);
+
+    for (int i = 0; i < count; i++) {
+        const char *key = is_raop ? android_dnssd_get_raop_txt_key(dnssd, i)
+                                  : android_dnssd_get_airplay_txt_key(dnssd, i);
+        const char *val = is_raop ? android_dnssd_get_raop_txt_val(dnssd, i)
+                                  : android_dnssd_get_airplay_txt_val(dnssd, i);
+        if (key && val) {
+            jstring jkey = env->NewStringUTF(key);
+            jstring jval = env->NewStringUTF(val);
+            env->CallObjectMethod(map, mapPut, jkey, jval);
+            env->DeleteLocalRef(jkey);
+            env->DeleteLocalRef(jval);
+        }
+    }
+
+    env->DeleteLocalRef(mapClass);
+    return map;
+}
+
+extern "C"
+JNIEXPORT jobject JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeGetRaopTxtRecords(
+        JNIEnv *env, jobject thiz, jlong handle) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->dnssd) return NULL;
+    return _build_txt_map(env, ctx->dnssd, 1);
+}
+
+extern "C"
+JNIEXPORT jobject JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeGetAirplayTxtRecords(
+        JNIEnv *env, jobject thiz, jlong handle) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->dnssd) return NULL;
+    return _build_txt_map(env, ctx->dnssd, 0);
+}
+
+extern "C"
+JNIEXPORT jstring JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeGetRaopServiceName(
+        JNIEnv *env, jobject thiz, jlong handle) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->dnssd) return NULL;
+    return env->NewStringUTF(android_dnssd_get_raop_servname(ctx->dnssd));
+}
+
+extern "C"
+JNIEXPORT jstring JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeGetServerName(
+        JNIEnv *env, jobject thiz, jlong handle) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->dnssd) return NULL;
+    int len = 0;
+    const char *name = dnssd_get_name(ctx->dnssd, &len);
+    return env->NewStringUTF(name);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeSetPlist(
+        JNIEnv *env, jobject thiz, jlong handle, jstring key, jint value) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->raop) return;
+    const char *key_c = env->GetStringUTFChars(key, NULL);
+    raop_set_plist(ctx->raop, key_c, value);
+    env->ReleaseStringUTFChars(key, key_c);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeSetH265Enabled(
+        JNIEnv *env, jobject thiz, jlong handle, jboolean enabled) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx) return;
+    ctx->cb_ctx.h265_enabled = enabled ? 1 : 0;
+    /* Set DNS-SD feature bit 42 (SupportsScreenMultiCodec) for H265 */
+    if (ctx->dnssd) {
+        dnssd_set_airplay_features(ctx->dnssd, 42, enabled ? 1 : 0);
+    }
+}
+
+/* hls plist gates raop.c's hls support; feature bits 0/4 advertise it over dns-sd */
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeSetHlsEnabled(
+        JNIEnv *env, jobject thiz, jlong handle, jboolean enabled) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->raop) return;
+    raop_set_plist(ctx->raop, "hls", enabled ? 1 : 0);
+    if (ctx->dnssd) {
+        dnssd_set_airplay_features(ctx->dnssd, 0, enabled ? 1 : 0);
+        dnssd_set_airplay_features(ctx->dnssd, 4, enabled ? 1 : 0);
+    }
+}
+
+/* feature bit 9 advertises audio support over dns-sd */
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeSetAudioEnabled(
+        JNIEnv *env, jobject thiz, jlong handle, jboolean enabled) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->dnssd) return;
+    dnssd_set_airplay_features(ctx->dnssd, 9, enabled ? 1 : 0);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeSetCodecs(
+        JNIEnv *env, jobject thiz, jlong handle, jboolean alac, jboolean aac) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->dnssd) return;
+    android_dnssd_set_codecs(ctx->dnssd, alac ? 1 : 0, aac ? 1 : 0);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeUpdatePlaybackInfo(
+        JNIEnv *env, jobject thiz, jlong handle,
+        jfloat position, jfloat duration, jfloat rate, jboolean readyToPlay) {
+
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx) return;
+    android_callbacks_update_playback_info(&ctx->cb_ctx, position, duration, rate, readyToPlay ? 1 : 0);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeSetDefaultStreamValues(
+        JNIEnv *env, jobject thiz, jint sampleRate, jint framesPerBurst) {
+    audio_engine_set_default_stream_values(sampleRate, framesPerBurst);
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeServerAudioStart(
+        JNIEnv *env, jobject thiz, jlong handle) {
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->cb_ctx.audio_engine) return JNI_FALSE;
+    return audio_engine_start(ctx->cb_ctx.audio_engine) ? JNI_TRUE : JNI_FALSE;
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeServerAudioStop(
+        JNIEnv *env, jobject thiz, jlong handle) {
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (ctx && ctx->cb_ctx.audio_engine) audio_engine_pause(ctx->cb_ctx.audio_engine);
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeServerAudioConfigure(
+        JNIEnv *env, jobject thiz, jlong handle, jint cushionMs, jint percentilePct,
+        jint oboeBufferFrames, jboolean forceSwAlac, jboolean realtimePriority, jboolean lowLatency,
+        jboolean benchmarkLog) {
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->cb_ctx.audio_engine) return JNI_FALSE;
+    return audio_engine_configure(ctx->cb_ctx.audio_engine, cushionMs, percentilePct,
+                                  oboeBufferFrames, forceSwAlac, realtimePriority, lowLatency,
+                                  benchmarkLog) ? JNI_TRUE : JNI_FALSE;
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeServerAudioSetVolume(
+        JNIEnv *env, jobject thiz, jlong handle, jfloat volume) {
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (ctx && ctx->cb_ctx.audio_engine) audio_engine_set_volume(ctx->cb_ctx.audio_engine, volume);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeServerAudioFormat(
+        JNIEnv *env, jobject thiz, jlong handle, jint ct, jint spf) {
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (ctx && ctx->cb_ctx.audio_engine) audio_engine_on_format(ctx->cb_ctx.audio_engine, ct, spf);
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_io_github_jqssun_airplay_bridge_NativeBridge_nativeServerAudioDebug(
+        JNIEnv *env, jobject thiz, jlong handle, jobject buf) {
+    server_ctx_t *ctx = (server_ctx_t *)(intptr_t)handle;
+    if (!ctx || !ctx->cb_ctx.audio_engine || !buf) return JNI_FALSE;
+    void *addr = env->GetDirectBufferAddress(buf);
+    jlong cap = env->GetDirectBufferCapacity(buf);
+    if (!addr || cap <= 0) return JNI_FALSE;
+    return audio_engine_get_debug(ctx->cb_ctx.audio_engine, addr, (size_t)cap) ? JNI_TRUE : JNI_FALSE;
+}

--- a/airplay/src/main/cpp/patches/UxPlay/0001-fix-hls-playlist-crash.patch
+++ b/airplay/src/main/cpp/patches/UxPlay/0001-fix-hls-playlist-crash.patch
@@ -1,0 +1,194 @@
+diff --git a/lib/airplay_video.c b/lib/airplay_video.c
+index 19505b2..fa8eeb4 100644
+--- a/lib/airplay_video.c
++++ b/lib/airplay_video.c
+@@ -64,6 +64,18 @@ struct airplay_video_s {
+     int num_uri;
+ };
+ 
++static char *_raw_copy_playlist(const char *s) {
++    size_t len = strlen(s);
++    char *copy = (char *) malloc(len + 1);
++    if (!copy) {
++        printf("Memory allocation failure (playlist_copy)\n");
++        exit(1);
++    }
++    memcpy(copy, s, len);
++    copy[len] = '\0';
++    return copy;
++}
++
+ //  initialize airplay_video service.
+ airplay_video_t *airplay_video_init(raop_t *raop, unsigned short http_port, const char *lang) {
+     char uri[] = "http://localhost:";
+@@ -631,10 +643,12 @@ int store_media_playlist(airplay_video_t *airplay_video, char * media_playlist,
+     /* dont store duplicate media paylists */
+     for (int i = 0; i < num ; i++) {
+         if (strcmp(media_data_store[i].uri, media_data_store[num].uri) == 0) {
+-            assert(strcmp(media_data_store[i].playlist, media_playlist) == 0);
+-            media_data_store[num].num = i;
+-            free (media_playlist);
+-            return 1;
++            if (strcmp(media_data_store[i].playlist, media_playlist) == 0) {
++                media_data_store[num].num = i;
++                free (media_playlist);
++                return 1;
++            }
++            break;
+         }
+     }
+     media_item_t *media_item = &media_data_store[num];
+@@ -791,59 +805,45 @@ char *adjust_master_playlist (char *fcup_response_data, int fcup_response_datale
+     return new_master;
+ }
+ 
++static char *_quoted_field(const char *hay, const char *key, size_t *len) {
++    const char *begin = strstr(hay, key);
++    if (begin) begin = strchr(begin, '"');
++    if (!begin) return NULL;
++    begin++;
++    const char *end = strchr(begin, '"');
++    if (!end) return NULL;
++    *len = end - begin;
++    char *val = (char *) calloc(*len + 1, sizeof(char));
++    assert(val);
++    memcpy(val, begin, *len);
++    return val;
++}
++
+ char *adjust_yt_condensed_playlist(const char *media_playlist) {
+ /* this copies a Media Playlist into a null-terminated string. 
+    If it has the "#YT-EXT-CONDENSED-URI" header, it is also expanded into 
+    the full Media Playlist format.
+    It  returns a pointer to the expanded playlist, WHICH MUST BE FREED AFTER USE */
+ 
+-    const char *base_uri_begin;
+-    const char *params_begin;
+-    const char *prefix_begin;
+-    size_t base_uri_len;
+-    size_t params_len;
+-    size_t prefix_len;
++    size_t base_uri_len = 0;
++    size_t params_len = 0;
++    size_t prefix_len = 0;
+     const char* ptr = strstr(media_playlist, "#EXTM3U\n");
++    if (!ptr) return _raw_copy_playlist(media_playlist);
+ 
+     ptr += strlen("#EXTM3U\n");
+-    assert(ptr);
+     if (strncmp(ptr, "#YT-EXT-CONDENSED-URL", strlen("#YT-EXT-CONDENSED-URL"))) {
+-        size_t len = strlen(media_playlist);
+-        char * playlist_copy = (char *) malloc(len + 1);
+-        if (!playlist_copy) {
+-            printf("Memory allocation failure (playlist_copy)\n");
+-            exit(1);
+-        }
+-        memcpy(playlist_copy, media_playlist, len);
+-        playlist_copy[len] = '\0';
+-        return playlist_copy;
+-    }
+-    ptr = strstr(ptr, "BASE-URI=");
+-    base_uri_begin = strchr(ptr, '"');
+-    base_uri_begin++;
+-    ptr = strchr(base_uri_begin, '"');
+-    base_uri_len = ptr - base_uri_begin;
+-    char *base_uri = (char *) calloc(base_uri_len + 1, sizeof(char));
+-    assert(base_uri);
+-    memcpy(base_uri, base_uri_begin, base_uri_len);  //must free
+-
+-    ptr = strstr(ptr, "PARAMS=");
+-    params_begin = strchr(ptr, '"');
+-    params_begin++;
+-    ptr = strchr(params_begin,'"');
+-    params_len = ptr - params_begin;
+-    char *params = (char *) calloc(params_len + 1, sizeof(char));
+-    assert(params);
+-    memcpy(params, params_begin, params_len);  //must free
+-
+-    ptr = strstr(ptr, "PREFIX=");
+-    prefix_begin = strchr(ptr, '"');
+-    prefix_begin++;
+-    ptr = strchr(prefix_begin,'"');
+-    prefix_len = ptr - prefix_begin;
+-    char *prefix = (char *) calloc(prefix_len + 1, sizeof(char));
+-    assert(prefix);
+-    memcpy(prefix, prefix_begin, prefix_len);  //must free
++        return _raw_copy_playlist(media_playlist);
++    }
++    char *base_uri = _quoted_field(ptr, "BASE-URI=", &base_uri_len);
++    char *params = _quoted_field(ptr, "PARAMS=", &params_len);
++    char *prefix = _quoted_field(ptr, "PREFIX=", &prefix_len);
++    if (!base_uri || !params || !prefix) {
++        free(base_uri);
++        free(params);
++        free(prefix);
++        return _raw_copy_playlist(media_playlist);
++    }
+ 
+     /* expand params */
+     int nparams = 0;
+@@ -886,8 +886,7 @@ char *adjust_yt_condensed_playlist(const char *media_playlist) {
+     }
+ 
+     size_t old_size = strlen(media_playlist);
+-    size_t new_len = old_size;
+-    new_len += count * (base_uri_len + params_len);
++    size_t new_len = old_size + (size_t) count * (base_uri_len + params_len + 2 * nparams + 2);
+ 
+     int byte_count = 0;
+     char * new_playlist = (char *) malloc(new_len + 1);
+@@ -900,7 +899,7 @@ char *adjust_yt_condensed_playlist(const char *media_playlist) {
+     char *new_pos = new_playlist;
+     ptr = old_pos;
+     ptr = strstr(old_pos, "#EXTINF:");
+-    size_t len = ptr - old_pos;
++    size_t len = (ptr ? ptr : old_pos + strlen(old_pos)) - old_pos;
+     /* copy header section before chunks */
+     memcpy(new_pos, old_pos, len);
+     byte_count += len;
+@@ -910,6 +909,7 @@ char *adjust_yt_condensed_playlist(const char *media_playlist) {
+         /* for each chunk */
+         const char *end = NULL;
+         const char *start = strstr(ptr, prefix);
++        if (!start) break;
+         len = start - ptr;
+         /* copy first line of chunk entry */
+         memcpy(new_pos, old_pos, len);
+@@ -945,6 +945,7 @@ char *adjust_yt_condensed_playlist(const char *media_playlist) {
+             byte_count++;
+             new_pos++;
+ 
++            if (!end) end = old_pos + strlen(old_pos);
+             len = end - old_pos;
+             end++;
+ 
+@@ -965,7 +966,8 @@ char *adjust_yt_condensed_playlist(const char *media_playlist) {
+     new_pos += len;
+     old_pos += len;
+ 
+-    assert(byte_count == (int) new_len);
++    new_playlist[byte_count] = '\0';
++    assert(byte_count <= (int) new_len);
+ 
+     free (prefix);
+     free (base_uri);
+diff --git a/lib/http_handlers.h b/lib/http_handlers.h
+index 7984be8..aa985bf 100644
+--- a/lib/http_handlers.h
++++ b/lib/http_handlers.h
+@@ -468,7 +468,6 @@ http_handler_action(raop_conn_t *conn, http_request_t *request, http_response_t
+ 
+     raop_t *raop = conn->raop;
+     airplay_video_t *airplay_video = (airplay_video_t *) hls_get_current_video(raop);
+-    assert(airplay_video);
+     bool data_is_plist = false;
+     plist_t req_root_node = NULL;
+     uint64_t uint_val = 0;
+@@ -476,6 +475,7 @@ http_handler_action(raop_conn_t *conn, http_request_t *request, http_response_t
+     int fcup_response_statuscode = 0;
+     char *type = NULL;
+     bool logger_debug = (logger_get_level(raop->logger) >= LOGGER_DEBUG);
++    if (!airplay_video) goto post_action_error;
+ 
+     const char* session_id = http_request_get_header(request, "X-Apple-Session-ID");
+     if (!session_id) {

--- a/airplay/src/main/cpp/patches/UxPlay/0002-fix-uaf-on-playlist-refresh.patch
+++ b/airplay/src/main/cpp/patches/UxPlay/0002-fix-uaf-on-playlist-refresh.patch
@@ -1,0 +1,159 @@
+diff --git a/lib/airplay_video.c b/lib/airplay_video.c
+index 39c83a0..21d342d 100644
+--- a/lib/airplay_video.c
++++ b/lib/airplay_video.c
+@@ -22,6 +22,7 @@
+ #include <string.h>
+ #include <stdbool.h>
+ #include <assert.h>
++#include <pthread.h>
+ 
+ #include "raop.h"
+ #include "airplay_video.h"
+@@ -62,6 +63,7 @@ struct airplay_video_s {
+     char *master_playlist;
+     media_item_t *media_data_store;
+     int num_uri;
++    pthread_mutex_t media_data_store_lock;
+ };
+ 
+ static char *_raw_copy_playlist(const char *s) {
+@@ -110,6 +112,7 @@ airplay_video_t *airplay_video_init(raop_t *raop, unsigned short http_port, cons
+     airplay_video->media_data_store = NULL;
+     airplay_video->master_playlist = NULL;
+     airplay_video->num_uri = 0;
++    pthread_mutex_init(&airplay_video->media_data_store_lock, NULL);
+     airplay_video->next_uri = 0;
+     return airplay_video;
+ }
+@@ -138,9 +141,12 @@ airplay_video_destroy(airplay_video_t *airplay_video) {
+     if (airplay_video->language_code) {
+        free(airplay_video->language_code);
+     }
++    pthread_mutex_lock(&airplay_video->media_data_store_lock);
+     if (airplay_video->media_data_store) {
+         destroy_media_data_store(airplay_video);
+     }
++    pthread_mutex_unlock(&airplay_video->media_data_store_lock);
++    pthread_mutex_destroy(&airplay_video->media_data_store_lock);
+     if (airplay_video->master_playlist){
+         free (airplay_video->master_playlist);
+     }
+@@ -306,10 +312,12 @@ int get_next_media_uri_id(airplay_video_t *airplay_video) {
+ }
+ 
+ void store_master_playlist(airplay_video_t *airplay_video, char *master_playlist) {
++    pthread_mutex_lock(&airplay_video->media_data_store_lock);
+     if (airplay_video->master_playlist) {
+         free (airplay_video->master_playlist);
+     }
+     airplay_video->master_playlist = master_playlist;
++    pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+ }
+ 
+ typedef struct language_s {
+@@ -536,7 +544,10 @@ char * select_master_playlist_language(airplay_video_t *airplay_video, char *mas
+ }
+ 
+ char *get_master_playlist(airplay_video_t *airplay_video) {
+-    return  airplay_video->master_playlist;
++    pthread_mutex_lock(&airplay_video->media_data_store_lock);
++    char *copy = airplay_video->master_playlist ? _raw_copy_playlist(airplay_video->master_playlist) : NULL;
++    pthread_mutex_unlock(&airplay_video->media_data_store_lock);
++    return copy;
+ }
+ 
+ /* media_data_store */
+@@ -562,6 +573,7 @@ void destroy_media_data_store(airplay_video_t *airplay_video) {
+ }
+ 
+ void create_media_data_store(airplay_video_t * airplay_video, char ** uri_list, int num_uri) {  
++    pthread_mutex_lock(&airplay_video->media_data_store_lock);
+     destroy_media_data_store(airplay_video);
+     media_item_t *media_data_store = calloc(num_uri, sizeof(media_item_t));
+     if (!media_data_store) {
+@@ -581,6 +593,7 @@ void create_media_data_store(airplay_video_t * airplay_video, char ** uri_list,
+     }
+     airplay_video->media_data_store = media_data_store;
+     airplay_video->num_uri = num_uri;
++    pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+ }
+ 
+ 
+@@ -634,10 +647,13 @@ static int parse_media_playlist(media_item_t *media_item) {
+ }
+ 
+ int store_media_playlist(airplay_video_t *airplay_video, char * media_playlist, int *count, float *duration, bool *endlist, int num) {
++    pthread_mutex_lock(&airplay_video->media_data_store_lock);
+     media_item_t *media_data_store = airplay_video->media_data_store;
+     if ( num < 0 ||  num >= airplay_video->num_uri) {
++        pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+         return -1;
+     } else if (media_data_store[num].playlist) {
++        pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+         return -2;
+     }
+     /* dont store duplicate media paylists */
+@@ -646,6 +662,7 @@ int store_media_playlist(airplay_video_t *airplay_video, char * media_playlist,
+             if (strcmp(media_data_store[i].playlist, media_playlist) == 0) {
+                 media_data_store[num].num = i;
+                 free (media_playlist);
++                pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+                 return 1;
+             }
+             break;
+@@ -657,21 +674,31 @@ int store_media_playlist(airplay_video_t *airplay_video, char * media_playlist,
+     media_item->duration = *duration;
+     media_item->endlist = *endlist;
+     parse_media_playlist(media_item);
++    pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+     return 0;
+ }
+ 
+ char * get_media_playlist(airplay_video_t *airplay_video, int *count, float *duration, const char *uri) {
++    pthread_mutex_lock(&airplay_video->media_data_store_lock);
+     media_item_t *media_data_store = airplay_video->media_data_store;
+     if (media_data_store == NULL) {
++        pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+         return NULL;
+     }
+     for (int i = 0; i < airplay_video->num_uri; i++) {
+         if (strstr(media_data_store[i].uri, uri)) {
+-            *count = media_data_store[media_data_store[i].num].count;
+-            *duration = media_data_store[media_data_store[i].num].duration;
+-            return media_data_store[media_data_store[i].num].playlist;
++            const char *playlist = media_data_store[media_data_store[i].num].playlist;
++            char *copy = NULL;
++            if (playlist) {
++                *count = media_data_store[media_data_store[i].num].count;
++                *duration = media_data_store[media_data_store[i].num].duration;
++                copy = _raw_copy_playlist(playlist);
++            }
++            pthread_mutex_unlock(&airplay_video->media_data_store_lock);
++            return copy;
+         }
+     }
++    pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+     return NULL;
+ }
+ 
+diff --git a/lib/http_handlers.h b/lib/http_handlers.h
+index aa985bf..fbc7a7a 100644
+--- a/lib/http_handlers.h
++++ b/lib/http_handlers.h
+@@ -978,6 +978,7 @@ http_handler_hls(raop_conn_t *conn,  http_request_t *request, http_response_t *r
+             }
+             memcpy(data, master_playlist, len);
+             data[len] = '\0';
++            free(master_playlist);
+             *response_data = data;
+             *response_datalen = (int ) len;
+         } else {
+@@ -990,6 +991,7 @@ http_handler_hls(raop_conn_t *conn,  http_request_t *request, http_response_t *r
+         char *media_playlist = get_media_playlist(airplay_video, &chunks, &duration, url);
+         if (media_playlist) {
+             char *data  = adjust_yt_condensed_playlist(media_playlist);
++            free(media_playlist);
+             *response_data = data;
+             *response_datalen = strlen(data);
+             logger_log(raop->logger, LOGGER_INFO,

--- a/airplay/src/main/cpp/patches/UxPlay/0003-refresh-live-media-playlists-on-demand.patch
+++ b/airplay/src/main/cpp/patches/UxPlay/0003-refresh-live-media-playlists-on-demand.patch
@@ -1,0 +1,278 @@
+diff --git a/lib/airplay_video.c b/lib/airplay_video.c
+index ec478dd..1b8c61c 100644
+--- a/lib/airplay_video.c
++++ b/lib/airplay_video.c
+@@ -23,10 +23,13 @@
+ #include <stdbool.h>
+ #include <assert.h>
+ #include <pthread.h>
++#include <time.h>
+ 
+ #include "raop.h"
+ #include "airplay_video.h"
+ 
++#define MEDIA_PLAYLIST_REFRESH_SECS 5
++
+ typedef enum playlist_type_e {
+     NONE,
+     VOD,
+@@ -43,6 +46,8 @@ struct media_item_s {
+     playlist_type_t playlist_type;
+     int hls_version;
+     int media_sequence;
++    bool fetch_pending;
++    time_t last_fetched;
+ };
+ 
+ struct airplay_video_s {
+@@ -64,6 +69,7 @@ struct airplay_video_s {
+     media_item_t *media_data_store;
+     int num_uri;
+     pthread_mutex_t media_data_store_lock;
++    bool initial_fetch_complete;
+ };
+ 
+ static char *_raw_copy_playlist(const char *s) {
+@@ -593,9 +599,18 @@ void create_media_data_store(airplay_video_t * airplay_video, char ** uri_list,
+     }
+     airplay_video->media_data_store = media_data_store;
+     airplay_video->num_uri = num_uri;
++    airplay_video->initial_fetch_complete = false;
+     pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+ }
+ 
++void set_initial_fetch_complete(airplay_video_t *airplay_video) {
++    airplay_video->initial_fetch_complete = true;
++}
++
++bool get_initial_fetch_complete(airplay_video_t *airplay_video) {
++    return airplay_video->initial_fetch_complete;
++}
++
+ 
+ static int parse_media_playlist(media_item_t *media_item) {
+     const char *ptr = media_item->playlist;
+@@ -652,20 +667,28 @@ int store_media_playlist(airplay_video_t *airplay_video, char * media_playlist,
+     if ( num < 0 ||  num >= airplay_video->num_uri) {
+         pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+         return -1;
+-    } else if (media_data_store[num].playlist) {
++    } else if (media_data_store[num].playlist && !media_data_store[num].fetch_pending) {
+         pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+         return -2;
+     }
+-    /* dont store duplicate media paylists */
+-    for (int i = 0; i < num ; i++) {
+-        if (strcmp(media_data_store[i].uri, media_data_store[num].uri) == 0) {
+-            if (strcmp(media_data_store[i].playlist, media_playlist) == 0) {
+-                media_data_store[num].num = i;
+-                free (media_playlist);
+-                pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+-                return 1;
++    if (media_data_store[num].fetch_pending) {
++        media_data_store[num].fetch_pending = false;
++        if (media_data_store[num].playlist) {
++            free(media_data_store[num].playlist);
++            media_data_store[num].playlist = NULL;
++        }
++    } else {
++        /* dont store duplicate media paylists */
++        for (int i = 0; i < num ; i++) {
++            if (strcmp(media_data_store[i].uri, media_data_store[num].uri) == 0) {
++                if (strcmp(media_data_store[i].playlist, media_playlist) == 0) {
++                    media_data_store[num].num = i;
++                    free (media_playlist);
++                    pthread_mutex_unlock(&airplay_video->media_data_store_lock);
++                    return 1;
++                }
++                break;
+             }
+-            break;
+         }
+     }
+     media_item_t *media_item = &media_data_store[num];
+@@ -673,12 +696,14 @@ int store_media_playlist(airplay_video_t *airplay_video, char * media_playlist,
+     media_item->count = *count;
+     media_item->duration = *duration;
+     media_item->endlist = *endlist;
++    media_item->last_fetched = time(NULL);
+     parse_media_playlist(media_item);
+     pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+     return 0;
+ }
+ 
+-char * get_media_playlist(airplay_video_t *airplay_video, int *count, float *duration, const char *uri) {
++char * get_media_playlist(airplay_video_t *airplay_video, int *count, float *duration, const char *uri, bool *should_fetch, const char **remote_uri) {
++    *should_fetch = false;
+     pthread_mutex_lock(&airplay_video->media_data_store_lock);
+     media_item_t *media_data_store = airplay_video->media_data_store;
+     if (media_data_store == NULL) {
+@@ -687,12 +712,20 @@ char * get_media_playlist(airplay_video_t *airplay_video, int *count, float *dur
+     }
+     for (int i = 0; i < airplay_video->num_uri; i++) {
+         if (strstr(media_data_store[i].uri, uri)) {
+-            const char *playlist = media_data_store[media_data_store[i].num].playlist;
++            media_item_t *item = &media_data_store[media_data_store[i].num];
+             char *copy = NULL;
+-            if (playlist) {
+-                *count = media_data_store[media_data_store[i].num].count;
+-                *duration = media_data_store[media_data_store[i].num].duration;
+-                copy = _raw_copy_playlist(playlist);
++            bool stale = true;
++            if (item->playlist) {
++                *count = item->count;
++                *duration = item->duration;
++                copy = _raw_copy_playlist(item->playlist);
++                stale = !item->endlist &&
++                        time(NULL) - item->last_fetched >= MEDIA_PLAYLIST_REFRESH_SECS;
++            }
++            if (stale && !item->fetch_pending) {
++                item->fetch_pending = true;
++                *should_fetch = true;
++                *remote_uri = item->uri;
+             }
+             pthread_mutex_unlock(&airplay_video->media_data_store_lock);
+             return copy;
+@@ -710,6 +743,22 @@ char * get_media_uri_by_num(airplay_video_t *airplay_video, int num) {
+     return NULL;
+ }
+ 
++int get_media_uri_index_by_remote_url(airplay_video_t *airplay_video, const char *remote_url) {
++    pthread_mutex_lock(&airplay_video->media_data_store_lock);
++    media_item_t *media_data_store = airplay_video->media_data_store;
++    int found = -1;
++    if (media_data_store) {
++        for (int i = 0; i < airplay_video->num_uri; i++) {
++            if (media_data_store[i].uri && strcmp(media_data_store[i].uri, remote_url) == 0) {
++                found = i;
++                break;
++            }
++        }
++    }
++    pthread_mutex_unlock(&airplay_video->media_data_store_lock);
++    return found;
++}
++
+ int analyze_media_playlist(char *playlist, float *duration, bool *endlist) {
+     float next;
+     int count = 0;
+@@ -958,10 +1007,17 @@ char *adjust_yt_condensed_playlist(const char *media_playlist) {
+             if (i != last) {
+                 end = strchr(end, '/');
+             } else {
+-                /* the next line starts with either #EXTINF (usually) 
++                /* the next line starts with either #EXTINF (usually)
+                 or #EXT-X-ENDLIST (at last chunk)*/
+ 	            end = strstr(end, "#EXT");
+             }
++            if (!end) {
++                if (i == last) {
++                    end = old_pos + strlen(old_pos);
++                } else {
++                    goto stop_rewriting_chunks;
++                }
++            }
+             *new_pos = '/';
+             byte_count++;
+             new_pos++;
+@@ -972,7 +1028,9 @@ char *adjust_yt_condensed_playlist(const char *media_playlist) {
+             byte_count++;
+             new_pos++;
+ 
+-            if (!end) end = old_pos + strlen(old_pos);
++            if (end < old_pos) {
++                goto stop_rewriting_chunks;
++            }
+             len = end - old_pos;
+             end++;
+ 
+@@ -984,7 +1042,11 @@ char *adjust_yt_condensed_playlist(const char *media_playlist) {
+                 old_pos++; /* last entry is not followed by "/" separator */
+             }
+         }
++        if (ptr && old_pos != ptr) {
++            goto stop_rewriting_chunks;
++        }
+     }
++ stop_rewriting_chunks:
+     /* copy tail */
+      
+     len = media_playlist + strlen(media_playlist) - old_pos;
+diff --git a/lib/airplay_video.h b/lib/airplay_video.h
+index 95ad87c..77fdcb0 100644
+--- a/lib/airplay_video.h
++++ b/lib/airplay_video.h
+@@ -51,6 +51,9 @@ void set_next_media_uri_id(airplay_video_t *airplay_video, int id);
+ int get_next_media_uri_id(airplay_video_t *airplay_video);
+ int get_num_media_uri(airplay_video_t *airplay_video);
+ char *get_media_uri_by_num(airplay_video_t *airplay_video, int num);
++int get_media_uri_index_by_remote_url(airplay_video_t *airplay_video, const char *remote_url);
++void set_initial_fetch_complete(airplay_video_t *airplay_video);
++bool get_initial_fetch_complete(airplay_video_t *airplay_video);
+ 
+ int analyze_media_playlist(char *playlist, float *duration, bool *endlist);
+ int create_media_uri_table(const char *url_prefix, const char *master_playlist_data,
+@@ -59,7 +62,7 @@ void store_master_playlist(airplay_video_t *airplay_video, char *master_playlist
+ char *select_master_playlist_language(airplay_video_t *airplay_video, char *master_playlist);
+ int store_media_playlist(airplay_video_t *airplay_video, char *media_playlist, int *count, float *duration, bool*endlist, int num);
+ char *get_master_playlist(airplay_video_t *airplay_video);
+-char *get_media_playlist(airplay_video_t *airplay_video, int *count, float *duration, const char *uri);
++char *get_media_playlist(airplay_video_t *airplay_video, int *count, float *duration, const char *uri, bool *should_fetch, const char **remote_uri);
+ 
+ void destroy_media_data_store(airplay_video_t *airplay_video);
+ void create_media_data_store(airplay_video_t * airplay_video, char ** media_data_store, int num_uri);
+diff --git a/lib/http_handlers.h b/lib/http_handlers.h
+index fbc7a7a..f49e62c 100644
+--- a/lib/http_handlers.h
++++ b/lib/http_handlers.h
+@@ -676,6 +676,18 @@ http_handler_action(raop_conn_t *conn, http_request_t *request, http_response_t
+             float duration = 0.0f;
+             bool endlist = false;
+             int count = analyze_media_playlist(playlist, &duration, &endlist);
++            if (get_initial_fetch_complete(airplay_video)) {
++                int uri_num = get_media_uri_index_by_remote_url(airplay_video, fcup_response_url);
++                if (uri_num < 0) {
++                    free(playlist);
++                } else {
++                    store_media_playlist(airplay_video, playlist, &count, &duration, &endlist, uri_num);
++                }
++                plist_mem_free(fcup_response_url);
++                plist_mem_free(type);
++                plist_free(req_root_node);
++                return;
++            }
+             int uri_num = get_next_media_uri_id(airplay_video);
+             --uri_num;    // (next num is current num + 1)
+             int ret = store_media_playlist(airplay_video, playlist, &count, &duration, &endlist, uri_num);
+@@ -698,6 +710,7 @@ http_handler_action(raop_conn_t *conn, http_request_t *request, http_response_t
+                                                              get_next_FCUP_RequestID(airplay_video));
+             set_next_media_uri_id(airplay_video, ++uri_num);
+         } else {
++            set_initial_fetch_complete(airplay_video);
+             raop->callbacks.on_video_play(raop->callbacks.cls,
+                                                 get_playback_location(airplay_video),
+                                                 get_start_position_seconds(airplay_video));
+@@ -988,7 +1001,9 @@ http_handler_hls(raop_conn_t *conn,  http_request_t *request, http_response_t *r
+     } else {
+         int chunks = 0;
+         float duration = 0.0f;
+-        char *media_playlist = get_media_playlist(airplay_video, &chunks, &duration, url);
++        bool should_fetch = false;
++        const char *remote_uri = NULL;
++        char *media_playlist = get_media_playlist(airplay_video, &chunks, &duration, url, &should_fetch, &remote_uri);
+         if (media_playlist) {
+             char *data  = adjust_yt_condensed_playlist(media_playlist);
+             free(media_playlist);
+@@ -999,7 +1014,11 @@ http_handler_hls(raop_conn_t *conn,  http_request_t *request, http_response_t *r
+         } else {
+             logger_log(raop->logger, LOGGER_ERR,"requested media playlist %s not found", url); 
+         }
+-	    
++        if (should_fetch) {
++            fcup_request((void *) conn, remote_uri, get_apple_session_id(airplay_video),
++                         get_next_FCUP_RequestID(airplay_video));
++        }
++
+     }
+ 
+     http_response_add_header(response, "Access-Control-Allow-Headers", "Content-type");

--- a/airplay/src/main/cpp/patches/UxPlay/0004-video-sender-compat.patch
+++ b/airplay/src/main/cpp/patches/UxPlay/0004-video-sender-compat.patch
@@ -1,0 +1,277 @@
+diff --git a/lib/http_handlers.h b/lib/http_handlers.h
+index f49e62c..8a3f192 100644
+--- a/lib/http_handlers.h
++++ b/lib/http_handlers.h
+@@ -738,17 +738,33 @@ http_handler_action(raop_conn_t *conn, http_request_t *request, http_response_t
+    "start position in seconds".   Once this request is received by the Sever, the Server sends a POST /event
+    "FCUP Request" request to the Client on the reverse http channel, to request the HLS Master Playlist */
+ 
++static char *_plist_dup_string(plist_t dict, const char *key) {
++    plist_t node = plist_dict_get_item(dict, key);
++    char *val = NULL;
++    if (node) {
++        plist_get_string_val(node, &val);
++    }
++    if (!val) {
++        return NULL;
++    }
++    char *copy = strdup(val);
++    plist_mem_free(val);
++    return copy;
++}
++
+ static void
+ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *response,
+                       char **response_data, int *response_datalen) {
+     raop_t *raop = conn->raop;
+     char* playback_location = NULL;
++    char* playback_uuid = NULL;
+     char* client_proc_name = NULL;
+     plist_t req_root_node = NULL;
+     float start_position_seconds = 0.0f;
+     bool data_is_binary_plist = false;
+     char supported_hls_proc_names[] = "YouTube;";
+     airplay_video_t *airplay_video = NULL;
++    int id = -1;
+     
+     logger_log(raop->logger, LOGGER_DEBUG, "http_handler_play");
+ 
+@@ -760,28 +776,80 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
+ 
+     int request_datalen = -1;    
+     const char *request_data = http_request_get_data(request, &request_datalen);
+-
+-    if (request_datalen > 0) {
+-        char *header_str = NULL;
+-        http_request_get_header_string(request, &header_str);
+-        logger_log(raop->logger, LOGGER_DEBUG, "request header:\n%s", header_str);
+-        data_is_binary_plist = (strstr(header_str, "x-apple-binary-plist") != NULL);
+-        free (header_str);
++    if (request_datalen <= 0) {
++        goto play_error;
+     }
+ 
+-    if (!data_is_binary_plist) {
+-         logger_log(raop->logger, LOGGER_ERR, "Play request Content is not binary_plist (unsupported)");
+-         goto play_error;
++    char *header_str = NULL;
++    http_request_get_header_string(request, &header_str);
++    logger_log(raop->logger, LOGGER_DEBUG, "request header:\n%s", header_str);
++    data_is_binary_plist = (strstr(header_str, "x-apple-binary-plist") != NULL);
++    free (header_str);
++
++    if (data_is_binary_plist) {
++        plist_from_bin(request_data, request_datalen, &req_root_node);
++
++        playback_uuid = _plist_dup_string(req_root_node, "uuid");
++        playback_location = _plist_dup_string(req_root_node, "Content-Location");
++
++        plist_t req_client_proc_name_node = plist_dict_get_item(req_root_node, "clientProcName");
++        if (req_client_proc_name_node) {
++            plist_get_string_val(req_client_proc_name_node, &client_proc_name);
++            if (client_proc_name && !strstr(supported_hls_proc_names, client_proc_name)){
++                logger_log(raop->logger, LOGGER_WARNING, "Unsupported HLS streaming format: clientProcName %s not found in supported list: %s",
++                           client_proc_name, supported_hls_proc_names);
++            }
++            plist_mem_free(client_proc_name);
++            client_proc_name = NULL;
++        }
++
++        plist_t req_start_position_seconds_node = plist_dict_get_item(req_root_node, "Start-Position-Seconds");
++        if (!req_start_position_seconds_node) {
++            req_start_position_seconds_node = plist_dict_get_item(req_root_node, "Start-Position");
++        }
++        if (!req_start_position_seconds_node) {
++            logger_log(raop->logger, LOGGER_INFO, "No Start-Position-Seconds in Play request");
++        } else {
++             double start_position = 0.0;
++             plist_get_real_val(req_start_position_seconds_node, &start_position);
++             start_position_seconds = (float) start_position;
++        }
++    } else {
++        char *body = (char *) calloc(request_datalen + 1, sizeof(char));
++        if (!body) {
++            printf("Memory allocation failed (body)\n");
++            exit(1);
++        }
++        memcpy(body, request_data, request_datalen);
++        char *saveptr = NULL;
++        for (char *line = strtok_r(body, "\r\n", &saveptr); line != NULL;
++             line = strtok_r(NULL, "\r\n", &saveptr)) {
++            char *sep = strchr(line, ':');
++            if (!sep) {
++                continue;
++            }
++            *sep = '\0';
++            char *value = sep + 1;
++            while (*value == ' ' || *value == '\t') {
++                value++;
++            }
++            if (!strcmp(line, "Content-Location")) {
++                free(playback_location);
++                playback_location = strdup(value);
++            } else if (!strcmp(line, "Start-Position")) {
++                start_position_seconds = (float) atof(value);
++            }
++        }
++        free(body);
+     }
+ 
+-    plist_from_bin(request_data, request_datalen, &req_root_node);
++    if (!playback_location || !strlen(playback_location)) {
++        goto play_error;
++    }
+ 
+-    plist_t req_uuid_node = plist_dict_get_item(req_root_node, "uuid");
+-    if (!req_uuid_node) {
+-       goto play_error;
++    if (!playback_uuid) {
++        playback_uuid = strdup(apple_session_id);
+     }
+-    char* playback_uuid = NULL;
+-    plist_get_string_val(req_uuid_node, &playback_uuid);
+ 
+ #if 0
+     for (int i = 0; i < MAX_AIRPLAY_VIDEO; i++) {
+@@ -793,14 +861,21 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
+     printf("new playback_uuid %s\n\n", playback_uuid);
+ #endif
+ 
+-    int id = -1;
+     id = get_playlist_by_uuid(raop, playback_uuid);
+ 
++    if (id >= 0 && !get_playback_location(raop->airplay_video[id])) {
++        raop_destroy_airplay_video(raop, id);
++        id = -1;
++    }
++
+     /* check if playlist is already downloaded and stored (may have been interrupted by advertisements ) */
+     if (id >= 0) {
+       //printf("====use EXISTING  airplay_video[%d] %p %s %s\n", id, raop->airplay_video[id], playback_uuid, get_playback_uuid(raop->airplay_video[id]));
+-        plist_mem_free(playback_uuid);
+-        plist_free(req_root_node);
++        free(playback_uuid);
++        free(playback_location);
++        if (req_root_node) {
++            plist_free(req_root_node);
++        }
+         raop->current_video = id;
+         airplay_video = hls_get_current_video(raop);
+         assert(airplay_video);
+@@ -849,7 +924,8 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
+     assert(airplay_video);
+     set_apple_session_id(airplay_video, apple_session_id, strlen(apple_session_id));
+     set_playback_uuid(airplay_video, playback_uuid, strlen(playback_uuid));
+-    plist_mem_free (playback_uuid);
++    free(playback_uuid);
++    playback_uuid = NULL;
+     count++;
+ 
+     /* ensure that space will always be available for adding future playlists */
+@@ -870,42 +946,12 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
+ 	       get_duration(raop->airplay_video[i]));
+     }
+ #endif
+-	   
+-    plist_t req_content_location_node = plist_dict_get_item(req_root_node, "Content-Location");
+-    if (!req_content_location_node) {
+-        goto play_error;
+-    } else {
+-        plist_get_string_val(req_content_location_node, &playback_location);
+-    }
+ 
+-    plist_t req_client_proc_name_node = plist_dict_get_item(req_root_node, "clientProcName");
+-    if (!req_client_proc_name_node) {
+-        goto play_error;
+-    } else {
+-        plist_get_string_val(req_client_proc_name_node, &client_proc_name);
+-        if (!strstr(supported_hls_proc_names, client_proc_name)){
+-            logger_log(raop->logger, LOGGER_WARNING, "Unsupported HLS streaming format: clientProcName %s not found in supported list: %s",
+-                       client_proc_name, supported_hls_proc_names);
+-        }
+-        plist_mem_free(client_proc_name);
+-    }
+-
+-    plist_t req_start_position_seconds_node = plist_dict_get_item(req_root_node, "Start-Position-Seconds");
+-    if (!req_start_position_seconds_node) {
+-        logger_log(raop->logger, LOGGER_INFO, "No Start-Position-Seconds in Play request");	    
+-    } else {
+-         double start_position = 0.0;
+-         plist_get_real_val(req_start_position_seconds_node, &start_position);
+-         start_position_seconds = (float) start_position;
+-    }
+     set_start_position_seconds(airplay_video, (float) start_position_seconds);
+ 
+     /* we only support HLS if the playback location is terminated by "/master.m3u8" */
+     const char *uri_suffix = strstr(playback_location, "/master.m3u8");
+-    if (!uri_suffix) { 
+-        logger_log(raop->logger, LOGGER_ERR, "Content-Location has unsupported form:\n%s\n", playback_location);	    
+-        goto play_error;
+-    } else {
++    if (uri_suffix) {
+         size_t len = strlen(get_uri_local_prefix(airplay_video)) + strlen(uri_suffix);
+         char *location = (char *) calloc(len + 1, sizeof(char));
+         if (!location) {
+@@ -926,11 +972,20 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
+         *end = '\0';						  
+         set_uri_prefix(airplay_video, uri_prefix, strlen(uri_prefix));
+         free (uri_prefix);
++        set_next_media_uri_id(airplay_video, 0);
++        fcup_request((void *) conn, playback_location, apple_session_id, get_next_FCUP_RequestID(airplay_video));
++    } else if (!strncmp(playback_location, "http://", strlen("http://")) ||
++               !strncmp(playback_location, "https://", strlen("https://"))) {
++        set_playback_location(airplay_video, playback_location, strlen(playback_location));
++        raop->callbacks.on_video_play(raop->callbacks.cls,
++                                      get_playback_location(airplay_video),
++                                      start_position_seconds);
++    } else {
++        logger_log(raop->logger, LOGGER_ERR, "Content-Location has unsupported form:\n%s\n", playback_location);
++        goto play_error;
+     }
+-    set_next_media_uri_id(airplay_video, 0);
+-    fcup_request((void *) conn, playback_location, apple_session_id, get_next_FCUP_RequestID(airplay_video));
+ 
+-    plist_mem_free(playback_location);
++    free(playback_location);
+ 
+     if (req_root_node) {
+         plist_free(req_root_node);
+@@ -938,14 +993,16 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
+     return;
+ 
+  play_error:;
+-    plist_mem_free(playback_location);
++    free(playback_location);
++    free(playback_uuid);
+     if (req_root_node) {
+         plist_free(req_root_node);
+     }
++    if (id >= 0 && raop->airplay_video[id] && !get_playback_location(raop->airplay_video[id])) {
++        raop_destroy_airplay_video(raop, id);
++    }
+     logger_log(raop->logger, LOGGER_ERR, "Could not find valid Plist Data for POST/play request, Unhandled");
+     http_response_init(response, "HTTP/1.1", 400, "Bad Request");
+-    http_response_set_disconnect(response, 1);
+-    raop->callbacks.conn_reset(raop->callbacks.cls, 2);
+ }
+ 
+ /* the HLS handler handles http requests GET /[uri] on the HLS channel from the media player to the Server, asking for
+diff --git a/lib/raop_handlers.h b/lib/raop_handlers.h
+index 1aeba28..14821da 100644
+--- a/lib/raop_handlers.h
++++ b/lib/raop_handlers.h
+@@ -468,12 +468,8 @@ raop_handler_pairverify(raop_conn_t *conn,
+     raop_t *raop = conn->raop;
+     bool register_check = false;  
+     if (pairing_session_check_handshake_status(conn->session)) {
+-        if (raop->use_pin) {
+-            pairing_session_set_setup_status(conn->session);
+-            register_check = true;
+-        } else {
+-            return;
+-        }
++        pairing_session_set_setup_status(conn->session);
++        register_check = raop->use_pin;
+     }
+     unsigned char public_key[X25519_KEY_SIZE];
+     unsigned char signature[PAIRING_SIG_SIZE];

--- a/airplay/src/main/cpp/patches/UxPlay/0005-signal-video-reset-on-abandoned-play-connection.patch
+++ b/airplay/src/main/cpp/patches/UxPlay/0005-signal-video-reset-on-abandoned-play-connection.patch
@@ -1,0 +1,85 @@
+diff --git a/lib/http_handlers.h b/lib/http_handlers.h
+index 8a3f192..d76c984 100644
+--- a/lib/http_handlers.h
++++ b/lib/http_handlers.h
+@@ -152,6 +152,7 @@ http_handler_stop(raop_conn_t *conn, http_request_t *request, http_response_t *r
+     raop_t *raop = conn->raop;
+     logger_log(raop->logger, LOGGER_INFO, "client HTTP request POST stop");
+ 
++    raop->video_play_conn = NULL;
+     raop->callbacks.on_video_stop(raop->callbacks.cls);
+ }
+ 
+@@ -985,6 +986,8 @@ http_handler_play(raop_conn_t *conn, http_request_t *request, http_response_t *r
+         goto play_error;
+     }
+ 
++    raop->video_play_conn = (void *) conn;
++
+     free(playback_location);
+ 
+     if (req_root_node) {
+diff --git a/lib/raop.c b/lib/raop.c
+index 7098fae..86db001 100644
+--- a/lib/raop.c
++++ b/lib/raop.c
+@@ -88,6 +88,7 @@ struct raop_s {
+     /* activate support for HLS live streaming */
+     bool hls_support;
+     bool hls_pending;
++    void *video_play_conn;
+   
+     /* used in digest authentication */
+     char *nonce;
+@@ -549,6 +550,13 @@ conn_destroy(void *ptr) {
+     raop_t *raop = conn->raop;
+     logger_log(raop->logger, LOGGER_DEBUG, "Destroying connection");
+ 
++    if (raop->video_play_conn == ptr) {
++        raop->video_play_conn = NULL;
++        if (raop->callbacks.video_reset) {
++            raop->callbacks.video_reset(raop->callbacks.cls, RESET_TYPE_HLS_CONN_CLOSED);
++        }
++    }
++
+     if (raop->callbacks.conn_destroy) {
+         raop->callbacks.conn_destroy(raop->callbacks.cls);
+     }
+@@ -638,6 +646,7 @@ raop_init(raop_callbacks_t *callbacks) {
+ 
+     raop->hls_support = false;
+     raop->hls_pending = false;
++    raop->video_play_conn = NULL;
+     
+     raop->nonce = NULL;
+ 
+@@ -854,6 +863,7 @@ void raop_remove_known_connections(raop_t * raop) {
+ }
+ 
+ void raop_remove_hls_connections(raop_t * raop) {
++    raop->video_play_conn = NULL;
+     httpd_remove_connections_by_type(raop->httpd, CONNECTION_TYPE_HLS);
+     httpd_remove_connections_by_type(raop->httpd, CONNECTION_TYPE_PTTH);
+     httpd_remove_connections_by_type(raop->httpd, CONNECTION_TYPE_AIRPLAY);
+@@ -880,6 +890,7 @@ void raop_handle_eos(raop_t *raop) {
+     assert (id >= 0);
+     raop_destroy_airplay_video(raop, id);
+     raop->current_video = -1;
++    raop->video_play_conn = NULL;
+     /* reset video without deleting raop->airplay_video */
+     raop->callbacks.video_reset(raop->callbacks.cls, RESET_TYPE_HLS_EOS);
+ }
+diff --git a/lib/raop.h b/lib/raop.h
+index fcc3fe9..e635768 100644
+--- a/lib/raop.h
++++ b/lib/raop.h
+@@ -65,7 +65,8 @@ typedef enum reset_type_e {
+     RESET_TYPE_HLS_SHUTDOWN,
+     RESET_TYPE_HLS_EOS,
+     RESET_TYPE_ON_VIDEO_PLAY,
+-    RESET_TYPE_RTP_TO_HLS_TEARDOWN
++    RESET_TYPE_RTP_TO_HLS_TEARDOWN,
++    RESET_TYPE_HLS_CONN_CLOSED
+ } reset_type_t;
+ 
+ struct raop_callbacks_s {

--- a/airplay/src/main/cpp/timeline_buffer.h
+++ b/airplay/src/main/cpp/timeline_buffer.h
@@ -1,0 +1,387 @@
+#ifndef TIMELINE_BUFFER_H
+#define TIMELINE_BUFFER_H
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "audio_time.h"
+
+/*
+ * lock-free SPSC ring of int16 samples (interleaved frames); positions are
+ * non-wrapping 64-bit counters so empty/full are unambiguous without spare slot
+ */
+class SpscRing {
+public:
+    explicit SpscRing(size_t capacitySamples)
+        : mCapacity(capacitySamples), mBuf(new int16_t[capacitySamples]) {}
+
+    size_t available() const {  // samples readable
+        return mWrite.load(std::memory_order_acquire) - mRead.load(std::memory_order_acquire);
+    }
+
+    // producer: push up to n samples, drops what doesn't fit
+    size_t write(const int16_t *src, size_t n) {
+        const size_t w = mWrite.load(std::memory_order_relaxed);
+        const size_t r = mRead.load(std::memory_order_acquire);
+        const size_t freeSpace = mCapacity - (w - r);
+        if (n > freeSpace) n = freeSpace;
+        const size_t wi = w % mCapacity;
+        const size_t first = (n < mCapacity - wi) ? n : (mCapacity - wi);
+        memcpy(&mBuf[wi], src, first * sizeof(int16_t));
+        if (n > first) memcpy(&mBuf[0], src + first, (n - first) * sizeof(int16_t));
+        mWrite.store(w + n, std::memory_order_release);
+        return n;
+    }
+
+    // consumer: pop up to n samples
+    size_t read(int16_t *dst, size_t n) {
+        const size_t r = mRead.load(std::memory_order_relaxed);
+        const size_t w = mWrite.load(std::memory_order_acquire);
+        const size_t avail = w - r;
+        if (n > avail) n = avail;
+        const size_t ri = r % mCapacity;
+        const size_t first = (n < mCapacity - ri) ? n : (mCapacity - ri);
+        memcpy(dst, &mBuf[ri], first * sizeof(int16_t));
+        if (n > first) memcpy(dst + first, &mBuf[0], (n - first) * sizeof(int16_t));
+        mRead.store(r + n, std::memory_order_release);
+        return n;
+    }
+
+    // consumer: discard up to n oldest samples
+    void skip(size_t n) {
+        const size_t r = mRead.load(std::memory_order_relaxed);
+        const size_t w = mWrite.load(std::memory_order_acquire);
+        const size_t avail = w - r;
+        if (n > avail) n = avail;
+        mRead.store(r + n, std::memory_order_release);
+    }
+
+private:
+    const size_t mCapacity;
+    std::unique_ptr<int16_t[]> mBuf;
+    std::atomic<size_t> mWrite{0};
+    std::atomic<size_t> mRead{0};
+};
+
+/*
+ * adaptive jitter cushion tuner, NetEQ-inspired but simplified: decaying histogram of
+ * packet jitter, cushion = high percentile of it + 1 packet of margin.
+ * observe() is producer-thread only; result published via atomic, consumer reads it live
+ */
+class DelayTracker {
+public:
+    // staticCushionMs > 0: fixed cushion, tuner disabled
+    // staticCushionMs <= 0: tune between MIN_CUSHION_MS and MAX_CUSHION_MS
+    DelayTracker(int sampleRate, int channels, int staticCushionMs, int percentilePct)
+        : mSampleRate(sampleRate), mChannels(channels),
+          mAdaptive(staticCushionMs <= 0),
+          mFloor(msToSamples(sampleRate, channels, mAdaptive ? MIN_CUSHION_MS : staticCushionMs)),
+          mCeil(msToSamples(sampleRate, channels, mAdaptive ? MAX_CUSHION_MS : staticCushionMs)),
+          mPercentilePct(percentilePct),
+          mTuned(mFloor) {}
+
+    // ptsNs: packet presentation time; arrivalNs: local arrival time; durNs: packet duration
+    void observe(int64_t ptsNs, int64_t arrivalNs, int64_t durNs) {
+        if (!mAdaptive) return;
+
+        const int64_t raw = arrivalNs - ptsNs; // arrival latency
+        // jitter = latency relative to min latency seen so far (mBaseNs)
+        if (!mHaveBase) { mBaseNs = raw; mHaveBase = true; }
+        else if (raw < mBaseNs) mBaseNs = raw;
+        // creep mBaseNs up slowly: counters clock drift and one freak fast packet
+        else mBaseNs += (raw - mBaseNs) >> BASE_CREEP_SHIFT;
+        int64_t rel = raw - mBaseNs;
+        if (rel < 0) rel = 0;
+
+        int bin = (int)(rel / BUCKET_NS);
+        if (bin >= NBUCKETS) bin = NBUCKETS - 1;
+
+        // decay: each bin bleeds 1/2^FORGET_SHIFT per packet, current bin topped up by
+        // ONE/2^FORGET_SHIFT, so total converges to ONE
+        int64_t sum = 0;
+        for (int i = 0; i < NBUCKETS; i++) {
+            mHist[i] -= (mHist[i] + (1 << FORGET_SHIFT) - 1) >> FORGET_SHIFT;
+            sum += mHist[i];
+        }
+        mHist[bin] += ONE >> FORGET_SHIFT;
+        sum += ONE >> FORGET_SHIFT;
+
+        // cushion = smallest delay whose cumulative histogram share reaches percentile
+        const int64_t thresh = sum * mPercentilePct / 100;
+        int64_t cum = 0; int b = 0;
+        for (; b < NBUCKETS - 1; b++) { cum += mHist[b]; if (cum >= thresh) break; }
+        // bin is lower bound on delay: take top edge + margin. margin must keep output
+        // fed for one data callback and tide us over until next packet
+        const int64_t marginNs = std::max(durNs, mOutputBufferNs.load(std::memory_order_relaxed));
+        const int64_t targetNs = (int64_t)(b + 1) * BUCKET_NS + marginNs;
+        size_t samples = (size_t)(targetNs * mSampleRate / NS_PER_SEC) * mChannels;
+        if (samples < mFloor) samples = mFloor;
+        if (samples > mCeil) samples = mCeil;
+        mTuned.store(samples, std::memory_order_relaxed);
+    }
+
+    // reset clock base after discontinuity or clock shift/resync so it doesn't poison
+    // jitter calculations; producer-thread only (same as observe())
+    void reanchor() { mHaveBase = false; }
+
+    // latest tuned cushion in samples; any thread
+    size_t target() const { return mTuned.load(std::memory_order_relaxed); }
+
+    void noteOutputBufferFrames(int frames) {
+        mOutputBufferNs.store((int64_t)frames * NS_PER_SEC / mSampleRate, std::memory_order_relaxed);
+    }
+
+    // largest cushion tuner can reach, in samples
+    size_t ceil() const { return mCeil; }
+
+private:
+    static size_t msToSamples(int sampleRate, int channels, int ms) {
+        return (size_t)sampleRate * ms / 1000 * channels;
+    }
+
+    static constexpr int MIN_CUSHION_MS = 0;             // algorithm already enforces effective floor
+    static constexpr int MAX_CUSHION_MS = 1000;
+    static constexpr int BUCKET_MS = 5;                  // histogram granularity
+    static constexpr int NBUCKETS = MAX_CUSHION_MS / BUCKET_MS;
+    static constexpr int64_t BUCKET_NS = (int64_t)BUCKET_MS * 1000000LL;
+    static constexpr int FORGET_SHIFT = 8;               // ~1/256 decay per packet (~6s @ 23ms)
+    static constexpr int BASE_CREEP_SHIFT = 10;          // mBaseNs creep speed
+    static constexpr int64_t ONE = 1 << 20;              // histogram fixed-point unit
+
+    const int mSampleRate;
+    const int mChannels;
+    const bool mAdaptive;                // false = fixed cushion (tuner disabled)
+    const size_t mFloor;
+    const size_t mCeil;
+    const int mPercentilePct;            // arrival-delay percentile cushion targets
+    std::atomic<size_t> mTuned;
+    std::atomic<int64_t> mOutputBufferNs{0};  // output->producer: oboe output buffer duration
+    int64_t mHist[NBUCKETS] = {};
+    int64_t mBaseNs = 0;
+    bool mHaveBase = false;
+};
+
+// cumulative diagnostic counters, bumped from producer/consumer, read from stats thread
+class TimelineMetrics {
+public:
+    // packed: nests into AudioDebugData with fixed layout
+    struct __attribute__((packed)) Debug {
+        uint32_t trims, drops, silences, underruns;  // cumulative; 32-bit to avoid wrap
+    };
+
+    void countTrim()     { mTrims.fetch_add(1, std::memory_order_relaxed); }
+    void countDrop()     { mDrops.fetch_add(1, std::memory_order_relaxed); }
+    void countSilence()  { mSilences.fetch_add(1, std::memory_order_relaxed); }
+    void countUnderrun() { mUnderruns.fetch_add(1, std::memory_order_relaxed); }
+
+    // any thread
+    Debug debugInfo() const {
+        Debug d{};
+        d.trims = mTrims.load(std::memory_order_relaxed);
+        d.drops = mDrops.load(std::memory_order_relaxed);
+        d.silences = mSilences.load(std::memory_order_relaxed);
+        d.underruns = mUnderruns.load(std::memory_order_relaxed);
+        return d;
+    }
+
+private:
+    std::atomic<uint32_t> mTrims{0};      // backlog exceeded cap and was trimmed
+    std::atomic<uint32_t> mDrops{0};      // late packets dropped, pts slot already passed
+    std::atomic<uint32_t> mSilences{0};   // gaps filled with silence
+    std::atomic<uint32_t> mUnderruns{0};  // ring ran dry, output padded with silence
+};
+
+/*
+ * Timeline-synchronized playout buffer: absorbs jitter, clock drift and clock resyncs,
+ * syncs audio to its presentation-time tag.
+ *
+ * One concurrent reader + one concurrent writer OK; multiple readers or writers NOT safe.
+ * samples = frames * channels
+ */
+class TimelineBuffer {
+public:
+    // cushion policy lives in mTracker; timeline reads mTracker.target() live
+    TimelineBuffer(int sampleRate, int channels, int staticCushionMs, int percentilePct)
+        : mSampleRate(sampleRate),
+          mChannels(channels),
+          mTracker(sampleRate, channels, staticCushionMs, percentilePct),
+          // ring can't be reallocated mid-stream: size for worst-case backlog, i.e. cap
+          // of largest reachable cushion + one throttle window of overshoot (trims are
+          // throttled), 2x slack
+          mRing(2 * capOf(mTracker.ceil()) + (size_t)sampleRate * TRIM_THROTTLE_MS / 1000 * channels) {}
+
+    void noteOutputBufferFrames(int frames) { mTracker.noteOutputBufferFrames(frames); }
+
+    // producer: push samples
+    void write(const int16_t *pcm, size_t samples, int64_t ptsNs) {
+        if (samples == 0) return;
+        // pts 0 = sender clock not NTP synced yet
+        if (ptsNs == 0) {
+            mRing.write(pcm, samples);
+            return;
+        }
+        const int64_t durNs = samples * NS_PER_SEC / mChannels / mSampleRate;
+
+        // consumer underran since last write: it already played the gap as real-time
+        // silence, re-anchor so we don't also insert it here
+        if (mUnderran.exchange(false, std::memory_order_relaxed)) {
+            mExpectedPtsNs = ptsNs;
+        }
+        const int64_t gapNs = ptsNs - mExpectedPtsNs;
+
+        // large gap: possible discontinuity or clock shift. reanchor() must precede
+        // observe() so the reset applies to this observation
+        if (gapNs > MAX_GAP_NS || gapNs < -MAX_GAP_NS) mTracker.reanchor();
+
+        // no-op in static-cushion mode
+        mTracker.observe(ptsNs, monoNs(), durNs);
+
+        if (gapNs > MAX_GAP_NS || gapNs < -MAX_GAP_NS) {
+            // discontinuity: write immediately. new sound after long silence resets
+            // backlog to ideal size (less latency); on clock resync we keep the sound
+        } else if (gapNs > SLACK_NS) {
+            // sender left gap: reproduce as silence so timing is exact
+            const size_t silenceFrames = (size_t)(gapNs * mSampleRate / NS_PER_SEC);
+            writeSilenceFrames(silenceFrames);
+            mMetrics.countSilence();
+        } else if (gapNs < -SLACK_NS) {
+            // slot already passed (late/overlap): drop
+            mMetrics.countDrop();
+            return;
+        }
+        mRing.write(pcm, samples);
+        mExpectedPtsNs = ptsNs + durNs;
+    }
+
+    // consumer: pop frames*channels samples into out, silence-padded on underrun
+    void read(int16_t *out, int32_t frames) {
+        const size_t need = (size_t)frames * mChannels;
+        const size_t tuned = mTracker.target();
+        const int64_t now = monoNs();
+
+        // bound latency: cap tracks tuned cushion live so a calmed link sheds latency
+        // without an underrun. each trim costs a glitch, so be conservative: trim only
+        // after backlog stayed above cap for TRIM_SUSTAIN (skip transient spikes), at
+        // most once per TRIM_THROTTLE, and not within that window of an underrun
+        // (trimming while rebuilding cushion is counterproductive)
+        const size_t avail = mRing.available();
+        if (avail > capOf(tuned)) {
+            if (mAboveCapSinceNs == 0) mAboveCapSinceNs = now;
+        } else {
+            mAboveCapSinceNs = 0;
+        }
+        if (mAboveCapSinceNs != 0 && now - mAboveCapSinceNs >= TRIM_SUSTAIN_NS
+                && now - mLastTrimBlockNs >= TRIM_THROTTLE_NS) {
+            mRing.skip(avail - tuned);
+            mMetrics.countTrim();
+            mLastTrimBlockNs = now;
+            mAboveCapSinceNs = 0;
+        }
+
+        // prebuffer: hold output until cushion fills, builds jitter headroom
+        if (mPriming) {
+            const size_t buffered = mRing.available();
+            // time the wait only while holding partial data; reset on empty ring so the
+            // producer gets the full window once a sound starts, otherwise we could time
+            // out on pre-sound silence and underrun the instant the first frame lands
+            if (buffered == 0) mPrimeSilenceFrames = 0;
+            else mPrimeSilenceFrames += (uint32_t)frames;
+            // short sound can end before filling cushion; after holding partial data
+            // through 2x cushion of silence the sound is complete: play it
+            const uint32_t starveFrames = (uint32_t)(2 * tuned / mChannels);
+            const bool starved = buffered > 0 && mPrimeSilenceFrames >= starveFrames;
+            // also keep priming on empty ring: with 0 cushion `buffered < tuned` is
+            // never true, so we'd otherwise underrun on every empty read between sounds
+            if (buffered == 0 || (buffered < tuned && !starved)) {
+                memset(out, 0, need * sizeof(int16_t));
+                return;
+            }
+            mPriming = false;
+            mPrimeSilenceFrames = 0;
+        }
+
+        const size_t got = mRing.read(out, need);
+        if (got < need) {
+            memset(out + got, 0, (need - got) * sizeof(int16_t));
+            mPriming = true;
+            mLastTrimBlockNs = now;  // hold off trims while rebuilding
+            mUnderran.store(true, std::memory_order_relaxed);  // producer re-anchors
+            mMetrics.countUnderrun();
+        }
+    }
+
+    // call after discontinuity or clock shift/resync; producer-side, must not run
+    // concurrently with write()
+    void reanchorTracker() { mTracker.reanchor(); }
+
+    // rebuild prebuffer cushion before resuming, e.g. after output stream restart;
+    // must not run concurrently with read()
+    void reprime() { mPriming = true; }
+
+    // drop buffered audio + rebuild cushion, so resume after pause doesn't play stale
+    // tail; only while output callback is stopped (skip() is consumer-side)
+    void flushAndReprime() {
+        mRing.skip(mRing.available());
+        mPriming = true;
+    }
+
+    // debug snapshot: backlog + tuned cushion (ms) + counters; reads only atomics, any thread
+    struct __attribute__((packed)) Debug {
+        uint16_t backlogMs;         // bounded by ring (few seconds)
+        uint16_t tunedCushionMs;    // bounded by MAX_CUSHION_MS
+        TimelineMetrics::Debug metrics;
+    };
+    Debug debugInfo() const {
+        Debug d{};
+        d.backlogMs = (uint16_t)(mRing.available() / mChannels * 1000 / mSampleRate);
+        d.tunedCushionMs = (uint16_t)(mTracker.target() / mChannels * 1000 / mSampleRate);
+        d.metrics = mMetrics.debugInfo();
+        return d;
+    }
+
+private:
+
+    // latency ceiling for cushion: 2x, but never below TRIM_FLOOR_MS so tiny cushion
+    // still gets slack before a trim (trim costs a glitch)
+    size_t capOf(size_t cushionSamples) const {
+        return std::max(cushionSamples * 2, (size_t)mSampleRate * TRIM_FLOOR_MS / 1000 * mChannels);
+    }
+
+    void writeSilenceFrames(size_t frames) {
+        int16_t zeros[512] = {0};  // 256 stereo frames per chunk
+        size_t samples = frames * mChannels;
+        while (samples > 0) {
+            const size_t n = std::min<size_t>(samples, 512);
+            mRing.write(zeros, n);
+            samples -= n;
+        }
+    }
+
+    static constexpr int64_t SLACK_NS = 10'000'000LL;    // ignore <10ms gaps (NTP shift, rounding)
+    static constexpr int64_t MAX_GAP_NS = 750'000'000LL; // >750ms = discontinuity, re-anchor
+    static constexpr int TRIM_FLOOR_MS = 30;             // min trim point even for tiny cushion
+    static constexpr int TRIM_THROTTLE_MS = 2000;        // min spacing between trims, and after underrun
+    static constexpr int64_t TRIM_THROTTLE_NS = (int64_t)TRIM_THROTTLE_MS * 1'000'000LL;
+    static constexpr int TRIM_SUSTAIN_MS = 2000;         // backlog must exceed cap this long before trim
+    static constexpr int64_t TRIM_SUSTAIN_NS = (int64_t)TRIM_SUSTAIN_MS * 1'000'000LL;
+
+    const int mSampleRate;
+    const int mChannels;
+    DelayTracker mTracker;               // owns cushion policy; read live each read()
+    SpscRing mRing;
+    TimelineMetrics mMetrics;
+    bool mPriming = true;                // stream start: buffer output to build cushion
+    uint32_t mPrimeSilenceFrames = 0;    // consumer-only: silence frames output while priming with partial data
+    int64_t mLastTrimBlockNs = 0;        // consumer-only: last trim/underrun time (trim throttle)
+    int64_t mAboveCapSinceNs = 0;        // consumer-only: when backlog first exceeded cap (0 = under)
+    std::atomic<bool> mUnderran{false};  // consumer->producer: underrun happened
+
+    int64_t mExpectedPtsNs = 0;          // presentation time expected at write head
+};
+
+#endif  // TIMELINE_BUFFER_H

--- a/airplay/src/main/kotlin/com/immortal/airplay/AirPlayEngine.kt
+++ b/airplay/src/main/kotlin/com/immortal/airplay/AirPlayEngine.kt
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.airplay
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.util.Log
+import androidx.core.content.ContextCompat
+import io.github.jqssun.airplay.Prefs
+import io.github.jqssun.airplay.service.AirPlayService
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * The host-facing entry point to the receiver.
+ *
+ * Deliberately thin: the real work lives in the vendored
+ * [io.github.jqssun.airplay.service.AirPlayService], which owns the native handle, the renderers,
+ * mDNS registration and the media session. This exists so a host never has to reach into the
+ * `io.github.jqssun.airplay` namespace directly, and so the awkward parts — is there even a native
+ * library for this ABI, does the service need an action, is it already running — have one answer
+ * instead of several.
+ *
+ * Typical host wiring:
+ * ```
+ * AirPlayHost.surfaceActivity = AirPlayActivity::class.java
+ * AirPlayOptions(deviceName = FleetConfig.name(ctx), requirePin = true).applyTo(ctx)
+ * AirPlayEngine.start(ctx)
+ * ```
+ */
+object AirPlayEngine {
+
+    private const val TAG = "AirPlayEngine"
+
+    /** The one ABI the native build produces — see `abiFilters` in the module's build script. */
+    private const val ABI = "arm64-v8a"
+
+    @Volatile private var supported: Boolean? = null
+
+    /** Counts starts, so an in-flight [stop] can tell that one has overtaken it. */
+    private val epoch = AtomicInteger(0)
+
+    /**
+     * [isSupported] once that has settled, an ABI test that touches no native code before then.
+     *
+     * For UI gates: [isSupported] dlopens the native stack (`libairplay_native.so` plus
+     * `libc++_shared.so` and `liboboe.so`) and runs its static initialisers on the calling thread,
+     * which a launcher's home screen cannot pay on behalf of users who never enable AirPlay. The
+     * two can only disagree on an arm64 device whose APK is missing the library it was built with,
+     * and [start] still checks the real thing, so that costs a dead settings row, not a crash.
+     */
+    fun isProbablySupported(): Boolean =
+        supported ?: (Build.SUPPORTED_ABIS?.contains(ABI) == true)
+
+    /**
+     * Whether the native stack can run here, cached after the first call.
+     *
+     * The CMake build is filtered to `arm64-v8a` (every Portal is arm64), so on any other ABI there
+     * simply is no `libairplay_native.so`. Resolving that lazily — rather than letting
+     * `NativeBridge`'s `System.loadLibrary` run in a static initialiser at an arbitrary moment —
+     * is what keeps a host's JVM unit tests and non-arm64 devices from dying with
+     * `UnsatisfiedLinkError`. Check this before offering AirPlay in a settings UI.
+     */
+    fun isSupported(): Boolean {
+        supported?.let { return it }
+        val result = runCatching {
+            System.loadLibrary("airplay_native")
+            true
+        }.getOrElse { e ->
+            Log.i(TAG, "AirPlay unavailable on ${Build.SUPPORTED_ABIS.firstOrNull()}: ${e.message}")
+            false
+        }
+        supported = result
+        return result
+    }
+
+    /**
+     * Start the receiver as a foreground service. No-op (returning false) when [isSupported] is
+     * false, so a host can call this unconditionally.
+     *
+     * Configure first via [AirPlayOptions.applyTo] — the service reads its settings on start.
+     *
+     * The action is not optional. `AirPlayService.onStartCommand` ignores any intent whose action
+     * is not [AirPlayService.ACTION_START_SERVER], so an actionless start would leave the receiver
+     * down *and* — because this is a `startForegroundService` — let the system kill the process for
+     * never calling `startForeground()` in time.
+     */
+    fun start(context: Context): Boolean {
+        if (!isSupported()) return false
+        val ctx = context.applicationContext
+        val intent = Intent(ctx, AirPlayService::class.java)
+            .setAction(AirPlayService.ACTION_START_SERVER)
+        // Bumped before the intent, so any stop still waiting on a bind sees that it has been
+        // overtaken however quickly this start follows it.
+        epoch.incrementAndGet()
+        return runCatching {
+            ContextCompat.startForegroundService(ctx, intent)
+            true
+        }.onFailure { Log.w(TAG, "failed to start AirPlay service", it) }.getOrDefault(false)
+    }
+
+    /**
+     * Stop the receiver and drop its mDNS advertisement. Safe to call when not running.
+     *
+     * Goes through the service instance rather than relying on `stopService` alone: a host that
+     * binds the service (portal-receiver's own UI does) keeps it alive through `stopService`, so
+     * without this the server would keep advertising after the user turned it off.
+     */
+    fun stop(context: Context) {
+        val ctx = context.applicationContext
+        // First and unconditionally: this half needs no instance, and the bind below can take
+        // [BIND_TIMEOUT_MS] to conclude there is nothing to bind to. On a receiver that was already
+        // stopped that is the whole call, and nothing should wait five seconds for it.
+        runCatching { ctx.stopService(Intent(ctx, AirPlayService::class.java)) }
+            .onFailure { Log.w(TAG, "stopService failed", it) }
+        val issued = epoch.get()
+        withService(ctx) { service, _ ->
+            // Reaching the instance is asynchronous, and "off, then on again" is a fast pair of
+            // taps: without this the stop's own binder callback would land after the restart and
+            // shut down the server the user has just turned back on.
+            if (epoch.get() != issued) {
+                Log.i(TAG, "stop superseded by a later start")
+                return@withService
+            }
+            runCatching { service?.stopServer() }
+                .onFailure { Log.w(TAG, "stopServer failed", it) }
+        }
+    }
+
+    /**
+     * Apply new settings to a receiver that may already be running: persists them, then restarts
+     * the server in place so they take effect. Suits a settings-registry "on applied" hook.
+     *
+     * The stop goes through the bound instance, because `startServer` early-returns while the state
+     * is still RUNNING — without stopping first, a restart would silently keep the old
+     * configuration (and the old advertised name) live.
+     *
+     * The *start* then goes back through [start], not through `service.startServer(name)`, and that
+     * distinction is load-bearing. `startServer(name)` calls `startForegroundService` and then
+     * `startForeground` synchronously, in that order — so by the time the system delivers that
+     * start request, the `startForeground` answering it has already happened, and nothing answers
+     * the request itself. Following `stopServer()` (which has just called `stopForeground` +
+     * `stopSelf`) that is fatal: the five-second window elapses and the system kills the whole
+     * process with `RemoteServiceException: Context.startForegroundService() did not then call
+     * Service.startForeground()`, leaving the receiver down and unadvertised. Observed on a gen-2
+     * Portal, reproducibly, on every settings change.
+     *
+     * [start] sends an `ACTION_START_SERVER` intent instead, and `onStartCommand` answers it by
+     * calling `promoteToForeground()` before starting the server — the contract the platform
+     * actually wants. The name is read from the prefs `applyTo` just wrote, so it is still the new
+     * one.
+     *
+     * [onApplied] reports whether the restart reached the receiver. False covers nothing to restart
+     * (`running` false, or no native stack) and a bind that never reached the instance — there the
+     * *old* settings stay live, because `startServer` early-returns while the state is RUNNING and
+     * the stop that would have cleared it never landed. Nothing here retries, and the new settings
+     * are already in prefs by then, so a host that cares (a rename is a one-shot user action, with
+     * no second event to notice the miss by) has to drive that itself. True means the restart was
+     * issued, not that the server came back up: only its own state answers that. Runs on the main
+     * thread unless the bind fails outright, which settles on the calling thread.
+     */
+    fun reconfigure(
+        context: Context,
+        options: AirPlayOptions,
+        running: Boolean,
+        onApplied: (Boolean) -> Unit = {},
+    ) {
+        options.applyTo(context)
+        if (!running || !isSupported()) {
+            onApplied(false)
+            return
+        }
+        val ctx = context.applicationContext
+        withService(ctx) { service, unanswered ->
+            if (unanswered) {
+                // Seconds late and blind: whatever the receiver is doing now, this restart is no
+                // longer the answer to it — starting here could re-advertise one the user has since
+                // turned off. Report the miss instead.
+                Log.w(TAG, "reconfigure: never reached the service")
+                onApplied(false)
+                return@withService
+            }
+            runCatching { service?.stopServer() }
+                .onFailure { Log.w(TAG, "reconfigure: stop failed", it) }
+            // A null service here means nothing was running to reconfigure, so this start brings
+            // the receiver up on the settings just written.
+            onApplied(start(ctx))
+        }
+    }
+
+    /**
+     * Run [block] against the live service, then unbind.
+     *
+     * `bindService` never creates the service here (no `BIND_AUTO_CREATE`), so this reaches an
+     * already-running receiver and reports null when there is nothing to talk to — which is the
+     * distinction both callers above need. [block] runs on the main thread via the binder callback,
+     * except on the rare synchronous failure path, where it runs on the caller's thread.
+     *
+     * `unanswered` means the bind was still outstanding at [BIND_TIMEOUT_MS] — the receiver is not
+     * running, or the system was that late with the binder. Those are genuinely indistinguishable
+     * from here (a passive bind to a service that is not running succeeds and then simply waits),
+     * so what it reports is "we never reached an instance", not "there was none". A caller that
+     * would act differently on the two has to get its certainty elsewhere.
+     */
+    private fun withService(ctx: Context, block: (AirPlayService?, Boolean) -> Unit) =
+        OneShotConnection(ctx, block).bind()
+
+    /**
+     * How long to wait for a bind that the system may never answer.
+     *
+     * Not a latency the callers normally pay: a live service is dispatched as a main-looper message
+     * from our own process, and the queue is ordered by timestamp, so a busy main thread delays both
+     * and the connection still wins. This only bounds the case where nothing is there to answer —
+     * where the block does no more than a stopService that no one is waiting on.
+     */
+    private const val BIND_TIMEOUT_MS = 5_000L
+
+    /**
+     * A passive bind that always settles exactly once, either with the connected service or with
+     * null, and always unbinds.
+     *
+     * The timeout is what makes a passive bind usable. Without `BIND_AUTO_CREATE`, binding to a
+     * service that is *not running* still succeeds — the system registers the connection and simply
+     * holds it until someone else starts the service. So there is no callback to wait for and no
+     * "not running" result: left alone the registration outlives the call, and the next [start]
+     * hands the binder to it, running a `stopServer()` from an hours-old settings change against the
+     * receiver the user has only just turned on. Unbinding on timeout is what discards it.
+     */
+    private class OneShotConnection(
+        private val ctx: Context,
+        private val block: (AirPlayService?, Boolean) -> Unit,
+    ) : ServiceConnection, Runnable {
+
+        private val settled = AtomicBoolean(false)
+        private val handler = Handler(Looper.getMainLooper())
+
+        fun bind() {
+            val bound = runCatching {
+                ctx.bindService(Intent(ctx, AirPlayService::class.java), this, 0)
+            }.getOrDefault(false)
+            if (bound) handler.postDelayed(this, BIND_TIMEOUT_MS) else settle(null, unanswered = false)
+        }
+
+        /** The timeout body. */
+        override fun run() = settle(null, unanswered = true)
+
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) =
+            settle((binder as? AirPlayService.LocalBinder)?.service, unanswered = false)
+
+        override fun onServiceDisconnected(name: ComponentName?) = settle(null, unanswered = false)
+
+        override fun onNullBinding(name: ComponentName?) = settle(null, unanswered = false)
+
+        private fun settle(service: AirPlayService?, unanswered: Boolean) {
+            if (!settled.compareAndSet(false, true)) return
+            handler.removeCallbacks(this)
+            try {
+                block(service, unanswered)
+            } finally {
+                // Throws if the bind never took; that is the one path where there is nothing to release.
+                runCatching { ctx.unbindService(this) }
+            }
+        }
+    }
+}

--- a/airplay/src/main/kotlin/com/immortal/airplay/AirPlayHost.kt
+++ b/airplay/src/main/kotlin/com/immortal/airplay/AirPlayHost.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.airplay
+
+/**
+ * The one seam between the vendored upstream tree and its host app.
+ *
+ * Upstream's [io.github.jqssun.airplay.service.AirPlayService] hard-references `MainActivity` when a
+ * sender connects, to bring the rendering surface to the front. That is the *only* symbol in the
+ * whole vendored protocol layer that assumes a particular app shell, so instead of forking the file
+ * we route it through here: each host registers the Activity it wants raised.
+ *
+ * - portal-receiver registers `MainActivity`.
+ * - Immortal registers its full-screen `AirPlayActivity`.
+ *
+ * Leave it null to suppress the launch entirely (an audio-only host that never shows a surface).
+ *
+ * Keeping this to a single mutable field is deliberate: the corresponding local patch against
+ * upstream is two lines, so `airplay/sync-upstream.sh` stays a clean diff. See airplay/UPSTREAM.md.
+ */
+object AirPlayHost {
+
+    /**
+     * Activity brought to the front when a sender opens a connection. Set it before the receiver is
+     * started — typically from the host's `Application.onCreate` or its own service.
+     */
+    @Volatile
+    @JvmStatic
+    var surfaceActivity: Class<*>? = null
+}

--- a/airplay/src/main/kotlin/com/immortal/airplay/AirPlayOptions.kt
+++ b/airplay/src/main/kotlin/com/immortal/airplay/AirPlayOptions.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.airplay
+
+import android.content.Context
+import io.github.jqssun.airplay.Prefs
+
+/**
+ * Typed configuration for the receiver, owned by the host app.
+ *
+ * The vendored [io.github.jqssun.airplay.service.AirPlayService] reads its settings straight from
+ * SharedPreferences via [Prefs] — around thirty call sites. Rewriting that to take an options
+ * object would fork the single highest-churn file in the module, so instead this class *writes*
+ * those same keys and the vendored code keeps reading them unchanged. The host still gets a typed,
+ * validated surface; upstream still syncs cleanly.
+ *
+ * Only the settings a host realistically exposes are modelled here. Everything else keeps
+ * upstream's default, which is what [Prefs] already encodes.
+ *
+ * Immortal maps its `airplay` settings domain onto this; portal-receiver's own Settings screen
+ * writes the same prefs directly.
+ */
+data class AirPlayOptions(
+    /**
+     * Name advertised over mDNS. Never hardcode a model: portal-receiver seeds [android.os.Build.MODEL],
+     * Immortal passes its `FleetConfig` device name. Blank falls back to upstream's default.
+     */
+    val deviceName: String,
+    /** RAOP/AirPlay port. Upstream default is 7000. */
+    val port: Int = Prefs.DEF_SERVER_PORT,
+    /** Ask the sender for an on-screen PIN before accepting a connection. */
+    val requirePin: Boolean = Prefs.DEF_REQUIRE_PIN,
+    /** Advertise screen mirroring. Turn off for an audio-only receiver. */
+    val allowMirroring: Boolean = Prefs.DEF_ADVERTISE_VIDEO,
+    /** Advertise audio streaming — off hides the device from music senders entirely. */
+    val allowAudio: Boolean = Prefs.DEF_ADVERTISE_AUDIO,
+    /** Offer H.265/HEVC when the device has a decoder for it. */
+    val h265: Boolean = Prefs.DEF_H265_ENABLED,
+    /** Advertise the panel's real resolution instead of a fixed one. */
+    val autoResolution: Boolean = Prefs.DEF_AUTO_RES,
+    /** Fixed resolution as `WxH`, used only when [autoResolution] is false. */
+    val resolution: String = Prefs.DEF_RESOLUTION,
+    /** Maximum frame rate advertised to senders. */
+    val maxFps: Int = Prefs.DEF_MAX_FPS,
+    /** Bring the host's surface Activity to the front when a sender connects. */
+    val launchOnConnect: Boolean = Prefs.DEF_LAUNCH_ON_CONNECT,
+    /** Let a new sender take over from the current one instead of being refused. */
+    val allowNewConnections: Boolean = Prefs.DEF_ALLOW_NEW_CONN,
+) {
+
+    /**
+     * Persist these values into the prefs the vendored service reads.
+     *
+     * Call before starting the receiver, or from the host's settings-applied hook — the service
+     * re-reads them on start, so a change takes effect on the next start/restart.
+     */
+    fun applyTo(context: Context) {
+        val prefs = context.applicationContext
+            .getSharedPreferences(Prefs.NAME, Context.MODE_PRIVATE)
+        prefs.edit().apply {
+            // Written even when blank resolves to the default: skipping the key would leave the
+            // *previous* name advertised, and a host comparing options objects would see no change
+            // to apply, so the stale name would stick for good.
+            putString(Prefs.SERVER_NAME, resolvedName())
+            putInt(Prefs.SERVER_PORT, port.coerceIn(1, 65535))
+            putBoolean(Prefs.REQUIRE_PIN, requirePin)
+            putBoolean(Prefs.ADVERTISE_VIDEO, allowMirroring)
+            putBoolean(Prefs.ADVERTISE_AUDIO, allowAudio)
+            putBoolean(Prefs.H265_ENABLED, h265)
+            putBoolean(Prefs.AUTO_RES, autoResolution)
+            putString(Prefs.RESOLUTION, sanitizedResolution())
+            putInt(Prefs.MAX_FPS, maxFps.coerceIn(1, 240))
+            putBoolean(Prefs.LAUNCH_ON_CONNECT, launchOnConnect)
+            putBoolean(Prefs.ALLOW_NEW_CONN, allowNewConnections)
+        }.apply()
+    }
+
+    /** [deviceName] as it will be advertised: trimmed, or upstream's default when blank. */
+    private fun resolvedName(): String =
+        deviceName.trim().takeIf { it.isNotEmpty() } ?: Prefs.DEF_SERVER_NAME
+
+    /**
+     * Normalise [resolution] to something the service can actually parse, falling back to "auto".
+     *
+     * This has to happen here rather than being left to the setter: the service splits the stored
+     * string on a literal lowercase "x" and calls `toInt()` on both halves with no guard, so a
+     * value like "1920X1080", "1920*1080" or "1920x" throws out of `startServer` and takes the
+     * foreground service down on *every* start attempt — a persisted crash loop from one bad
+     * setting.
+     */
+    private fun sanitizedResolution(): String {
+        val value = resolution.trim().lowercase()
+        if (value == "auto" || value.isEmpty()) return Prefs.DEF_RESOLUTION
+        val parts = value.split("x")
+        if (parts.size != 2) return Prefs.DEF_RESOLUTION
+        val w = parts[0].trim().toIntOrNull() ?: return Prefs.DEF_RESOLUTION
+        val h = parts[1].trim().toIntOrNull() ?: return Prefs.DEF_RESOLUTION
+        if (w !in 1..7680 || h !in 1..7680) return Prefs.DEF_RESOLUTION
+        return "${w}x$h"
+    }
+}

--- a/airplay/src/main/kotlin/com/immortal/airplay/AirPlaySession.kt
+++ b/airplay/src/main/kotlin/com/immortal/airplay/AirPlaySession.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.airplay
+
+import io.github.jqssun.airplay.service.AirPlayService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+/**
+ * What a sender is currently doing, as the three questions a host actually asks.
+ *
+ * The service exposes this as four independent flags plus a poll timestamp, and every consumer that
+ * folds them itself ends up with a slightly different idea of when video is "live" — which matters,
+ * because the mirroring → AirPlay-video handover briefly leaves *all* of them false and a consumer
+ * that reads that as "the sender is gone" tears the session down mid-handover.
+ */
+data class AirPlaySession(
+    /** A sender is connected. False means the session is over, whatever the other two say. */
+    val connected: Boolean,
+    /** The sender is streaming audio with no picture. */
+    val audioOnly: Boolean,
+    /** A picture is live or imminent: mirroring, AirPlay video, or a video channel just polled. */
+    val video: Boolean,
+)
+
+/**
+ * How long a session may look finished while it is only handing over.
+ *
+ * Mirroring stops before the AirPlay-video URL arrives; the measured gap is around a second. Any
+ * host reaction that tears something down on "the video ended" — closing a surface, handing back
+ * the speakers — has to wait this out first, or it fires in the middle of a YouTube cast. Several
+ * times the measured gap, because over-waiting only costs a stale frame or a quiet speaker.
+ */
+const val AIRPLAY_HANDOVER_GRACE_MS = 5_000L
+
+/**
+ * The session as one flow.
+ *
+ * `videoSessionPending` is sampled rather than collected — it is a timestamp window, not a flow, so
+ * it has no edges of its own. It only ever widens [AirPlaySession.video], and the flags it rides
+ * along with change often enough during a handover to carry it. Including it is what makes the gap
+ * between mirroring and AirPlay video read as "still video", roughly a second before the URL lands.
+ */
+fun AirPlayService.sessionFlow(): Flow<AirPlaySession> =
+    combine(connectionCount, audioOnly, mirroringActive, videoPlaybackActive) {
+        connections,
+        audio,
+        mirroring,
+        playback ->
+        AirPlaySession(
+            connected = connections > 0,
+            audioOnly = audio,
+            video = mirroring || playback || videoSessionPending(),
+        )
+    }

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/Display.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/Display.kt
@@ -1,0 +1,13 @@
+package io.github.jqssun.airplay
+
+import android.content.Context
+import android.hardware.display.DisplayManager
+import android.view.Display
+
+// physical panel resolution
+fun Context.realDisplaySize(): Pair<Int, Int> {
+    val mode = getSystemService(DisplayManager::class.java)
+        ?.getDisplay(Display.DEFAULT_DISPLAY)?.mode
+    return if (mode != null) mode.physicalWidth to mode.physicalHeight
+    else resources.displayMetrics.let { it.widthPixels to it.heightPixels }
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/Prefs.kt
@@ -1,0 +1,49 @@
+package io.github.jqssun.airplay
+
+import android.media.MediaFormat
+
+/** Centralized preference keys and defaults. */
+object Prefs {
+    const val NAME = "settings"
+
+    const val SERVER_NAME = "server_name"; const val DEF_SERVER_NAME = "Android AirPlay"
+    const val FALLBACK_MAC_ADDRESS = "fallback_mac_address"
+    const val SERVER_PORT = "server_port"; const val DEF_SERVER_PORT = 7000
+    const val AUTO_START = "auto_start"; const val DEF_AUTO_START = true
+    const val BOOT_AUTO_START = "boot_auto_start"; const val DEF_BOOT_AUTO_START = true
+    const val RUN_IN_BACKGROUND = "run_in_background"; const val DEF_RUN_IN_BACKGROUND = true
+    const val H265_ENABLED = "h265_enabled"; const val DEF_H265_ENABLED = true
+    const val ENFORCE_SDR = "enforce_sdr"; const val DEF_ENFORCE_SDR = true
+    val KEY_ALLOW_FRAME_DROP: String = MediaFormat.KEY_ALLOW_FRAME_DROP; const val DEF_KEY_ALLOW_FRAME_DROP = true
+    val KEY_PRIORITY: String = MediaFormat.KEY_PRIORITY; const val DEF_KEY_PRIORITY = true
+    val KEY_OPERATING_RATE: String = MediaFormat.KEY_OPERATING_RATE; const val DEF_KEY_OPERATING_RATE = true
+    const val LOW_LATENCY = "low_latency"; const val DEF_LOW_LATENCY = false
+    const val SCHEDULED_OUTPUT_BUFFER_RELEASE = "scheduled_output_buffer_release"; const val DEF_SCHEDULED_OUTPUT_BUFFER_RELEASE = false
+    const val AUDIO_AUTO_BUFFER = "audio_auto_buffer"; const val DEF_AUDIO_AUTO_BUFFER = true
+    // fixed cushion ms, used only when AUDIO_AUTO_BUFFER is off
+    const val AUDIO_CUSHION_MS = "audio_cushion_ms"; const val DEF_AUDIO_CUSHION_MS = 40
+    // slider step 0..4 mapping to arrival-delay percentile the cushion targets;
+    // lower = less latency, higher = more stable
+    const val AUDIO_ADAPTIVE_STEP = "audio_adaptive_step"; const val DEF_AUDIO_ADAPTIVE_STEP = 3
+    val ADAPTIVE_PERCENTILES = intArrayOf(80, 85, 90, 95, 99)
+    const val OBOE_BUFFER_FRAMES = "oboe_buffer_frames"; const val DEF_OBOE_BUFFER_FRAMES = 0
+    const val ALAC_ENABLED = "alac_enabled"; const val DEF_ALAC_ENABLED = false
+    const val FORCE_SW_ALAC = "force_sw_alac"; const val DEF_FORCE_SW_ALAC = true
+    const val AAC_ENABLED = "aac_enabled"; const val DEF_AAC_ENABLED = true
+    const val RESOLUTION = "resolution"; const val DEF_RESOLUTION = "auto"
+    const val AUTO_RES = "auto_res"; const val DEF_AUTO_RES = false
+    const val MAX_FPS = "max_fps"; const val DEF_MAX_FPS = 60
+    const val OVERSCANNED = "overscanned"; const val DEF_OVERSCANNED = false
+    const val REQUIRE_PIN = "require_pin"; const val DEF_REQUIRE_PIN = false
+    const val ALLOW_NEW_CONN = "allow_new_conn"; const val DEF_ALLOW_NEW_CONN = true
+    const val AUDIO_LATENCY_MS = "audio_latency_ms"; const val DEF_AUDIO_LATENCY_MS = -1
+    const val DEBUG_ENABLED = "debug_enabled"; const val DEF_DEBUG_ENABLED = false
+    const val DEVELOPER_OPTIONS = "developer_options"; const val DEF_DEVELOPER_OPTIONS = false
+    const val BENCHMARK_LOG = "benchmark_log"; const val DEF_BENCHMARK_LOG = false
+    const val IDLE_PREVIEW = "idle_preview"; const val DEF_IDLE_PREVIEW = false
+    const val AUTO_FULLSCREEN = "auto_fullscreen"; const val DEF_AUTO_FULLSCREEN = true
+    const val KEEP_SCREEN_ON = "keep_screen_on"; const val DEF_KEEP_SCREEN_ON = true
+    const val ADVERTISE_VIDEO = "advertise_video"; const val DEF_ADVERTISE_VIDEO = true
+    const val ADVERTISE_AUDIO = "advertise_audio"; const val DEF_ADVERTISE_AUDIO = true
+    const val LAUNCH_ON_CONNECT = "launch_on_connect"; const val DEF_LAUNCH_ON_CONNECT = true
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/audio/DacpController.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/audio/DacpController.kt
@@ -1,0 +1,119 @@
+package io.github.jqssun.airplay.audio
+
+import android.content.Context
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import android.util.Log
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.Executors
+
+/**
+ * Sends DACP (Digital Audio Control Protocol) commands back to the AirPlay sender.
+ * Resolves the sender's control port via mDNS, then sends HTTP GET requests.
+ */
+class DacpController(ctx: Context) {
+
+    private val nsdManager = ctx.getSystemService(Context.NSD_SERVICE) as NsdManager
+    private val exec = Executors.newSingleThreadExecutor()
+
+    @Volatile var dacpId = ""
+    @Volatile var activeRemote = ""
+    @Volatile private var host = ""
+    @Volatile private var port = 0
+
+    fun update(dacpId: String, activeRemote: String) {
+        this.dacpId = dacpId
+        this.activeRemote = activeRemote
+        _resolve()
+    }
+
+    fun play() = _send("/ctrl-int/1/play")
+    fun pause() = _send("/ctrl-int/1/pause")
+    fun nextItem() = _send("/ctrl-int/1/nextitem")
+    fun prevItem() = _send("/ctrl-int/1/previtem")
+    fun volumeUp() = _send("/ctrl-int/1/volumeup")
+    fun volumeDown() = _send("/ctrl-int/1/volumedown")
+    fun muteToggle() = _send("/ctrl-int/1/mutetoggle")
+    fun beginFastForward() = _send("/ctrl-int/1/beginff")
+    fun beginRewind() = _send("/ctrl-int/1/beginrew")
+    fun playResume() = _send("/ctrl-int/1/playresume")
+
+    fun reset() {
+        dacpId = ""
+        activeRemote = ""
+        host = ""
+        port = 0
+    }
+
+    fun release() {
+        reset()
+        exec.shutdownNow()
+    }
+
+    private fun _resolve() {
+        if (dacpId.isEmpty()) return
+        val serviceName = "iTunes_Ctrl_$dacpId"
+        val info = NsdServiceInfo().apply {
+            serviceType = "_dacp._tcp"
+            this.serviceName = serviceName
+        }
+        try {
+            nsdManager.resolveService(info, object : NsdManager.ResolveListener {
+                override fun onResolveFailed(si: NsdServiceInfo, code: Int) {
+                    Log.w(TAG, "DACP resolve failed: $code")
+                }
+                override fun onServiceResolved(si: NsdServiceInfo) {
+                    host = si.host.hostAddress ?: return
+                    port = si.port
+                    Log.i(TAG, "DACP resolved: $host:$port")
+                }
+            })
+        } catch (e: Exception) {
+            Log.w(TAG, "DACP resolve error", e)
+        }
+    }
+
+    private fun _send(path: String): ListenableFuture<Unit> {
+        val result = SettableFuture.create<Unit>()
+        if (host.isEmpty() || activeRemote.isEmpty()) {
+            result.setException(IOException("dacp endpoint not resolved"))
+            return result
+        }
+        try {
+            exec.execute {
+                try {
+                    val url = "http://$host:$port$path"
+                    val conn = URL(url).openConnection() as HttpURLConnection
+                    conn.requestMethod = "GET"
+                    conn.setRequestProperty("Active-Remote", activeRemote)
+                    conn.setRequestProperty("Host", "$host:$port")
+                    conn.connectTimeout = 2000
+                    conn.readTimeout = 2000
+                    val code = conn.responseCode
+                    try { conn.inputStream.readBytes() } catch (_: Exception) {}
+                    conn.disconnect()
+                    if (code in 200..299) {
+                        result.set(Unit)
+                    } else {
+                        Log.w(TAG, "DACP $path -> HTTP $code")
+                        result.setException(IOException("HTTP $code"))
+                    }
+                } catch (e: Exception) {
+                    Log.w(TAG, "DACP send failed: $path", e)
+                    result.setException(e)
+                }
+            }
+        } catch (e: Exception) {
+            result.setException(e)
+        }
+        return result
+    }
+
+    companion object {
+        private const val TAG = "DacpController"
+    }
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/audio/DacpPlayer.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/audio/DacpPlayer.kt
@@ -1,0 +1,107 @@
+package io.github.jqssun.airplay.audio
+
+import android.os.Looper
+import androidx.media3.common.C
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
+import androidx.media3.common.SimpleBasePlayer
+import androidx.media3.common.util.UnstableApi
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.MoreExecutors
+
+// exposes sender's audio session as media3 player
+@androidx.annotation.OptIn(UnstableApi::class)
+class DacpPlayer(
+    looper: Looper,
+    private val dacp: () -> DacpController?,
+    private val snapshot: () -> Snapshot,
+    private val positionMs: () -> Long,
+    private val setPlaying: (Boolean) -> Unit,
+) : SimpleBasePlayer(looper) {
+
+    data class Snapshot(
+        val track: TrackInfo,
+        val artworkData: ByteArray?,
+        val durationMs: Long,
+        val playing: Boolean,
+        val active: Boolean,
+    )
+
+    // must be called on the constructor looper
+    fun refresh() = invalidateState()
+
+    override fun getState(): State {
+        val s = snapshot()
+        if (!s.active) {
+            return State.Builder().setAvailableCommands(Player.Commands.EMPTY).build()
+        }
+        val metadata = MediaMetadata.Builder()
+            .setTitle(s.track.title)
+            .setArtist(s.track.artist)
+            .setAlbumTitle(s.track.album)
+            .apply {
+                s.artworkData?.let { setArtworkData(it, MediaMetadata.PICTURE_TYPE_FRONT_COVER) }
+            }
+            .build()
+        return State.Builder()
+            .setAvailableCommands(
+                Player.Commands.Builder()
+                    .addAll(
+                        Player.COMMAND_PLAY_PAUSE,
+                        Player.COMMAND_SEEK_TO_NEXT,
+                        Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+                        Player.COMMAND_SEEK_TO_PREVIOUS,
+                        Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+                        Player.COMMAND_GET_CURRENT_MEDIA_ITEM,
+                        Player.COMMAND_GET_TIMELINE,
+                        Player.COMMAND_GET_METADATA,
+                    )
+                    .build()
+            )
+            .setPlaylist(
+                listOf(
+                    MediaItemData.Builder(UID_PREVIOUS).build(),
+                    MediaItemData.Builder(UID_CURRENT)
+                        .setMediaMetadata(metadata)
+                        .setDurationUs(if (s.durationMs > 0) s.durationMs * 1000 else C.TIME_UNSET)
+                        .setIsSeekable(false)
+                        .build(),
+                    MediaItemData.Builder(UID_NEXT).build(),
+                )
+            )
+            .setCurrentMediaItemIndex(1)
+            .setPlaybackState(Player.STATE_READY)
+            .setPlayWhenReady(s.playing, Player.PLAY_WHEN_READY_CHANGE_REASON_REMOTE)
+            .setContentPositionMs(PositionSupplier { positionMs() })
+            // seekToPrevious must always mean "previous item", never "restart current"
+            .setMaxSeekToPreviousPositionMs(Long.MAX_VALUE)
+            .build()
+    }
+
+    override fun handleSetPlayWhenReady(playWhenReady: Boolean): ListenableFuture<*> {
+        val dacp = dacp() ?: return Futures.immediateVoidFuture()
+        return Futures.transform(
+            if (playWhenReady) dacp.play() else dacp.pause(),
+            { setPlaying(playWhenReady) },
+            MoreExecutors.directExecutor()
+        )
+    }
+
+    override fun handleSeek(mediaItemIndex: Int, positionMs: Long, seekCommand: Int): ListenableFuture<*> {
+        val dacp = dacp() ?: return Futures.immediateVoidFuture()
+        return when (seekCommand) {
+            Player.COMMAND_SEEK_TO_NEXT, Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM ->
+                dacp.nextItem()
+            Player.COMMAND_SEEK_TO_PREVIOUS, Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM ->
+                dacp.prevItem()
+            else -> Futures.immediateVoidFuture()
+        }
+    }
+
+    private companion object {
+        const val UID_PREVIOUS = "previous"
+        const val UID_CURRENT = "current"
+        const val UID_NEXT = "next"
+    }
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/audio/DmapParser.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/audio/DmapParser.kt
@@ -1,0 +1,52 @@
+package io.github.jqssun.airplay.audio
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/** Parses DMAP (iTunes metadata) binary TLV format into a tag->value map. */
+object DmapParser {
+
+    // tags whose payload is an integer (1/2/4/8 bytes)
+    private val INT_TAGS = setOf(
+        "astm", // duration ms
+        "astn", // track number
+        "asdk", // data kind
+        "asts", // ???
+        "miid", // item id
+        "mcti", // container item id
+        "mper", // persistent id
+        "asai", // album id
+        "asri", // artist id
+        "asci", // composer id
+        "asgi", // genre id
+    )
+
+    // tags that are containers (contain nested dmap items)
+    private val CONTAINER_TAGS = setOf("mlit", "mcon", "mlcl")
+
+    fun parse(data: ByteArray): Map<String, Any> {
+        val result = mutableMapOf<String, Any>()
+        val buf = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN)
+        while (buf.remaining() >= 8) {
+            val tagBytes = ByteArray(4)
+            buf.get(tagBytes)
+            val tag = String(tagBytes, Charsets.US_ASCII)
+            val len = buf.int
+            if (len < 0 || len > buf.remaining()) break
+            val payload = ByteArray(len)
+            buf.get(payload)
+            result[tag] = when {
+                tag in CONTAINER_TAGS -> parse(payload)
+                tag in INT_TAGS -> _readInt(payload)
+                else -> String(payload, Charsets.UTF_8)
+            }
+        }
+        return result
+    }
+
+    private fun _readInt(b: ByteArray): Long {
+        var v = 0L
+        for (byte in b) v = (v shl 8) or (byte.toLong() and 0xFF)
+        return v
+    }
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/audio/TrackInfo.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/audio/TrackInfo.kt
@@ -1,0 +1,40 @@
+package io.github.jqssun.airplay.audio
+
+import android.graphics.Bitmap
+
+data class TrackInfo(
+    val title: String = "",
+    val artist: String = "",
+    val album: String = "",
+    val genre: String = "",
+    val durationMs: Long = 0,
+    val coverArt: Bitmap? = null,
+) {
+    companion object {
+        fun fromDmap(map: Map<String, Any>, existingArt: Bitmap? = null): TrackInfo {
+            // DMAP data is often wrapped in mlit container
+            val flat = _flatten(map)
+            return TrackInfo(
+                title = flat["minm"] as? String ?: "",
+                artist = flat["asar"] as? String ?: "",
+                album = flat["asal"] as? String ?: "",
+                genre = flat["asgn"] as? String ?: "",
+                durationMs = (flat["astm"] as? Long) ?: 0L,
+                coverArt = existingArt,
+            )
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        private fun _flatten(map: Map<String, Any>): Map<String, Any> {
+            val result = mutableMapOf<String, Any>()
+            for ((k, v) in map) {
+                if (v is Map<*, *>) {
+                    result.putAll(_flatten(v as Map<String, Any>))
+                } else {
+                    result[k] = v
+                }
+            }
+            return result
+        }
+    }
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/bridge/LogListener.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/bridge/LogListener.kt
@@ -1,0 +1,9 @@
+package io.github.jqssun.airplay.bridge
+
+/**
+ * log lines from native code, forwarded to UI; called directly from native threads
+ * (attached to JVM for the call), implementations must be thread-safe and cheap
+ */
+interface LogListener {
+    fun onLog(msg: String)
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/bridge/NativeBridge.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/bridge/NativeBridge.kt
@@ -1,0 +1,47 @@
+package io.github.jqssun.airplay.bridge
+
+object NativeBridge {
+    init {
+        System.loadLibrary("airplay_native")
+    }
+
+    external fun nativeInit(
+        callback: RaopCallbackHandler,
+        hwAddr: ByteArray,
+        name: String,
+        keyFile: String,
+        nohold: Boolean,
+        requirePin: Boolean
+    ): Long
+
+    external fun nativeStart(handle: Long, port: Int): Int
+    external fun nativeStop(handle: Long)
+    external fun nativeDestroy(handle: Long)
+
+    external fun nativeSetDisplaySize(handle: Long, w: Int, h: Int, fps: Int)
+    external fun nativeSetPlist(handle: Long, key: String, value: Int)
+    external fun nativeSetH265Enabled(handle: Long, enabled: Boolean)
+    external fun nativeSetCodecs(handle: Long, alac: Boolean, aac: Boolean)
+    external fun nativeSetHlsEnabled(handle: Long, enabled: Boolean)
+    external fun nativeSetAudioEnabled(handle: Long, enabled: Boolean)
+    external fun nativeUpdatePlaybackInfo(
+        handle: Long, position: Float, duration: Float, rate: Float, readyToPlay: Boolean
+    )
+
+    external fun nativeGetRaopTxtRecords(handle: Long): Map<String, String>?
+    external fun nativeGetAirplayTxtRecords(handle: Long): Map<String, String>?
+    external fun nativeGetRaopServiceName(handle: Long): String?
+    external fun nativeGetServerName(handle: Long): String?
+
+    external fun nativeSetDefaultStreamValues(sampleRate: Int, framesPerBurst: Int)
+    external fun nativeServerAudioConfigure(handle: Long, cushionMs: Int, percentilePct: Int,
+                                            oboeBufferFrames: Int, forceSwAlac: Boolean,
+                                            realtimePriority: Boolean, lowLatency: Boolean,
+                                            benchmarkLog: Boolean): Boolean
+    external fun nativeServerAudioStart(handle: Long): Boolean
+    external fun nativeServerAudioStop(handle: Long)
+    external fun nativeServerAudioSetVolume(handle: Long, volume: Float)
+    external fun nativeServerAudioFormat(handle: Long, ct: Int, spf: Int)
+    // fills direct buffer with packed debug snapshot; false if audio isn't running
+    external fun nativeServerAudioDebug(handle: Long, buf: java.nio.ByteBuffer): Boolean
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/bridge/RaopCallbackHandler.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/bridge/RaopCallbackHandler.kt
@@ -1,0 +1,24 @@
+package io.github.jqssun.airplay.bridge
+
+interface RaopCallbackHandler {
+    fun onVideoData(data: ByteArray, ntpTimeNs: Long, isH265: Boolean)
+    fun onAudioFormat(ct: Int, spf: Int, usingScreen: Boolean)
+    fun onVideoSize(srcW: Float, srcH: Float, w: Float, h: Float)
+    fun onVolumeChange(volume: Float)
+    fun onConnectionInit()
+    fun onConnectionDestroy()
+    fun onConnectionReset(reason: Int)
+    fun onDisplayPin(pin: String)
+    fun onMetadata(data: ByteArray)
+    fun onCoverArt(data: ByteArray)
+    fun onProgress(start: Long, curr: Long, end: Long)
+    fun onDacpId(dacpId: String, activeRemote: String)
+    fun onAudioOnly(audioOnly: Boolean)
+    // video (hls), distinct from mirroring and raop audio
+    fun onVideoPlay(location: String, startPositionSeconds: Float)
+    fun onVideoScrub(positionSeconds: Float)
+    fun onVideoRate(rate: Float)
+    fun onVideoStop()
+    // fired per sender GET /playback-info poll; polling starts before /play
+    fun onVideoSessionPoll()
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/discovery/NsdServiceManager.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/discovery/NsdServiceManager.kt
@@ -1,0 +1,94 @@
+package io.github.jqssun.airplay.discovery
+
+import android.content.Context
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import android.net.wifi.WifiManager
+import android.util.Log
+
+class NsdServiceManager(private val ctx: Context) {
+
+    private val nsdManager = ctx.getSystemService(Context.NSD_SERVICE) as NsdManager
+    private var multicastLock: WifiManager.MulticastLock? = null
+    private var raopRegistration: NsdManager.RegistrationListener? = null
+    private var airplayRegistration: NsdManager.RegistrationListener? = null
+
+    fun acquireMulticastLock() {
+        val wifi = ctx.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        multicastLock = wifi.createMulticastLock("airplay_mdns").apply {
+            setReferenceCounted(false)
+            acquire()
+        }
+    }
+
+    fun registerRaop(serviceName: String, port: Int, txtRecords: Map<String, String>) {
+        val info = NsdServiceInfo().apply {
+            this.serviceName = serviceName
+            serviceType = "_raop._tcp"
+            this.port = port
+            txtRecords.forEach { (k, v) -> setAttribute(k, v) }
+        }
+
+        raopRegistration = object : NsdManager.RegistrationListener {
+            override fun onServiceRegistered(info: NsdServiceInfo) {
+                Log.i(TAG, "RAOP registered: ${info.serviceName}")
+            }
+            override fun onRegistrationFailed(info: NsdServiceInfo, code: Int) {
+                Log.e(TAG, "RAOP registration failed: $code")
+            }
+            override fun onServiceUnregistered(info: NsdServiceInfo) {
+                Log.i(TAG, "RAOP unregistered")
+            }
+            override fun onUnregistrationFailed(info: NsdServiceInfo, code: Int) {
+                Log.e(TAG, "RAOP unregister failed: $code")
+            }
+        }
+        nsdManager.registerService(info, NsdManager.PROTOCOL_DNS_SD, raopRegistration)
+    }
+
+    fun registerAirplay(serviceName: String, port: Int, txtRecords: Map<String, String>) {
+        val info = NsdServiceInfo().apply {
+            this.serviceName = serviceName
+            serviceType = "_airplay._tcp"
+            this.port = port
+            txtRecords.forEach { (k, v) -> setAttribute(k, v) }
+        }
+
+        airplayRegistration = object : NsdManager.RegistrationListener {
+            override fun onServiceRegistered(info: NsdServiceInfo) {
+                Log.i(TAG, "AirPlay registered: ${info.serviceName}")
+            }
+            override fun onRegistrationFailed(info: NsdServiceInfo, code: Int) {
+                Log.e(TAG, "AirPlay registration failed: $code")
+            }
+            override fun onServiceUnregistered(info: NsdServiceInfo) {
+                Log.i(TAG, "AirPlay unregistered")
+            }
+            override fun onUnregistrationFailed(info: NsdServiceInfo, code: Int) {
+                Log.e(TAG, "AirPlay unregister failed: $code")
+            }
+        }
+        nsdManager.registerService(info, NsdManager.PROTOCOL_DNS_SD, airplayRegistration)
+    }
+
+    fun unregisterAll() {
+        raopRegistration?.let {
+            try { nsdManager.unregisterService(it) } catch (_: Exception) {}
+            raopRegistration = null
+        }
+        airplayRegistration?.let {
+            try { nsdManager.unregisterService(it) } catch (_: Exception) {}
+            airplayRegistration = null
+        }
+    }
+
+    fun release() {
+        unregisterAll()
+        multicastLock?.release()
+        multicastLock = null
+    }
+
+    companion object {
+        private const val TAG = "NsdServiceManager"
+    }
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/download/VideoDownloader.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/download/VideoDownloader.kt
@@ -1,0 +1,135 @@
+package io.github.jqssun.airplay.download
+
+import android.content.ContentValues
+import android.content.Context
+import android.media.MediaScannerConnection
+import android.os.Build
+import android.os.Environment
+import android.os.Handler
+import android.os.Looper
+import android.provider.MediaStore
+import android.util.Log
+import android.widget.Toast
+import androidx.media3.common.MediaItem
+import androidx.media3.transformer.Composition
+import androidx.media3.transformer.ExportException
+import androidx.media3.transformer.ExportResult
+import androidx.media3.transformer.ProgressHolder
+import androidx.media3.transformer.Transformer
+import io.github.jqssun.airplay.R
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.concurrent.thread
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+// transformer requires a looper thread
+class VideoDownloader(private val context: Context) {
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var transformer: Transformer? = null
+
+    // null = idle, -1 = unknown, else 0..100
+    private val _progress = MutableStateFlow<Int?>(null)
+    val progress = _progress.asStateFlow()
+
+    private val _progressTick = object : Runnable {
+        override fun run() {
+            val t = transformer ?: return
+            val holder = ProgressHolder()
+            if (t.getProgress(holder) == Transformer.PROGRESS_STATE_AVAILABLE) {
+                _progress.value = holder.progress
+            }
+            mainHandler.postDelayed(this, PROGRESS_INTERVAL_MS)
+        }
+    }
+
+    fun start(location: String) = mainHandler.post {
+        if (transformer != null) return@post
+        _progress.value = -1
+        val file = File(context.cacheDir, TEMP_NAME)
+        val t = Transformer.Builder(context)
+            .addListener(object : Transformer.Listener {
+                override fun onCompleted(composition: Composition, result: ExportResult) {
+                    _reset()
+                    thread {
+                        val path = _publish(file)
+                        file.delete()
+                        _toast(
+                            if (path != null) context.getString(R.string.download_saved, path)
+                            else context.getString(R.string.download_failed)
+                        )
+                    }
+                }
+                override fun onError(composition: Composition, result: ExportResult, exception: ExportException) {
+                    Log.w(TAG, "export failed", exception)
+                    _reset()
+                    file.delete()
+                    _toast(context.getString(R.string.download_failed))
+                }
+            })
+            .build()
+        transformer = t
+        t.start(MediaItem.fromUri(location), file.absolutePath)
+        mainHandler.postDelayed(_progressTick, PROGRESS_INTERVAL_MS)
+    }
+
+    fun cancel() = mainHandler.post {
+        transformer?.cancel() ?: return@post
+        _reset()
+        File(context.cacheDir, TEMP_NAME).delete()
+    }
+
+    private fun _reset() {
+        mainHandler.removeCallbacks(_progressTick)
+        transformer = null
+        _progress.value = null
+    }
+
+    private fun _publish(file: File): String? {
+        val stamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+        val name = "AirPlay_$stamp.mp4"
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                val resolver = context.contentResolver
+                val values = ContentValues().apply {
+                    put(MediaStore.Video.Media.DISPLAY_NAME, name)
+                    put(MediaStore.Video.Media.MIME_TYPE, "video/mp4")
+                    put(MediaStore.Video.Media.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+                    put(MediaStore.Video.Media.IS_PENDING, 1)
+                }
+                val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values) ?: return null
+                resolver.openOutputStream(uri)!!.use { out -> file.inputStream().use { it.copyTo(out) } }
+                values.clear()
+                values.put(MediaStore.Video.Media.IS_PENDING, 0)
+                resolver.update(uri, values, null, null)
+                val path = resolver.query(uri, arrayOf(MediaStore.MediaColumns.DATA), null, null, null)?.use {
+                    if (it.moveToFirst()) it.getString(0) else null
+                }
+                return path ?: "${Environment.DIRECTORY_DOWNLOADS}/$name"
+            } else {
+                // pre-q public storage needs a runtime permission
+                val dir = context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS) ?: return null
+                val dest = File(dir, name)
+                file.copyTo(dest, overwrite = true)
+                MediaScannerConnection.scanFile(context, arrayOf(dest.absolutePath), arrayOf("video/mp4"), null)
+                return dest.absolutePath
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "publish failed", e)
+            return null
+        }
+    }
+
+    private fun _toast(msg: String) = mainHandler.post {
+        Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
+    }
+
+    companion object {
+        private const val TAG = "VideoDownloader"
+        private const val TEMP_NAME = "video_download.mp4"
+        private const val PROGRESS_INTERVAL_MS = 500L
+    }
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/renderer/AirPlayVideoPlayer.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/renderer/AirPlayVideoPlayer.kt
@@ -1,0 +1,185 @@
+package io.github.jqssun.airplay.renderer
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.Surface
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
+import androidx.media3.common.VideoSize
+import androidx.media3.exoplayer.ExoPlayer
+
+// rate is 0 while buffering; speed is the configured rate regardless of pause state
+// native reads the effective rate, overlay reads playWhenReady + speed + skipSilence
+data class PlaybackSnapshot(
+    val position: Float,
+    val duration: Float,
+    val rate: Float,
+    val ready: Boolean,
+    val playWhenReady: Boolean,
+    val speed: Float = 1f,
+    val skipSilence: Boolean = false,
+    val buffering: Boolean = false,
+)
+
+// exoplayer calls stay on the main thread; native only reads the onPlaybackInfo snapshot
+class AirPlayVideoPlayer(private val context: Context) {
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var player: ExoPlayer? = null
+    private var pendingSurface: Surface? = null
+
+    var onPlaybackInfo: ((PlaybackSnapshot) -> Unit)? = null
+    var onVideoSize: ((width: Int, height: Int, aspect: Float) -> Unit)? = null
+    var onTitle: ((String?) -> Unit)? = null
+    var onEnded: (() -> Unit)? = null
+
+    private val _reportTick = object : Runnable {
+        override fun run() {
+            _reportPlaybackInfo()
+            mainHandler.postDelayed(this, REPORT_INTERVAL_MS)
+        }
+    }
+
+    private val _listener = object : Player.Listener {
+        override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+            Log.w(TAG, "playback error", error)
+            onEnded?.invoke()
+        }
+        override fun onPlaybackStateChanged(state: Int) {
+            if (state == Player.STATE_ENDED) onEnded?.invoke()
+        }
+        override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+            // duration is usually established here (esp. hls): report so the held /play releases
+            _reportPlaybackInfo()
+        }
+        override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
+            onTitle?.invoke(mediaMetadata.title?.toString())
+        }
+        override fun onVideoSizeChanged(videoSize: VideoSize) {
+            if (videoSize.height == 0) return
+            val width = (videoSize.width * videoSize.pixelWidthHeightRatio).toInt()
+            onVideoSize?.invoke(width, videoSize.height, width.toFloat() / videoSize.height)
+        }
+    }
+
+    fun play(location: String, startPositionSeconds: Float) = mainHandler.post {
+        // recycling must not report the stopped sentinel: senders poll right after /play
+        _stopInternal(reportStopped = false)
+        val p = ExoPlayer.Builder(context).build().also {
+            it.addListener(_listener)
+            pendingSurface?.let { s -> it.setVideoSurface(s) }
+        }
+        player = p
+        p.setMediaItem(MediaItem.fromUri(location), (startPositionSeconds * 1000).toLong())
+        p.playWhenReady = true
+        p.prepare()
+        onPlaybackInfo?.invoke(PlaybackSnapshot(startPositionSeconds, 0f, 0f, false, true))
+        mainHandler.postDelayed(_reportTick, REPORT_INTERVAL_MS)
+    }
+
+    fun scrub(positionSeconds: Float) = mainHandler.post {
+        player?.seekTo((positionSeconds * 1000).toLong())
+    }
+
+    // coalesces the seek spam from drag-seeking
+    @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+    fun setScrubbing(enabled: Boolean) = mainHandler.post {
+        player?.isScrubbingModeEnabled = enabled
+    }
+
+    fun setRate(rate: Float) = mainHandler.post {
+        val p = player ?: return@post
+        if (rate <= 0f) {
+            p.playWhenReady = false
+        } else {
+            p.playbackParameters = PlaybackParameters(rate.coerceAtLeast(0.1f))
+            p.playWhenReady = true
+        }
+    }
+
+    // local-only: the sender self-syncs from its next /playback-info poll
+    fun setPlaying(playing: Boolean) = mainHandler.post {
+        player?.playWhenReady = playing
+    }
+
+    // local speed toggle: unlike setRate it must not resume a paused player
+    fun setSpeed(speed: Float) = mainHandler.post {
+        player?.playbackParameters = PlaybackParameters(speed.coerceAtLeast(0.1f))
+    }
+
+    fun setSkipSilence(enabled: Boolean) = mainHandler.post {
+        player?.skipSilenceEnabled = enabled
+    }
+
+    fun seekBy(deltaMs: Long) = mainHandler.post {
+        val p = player ?: return@post
+        var target = (p.currentPosition + deltaMs).coerceAtLeast(0)
+        val duration = p.duration
+        if (duration != C.TIME_UNSET) {
+            target = target.coerceAtMost(duration)
+        }
+        p.seekTo(target)
+    }
+
+    fun setSurface(surface: Surface) = mainHandler.post {
+        pendingSurface = surface
+        player?.setVideoSurface(surface)
+    }
+
+    // no-op if a newer surface already replaced this one
+    fun clearSurface(surface: Surface) = mainHandler.post {
+        if (pendingSurface !== surface) return@post
+        pendingSurface = null
+        player?.setVideoSurface(null)
+    }
+
+    fun stop() = mainHandler.post { _stopInternal(reportStopped = true) }
+
+    private fun _stopInternal(reportStopped: Boolean) {
+        mainHandler.removeCallbacks(_reportTick)
+        player?.let {
+            it.removeListener(_listener)
+            it.release()
+        }
+        player = null
+        // duration=-1 is the "video finished" sentinel for the playback-info handler
+        if (reportStopped) {
+            onPlaybackInfo?.invoke(PlaybackSnapshot(0f, -1f, 0f, false, false))
+        }
+    }
+
+    private fun _reportPlaybackInfo() {
+        val p = player ?: return
+        val durationMs = p.duration
+        val position = p.currentPosition / 1000f
+        // 0 = live/unknown (TIME_UNSET); a real value only exists for vod
+        val duration = if (durationMs == C.TIME_UNSET) 0f else durationMs / 1000f
+        val rate = if (p.playWhenReady && p.playbackState == Player.STATE_READY) p.playbackParameters.speed else 0f
+        // readyToPlay = the timeline is established, NOT exoplayer's buffering state: for vod that means the duration is known; for live there is no duration so being playable is enough. the sender holds its timeline (and /play) until this, so it must not go true early
+        val ready = if (p.isCurrentMediaItemLive) p.playbackState == Player.STATE_READY
+                    else durationMs != C.TIME_UNSET
+        onPlaybackInfo?.invoke(
+            PlaybackSnapshot(
+                position = position,
+                duration = duration,
+                rate = rate,
+                ready = ready,
+                playWhenReady = p.playWhenReady,
+                speed = p.playbackParameters.speed,
+                skipSilence = p.skipSilenceEnabled,
+                buffering = p.playbackState == Player.STATE_BUFFERING,
+            )
+        )
+    }
+
+    companion object {
+        private const val TAG = "AirPlayVideoPlayer"
+        private const val REPORT_INTERVAL_MS = 250L
+    }
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/renderer/AudioConfig.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/renderer/AudioConfig.kt
@@ -1,0 +1,15 @@
+package io.github.jqssun.airplay.renderer
+
+/**
+ * mirrors native AudioConfig struct; defaults must match preference defaults so a
+ * freshly-constructed AudioRenderer is sane
+ */
+data class AudioConfig(
+    val cushionMs: Int = 0,           // 0 = adaptive tuner, otherwise fixed cushion ms
+    val percentilePct: Int = 95,
+    val oboeBufferFrames: Int = 0,    // 0 = auto (two bursts)
+    val forceSwAlac: Boolean = false,
+    val realtimePriority: Boolean = true,
+    val lowLatency: Boolean = true,
+    val benchmarkLog: Boolean = false,
+)

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/renderer/AudioRenderer.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/renderer/AudioRenderer.kt
@@ -1,0 +1,110 @@
+package io.github.jqssun.airplay.renderer
+
+import io.github.jqssun.airplay.bridge.NativeBridge
+import io.github.jqssun.airplay.viewmodel.AudioDebug
+import kotlin.math.pow
+
+// wrapper around native audio engine
+class AudioRenderer {
+
+    @Volatile var config = AudioConfig(); private set
+
+    @Volatile var volume = 1.0f; private set
+    @Volatile var codecLabel = ""; private set
+
+    private var serverHandle = 0L
+
+    @Synchronized
+    fun attachEngine(server: Long) {
+        serverHandle = server
+        pushConfig()
+        NativeBridge.nativeServerAudioSetVolume(serverHandle, volume)
+    }
+
+    @Synchronized
+    fun detachEngine() {
+        serverHandle = 0L
+        codecLabel = ""
+    }
+
+    // open playout (first onAudioFormat, or resume after pause); idempotent natively
+    @Synchronized
+    fun start() {
+        if (serverHandle == 0L) return
+        NativeBridge.nativeServerAudioStart(serverHandle)
+    }
+
+    // releases oboe stream + audio device while idle; engine stays alive, freed on server destroy
+    @Synchronized
+    fun stop() {
+        if (serverHandle == 0L) return
+        NativeBridge.nativeServerAudioStop(serverHandle)
+        codecLabel = ""
+    }
+
+    @Synchronized
+    fun updateConfig(newConfig: AudioConfig) {
+        config = newConfig
+        pushConfig()
+    }
+
+    private fun pushConfig() {
+        if (serverHandle == 0L) return
+        NativeBridge.nativeServerAudioConfigure(
+            serverHandle, config.cushionMs, config.percentilePct, config.oboeBufferFrames,
+            config.forceSwAlac, config.realtimePriority, config.lowLatency, config.benchmarkLog)
+    }
+
+    private val debugBuf = java.nio.ByteBuffer.allocateDirect(DEBUG_BUF_BYTES)
+        .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+
+    // field order/width must mirror native packed AudioDebugData exactly
+    @Synchronized
+    fun audioDebug(): AudioDebug? {
+        if (serverHandle == 0L) return null
+        if (!NativeBridge.nativeServerAudioDebug(serverHandle, debugBuf)) return null
+        val buf = debugBuf
+        buf.rewind()
+        val backlogMs = buf.short.toInt() and 0xFFFF
+        val tunedCushionMs = buf.short.toInt() and 0xFFFF
+        val trims = buf.int
+        val drops = buf.int
+        val silences = buf.int
+        val underruns = buf.int
+        val meanUs = buf.int
+        val maxUs = buf.int
+        val held = buf.short.toInt() and 0xFFFF
+        val xrun = buf.int
+        val decodeErrors = buf.int
+        return AudioDebug(backlogMs, tunedCushionMs, trims, drops, silences, underruns, xrun,
+                          meanUs, maxUs, held, decodeErrors)
+    }
+
+    @Synchronized
+    fun setFormat(ct: Int, spf: Int) {
+        codecLabel = when (ct) {
+            CT_ALAC -> "ALAC"; CT_AAC_LC -> "AAC-LC"; CT_AAC_ELD -> "AAC-ELD"; else -> "?"
+        }
+        if (serverHandle != 0L) NativeBridge.nativeServerAudioFormat(serverHandle, ct, spf)
+    }
+
+    @Synchronized
+    fun setVolume(vol: Float) {
+        // dB: max = 0, min = -30, mute = -144
+        volume = when {
+            vol <= -144f -> 0f
+            vol >= 0f -> 1f
+            else -> 10f.pow(vol / 20f)
+        }
+        if (serverHandle == 0L) return
+        NativeBridge.nativeServerAudioSetVolume(serverHandle, volume)
+    }
+
+    companion object {
+        // must be >= native sizeof(AudioDebugData) (38 B)
+        private const val DEBUG_BUF_BYTES = 64
+        const val CT_ALAC = 2
+        const val CT_AAC_LC = 4
+        const val CT_AAC_ELD = 8
+    }
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/renderer/VideoPipeline.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/renderer/VideoPipeline.kt
@@ -1,0 +1,286 @@
+package io.github.jqssun.airplay.renderer
+
+import android.graphics.SurfaceTexture
+import android.opengl.EGL14
+import android.opengl.EGLConfig
+import android.opengl.EGLContext
+import android.opengl.EGLDisplay
+import android.opengl.EGLSurface
+import android.opengl.GLES11Ext
+import android.opengl.GLES20
+import android.opengl.Matrix
+import android.util.Log
+import android.view.Surface
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.FloatBuffer
+
+// decodes into an app-owned SurfaceTexture that outlives display surface
+// gl thread blits it to any surface attached, so fullscreen toggles re-point display without restarting codec
+class VideoPipeline {
+
+    private val lock = Object()
+    private var thread: Thread? = null
+    @Volatile private var running = false
+
+    private var eglDisplay: EGLDisplay = EGL14.EGL_NO_DISPLAY
+    private var eglContext: EGLContext = EGL14.EGL_NO_CONTEXT
+    private var eglConfig: EGLConfig? = null
+    private var pbuffer: EGLSurface = EGL14.EGL_NO_SURFACE
+    private var window: EGLSurface = EGL14.EGL_NO_SURFACE
+    private var winW = 0
+    private var winH = 0
+
+    private var oesTex = 0
+    private var program = 0
+    private var aPos = 0
+    private var aTex = 0
+    private var uTexMatrix = 0
+    private val texMatrix = FloatArray(16)
+    private var hasFrame = false
+
+    private var surfaceTexture: SurfaceTexture? = null
+    var inputSurface: Surface? = null; private set
+
+    @Volatile private var frameAvailable = false
+    private var pendingDisplay: Surface? = null
+    private var displayDirty = false
+    @Volatile private var videoW = 0
+    @Volatile private var videoH = 0
+
+    fun start() = synchronized(lock) {
+        if (running) return@synchronized
+        running = true
+        thread = Thread({ _loop() }, "VideoPipeline").also { it.start() }
+        while (inputSurface == null && running) lock.wait()
+    }
+
+    fun setDisplaySurface(surface: Surface?) = synchronized(lock) {
+        pendingDisplay = surface
+        displayDirty = true
+        lock.notifyAll()
+    }
+
+    fun setVideoSize(w: Int, h: Int) {
+        videoW = w
+        videoH = h
+        surfaceTexture?.setDefaultBufferSize(w, h)
+    }
+
+    fun release() {
+        synchronized(lock) {
+            if (!running) return
+            running = false
+            lock.notifyAll()
+        }
+        thread?.join()
+        thread = null
+    }
+
+    private fun _loop() {
+        try {
+            _initEgl()
+            _initGl()
+        } catch (e: Exception) {
+            Log.e(TAG, "GL init failed", e)
+            synchronized(lock) { running = false; lock.notifyAll() }
+            return
+        }
+        Matrix.setIdentityM(texMatrix, 0)
+        synchronized(lock) {
+            inputSurface = Surface(surfaceTexture)
+            lock.notifyAll()
+        }
+        while (true) {
+            var newDisplay: Surface? = null
+            var displayChanged = false
+            var doFrame = false
+            synchronized(lock) {
+                while (running && !frameAvailable && !displayDirty) lock.wait()
+                if (running && displayDirty) {
+                    newDisplay = pendingDisplay
+                    displayChanged = true
+                    displayDirty = false
+                }
+                if (running && frameAvailable) {
+                    frameAvailable = false
+                    doFrame = true
+                }
+            }
+            if (!running) break
+            if (displayChanged) _bindDisplay(newDisplay)
+            if (doFrame) _consumeAndDraw()
+        }
+        _releaseGl()
+    }
+
+    private fun _bindDisplay(surface: Surface?) {
+        if (window != EGL14.EGL_NO_SURFACE) {
+            EGL14.eglMakeCurrent(eglDisplay, pbuffer, pbuffer, eglContext)
+            EGL14.eglDestroySurface(eglDisplay, window)
+            window = EGL14.EGL_NO_SURFACE
+        }
+        if (surface == null || !surface.isValid) return
+        window = EGL14.eglCreateWindowSurface(eglDisplay, eglConfig, surface, intArrayOf(EGL14.EGL_NONE), 0)
+        if (window == EGL14.EGL_NO_SURFACE) {
+            Log.w(TAG, "eglCreateWindowSurface failed: ${EGL14.eglGetError()}")
+            return
+        }
+        EGL14.eglMakeCurrent(eglDisplay, window, window, eglContext)
+        winW = _query(EGL14.EGL_WIDTH)
+        winH = _query(EGL14.EGL_HEIGHT)
+        // an idle source sends no new frames, so repaint last one or new surface stays black
+        if (hasFrame) _render()
+    }
+
+    private fun _consumeAndDraw() {
+        val st = surfaceTexture ?: return
+        if (window == EGL14.EGL_NO_SURFACE) {
+            // no display: keep consuming so decoder doesn't stall
+            EGL14.eglMakeCurrent(eglDisplay, pbuffer, pbuffer, eglContext)
+            st.updateTexImage()
+            hasFrame = true
+            return
+        }
+        EGL14.eglMakeCurrent(eglDisplay, window, window, eglContext)
+        st.updateTexImage()
+        st.getTransformMatrix(texMatrix)
+        hasFrame = true
+        _render()
+    }
+
+    private fun _render() {
+        GLES20.glViewport(0, 0, winW, winH)
+        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT)
+        GLES20.glUseProgram(program)
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, oesTex)
+        GLES20.glUniformMatrix4fv(uTexMatrix, 1, false, texMatrix, 0)
+        GLES20.glEnableVertexAttribArray(aPos)
+        GLES20.glVertexAttribPointer(aPos, 2, GLES20.GL_FLOAT, false, 0, POS)
+        GLES20.glEnableVertexAttribArray(aTex)
+        GLES20.glVertexAttribPointer(aTex, 2, GLES20.GL_FLOAT, false, 0, TEX)
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
+        GLES20.glDisableVertexAttribArray(aPos)
+        GLES20.glDisableVertexAttribArray(aTex)
+        EGL14.eglSwapBuffers(eglDisplay, window)
+    }
+
+    private fun _query(what: Int): Int {
+        val v = IntArray(1)
+        EGL14.eglQuerySurface(eglDisplay, window, what, v, 0)
+        return v[0]
+    }
+
+    private fun _initEgl() {
+        eglDisplay = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY)
+        EGL14.eglInitialize(eglDisplay, IntArray(2), 0, IntArray(2), 1)
+        val attribs = intArrayOf(
+            EGL14.EGL_RENDERABLE_TYPE, EGL14.EGL_OPENGL_ES2_BIT,
+            EGL14.EGL_SURFACE_TYPE, EGL14.EGL_WINDOW_BIT or EGL14.EGL_PBUFFER_BIT,
+            EGL14.EGL_RED_SIZE, 8, EGL14.EGL_GREEN_SIZE, 8, EGL14.EGL_BLUE_SIZE, 8,
+            EGL14.EGL_NONE
+        )
+        val configs = arrayOfNulls<EGLConfig>(1)
+        EGL14.eglChooseConfig(eglDisplay, attribs, 0, configs, 0, 1, IntArray(1), 0)
+        eglConfig = configs[0]
+        eglContext = EGL14.eglCreateContext(
+            eglDisplay, eglConfig, EGL14.EGL_NO_CONTEXT,
+            intArrayOf(EGL14.EGL_CONTEXT_CLIENT_VERSION, 2, EGL14.EGL_NONE), 0
+        )
+        pbuffer = EGL14.eglCreatePbufferSurface(
+            eglDisplay, eglConfig, intArrayOf(EGL14.EGL_WIDTH, 1, EGL14.EGL_HEIGHT, 1, EGL14.EGL_NONE), 0
+        )
+        EGL14.eglMakeCurrent(eglDisplay, pbuffer, pbuffer, eglContext)
+    }
+
+    private fun _initGl() {
+        program = _buildProgram()
+        aPos = GLES20.glGetAttribLocation(program, "aPos")
+        aTex = GLES20.glGetAttribLocation(program, "aTex")
+        uTexMatrix = GLES20.glGetUniformLocation(program, "uTexMatrix")
+        val tex = IntArray(1)
+        GLES20.glGenTextures(1, tex, 0)
+        oesTex = tex[0]
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, oesTex)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE)
+        surfaceTexture = SurfaceTexture(oesTex).also {
+            if (videoW > 0 && videoH > 0) it.setDefaultBufferSize(videoW, videoH)
+            it.setOnFrameAvailableListener {
+                synchronized(lock) { frameAvailable = true; lock.notifyAll() }
+            }
+        }
+    }
+
+    private fun _buildProgram(): Int {
+        val vs = _shader(GLES20.GL_VERTEX_SHADER, VERT)
+        val fs = _shader(GLES20.GL_FRAGMENT_SHADER, FRAG)
+        return GLES20.glCreateProgram().also {
+            GLES20.glAttachShader(it, vs)
+            GLES20.glAttachShader(it, fs)
+            GLES20.glLinkProgram(it)
+            GLES20.glDeleteShader(vs)
+            GLES20.glDeleteShader(fs)
+        }
+    }
+
+    private fun _shader(type: Int, src: String): Int {
+        return GLES20.glCreateShader(type).also {
+            GLES20.glShaderSource(it, src)
+            GLES20.glCompileShader(it)
+            val ok = IntArray(1)
+            GLES20.glGetShaderiv(it, GLES20.GL_COMPILE_STATUS, ok, 0)
+            if (ok[0] == 0) Log.e(TAG, "shader compile failed: ${GLES20.glGetShaderInfoLog(it)}")
+        }
+    }
+
+    private fun _releaseGl() {
+        surfaceTexture?.release()
+        surfaceTexture = null
+        inputSurface?.release()
+        inputSurface = null
+        if (eglDisplay != EGL14.EGL_NO_DISPLAY) {
+            EGL14.eglMakeCurrent(eglDisplay, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_SURFACE, EGL14.EGL_NO_CONTEXT)
+            if (window != EGL14.EGL_NO_SURFACE) EGL14.eglDestroySurface(eglDisplay, window)
+            if (pbuffer != EGL14.EGL_NO_SURFACE) EGL14.eglDestroySurface(eglDisplay, pbuffer)
+            EGL14.eglDestroyContext(eglDisplay, eglContext)
+            EGL14.eglTerminate(eglDisplay)
+        }
+        eglDisplay = EGL14.EGL_NO_DISPLAY
+        window = EGL14.EGL_NO_SURFACE
+        pbuffer = EGL14.EGL_NO_SURFACE
+    }
+
+    companion object {
+        private const val TAG = "VideoPipeline"
+
+        private val POS = _fb(floatArrayOf(-1f, -1f, 1f, -1f, -1f, 1f, 1f, 1f))
+        private val TEX = _fb(floatArrayOf(0f, 0f, 1f, 0f, 0f, 1f, 1f, 1f))
+
+        private fun _fb(a: FloatArray): FloatBuffer =
+            ByteBuffer.allocateDirect(a.size * 4).order(ByteOrder.nativeOrder())
+                .asFloatBuffer().apply { put(a); position(0) }
+
+        private const val VERT =
+            "attribute vec2 aPos;\n" +
+            "attribute vec2 aTex;\n" +
+            "uniform mat4 uTexMatrix;\n" +
+            "varying vec2 vTex;\n" +
+            "void main() {\n" +
+            "  gl_Position = vec4(aPos, 0.0, 1.0);\n" +
+            "  vTex = (uTexMatrix * vec4(aTex, 0.0, 1.0)).xy;\n" +
+            "}\n"
+
+        private const val FRAG =
+            "#extension GL_OES_EGL_image_external : require\n" +
+            "precision mediump float;\n" +
+            "varying vec2 vTex;\n" +
+            "uniform samplerExternalOES sTex;\n" +
+            "void main() {\n" +
+            "  gl_FragColor = texture2D(sTex, vTex);\n" +
+            "}\n"
+    }
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/renderer/VideoRenderer.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/renderer/VideoRenderer.kt
@@ -1,0 +1,333 @@
+package io.github.jqssun.airplay.renderer
+
+import android.media.MediaCodec
+import android.media.MediaCodecList
+import android.media.MediaFormat
+import android.util.Log
+import android.view.Surface
+
+class VideoRenderer {
+
+    private val lock = Object()
+    private val pipeline = VideoPipeline()
+    private var codec: MediaCodec? = null
+    private var displaySurface: Surface? = null
+    private var currentH265 = false
+    private var videoWidth = 0
+    private var videoHeight = 0
+    private var firstFrameQueued = false
+
+    // stats
+    @Volatile var fps = 0; private set
+    @Volatile var bitrateBps = 0L; private set
+    @Volatile var frameCount = 0L; private set
+    @Volatile var codecName = ""; private set
+    @Volatile var droppedFrames = 0L; private set
+    @Volatile var framePacingJitterUs = 0L; private set
+
+    var enforceSdr = true
+    var keyAllowFrameDrop = true
+    var realtimeDecoderPriority = true
+    var lowLatency = true
+    var operatingRateHint = false
+    var scheduledOutputBufferRelease = true
+    var benchmarkLog = false
+    var benchmarkLogCallback: ((String) -> Unit)? = null
+    private var _framesThisSec = 0
+    private var _bytesThisSec = 0L
+    private var _lastStatReset = 0L
+    private val _frameIntervalsNs = LongArray(120)
+    private var _frameIntervalIdx = 0
+    private var _frameIntervalCount = 0
+    private var _lastOutputFrameNs = 0L
+    // anchors that map decoder PTS (us) to System.nanoTime() for scheduled rendering
+    private var _ptsBaseUs = Long.MIN_VALUE
+    private var _wallBaseNs = 0L
+
+    fun setResolution(w: Int, h: Int) {
+        videoWidth = w
+        videoHeight = h
+        pipeline.setVideoSize(w, h)
+    }
+
+    // doesn't restart codec; decoder renders into pipeline's own persistent surface
+    fun setSurface(surface: Surface) = synchronized(lock) {
+        displaySurface = surface
+        pipeline.setDisplaySurface(surface)
+    }
+
+    fun clearSurface(surface: Surface) = synchronized(lock) {
+        if (displaySurface !== surface) return@synchronized
+        displaySurface = null
+        pipeline.setDisplaySurface(null)
+    }
+
+    private fun _updateStats(size: Int) {
+        val now = System.currentTimeMillis()
+        if (now - _lastStatReset >= 1000) {
+            fps = _framesThisSec
+            bitrateBps = _bytesThisSec * 8
+            framePacingJitterUs = _computeFramePacingJitterUs()
+            _framesThisSec = 0
+            _bytesThisSec = 0
+            _lastStatReset = now
+            if (benchmarkLog) _emitBenchmarkLine()
+        }
+        _framesThisSec++
+        _bytesThisSec += size
+        frameCount++
+    }
+
+    private fun _emitBenchmarkLine() {
+        val msg = "fps=$fps bitrate=${bitrateBps / 1000}kbps " +
+            "jitter=${framePacingJitterUs}us frames=$frameCount " +
+            "dropped=$droppedFrames codec=$codecName " +
+            "res=${videoWidth}x${videoHeight}"
+        Log.i(BENCH_TAG, msg)
+        benchmarkLogCallback?.invoke(msg)
+    }
+
+    fun feedFrame(data: ByteArray, ntpTimeNs: Long, isH265: Boolean) {
+        _updateStats(data.size)
+
+        synchronized(lock) {
+            if (videoWidth == 0 || videoHeight == 0) return
+
+            if (codec == null || isH265 != currentH265) {
+                // a stale reference frame decodes to corruption, so wait for a keyframe to (re)start
+                if (!_isKeyframe(data, isH265)) {
+                    if (codec != null) stopCodec()
+                    return
+                }
+                stopCodec()
+            }
+
+            try {
+                if (codec == null) startCodec(isH265)
+                _feedToCodec(data, ntpTimeNs)
+                drainOutput()
+            } catch (e: Exception) {
+                Log.w(TAG, "Codec error, resetting", e)
+                stopCodec()
+            }
+        }
+    }
+
+    private fun _feedToCodec(data: ByteArray, ntpTimeNs: Long) {
+        val c = codec ?: return
+        // dropping a frame desyncs decoder until the next keyframe, but source would only send one on (re)connect
+        val retries = if (firstFrameQueued) FEED_RETRIES else FIRST_FEED_RETRIES
+        repeat(retries) {
+            val idx = c.dequeueInputBuffer(FEED_WAIT_US)
+            if (idx >= 0) {
+                val buf = c.getInputBuffer(idx) ?: return
+                buf.clear()
+                buf.put(data)
+                c.queueInputBuffer(idx, 0, data.size, ntpTimeNs / 1000, 0)
+                firstFrameQueued = true
+                return
+            }
+            drainOutput()
+        }
+        droppedFrames++
+        Log.w(TAG, "Decoder input queue full; dropping frame. drops=$droppedFrames")
+    }
+
+    private fun _isKeyframe(data: ByteArray, isH265: Boolean): Boolean {
+        if (data.size < 5) return false
+        var i = 0
+        while (i <= data.size - 5) {
+            if (data[i] == 0.toByte() && data[i + 1] == 0.toByte() &&
+                data[i + 2] == 0.toByte() && data[i + 3] == 1.toByte()) {
+                val key = if (isH265) {
+                    val type = (data[i + 4].toInt() shr 1) and 0x3F
+                    type == 19 || type == 20 || type == 21 || type == 32 || type == 33
+                } else {
+                    val type = data[i + 4].toInt() and 0x1F
+                    type == 5 || type == 7
+                }
+                if (key) return true
+            }
+            i++
+        }
+        return false
+    }
+
+    private fun startCodec(h265: Boolean) {
+        pipeline.start()
+        pipeline.setVideoSize(videoWidth, videoHeight)
+        val s = pipeline.inputSurface ?: return
+        currentH265 = h265
+        val mime = if (h265) MediaFormat.MIMETYPE_VIDEO_HEVC else MediaFormat.MIMETYPE_VIDEO_AVC
+
+        val format = MediaFormat.createVideoFormat(mime, videoWidth, videoHeight)
+        val maxInput = maxOf(videoWidth * videoHeight * 3 / 4, 1024 * 1024)
+        format.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, maxInput)
+        if (enforceSdr) {
+            format.setInteger(MediaFormat.KEY_COLOR_STANDARD, MediaFormat.COLOR_STANDARD_BT709)
+            format.setInteger(MediaFormat.KEY_COLOR_RANGE, MediaFormat.COLOR_RANGE_LIMITED)
+            format.setInteger(MediaFormat.KEY_COLOR_TRANSFER, MediaFormat.COLOR_TRANSFER_SDR_VIDEO)
+        }
+        if (realtimeDecoderPriority) {
+            format.setInteger(MediaFormat.KEY_PRIORITY, 0)
+        }
+        if (operatingRateHint && android.os.Build.VERSION.SDK_INT >= 23) {
+            format.setInteger(MediaFormat.KEY_OPERATING_RATE, Short.MAX_VALUE.toInt())
+        }
+        if (android.os.Build.VERSION.SDK_INT >= 29) {
+            format.setInteger(MediaFormat.KEY_ALLOW_FRAME_DROP, if (keyAllowFrameDrop) 1 else 0)
+        }
+        if (lowLatency && android.os.Build.VERSION.SDK_INT >= 30) {
+            format.setInteger(MediaFormat.KEY_LOW_LATENCY, 1)
+        }
+
+        firstFrameQueued = false
+        try {
+            _startDecoder(MediaCodec.createDecoderByType(mime), format, s, h265)
+        } catch (e: Exception) {
+            // strict hw decoders reject configs beyond their real limits
+            val sw = _softwareDecoder(mime)?.takeIf {
+                it.getCapabilitiesForType(mime).videoCapabilities
+                    ?.isSizeSupported(videoWidth, videoHeight) == true
+            } ?: throw e
+            Log.w(TAG, "Hardware decoder failed, trying software fallback", e)
+            _startDecoder(MediaCodec.createByCodecName(sw.name), format, s, h265)
+        }
+        Log.i(TAG, "Video codec started: $mime ${videoWidth}x${videoHeight} ($codecName)")
+    }
+
+    private fun _startDecoder(c: MediaCodec, format: MediaFormat, surface: Surface, h265: Boolean) {
+        try {
+            c.configure(format, surface, null, 0)
+            c.start()
+        } catch (e: Exception) {
+            try { c.release() } catch (_: Exception) {}
+            throw e
+        }
+        codec = c
+        codecName = (if (h265) "H.265" else "H.264") + " (${c.name})"
+    }
+
+    private fun stopCodec() {
+        _frameIntervalIdx = 0
+        _frameIntervalCount = 0
+        _lastOutputFrameNs = 0L
+        _ptsBaseUs = Long.MIN_VALUE
+        _wallBaseNs = 0L
+        codec?.let {
+            try {
+                it.stop()
+                it.release()
+            } catch (_: Exception) {}
+        }
+        codec = null
+    }
+
+    private fun drainOutput() {
+        val c = codec ?: return
+        val info = MediaCodec.BufferInfo()
+        while (true) {
+            val idx = c.dequeueOutputBuffer(info, 0)
+            if (idx < 0) break
+            _recordOutputFrameTime()
+            if (scheduledOutputBufferRelease) {
+                // schedule frame at VSYNC matching its NTP presentation time
+                val ptsUs = info.presentationTimeUs
+                if (_ptsBaseUs == Long.MIN_VALUE) {
+                    _ptsBaseUs = ptsUs
+                    _wallBaseNs = System.nanoTime()
+                }
+                c.releaseOutputBuffer(idx, _wallBaseNs + (ptsUs - _ptsBaseUs) * 1000L)
+            } else {
+                c.releaseOutputBuffer(idx, true)
+            }
+        }
+    }
+
+    fun release() = synchronized(lock) {
+        stopCodec()
+        pipeline.release()
+        fps = 0; bitrateBps = 0; frameCount = 0; codecName = ""
+        droppedFrames = 0; framePacingJitterUs = 0
+        _framesThisSec = 0; _bytesThisSec = 0
+        _frameIntervalIdx = 0; _frameIntervalCount = 0; _lastOutputFrameNs = 0L
+    }
+
+    private fun _recordOutputFrameTime() {
+        val now = System.nanoTime()
+        if (_lastOutputFrameNs > 0) {
+            _frameIntervalsNs[_frameIntervalIdx % _frameIntervalsNs.size] = now - _lastOutputFrameNs
+            _frameIntervalIdx++
+            _frameIntervalCount++
+        }
+        _lastOutputFrameNs = now
+    }
+
+    private fun _computeFramePacingJitterUs(): Long {
+        val count = _frameIntervalCount.coerceAtMost(_frameIntervalsNs.size)
+        if (count < 2) return 0
+
+        var sum = 0.0
+        var sumSq = 0.0
+        for (i in 0 until count) {
+            val interval = _frameIntervalsNs[i].toDouble()
+            sum += interval
+            sumSq += interval * interval
+        }
+        val mean = sum / count
+        val variance = (sumSq / count) - (mean * mean)
+        return (kotlin.math.sqrt(variance.coerceAtLeast(0.0)) / 1000.0).toLong()
+    }
+
+    companion object {
+        private const val TAG = "VideoRenderer"
+        private const val BENCH_TAG = "BENCHMARK"
+        private const val FEED_WAIT_US = 20_000L
+        private const val FEED_RETRIES = 10
+        private const val FIRST_FEED_RETRIES = 50
+
+        fun supportsH265(): Boolean {
+            val list = MediaCodecList(MediaCodecList.ALL_CODECS)
+            return list.codecInfos.any { info ->
+                !info.isEncoder && info.supportedTypes.any {
+                    it.equals(MediaFormat.MIMETYPE_VIDEO_HEVC, ignoreCase = true)
+                }
+            }
+        }
+
+        // smallest limits across codecs the sender may pick; unknown limits assume 1080p, which any device decodes
+        fun maxSupportedResolution(h265: Boolean): Pair<Int, Int> {
+            val mimes = listOfNotNull(
+                MediaFormat.MIMETYPE_VIDEO_AVC,
+                MediaFormat.MIMETYPE_VIDEO_HEVC.takeIf { h265 },
+            )
+            return mimes
+                .map { mime ->
+                    _decoderCaps(mime)?.let { it.supportedWidths.upper to it.supportedHeights.upper }
+                        ?: (1920 to 1080)
+                }
+                .reduce { (w1, h1), (w2, h2) -> minOf(w1, w2) to minOf(h1, h2) }
+        }
+
+        // caps of the decoder createDecoderByType would pick
+        private fun _decoderCaps(mime: String) = try {
+            MediaCodecList(MediaCodecList.REGULAR_CODECS).codecInfos
+                .firstOrNull { info ->
+                    !info.isEncoder && info.supportedTypes.any { it.equals(mime, ignoreCase = true) }
+                }?.getCapabilitiesForType(mime)?.videoCapabilities
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to get decoder capabilities", e)
+            null
+        }
+
+        private fun _softwareDecoder(mime: String) =
+            MediaCodecList(MediaCodecList.ALL_CODECS).codecInfos.firstOrNull { info ->
+                !info.isEncoder && info.supportedTypes.any { it.equals(mime, ignoreCase = true) } &&
+                    (if (android.os.Build.VERSION.SDK_INT >= 29) info.isSoftwareOnly
+                    else info.name.lowercase().let {
+                        it.startsWith("omx.google.") || it.startsWith("c2.android.") ||
+                            (!it.startsWith("omx.") && !it.startsWith("c2."))
+                    })
+            }
+    }
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/service/AirPlayService.kt
@@ -1,0 +1,994 @@
+package io.github.jqssun.airplay.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.SharedPreferences
+import android.content.pm.ServiceInfo
+import android.graphics.BitmapFactory
+import android.media.AudioManager
+import android.os.Binder
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.PowerManager
+import android.os.SystemClock
+import android.support.v4.media.MediaMetadataCompat
+import android.support.v4.media.session.MediaSessionCompat
+import android.support.v4.media.session.PlaybackStateCompat
+import android.util.Log
+import android.view.Surface
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleService
+import androidx.lifecycle.lifecycleScope
+import androidx.media.app.NotificationCompat as MediaNotificationCompat
+import com.immortal.airplay.AirPlayHost
+import io.github.jqssun.airplay.Prefs
+import io.github.jqssun.airplay.R
+import io.github.jqssun.airplay.realDisplaySize
+import io.github.jqssun.airplay.audio.DacpController
+import io.github.jqssun.airplay.audio.DacpPlayer
+import io.github.jqssun.airplay.audio.DmapParser
+import io.github.jqssun.airplay.audio.TrackInfo
+import io.github.jqssun.airplay.bridge.LogListener
+import io.github.jqssun.airplay.bridge.NativeBridge
+import io.github.jqssun.airplay.bridge.RaopCallbackHandler
+import io.github.jqssun.airplay.discovery.NsdServiceManager
+import io.github.jqssun.airplay.download.VideoDownloader
+import io.github.jqssun.airplay.renderer.AirPlayVideoPlayer
+import io.github.jqssun.airplay.renderer.AudioRenderer
+import io.github.jqssun.airplay.renderer.VideoRenderer
+import io.github.jqssun.airplay.viewmodel.DebugInfo
+import java.net.NetworkInterface
+import java.security.SecureRandom
+import kotlin.math.abs
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
+
+data class VideoPlaybackInfo(
+    val positionMs: Long = 0,
+    val durationMs: Long = 0,
+    val playing: Boolean = true,
+    val speed: Float = 1f,
+    val skipSilence: Boolean = false,
+    val buffering: Boolean = false,
+)
+
+class AirPlayService : LifecycleService(), RaopCallbackHandler, LogListener {
+
+    private var nativeHandle = 0L
+    private var nsdManager: NsdServiceManager? = null
+    private var wakeLock: PowerManager.WakeLock? = null
+    private var foregroundStarted = false
+
+    val videoRenderer = VideoRenderer()
+    val audioRenderer = AudioRenderer()
+    val airPlayVideoPlayer by lazy { AirPlayVideoPlayer(this) }
+    val videoDownloader by lazy { VideoDownloader(this) }
+
+    // hls urls point at the native httpd, valid only while the session lives
+    private val _videoLocation = MutableStateFlow<String?>(null)
+    val videoLocation = _videoLocation.asStateFlow()
+
+    private val prefs: SharedPreferences by lazy {
+        getSharedPreferences(Prefs.NAME, Context.MODE_PRIVATE)
+    }
+    private val _serverState = MutableStateFlow(ServerState.STOPPED)
+    val serverState = _serverState.asStateFlow()
+
+    private val _connectionCount = MutableStateFlow(0)
+    val connectionCount = _connectionCount.asStateFlow()
+
+    private val _videoAspect = MutableStateFlow(16f / 9f)
+    val videoAspect = _videoAspect.asStateFlow()
+
+    private val _videoResolution = MutableStateFlow("")
+    val videoResolution = _videoResolution.asStateFlow()
+
+    private val _audioOnly = MutableStateFlow(false)
+    val audioOnly = _audioOnly.asStateFlow()
+
+    private val _videoPlaybackActive = MutableStateFlow(false)
+    val videoPlaybackActive = _videoPlaybackActive.asStateFlow()
+
+    private val _videoPlaybackInfo = MutableStateFlow(VideoPlaybackInfo())
+    val videoPlaybackInfo = _videoPlaybackInfo.asStateFlow()
+
+    // bumped per /play so the ui resets transport state on back-to-back plays too
+    private val _videoPlaySeq = MutableStateFlow(0L)
+    val videoPlaySeq = _videoPlaySeq.asStateFlow()
+
+    private val _videoPlaybackAspect = MutableStateFlow(16f / 9f)
+    val videoPlaybackAspect = _videoPlaybackAspect.asStateFlow()
+
+    private val _videoPlaybackSize = MutableStateFlow<Pair<Int, Int>?>(null)
+    val videoPlaybackSize = _videoPlaybackSize.asStateFlow()
+
+    // container/manifest metadata
+    private val _videoTitle = MutableStateFlow("")
+    val videoTitle = _videoTitle.asStateFlow()
+
+    // recent /playback-info polls with no playback = pending video; polls start ~1s before /play
+    @Volatile private var _lastVideoPollAt = 0L
+    @Volatile private var _videoPollSuppressed = false
+
+    fun videoSessionPending(): Boolean =
+        !_videoPlaybackActive.value && !_audioOnly.value && !_mirroringActive.value &&
+            !_videoPollSuppressed &&
+            SystemClock.elapsedRealtime() - _lastVideoPollAt < VIDEO_POLL_PENDING_TIMEOUT_MS
+
+    // set once mirroring reports a real size; connectionCount can't tell session kinds apart
+    private val _mirroringActive = MutableStateFlow(false)
+    val mirroringActive = _mirroringActive.asStateFlow()
+
+    private val _trackInfo = MutableStateFlow(TrackInfo())
+    val trackInfo = _trackInfo.asStateFlow()
+
+    private val _positionMs = MutableStateFlow(0L)
+    val positionMs = _positionMs.asStateFlow()
+
+    private val _durationMs = MutableStateFlow(0L)
+    val durationMs = _durationMs.asStateFlow()
+
+    private val _playing = MutableStateFlow(true)
+    val playing = _playing.asStateFlow()
+
+    @Volatile private var _progressBaseMs = 0L
+    @Volatile private var _progressBaseTime = 0L
+
+    fun currentPositionMs(): Long {
+        if (_progressBaseTime == 0L || !_playing.value) return _positionMs.value
+        val elapsed = SystemClock.elapsedRealtime() - _progressBaseTime
+        return (_progressBaseMs + elapsed).coerceIn(0, _durationMs.value)
+    }
+
+    var dacpController: DacpController? = null
+        private set
+    lateinit var dacpPlayer: DacpPlayer
+        private set
+    private val _mainHandler = Handler(Looper.getMainLooper())
+    @Volatile private var _coverArtBytes: ByteArray? = null
+    private var mediaSession: MediaSessionCompat? = null
+    private var mediaReceiver: BroadcastReceiver? = null
+
+    var logCallback: ((String) -> Unit)? = null
+    var modeCallback: ((Boolean) -> Unit)? = null
+
+    @Volatile private var _lastPin: String? = null
+    var pinCallback: ((String?) -> Unit)? = null
+        set(value) {
+            field = value
+            // ui replay only: binding the activity must not mint a new native pin
+            value?.invoke(_lastPin)
+        }
+
+    private fun log(msg: String) {
+        Log.i(TAG, msg)
+        logCallback?.invoke(msg)
+    }
+
+    override fun onLog(msg: String) {
+        logCallback?.invoke(msg)
+    }
+
+    inner class LocalBinder : Binder() {
+        val service: AirPlayService
+            get() = this@AirPlayService
+    }
+
+    override fun onBind(intent: Intent): IBinder {
+        super.onBind(intent)
+        return LocalBinder()
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+        dacpController = DacpController(this)
+        dacpPlayer = DacpPlayer(
+            mainLooper,
+            dacp = { dacpController },
+            snapshot = {
+                DacpPlayer.Snapshot(
+                    track = _trackInfo.value,
+                    artworkData = _coverArtBytes,
+                    durationMs = _durationMs.value,
+                    playing = _playing.value,
+                    active = _audioOnly.value && _connectionCount.value > 0,
+                )
+            },
+            positionMs = ::currentPositionMs,
+            setPlaying = ::_setPlaying,
+        )
+        mediaSession = MediaSessionCompat(this, "AirPlay").apply {
+            setCallback(object : MediaSessionCompat.Callback() {
+                override fun onPlay() {
+                    if (_videoPlaybackActive.value) {
+                        airPlayVideoPlayer.setPlaying(true)
+                        return
+                    }
+                    _setPlaying(true)
+                    dacpController?.play()
+                }
+                override fun onPause() {
+                    if (_videoPlaybackActive.value) {
+                        airPlayVideoPlayer.setPlaying(false)
+                        return
+                    }
+                    _setPlaying(false)
+                    dacpController?.pause()
+                }
+                override fun onStop() {
+                    if (_videoPlaybackActive.value) stopVideoPlayback()
+                }
+                override fun onFastForward() {
+                    if (_videoPlaybackActive.value) airPlayVideoPlayer.seekBy(VIDEO_SEEK_STEP_MS)
+                }
+                override fun onRewind() {
+                    if (_videoPlaybackActive.value) airPlayVideoPlayer.seekBy(-VIDEO_SEEK_STEP_MS)
+                }
+                override fun onSeekTo(pos: Long) {
+                    if (_videoPlaybackActive.value) airPlayVideoPlayer.scrub(pos / 1000f)
+                }
+                override fun onSkipToNext() {
+                    if (!_videoPlaybackActive.value) dacpController?.nextItem()
+                }
+                override fun onSkipToPrevious() {
+                    if (!_videoPlaybackActive.value) dacpController?.prevItem()
+                }
+            })
+        }
+        mediaReceiver = object : BroadcastReceiver() {
+            override fun onReceive(ctx: Context, intent: Intent) {
+                when (intent.action) {
+                    ACTION_PLAY_PAUSE -> togglePlayPause()
+                    ACTION_NEXT -> dacpController?.nextItem()
+                    ACTION_PREV -> dacpController?.prevItem()
+                }
+            }
+        }
+        val filter = IntentFilter().apply {
+            addAction(ACTION_PLAY_PAUSE)
+            addAction(ACTION_NEXT)
+            addAction(ACTION_PREV)
+        }
+        ContextCompat.registerReceiver(this, mediaReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
+
+        airPlayVideoPlayer.onVideoSize = { width, height, aspect ->
+            _videoPlaybackAspect.value = aspect
+            _videoPlaybackSize.value = width to height
+        }
+        airPlayVideoPlayer.onTitle = { _videoTitle.value = it ?: "" }
+        airPlayVideoPlayer.onEnded = { _endVideoPlayback("AirPlay Video stopped (player)") }
+        airPlayVideoPlayer.onPlaybackInfo = { snapshot ->
+            if (nativeHandle != 0L) {
+                NativeBridge.nativeUpdatePlaybackInfo(nativeHandle, snapshot.position, snapshot.duration, snapshot.rate, snapshot.ready)
+            }
+            if (_videoPlaybackActive.value) {
+                _updateVideoPlaybackState(snapshot.position, snapshot.rate)
+                _videoPlaybackInfo.value = VideoPlaybackInfo(
+                    positionMs = (snapshot.position * 1000).toLong(),
+                    durationMs = if (snapshot.duration > 0f) (snapshot.duration * 1000).toLong() else 0L,
+                    playing = snapshot.playWhenReady,
+                    speed = snapshot.speed,
+                    skipSilence = snapshot.skipSilence,
+                    buffering = snapshot.buffering,
+                )
+            }
+        }
+        lifecycleScope.launch {
+            prefs.audioConfigFlow()
+                .debounce(AUDIO_CONFIG_DEBOUNCE_MS)
+                .collect { audioRenderer.updateConfig(it) }
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_START_SERVER) {
+            promoteToForeground()
+            val name = prefs.getString(Prefs.SERVER_NAME, Prefs.DEF_SERVER_NAME) ?: Prefs.DEF_SERVER_NAME
+            startServer(name, ensureServiceStarted = false)
+            if (_serverState.value != ServerState.RUNNING) stopSelf(startId)
+        }
+        return START_NOT_STICKY
+    }
+
+    fun startServer(name: String) {
+        startServer(name, ensureServiceStarted = true)
+    }
+
+    private fun startServer(name: String, ensureServiceStarted: Boolean) {
+        if (_serverState.value == ServerState.RUNNING) return
+        val effectiveName = name.ifBlank { Prefs.DEF_SERVER_NAME }
+
+        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+        wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "airplay:server").apply { acquire() }
+
+        nsdManager = NsdServiceManager(this).apply { acquireMulticastLock() }
+
+        val hwAddr = getHwAddr()
+        val keyFile = filesDir.resolve("airplay.pem").absolutePath
+        val nohold = prefs.getBoolean(Prefs.ALLOW_NEW_CONN, Prefs.DEF_ALLOW_NEW_CONN)
+        val requirePin = prefs.getBoolean(Prefs.REQUIRE_PIN, Prefs.DEF_REQUIRE_PIN)
+
+        // oboe's OpenSL ES backend (pre-AAudio devices, API < 27) can't discover native
+        // rate / burst size itself; feed it AudioManager values so low-latency buffer
+        // sizing works there
+        // see: https://github.com/google/oboe/blob/main/docs/GettingStarted.md#obtaining-optimal-latency
+        val am = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        NativeBridge.nativeSetDefaultStreamValues(
+            am.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE)?.toIntOrNull() ?: 0,
+            am.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER)?.toIntOrNull() ?: 0
+        )
+        nativeHandle = NativeBridge.nativeInit(this, hwAddr, effectiveName, keyFile, nohold, requirePin)
+        if (nativeHandle == 0L) {
+            log("Native init failed")
+            _failStart()
+            return
+        }
+        audioRenderer.attachEngine(nativeHandle)
+
+        // apply settings from preferences
+        val maxFps = prefs.getInt(Prefs.MAX_FPS, Prefs.DEF_MAX_FPS)
+        val overscanned = prefs.getBoolean(Prefs.OVERSCANNED, Prefs.DEF_OVERSCANNED)
+        val audioLatencyMs = prefs.getInt(Prefs.AUDIO_LATENCY_MS, Prefs.DEF_AUDIO_LATENCY_MS)
+        val h265 = prefs.getBoolean(Prefs.H265_ENABLED, Prefs.DEF_H265_ENABLED) && VideoRenderer.supportsH265()
+        val alac = prefs.getBoolean(Prefs.ALAC_ENABLED, Prefs.DEF_ALAC_ENABLED)
+        val aac = prefs.getBoolean(Prefs.AAC_ENABLED, Prefs.DEF_AAC_ENABLED)
+
+        val realtimePriority = prefs.getBoolean(Prefs.KEY_PRIORITY, Prefs.DEF_KEY_PRIORITY)
+        val lowLatency = prefs.getBoolean(Prefs.LOW_LATENCY, Prefs.DEF_LOW_LATENCY)
+        videoRenderer.enforceSdr = prefs.getBoolean(Prefs.ENFORCE_SDR, Prefs.DEF_ENFORCE_SDR)
+        videoRenderer.keyAllowFrameDrop = prefs.getBoolean(Prefs.KEY_ALLOW_FRAME_DROP, Prefs.DEF_KEY_ALLOW_FRAME_DROP)
+        videoRenderer.realtimeDecoderPriority = realtimePriority
+        videoRenderer.lowLatency = lowLatency
+        videoRenderer.operatingRateHint = prefs.getBoolean(Prefs.KEY_OPERATING_RATE, Prefs.DEF_KEY_OPERATING_RATE)
+        videoRenderer.benchmarkLog = prefs.getBoolean(Prefs.BENCHMARK_LOG, Prefs.DEF_BENCHMARK_LOG)
+        videoRenderer.benchmarkLogCallback = { msg -> logCallback?.invoke(msg) }
+        videoRenderer.scheduledOutputBufferRelease = prefs.getBoolean(Prefs.SCHEDULED_OUTPUT_BUFFER_RELEASE, Prefs.DEF_SCHEDULED_OUTPUT_BUFFER_RELEASE)
+        NativeBridge.nativeSetH265Enabled(nativeHandle, h265)
+        NativeBridge.nativeSetCodecs(nativeHandle, alac, aac)
+        val advertiseVideo = prefs.getBoolean(Prefs.ADVERTISE_VIDEO, Prefs.DEF_ADVERTISE_VIDEO)
+        val advertiseAudio = prefs.getBoolean(Prefs.ADVERTISE_AUDIO, Prefs.DEF_ADVERTISE_AUDIO)
+        NativeBridge.nativeSetHlsEnabled(nativeHandle, advertiseVideo)
+        NativeBridge.nativeSetAudioEnabled(nativeHandle, advertiseAudio)
+        NativeBridge.nativeSetPlist(nativeHandle, "maxFPS", maxFps)
+        NativeBridge.nativeSetPlist(nativeHandle, "overscanned", if (overscanned) 1 else 0)
+        if (audioLatencyMs >= 0) {
+            NativeBridge.nativeSetPlist(nativeHandle, "audio_delay_micros", audioLatencyMs * 1000)
+        }
+
+        // set display params
+        val res = prefs.getString(Prefs.RESOLUTION, Prefs.DEF_RESOLUTION)!!
+        val (rawW, rawH) = when {
+            prefs.getBoolean(Prefs.AUTO_RES, Prefs.DEF_AUTO_RES) -> realDisplaySize()
+            res != "auto" && res.contains("x") -> res.split("x").let { it[0].toInt() to it[1].toInt() }
+            else -> resources.displayMetrics.let { it.widthPixels to it.heightPixels }
+        }
+        // strict decoders black-screen past their limits; advertised size is only upper bound for senders
+        val (maxW, maxH) = VideoRenderer.maxSupportedResolution(h265)
+        val w = rawW.coerceAtMost(maxW)
+        val h = rawH.coerceAtMost(maxH)
+        videoRenderer.setResolution(w, h)
+        _videoResolution.value = "${w}x${h}"
+        _videoAspect.value = w.toFloat() / h
+        NativeBridge.nativeSetDisplaySize(nativeHandle, w, h, maxFps)
+
+        val requestedPort = prefs.getInt(Prefs.SERVER_PORT, Prefs.DEF_SERVER_PORT).coerceIn(1, 65535)
+        val port = NativeBridge.nativeStart(nativeHandle, requestedPort)
+        if (port < 0) {
+            log("Failed to start on port $requestedPort")
+            _failStart()
+            return
+        }
+
+        // register mdns services
+        val raopTxt = NativeBridge.nativeGetRaopTxtRecords(nativeHandle) ?: emptyMap()
+        val airplayTxt = NativeBridge.nativeGetAirplayTxtRecords(nativeHandle) ?: emptyMap()
+        val raopName = NativeBridge.nativeGetRaopServiceName(nativeHandle) ?: "AirPlay"
+        val resolvedName = NativeBridge.nativeGetServerName(nativeHandle) ?: effectiveName
+
+        if (prefs.getBoolean(Prefs.ADVERTISE_AUDIO, Prefs.DEF_ADVERTISE_AUDIO)) {
+            nsdManager?.registerRaop(raopName, port, raopTxt)
+        }
+        nsdManager?.registerAirplay(resolvedName, port, airplayTxt)
+
+        _serverState.value = ServerState.RUNNING
+        if (ensureServiceStarted) {
+            ContextCompat.startForegroundService(this, Intent(this, AirPlayService::class.java))
+        }
+        promoteToForeground()
+        log("Server started on port $port")
+    }
+
+    private fun _failStart() {
+        audioRenderer.detachEngine()
+        if (nativeHandle != 0L) {
+            NativeBridge.nativeDestroy(nativeHandle)
+            nativeHandle = 0L
+        }
+        nsdManager?.release()
+        nsdManager = null
+        wakeLock?.release()
+        wakeLock = null
+        _serverState.value = ServerState.ERROR
+        if (foregroundStarted) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            foregroundStarted = false
+        }
+    }
+
+    fun stopServer() {
+        audioRenderer.detachEngine()
+        if (nativeHandle != 0L) {
+            NativeBridge.nativeStop(nativeHandle)
+            NativeBridge.nativeDestroy(nativeHandle)
+            nativeHandle = 0L
+        }
+        dacpController?.reset()
+        nsdManager?.release()
+        nsdManager = null
+        wakeLock?.release()
+        wakeLock = null
+        videoRenderer.release()
+        airPlayVideoPlayer.stop()
+        mediaSession?.isActive = false
+        _audioOnly.value = false
+        _videoPlaybackActive.value = false
+        _mirroringActive.value = false
+        _videoPlaybackInfo.value = VideoPlaybackInfo()
+        _lastVideoPollAt = 0
+        _videoPollSuppressed = false
+        _coverArtBytes = null
+        _trackInfo.value = TrackInfo()
+        _positionMs.value = 0
+        _durationMs.value = 0
+        _serverState.value = ServerState.STOPPED
+        _connectionCount.value = 0
+        _refreshDacpPlayer()
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        foregroundStarted = false
+        stopSelf()
+        log("Server stopped")
+    }
+
+    fun setVideoSurface(surface: Surface) {
+        videoRenderer.setSurface(surface)
+    }
+
+    fun clearVideoSurface(surface: Surface) {
+        videoRenderer.clearSurface(surface)
+    }
+
+    fun setVideoPlaybackSurface(surface: Surface) {
+        airPlayVideoPlayer.setSurface(surface)
+    }
+
+    fun clearVideoPlaybackSurface(surface: Surface) {
+        airPlayVideoPlayer.clearSurface(surface)
+    }
+
+    fun setVideoPlaying(playing: Boolean) {
+        airPlayVideoPlayer.setPlaying(playing)
+    }
+
+    fun seekVideoTo(positionMs: Long) {
+        airPlayVideoPlayer.scrub(positionMs / 1000f)
+    }
+
+    fun setVideoScrubbing(enabled: Boolean) {
+        airPlayVideoPlayer.setScrubbing(enabled)
+    }
+
+    fun setVideoSpeed(speed: Float) {
+        airPlayVideoPlayer.setSpeed(speed)
+    }
+
+    fun setVideoSkipSilence(enabled: Boolean) {
+        airPlayVideoPlayer.setSkipSilence(enabled)
+    }
+
+    fun seekVideoBy(deltaMs: Long) {
+        airPlayVideoPlayer.seekBy(deltaMs)
+    }
+
+    fun stopVideoPlayback() = _endVideoPlayback("AirPlay Video stopped (local)")
+
+    fun downloadVideo() {
+        _videoLocation.value?.let { videoDownloader.start(it) }
+    }
+
+    private fun _endVideoPlayback(message: String) {
+        if (!_videoPlaybackActive.value) return
+        // lingering polls after a stop must not bounce the UI back to a pending session
+        _videoPollSuppressed = true
+        _videoPlaybackActive.value = false
+        airPlayVideoPlayer.stop()
+        if (!_audioOnly.value) mediaSession?.isActive = false
+        log(message)
+    }
+
+    override fun onDestroy() {
+        stopServer()
+        dacpPlayer.release()
+        mediaReceiver?.let {
+            try { unregisterReceiver(it) } catch (_: Exception) {}
+        }
+        mediaReceiver = null
+        dacpController?.release()
+        dacpController = null
+        mediaSession?.release()
+        mediaSession = null
+        super.onDestroy()
+    }
+
+    // RaopCallbackHandler (called from native threads)
+
+    override fun onVideoData(data: ByteArray, ntpTimeNs: Long, isH265: Boolean) {
+        videoRenderer.feedFrame(data, ntpTimeNs, isH265)
+    }
+
+    override fun onVideoSessionPoll() {
+        _lastVideoPollAt = SystemClock.elapsedRealtime()
+    }
+
+    override fun onVideoPlay(location: String, startPositionSeconds: Float) {
+        _videoLocation.value = location
+        _videoPlaySeq.value++
+        _videoPollSuppressed = false
+        _videoPlaybackInfo.value = VideoPlaybackInfo(positionMs = (startPositionSeconds * 1000).toLong())
+        _videoPlaybackAspect.value = 16f / 9f
+        _videoPlaybackSize.value = null
+        _videoTitle.value = ""
+        _videoPlaybackActive.value = true
+        airPlayVideoPlayer.play(location, startPositionSeconds)
+        // claim media-button routing for keys that arrive as media-session events
+        mediaSession?.isActive = true
+        log("AirPlay Video play: $location @ ${startPositionSeconds}s")
+    }
+
+    override fun onVideoScrub(positionSeconds: Float) {
+        airPlayVideoPlayer.scrub(positionSeconds)
+    }
+
+    override fun onVideoRate(rate: Float) {
+        airPlayVideoPlayer.setRate(rate)
+    }
+
+    override fun onVideoStop() = _endVideoPlayback("AirPlay Video stopped")
+
+    override fun onAudioFormat(ct: Int, spf: Int, usingScreen: Boolean) {
+        clearPin()
+        audioRenderer.start()
+        audioRenderer.setFormat(ct, spf)
+        if (!usingScreen && !_audioOnly.value) {
+            // pure music streaming (not screen mirroring audio)
+            onAudioOnly(true)
+        }
+        log("Audio format: ct=$ct spf=$spf screen=$usingScreen")
+    }
+
+    override fun onVideoSize(srcW: Float, srcH: Float, w: Float, h: Float) {
+        clearPin()
+        if (w > 0 && h > 0) {
+            _videoAspect.value = w / h
+            _videoResolution.value = "${w.toInt()}x${h.toInt()}"
+            videoRenderer.setResolution(w.toInt(), h.toInt())
+            _mirroringActive.value = true
+        }
+        log("Video size: ${srcW}x${srcH} -> ${w}x${h}")
+    }
+
+    override fun onVolumeChange(volume: Float) {
+        audioRenderer.setVolume(volume)
+    }
+
+    override fun onConnectionInit() {
+        val firstConnection = _connectionCount.value == 0
+        _connectionCount.value++
+        log("Client connected (${_connectionCount.value})")
+        if (!firstConnection) return
+        // conn_init is only a tcp pre-auth signal. pin-required sessions must wait for
+        // onDisplayPin, otherwise the server ui can move before the client pin is current
+        if (requiresPin()) return
+        if (!shouldLaunchOnConnect()) return
+        launchMainActivity()
+    }
+
+    override fun onConnectionDestroy() {
+        _connectionCount.value = (_connectionCount.value - 1).coerceAtLeast(0)
+        if (_connectionCount.value == 0) {
+            // clients may drop without POST /stop; must run before the poll-state reset
+            _endVideoPlayback("AirPlay Video stopped (disconnect)")
+            // last client gone: release audio output devices to save power
+            audioRenderer.stop()
+            _audioOnly.value = false
+            _mirroringActive.value = false
+            _lastVideoPollAt = 0
+            _videoPollSuppressed = false
+            _coverArtBytes = null
+            _trackInfo.value = TrackInfo()
+            _positionMs.value = 0
+            _durationMs.value = 0
+            dacpController?.reset()
+            mediaSession?.isActive = false
+            _refreshDacpPlayer()
+        }
+        log("Client disconnected (${_connectionCount.value})")
+    }
+
+    override fun onConnectionReset(reason: Int) {
+        log("Connection reset: $reason")
+    }
+
+    override fun onDisplayPin(pin: String) {
+        // a new pin is the sync point with the client prompt: show every new value immediately
+        if (_lastPin == pin) return
+        _lastPin = pin
+        pinCallback?.invoke(pin)
+        _updateMediaNotification()
+    }
+
+    override fun onMetadata(data: ByteArray) {
+        val map = DmapParser.parse(data)
+        val info = TrackInfo.fromDmap(map, _trackInfo.value.coverArt)
+        _trackInfo.value = info
+        if (info.durationMs > 0) _durationMs.value = info.durationMs
+        _updateMediaMetadata()
+        _refreshDacpPlayer()
+        log("Track: ${info.artist} - ${info.title}")
+    }
+
+    override fun onCoverArt(data: ByteArray) {
+        val bmp = BitmapFactory.decodeByteArray(data, 0, data.size) ?: return
+        _coverArtBytes = data
+        _trackInfo.value = _trackInfo.value.copy(coverArt = bmp)
+        _updateMediaMetadata()
+        _refreshDacpPlayer()
+    }
+
+    override fun onProgress(start: Long, curr: Long, end: Long) {
+        val rate = 44100.0
+        val posMs = ((curr - start) / rate * 1000).toLong().coerceAtLeast(0)
+        val durMs = ((end - start) / rate * 1000).toLong().coerceAtLeast(0)
+        // pause/resume transitions emit degenerate progress; keep the last good value
+        if (durMs <= 0) return
+        _positionMs.value = posMs
+        _durationMs.value = durMs
+        _progressBaseMs = posMs
+        _progressBaseTime = SystemClock.elapsedRealtime()
+        _playing.value = true
+        _updatePlaybackState()
+        _refreshDacpPlayer()
+    }
+
+    override fun onDacpId(dacpId: String, activeRemote: String) {
+        dacpController?.update(dacpId, activeRemote)
+        log("DACP: $dacpId")
+    }
+
+    override fun onAudioOnly(audioOnly: Boolean) {
+        val prev = _audioOnly.value
+        _audioOnly.value = audioOnly
+        _refreshDacpPlayer()
+        if (audioOnly && !prev) {
+            mediaSession?.isActive = true
+            modeCallback?.invoke(true)
+            log("Audio mode")
+        } else if (!audioOnly && prev) {
+            mediaSession?.isActive = false
+            _coverArtBytes = null
+            _trackInfo.value = TrackInfo()
+            _positionMs.value = 0
+            _durationMs.value = 0
+            modeCallback?.invoke(false)
+            log("Mirror mode")
+        }
+    }
+
+    private fun _updateMediaMetadata() {
+        val info = _trackInfo.value
+        val builder = MediaMetadataCompat.Builder()
+            .putString(MediaMetadataCompat.METADATA_KEY_TITLE, info.title)
+            .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, info.artist)
+            .putString(MediaMetadataCompat.METADATA_KEY_ALBUM, info.album)
+            .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, _durationMs.value)
+        info.coverArt?.let { builder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, it) }
+        mediaSession?.setMetadata(builder.build())
+        _updateMediaNotification()
+    }
+
+    fun togglePlayPause() {
+        val nowPlaying = !_playing.value
+        _setPlaying(nowPlaying)
+        dacpController?.let { if (nowPlaying) it.play() else it.pause() }
+    }
+
+    private fun _setPlaying(playing: Boolean) {
+        _playing.value = playing
+        _refreshDacpPlayer()
+        if (playing) {
+            // resume extrapolation from current position
+            _progressBaseMs = _positionMs.value
+            _progressBaseTime = SystemClock.elapsedRealtime()
+        } else {
+            // freeze position
+            _positionMs.value = currentPositionMs()
+            _progressBaseTime = 0
+        }
+        _updatePlaybackState()
+    }
+
+    private fun _updatePlaybackState() {
+        // the sender's silent raop audio session must not overwrite video session state
+        if (_videoPlaybackActive.value) return
+        val isPlaying = _playing.value
+        val pbState = if (isPlaying) PlaybackStateCompat.STATE_PLAYING else PlaybackStateCompat.STATE_PAUSED
+        val speed = if (isPlaying) 1f else 0f
+        val state = PlaybackStateCompat.Builder()
+            .setActions(
+                PlaybackStateCompat.ACTION_PLAY or
+                    PlaybackStateCompat.ACTION_PAUSE or
+                    PlaybackStateCompat.ACTION_PLAY_PAUSE or
+                    PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
+                    PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS
+            )
+            .setState(pbState, _positionMs.value, speed, SystemClock.elapsedRealtime())
+            .build()
+        mediaSession?.setPlaybackState(state)
+        _updateMediaNotification()
+    }
+
+    // consumers extrapolate position from (position, speed, updateTime): push only discontinuities
+    private fun _updateVideoPlaybackState(positionSeconds: Float, rate: Float) {
+        val playing = rate > 0f
+        val posMs = (positionSeconds * 1000).toLong()
+        val now = SystemClock.elapsedRealtime()
+        val expectedMs = _lastVideoStatePosMs +
+            if (_lastVideoStateRate > 0f) ((now - _lastVideoStateAtMs) * _lastVideoStateRate).toLong() else 0L
+        if (rate == _lastVideoStateRate && abs(posMs - expectedMs) < 1000) return
+        _lastVideoStateRate = rate
+        _lastVideoStatePosMs = posMs
+        _lastVideoStateAtMs = now
+        val state = PlaybackStateCompat.Builder()
+            .setActions(
+                PlaybackStateCompat.ACTION_PLAY or
+                    PlaybackStateCompat.ACTION_PAUSE or
+                    PlaybackStateCompat.ACTION_PLAY_PAUSE or
+                    PlaybackStateCompat.ACTION_STOP or
+                    PlaybackStateCompat.ACTION_FAST_FORWARD or
+                    PlaybackStateCompat.ACTION_REWIND or
+                    PlaybackStateCompat.ACTION_SEEK_TO
+            )
+            .setState(
+                if (playing) PlaybackStateCompat.STATE_PLAYING else PlaybackStateCompat.STATE_PAUSED,
+                posMs,
+                rate,
+                now
+            )
+            .build()
+        mediaSession?.setPlaybackState(state)
+    }
+
+    private var _lastVideoStateRate = -1f
+    private var _lastVideoStatePosMs = 0L
+    private var _lastVideoStateAtMs = 0L
+
+    private fun _refreshDacpPlayer() {
+        _mainHandler.post { dacpPlayer.refresh() }
+    }
+
+    private fun clearPin() {
+        _lastPin = null
+        pinCallback?.invoke(null)
+        _updateMediaNotification()
+    }
+
+    fun collectDebugInfo() = DebugInfo(
+        videoCodec = videoRenderer.codecName,
+        videoRes = _videoResolution.value,
+        videoFps = videoRenderer.fps,
+        videoBitrate = videoRenderer.bitrateBps,
+        videoFrames = videoRenderer.frameCount,
+        droppedFrames = videoRenderer.droppedFrames,
+        framePacingJitterUs = videoRenderer.framePacingJitterUs,
+        audioCodec = audioRenderer.codecLabel,
+        audioVolume = (audioRenderer.volume * 100).toInt(),
+        audio = audioRenderer.audioDebug(),
+        connections = _connectionCount.value,
+    )
+
+    // helpers
+
+    private fun getHwAddr(): ByteArray {
+        try {
+            val interfaces = NetworkInterface.getNetworkInterfaces()
+            for (iface in interfaces) {
+                if (iface.name.startsWith("wlan") || iface.name.startsWith("eth")) {
+                    val mac = iface.hardwareAddress
+                    if (isUsableMac(mac)) return mac!!
+                }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to get hardware address", e)
+        }
+
+        // fall back to stable per-install random address
+        return persistedRandomMac()
+            ?: byteArrayOf(0xAA.toByte(), 0xBB.toByte(), 0xCC.toByte(), 0xDD.toByte(), 0xEE.toByte(), 0xFF.toByte())
+    }
+
+    private fun isUsableMac(mac: ByteArray?): Boolean =
+        mac != null && mac.size == 6 &&
+            mac.any { it != 0.toByte() } &&
+            !(mac[0] == 0x02.toByte() && mac.drop(1).all { it == 0.toByte() })
+
+    private fun persistedRandomMac(): ByteArray? {
+        macFromString(prefs.getString(Prefs.FALLBACK_MAC_ADDRESS, null))
+            ?.takeIf { isUsableMac(it) }?.let { return it }
+        repeat(10) {
+            val mac = randomAaiMac()
+            if (isUsableMac(mac)) {
+                prefs.edit().putString(Prefs.FALLBACK_MAC_ADDRESS, macToString(mac)).apply()
+                return mac
+            }
+        }
+        return null
+    }
+
+    // random locally-administered unicast MAC in AAI SLAP quadrant
+    private fun randomAaiMac(): ByteArray {
+        val mac = ByteArray(6).also { SecureRandom().nextBytes(it) }
+        mac[0] = ((mac[0].toInt() and 0xF0) or 0x0A).toByte()
+        return mac
+    }
+
+    private fun macToString(mac: ByteArray): String = mac.joinToString(":") { "%02x".format(it) }
+
+    private fun macFromString(s: String?): ByteArray? {
+        if (s == null) return null
+        return try {
+            s.split(":").map { it.toInt(16).toByte() }.toByteArray()
+        } catch (e: Exception) { null }
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.notification_channel),
+            NotificationManager.IMPORTANCE_LOW
+        )
+        (getSystemService(NOTIFICATION_SERVICE) as NotificationManager).createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(): Notification {
+        return _buildMediaNotification()
+    }
+
+    private fun promoteToForeground() {
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            buildNotification(),
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+        )
+        foregroundStarted = true
+    }
+
+    private fun requiresPin(): Boolean {
+        return prefs.getBoolean(Prefs.REQUIRE_PIN, Prefs.DEF_REQUIRE_PIN)
+    }
+
+    private fun shouldLaunchOnConnect(): Boolean {
+        return prefs.getBoolean(Prefs.LAUNCH_ON_CONNECT, Prefs.DEF_LAUNCH_ON_CONNECT)
+    }
+
+    private fun _buildMediaNotification(): Notification {
+        // LOCAL PATCH: upstream targets MainActivity. Route through AirPlayHost, falling back to
+        // whatever the host app's launcher entry point is. Both can legitimately be absent — an
+        // audio-only host may leave surfaceActivity null (see AirPlayHost) and a headless host has
+        // no LAUNCHER activity — and PendingIntent.getActivity NPEs on a null Intent, which would
+        // take down the foreground service on start. A tap-less notification is the right
+        // degradation. See airplay/UPSTREAM.md.
+        val intent = AirPlayHost.surfaceActivity?.let { Intent(this, it) }
+            ?: packageManager.getLaunchIntentForPackage(packageName)
+        val pi = intent?.let { PendingIntent.getActivity(this, 0, it, PendingIntent.FLAG_IMMUTABLE) }
+        val info = _trackInfo.value
+        val isAudio = _audioOnly.value && info.title.isNotEmpty()
+
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_media_play)
+            .setContentIntent(pi)
+            .setOngoing(true)
+
+        if (isAudio) {
+            builder.setContentTitle(info.title).setContentText(info.artist).setSubText(info.album)
+            info.coverArt?.let { builder.setLargeIcon(it) }
+            mediaSession?.sessionToken?.let { token ->
+                builder.setStyle(
+                    MediaNotificationCompat.MediaStyle()
+                        .setMediaSession(token)
+                        .setShowActionsInCompactView(0, 1, 2)
+                )
+                // transport action buttons
+                builder.addAction(android.R.drawable.ic_media_previous, "Prev", _mediaAction(ACTION_PREV))
+                builder.addAction(android.R.drawable.ic_media_pause, "Pause", _mediaAction(ACTION_PLAY_PAUSE))
+                builder.addAction(android.R.drawable.ic_media_next, "Next", _mediaAction(ACTION_NEXT))
+            }
+        } else {
+            if (_lastPin != null) {
+                // passive handoff only: do not launch/reorder the activity during pin auth
+                builder.setContentTitle(getString(R.string.notification_pin_title))
+                    .setContentText(getString(R.string.notification_pin_text, _lastPin))
+            } else {
+                builder.setContentTitle(getString(R.string.notification_title))
+                    .setContentText(getString(R.string.notification_text))
+            }
+        }
+        return builder.build()
+    }
+
+    private fun launchMainActivity() {
+        // LOCAL PATCH (second site of the only concern in the vendored Kotlin): upstream hard-references MainActivity
+        // here. Routed through AirPlayHost so each host app supplies its own surface Activity —
+        // portal-receiver's MainActivity, Immortal's AirPlayActivity. See airplay/UPSTREAM.md.
+        val target = AirPlayHost.surfaceActivity ?: return
+        Handler(Looper.getMainLooper()).post {
+            val launchIntent = Intent(this, target)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            try {
+                startActivity(launchIntent)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to launch activity", e)
+            }
+        }
+    }
+
+    private fun _mediaAction(action: String): PendingIntent {
+        val intent = Intent(action).setPackage(packageName)
+        return PendingIntent.getBroadcast(
+            this,
+            action.hashCode(),
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+    }
+
+    private fun _updateMediaNotification() {
+        if (_serverState.value != ServerState.RUNNING) return
+        val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        nm.notify(NOTIFICATION_ID, _buildMediaNotification())
+    }
+
+    enum class ServerState {
+        STOPPED,
+        RUNNING,
+        ERROR
+    }
+
+    companion object {
+        private const val TAG = "AirPlayService"
+        private const val CHANNEL_ID = "airplay_service"
+        private const val NOTIFICATION_ID = 1
+        const val ACTION_PLAY_PAUSE = "io.github.jqssun.airplay.PLAY_PAUSE"
+        const val ACTION_NEXT = "io.github.jqssun.airplay.NEXT"
+        const val ACTION_PREV = "io.github.jqssun.airplay.PREV"
+        const val ACTION_START_SERVER = "io.github.jqssun.airplay.START_SERVER"
+        // shared with dpad/double-tap seeks
+        const val VIDEO_SEEK_STEP_MS = 10_000L
+        const val VIDEO_POLL_PENDING_TIMEOUT_MS = 3_000L
+
+        private const val AUDIO_CONFIG_DEBOUNCE_MS = 500L
+    }
+}

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/service/AudioPrefs.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/service/AudioPrefs.kt
@@ -1,0 +1,31 @@
+package io.github.jqssun.airplay.service
+
+import android.content.SharedPreferences
+import io.github.jqssun.airplay.Prefs
+import io.github.jqssun.airplay.renderer.AudioConfig
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+fun readAudioConfig(p: SharedPreferences) = AudioConfig(
+    cushionMs = if (p.getBoolean(Prefs.AUDIO_AUTO_BUFFER, Prefs.DEF_AUDIO_AUTO_BUFFER)) 0
+                else p.getInt(Prefs.AUDIO_CUSHION_MS, Prefs.DEF_AUDIO_CUSHION_MS).coerceIn(1, 1000),
+    percentilePct = Prefs.ADAPTIVE_PERCENTILES[
+        p.getInt(Prefs.AUDIO_ADAPTIVE_STEP, Prefs.DEF_AUDIO_ADAPTIVE_STEP)
+            .coerceIn(0, Prefs.ADAPTIVE_PERCENTILES.size - 1)],
+    oboeBufferFrames = p.getInt(Prefs.OBOE_BUFFER_FRAMES, Prefs.DEF_OBOE_BUFFER_FRAMES).coerceIn(0, 8192),
+    forceSwAlac = p.getBoolean(Prefs.FORCE_SW_ALAC, Prefs.DEF_FORCE_SW_ALAC),
+    realtimePriority = p.getBoolean(Prefs.KEY_PRIORITY, Prefs.DEF_KEY_PRIORITY),
+    lowLatency = p.getBoolean(Prefs.LOW_LATENCY, Prefs.DEF_LOW_LATENCY),
+    benchmarkLog = p.getBoolean(Prefs.BENCHMARK_LOG, Prefs.DEF_BENCHMARK_LOG),
+)
+
+fun SharedPreferences.audioConfigFlow(): Flow<AudioConfig> = callbackFlow {
+    val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
+        trySend(readAudioConfig(this@audioConfigFlow))
+    }
+    trySend(readAudioConfig(this@audioConfigFlow))
+    registerOnSharedPreferenceChangeListener(listener)
+    awaitClose { unregisterOnSharedPreferenceChangeListener(listener) }
+}.distinctUntilChanged()

--- a/airplay/src/main/kotlin/io/github/jqssun/airplay/viewmodel/DebugModels.kt
+++ b/airplay/src/main/kotlin/io/github/jqssun/airplay/viewmodel/DebugModels.kt
@@ -1,0 +1,45 @@
+package io.github.jqssun.airplay.viewmodel
+
+// Split verbatim out of upstream's viewmodel/MainViewModel.kt so the :airplay module can own the
+// debug models that AudioRenderer and AirPlayService produce, while MainViewModel itself stays in
+// the app shell. Content is upstream's — keep it that way; see airplay/UPSTREAM.md.
+
+data class AudioDebug(
+    val backlogMs: Int,
+    val tunedCushionMs: Int,
+    val trims: Int,
+    val drops: Int,
+    val silences: Int,
+    val underruns: Int,
+    val xrun: Int,
+    val decodeMeanUs: Int,
+    val decodeMaxUs: Int,
+    val decodeHeld: Int,
+    val decodeErrors: Int,
+)
+
+data class DebugInfo(
+    val videoCodec: String = "",
+    val videoRes: String = "",
+    val videoFps: Int = 0,
+    val videoBitrate: Long = 0,
+    val videoFrames: Long = 0,
+    val droppedFrames: Long = 0,
+    val framePacingJitterUs: Long = 0,
+    val audioCodec: String = "",
+    val audioVolume: Int = 100,
+    val audio: AudioDebug? = null,
+    val connections: Int = 0,
+) {
+    val bitrateStr: String get() {
+        val kbps = videoBitrate / 1000
+        return if (kbps >= 1000) "${"%.1f".format(kbps / 1000.0)} Mbps" else "$kbps Kbps"
+    }
+    val jitterStr: String get() {
+        return if (framePacingJitterUs >= 1000) {
+            "${"%.1f".format(framePacingJitterUs / 1000.0)} ms"
+        } else {
+            "$framePacingJitterUs us"
+        }
+    }
+}

--- a/airplay/src/main/res/values/strings.xml
+++ b/airplay/src/main/res/values/strings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  The only strings the :airplay module itself resolves through R: the foreground-service
+  notification (service/AirPlayService.kt) and the video-download toasts
+  (download/VideoDownloader.kt). Values are upstream's verbatim.
+
+  Everything else in upstream's strings.xml belongs to the UI shell and stays in :app.
+  Keeping this file minimal is what lets the vendored sources compile inside the module with
+  no source edits at all — see airplay/UPSTREAM.md.
+-->
+<resources>
+    <!-- Notification -->
+    <string name="notification_channel">AirPlay Service</string>
+    <string name="notification_title">AirPlay Server Running</string>
+    <string name="notification_text">Accepting AirPlay connections</string>
+    <string name="notification_pin_title">AirPlay PIN Required</string>
+    <string name="notification_pin_text">PIN: %1$s</string>
+
+    <!-- Video download -->
+    <string name="download_saved">Saved to %1$s</string>
+    <string name="download_failed">Download failed</string>
+</resources>

--- a/airplay/sync-upstream.sh
+++ b/airplay/sync-upstream.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Sync the vendored AirPlay layer from jqssun/android-airplay-server.
+#
+# Copies only the paths listed in VENDORED below — upstream's UI shell is deliberately not tracked
+# (see UPSTREAM.md, "The vendor line"). Prints the resulting diff for review; it does not commit,
+# and it does not touch the submodule pins.
+#
+# Usage:
+#   airplay/sync-upstream.sh            # sync to upstream main
+#   airplay/sync-upstream.sh <ref>      # sync to a tag/branch/commit
+#   airplay/sync-upstream.sh --check    # report the delta without writing anything
+
+set -euo pipefail
+
+UPSTREAM_URL="https://github.com/jqssun/android-airplay-server.git"
+REF="main"
+CHECK_ONLY=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --check) CHECK_ONLY=1 ;;
+        -*) echo "unknown option: $arg" >&2; exit 2 ;;
+        *) REF="$arg" ;;
+    esac
+done
+
+# Repo-relative paths, identical on both sides apart from the module prefix.
+#   <upstream>/app/src/main/<path>   ->   <here>/airplay/src/main/<path>
+VENDORED=(
+    "cpp"
+    "kotlin/io/github/jqssun/airplay/bridge"
+    "kotlin/io/github/jqssun/airplay/renderer"
+    "kotlin/io/github/jqssun/airplay/audio"
+    "kotlin/io/github/jqssun/airplay/discovery"
+    "kotlin/io/github/jqssun/airplay/download"
+    "kotlin/io/github/jqssun/airplay/service"
+    "kotlin/io/github/jqssun/airplay/Prefs.kt"
+    "kotlin/io/github/jqssun/airplay/Display.kt"
+)
+
+cd "$(dirname "$0")/.."
+REPO_ROOT="$PWD"
+MODULE="$REPO_ROOT/airplay/src/main"
+
+# --ignore-submodules=dirty is required, not tidiness: applyUxplayPatches git-applies five patch
+# files inside the UxPlay submodule at CMake-configure time, so on any machine that has ever built
+# the project the submodule working tree is permanently dirty. Without this the guard trips every
+# time, with nothing to commit or stash at the superproject level. Submodule *pin* changes still
+# show up, which is what we actually care about here.
+if [[ -n "$(git status --porcelain --ignore-submodules=dirty -- airplay)" ]]; then
+    echo "airplay/ has uncommitted changes — commit or stash first, so the sync diff is readable." >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "==> fetching $UPSTREAM_URL at $REF"
+git clone --quiet --filter=blob:none --no-checkout "$UPSTREAM_URL" "$WORK/up"
+git -C "$WORK/up" checkout --quiet "$REF"
+UP_SHA="$(git -C "$WORK/up" rev-parse HEAD)"
+echo "    upstream is at $UP_SHA"
+
+echo "==> upstream submodule pins (update UPSTREAM.md if these moved)"
+git -C "$WORK/up" ls-tree HEAD app/src/main/cpp/third_party/ | awk '{printf "    %-12s %s\n", $4, substr($3,1,7)}'
+
+if [[ "$CHECK_ONLY" == 1 ]]; then
+    echo "==> --check: comparing without writing"
+fi
+
+for path in "${VENDORED[@]}"; do
+    src="$WORK/up/app/src/main/$path"
+    dst="$MODULE/$path"
+    if [[ ! -e "$src" ]]; then
+        echo "    !! upstream no longer has $path — the vendor line needs revisiting" >&2
+        continue
+    fi
+    # Submodule working trees live under cpp/third_party and are tracked by pin, not by content:
+    # upstream's clone is blobless and never checks them out, so they must be excluded from BOTH
+    # the copy and the comparison. Comparing them would report "differs" on every run for the one
+    # path that matters most.
+    if [[ "$CHECK_ONLY" == 1 ]]; then
+        if [[ -d "$src" ]]; then
+            diff -qr --exclude 'third_party' "$src" "$dst" >/dev/null 2>&1 || echo "    differs: $path"
+        else
+            diff -q "$src" "$dst" >/dev/null 2>&1 || echo "    differs: $path"
+        fi
+        continue
+    fi
+    if [[ -d "$src" ]]; then
+        rsync -a --delete --exclude 'third_party/' "$src/" "$dst/"
+    else
+        cp "$src" "$dst"
+    fi
+done
+
+if [[ "$CHECK_ONLY" == 1 ]]; then
+    exit 0
+fi
+
+echo
+echo "==> diff (review before committing)"
+git -C "$REPO_ROOT" --no-pager diff --stat -- airplay/src/main
+
+cat <<EOF
+
+DERIVED FROM UPSTREAM — NOT COPIED BY THIS SCRIPT, review by hand:
+  * viewmodel/DebugModels.kt   AudioDebug/DebugInfo, split out of upstream's MainViewModel.kt
+                               (which we do not vendor). AudioDebug's field list IS the decode
+                               layout for the packed buffer nativeServerAudioDebug fills and
+                               renderer/AudioRenderer unpacks — if upstream reorders or adds a
+                               field, the synced reader moves and this record does not. Diff
+                               upstream's MainViewModel.kt head against it.
+  * res/values/strings.xml     the seven strings the module resolves through R; upstream keeps
+                               them in the app's full strings.xml. Check the notification_* and
+                               download_* entries still exist and still have the same format args.
+
+Next:
+  1. Re-apply the LOCAL PATCH sites this sync clobbered (grep for 'LOCAL PATCH'): two in
+     service/AirPlayService.kt routing MainActivity through AirPlayHost, and the JNI thread-detach
+     hook in cpp/android_raop_callbacks.c (_get_env). See airplay/UPSTREAM.md.
+  2. Update the pins and the submodule table in airplay/UPSTREAM.md ($UP_SHA).
+  3. If a submodule pin moved above, bump it:
+       git -C airplay/src/main/cpp/third_party/<name> fetch --depth 1 origin <sha> && \\
+       git -C airplay/src/main/cpp/third_party/<name> checkout FETCH_HEAD
+  4. ./gradlew :app:assembleDebug, then verify on a gen-1 AND a gen-2 Portal.
+EOF

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,6 +28,13 @@ android {
   namespace = "com.immortal.launcher"
   compileSdk { version = release(36) { minorApiLevel = 1 } }
 
+  // Not because this module compiles native code — it doesn't — but because AGP strips the .so
+  // files it packages using the NDK's llvm-strip, and without a version to resolve it silently
+  // gives up ("Unable to strip the following libraries, packaging them as they are") and ships
+  // :airplay's libraries unstripped. That was 19 MB of .so instead of 8 MB. Keep in step with
+  // ndkVersion in airplay/build.gradle.kts.
+  ndkVersion = "27.0.12077973"
+
   defaultConfig {
     applicationId = "com.immortal.launcher"
     minSdk = 24
@@ -119,13 +126,25 @@ dependencies {
   // render the BitMatrix to a Bitmap ourselves, no Android-specific zxing module needed.
   implementation("com.google.zxing:core:3.5.3")
 
+  // AirPlay 2 receiver (audio / mirroring / AirPlay video). Ships its own service, permissions
+  // and ProGuard keep rules, so nothing else here changes. arm64-only native library; gate any
+  // UI on AirPlayEngine.isSupported(). See airplay/UPSTREAM.md and its licensing tripwire.
+  implementation(project(":airplay"))
+  // AirPlayControl and AirPlayActivity bind AirPlayService directly to follow a session, so :app
+  // compiles against its public surface: kotlinx-coroutines for the StateFlows it exposes, and
+  // lifecycle-service for its LifecycleService supertype. Both are `implementation` details of
+  // :airplay (hosts that only use AirPlayEngine need neither), so they're declared here.
+  implementation(libs.kotlinx.coroutines)
+  implementation(libs.androidx.lifecycle.service)
+
   // Media3 Transformer: on-device, hardware-accelerated video downscale/transcode for the
   // screensaver media cache ([VideoTranscoder]) — turns near-original remote clips into
   // 1200x800 derivatives the Portal stores and replays locally. -effect provides Presentation
-  // (aspect-fit resize); -common carries MediaItem etc.
-  implementation("androidx.media3:media3-transformer:1.5.1")
-  implementation("androidx.media3:media3-effect:1.5.1")
-  implementation("androidx.media3:media3-common:1.5.1")
+  // (aspect-fit resize); -common carries MediaItem etc. Version comes from the catalog, shared
+  // with :airplay (one media3 per APK).
+  implementation(libs.media3.transformer)
+  implementation(libs.media3.effect)
+  implementation(libs.media3.common)
 
   // Unit tests (pure JVM — no device/emulator). org.json provides a real
   // implementation so JSON-parsing logic can be tested off-device (the android.jar

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -189,6 +189,31 @@
             android:exported="false"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- "Stream from your iPhone": AirPlay on/off + how to connect. The AirPlay service
+             and its permissions come from the :airplay module by manifest merging; only
+             these two host Activities are declared here. -->
+        <activity
+            android:name=".AirPlayPairActivity"
+            android:exported="false"
+            android:label="AirPlay"
+            android:theme="@style/Theme.SampleApp" />
+
+        <!-- Where a cast renders: a full-screen SurfaceView, raised by AirPlayControl once
+             mirroring or AirPlay video is live (never for audio-only). Excluded from recents —
+             it's a stream, not a task. singleTask + configChanges so the mirroring -> AirPlay
+             video handover can't recreate the Activity and tear its surface down mid-session.
+             showWhenLocked/turnScreenOn let a cast land on a sleeping Portal; the background
+             start itself rides the SYSTEM_ALERT_WINDOW grant this app already holds. -->
+        <activity
+            android:name=".AirPlayActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:launchMode="singleTask"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
+            android:showWhenLocked="true"
+            android:turnScreenOn="true"
+            android:theme="@style/Theme.SampleApp" />
+
         <!-- Immortal-settings sub-screens (reached via a NavSpec from the registry-driven screen). -->
         <activity android:name=".MultiRoomActivity" android:exported="false" android:theme="@style/Theme.SampleApp" />
         <activity android:name=".MqttActivity" android:exported="false" android:theme="@style/Theme.SampleApp" />

--- a/app/src/main/java/com/immortal/launcher/AirPlayActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/AirPlayActivity.kt
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.ComponentName
+import android.content.Intent
+import android.content.ServiceConnection
+import android.graphics.Color as AndroidColor
+import android.os.Bundle
+import android.os.IBinder
+import android.util.Log
+import android.view.Surface
+import android.view.SurfaceHolder
+import android.view.Gravity
+import android.view.SurfaceView
+import android.view.View
+import android.view.WindowManager
+import android.widget.FrameLayout
+import kotlin.math.roundToInt
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.immortal.airplay.AIRPLAY_HANDOVER_GRACE_MS
+import com.immortal.airplay.sessionFlow
+import io.github.jqssun.airplay.service.AirPlayService
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/**
+ * The screen an AirPlay session renders on: a full-screen [SurfaceView] and nothing else. Raised by
+ * [AirPlayControl] only once mirroring or AirPlay video is live — audio-only stays headless.
+ *
+ * A session moves between two renderers inside the service: the MediaCodec mirror
+ * (`setVideoSurface`) and the ExoPlayer HLS player (`setVideoPlaybackSurface`). YouTube starts as
+ * mirroring and hands over to AirPlay video mid-stream. Each renderer gets its own [SurfaceView],
+ * swapped at the handover ([showSurfaceFor]); the Activity survives the transition rather than
+ * closing on the transient audio-only state it passes through ([observe]).
+ */
+class AirPlayActivity : ComponentActivity() {
+
+  private var service: AirPlayService? = null
+  private lateinit var root: FrameLayout
+  /** The live surface view, owned by exactly one consumer. Replaced, never re-pointed. */
+  private var videoView: SurfaceView? = null
+  private var shownConsumer: Consumer? = null
+  /** Pending "close because the session went audio-only", cancellable by any sign of video. */
+  private var closeJob: Job? = null
+
+  private enum class Consumer {
+    MIRROR,
+    VIDEO,
+  }
+
+  private val connection =
+      object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+          service = (binder as? AirPlayService.LocalBinder)?.service ?: return
+          observe()
+          wantedConsumer()?.let { showSurfaceFor(it) }
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+          service = null
+          shownConsumer = null
+          finish()
+        }
+      }
+
+  /**
+   * A surface callback bound to one consumer for the life of its [SurfaceView]. The consumer is
+   * captured here, not read from current state, so a late `surfaceDestroyed` for an already-replaced
+   * view clears the consumer it belonged to rather than the live one.
+   */
+  private inner class Callbacks(private val consumer: Consumer) : SurfaceHolder.Callback {
+    override fun surfaceCreated(holder: SurfaceHolder) = attach(consumer, holder.surface)
+
+    // Re-hand on every geometry change: the mirror renderer caches its viewport from the surface at
+    // creation and only refreshes it when handed a surface.
+    override fun surfaceChanged(holder: SurfaceHolder, format: Int, w: Int, h: Int) =
+        attach(consumer, holder.surface)
+
+    override fun surfaceDestroyed(holder: SurfaceHolder) = detach(consumer, holder.surface)
+  }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    // A cast is a "look at me" moment: hold the screen for the whole session, and keep the
+    // screensaver from relaunching its holding frame over the top when the dream stops.
+    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    DreamPolicy.suppressFrame = true
+    hideSystemBars()
+
+    root =
+        FrameLayout(this).apply {
+          setBackgroundColor(AndroidColor.BLACK)
+          // The container's size isn't known in onCreate, and it changes if the panel rotates.
+          addOnLayoutChangeListener { _, l, t, r, b, ol, ot, or_, ob ->
+            if (r - l != or_ - ol || b - t != ob - ot) applyAspect()
+          }
+        }
+    setContentView(root)
+
+    bindService(Intent(this, AirPlayService::class.java), connection, BIND_AUTO_CREATE)
+  }
+
+  /**
+   * Follow the session: re-route the surface between mirroring and AirPlay video, and close when the
+   * sender has gone.
+   *
+   * The mirror→video handover passes briefly through audio-only (mirroring stops before the video
+   * URL arrives), so audio-only only *arms* a close on a delay; any sign of video — which is what
+   * [com.immortal.airplay.AirPlaySession.video] folds together — disarms it. Losing the connection
+   * closes at once.
+   */
+  private fun observe() {
+    val svc = service ?: return
+    lifecycleScope.launch {
+      repeatOnLifecycle(Lifecycle.State.STARTED) {
+        svc.sessionFlow().collect { s ->
+          when {
+            // The sender is gone. Nothing to wait for.
+            !s.connected -> closeNow()
+            s.video -> {
+              disarmClose()
+              wantedConsumer()?.let { showSurfaceFor(it) }
+              // Same consumer, new source geometry (a phone rotating mid-mirror).
+              applyAspect()
+            }
+            s.audioOnly -> armClose()
+            // Between the two: no video flag, no audio flag. Hold the last frame rather than
+            // blanking — this gap is part of the handover.
+            else -> Unit
+          }
+        }
+      }
+    }
+    // Second collector: the aspect flows would overflow combine's five-flow limit above.
+    lifecycleScope.launch {
+      repeatOnLifecycle(Lifecycle.State.STARTED) {
+        combine(svc.videoAspect, svc.videoPlaybackAspect) { _, _ -> Unit }.collect { applyAspect() }
+      }
+    }
+  }
+
+  /** Arm a delayed close, re-checked against live state when it fires so a late handover still wins. */
+  private fun armClose() {
+    if (closeJob != null) return
+    closeJob =
+        lifecycleScope.launch {
+          delay(AIRPLAY_HANDOVER_GRACE_MS)
+          // Through the same fold the collector uses, so "the handover is over" cannot mean one
+          // thing here and another there. A sender that left during the grace counts too: the
+          // collector that would have closed on it is suspended while we are not started.
+          val s = service?.sessionFlow()?.first()
+          closeJob = null
+          if (s == null || !s.connected || (s.audioOnly && !s.video)) closeNow()
+        }
+  }
+
+  private fun disarmClose() {
+    closeJob?.cancel()
+    closeJob = null
+  }
+
+  private fun closeNow() {
+    disarmClose()
+    if (!isFinishing) finish()
+  }
+
+  /**
+   * Letterbox the surface to the source's aspect ratio. The renderer stretches the source to fill
+   * whatever surface it is given, so the view is *scaled* (not resized) by the fit factor — the
+   * black container then shows through as the bars. Both the container size and the ratio are
+   * measured, never assumed, so it holds for any panel and any mirrored source shape.
+   *
+   * Scaling rather than resizing is deliberate: resizing changes the Surface geometry, which forces
+   * the renderer's decoder to rebuild mid-stream and tears the picture. A view transform does not
+   * touch the Surface.
+   */
+  private fun applyAspect() {
+    val svc = service ?: return
+    if (!this::root.isInitialized) return
+    val view = videoView ?: return
+    val aspect =
+        when (shownConsumer) {
+          Consumer.VIDEO -> svc.videoPlaybackAspect.value
+          Consumer.MIRROR -> svc.videoAspect.value
+          null -> return
+        }
+    val cw = root.width
+    val ch = root.height
+    if (cw <= 0 || ch <= 0 || aspect <= 0f || !aspect.isFinite()) return
+    var w = cw
+    var h = (cw / aspect).roundToInt()
+    if (h > ch) {
+      h = ch
+      w = (ch * aspect).roundToInt()
+    }
+    if (w <= 0 || h <= 0) return
+    val sx = w.toFloat() / cw
+    val sy = h.toFloat() / ch
+    if (view.scaleX == sx && view.scaleY == sy) return
+    view.pivotX = cw / 2f
+    view.pivotY = ch / 2f
+    view.scaleX = sx
+    view.scaleY = sy
+  }
+
+  /**
+   * Give the live consumer its own fresh [SurfaceView], replacing the previous one. The two
+   * consumers are different producers (MediaCodec+GL vs ExoPlayer); sharing one Surface between them
+   * left the outgoing producer's frames composited under the incoming one after a handover, so each
+   * gets its own Surface and BufferQueue with explicit teardown — as upstream's UI does.
+   */
+  private fun showSurfaceFor(want: Consumer) {
+    if (want == shownConsumer) return
+    // Removing the old view synchronously fires its surfaceDestroyed → detach for its own consumer.
+    videoView?.let { root.removeView(it) }
+    shownConsumer = want
+    videoView =
+        SurfaceView(this).also { v ->
+          v.holder.addCallback(Callbacks(want))
+          root.addView(
+              v,
+              FrameLayout.LayoutParams(
+                  FrameLayout.LayoutParams.MATCH_PARENT,
+                  FrameLayout.LayoutParams.MATCH_PARENT,
+                  Gravity.CENTER))
+        }
+    applyAspect()
+  }
+
+  /** Pick the consumer the session currently calls for, or null while it is between the two. */
+  private fun wantedConsumer(): Consumer? {
+    val svc = service ?: return null
+    return when {
+      // AirPlay video wins when both look set: it is where a handover ends up, and mirroring has
+      // stopped feeding frames by then.
+      svc.videoPlaybackActive.value || svc.videoSessionPending() -> Consumer.VIDEO
+      svc.mirroringActive.value -> Consumer.MIRROR
+      else -> null
+    }
+  }
+
+  private fun attach(consumer: Consumer, s: Surface) {
+    val svc = service ?: return
+    if (!s.isValid) return
+    runCatching {
+          when (consumer) {
+            Consumer.MIRROR -> svc.setVideoSurface(s)
+            Consumer.VIDEO -> svc.setVideoPlaybackSurface(s)
+          }
+        }
+        .onFailure { Log.w(TAG, "failed to attach the surface to $consumer", it) }
+  }
+
+  /** Both clears are identity-guarded in the module, so a late one for a replaced view is a no-op. */
+  private fun detach(consumer: Consumer, s: Surface) {
+    val svc = service ?: return
+    runCatching {
+          when (consumer) {
+            Consumer.MIRROR -> svc.clearVideoSurface(s)
+            Consumer.VIDEO -> svc.clearVideoPlaybackSurface(s)
+          }
+        }
+        .onFailure { Log.w(TAG, "failed to detach the surface from $consumer", it) }
+  }
+
+  /** Immersive full-screen; a cast should not sit under the status bar. */
+  private fun hideSystemBars() {
+    @Suppress("DEPRECATION")
+    window.decorView.systemUiVisibility =
+        View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+            View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+            View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+            View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
+            View.SYSTEM_UI_FLAG_FULLSCREEN or
+            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+  }
+
+  override fun onDestroy() {
+    DreamPolicy.suppressFrame = false
+    // Drops the view, which fires surfaceDestroyed -> detach for whichever consumer owns it.
+    videoView?.let { root.removeView(it) }
+    videoView = null
+    shownConsumer = null
+    runCatching { unbindService(connection) }
+    service = null
+    super.onDestroy()
+  }
+
+  private companion object {
+    const val TAG = "ImmortalAirPlay"
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/AirPlayConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/AirPlayConfig.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import com.immortal.airplay.AirPlayOptions
+
+/**
+ * Config for the AirPlay receiver (`:airplay`) — stream audio, mirror a screen, or hand over an
+ * AirPlay video URL from an iPhone/iPad/Mac. Off by default; opening [AirPlayPairActivity] turns it
+ * on, the way [RemotePairActivity] opts the phone remote in.
+ *
+ * No server-name field: the Portal advertises under [FleetConfig.name], the same value the phone
+ * remote and Home Assistant use, so there is no second name to drift. [options] maps this config
+ * onto the module's own settings, which it reads directly ([AirPlayOptions.applyTo] writes them).
+ * The module keeps those in a prefs file named plain `settings`; Immortal's own files are all
+ * `immortal_*`, so they don't collide.
+ */
+object AirPlayConfig {
+  private const val PREFS = "airplay"
+
+  private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+  fun isEnabled(c: Context): Boolean = prefs(c).getBoolean("enabled", false)
+
+  fun setEnabled(c: Context, on: Boolean) = prefs(c).edit().putBoolean("enabled", on).apply()
+
+  /** Ask the sender for an on-screen PIN before accepting a connection. */
+  fun requirePin(c: Context): Boolean = prefs(c).getBoolean("require_pin", false)
+
+  fun setRequirePin(c: Context, on: Boolean) = prefs(c).edit().putBoolean("require_pin", on).apply()
+
+  /** Advertise screen mirroring / AirPlay video. Off leaves an audio-only speaker. */
+  fun allowMirroring(c: Context): Boolean = prefs(c).getBoolean("allow_mirroring", true)
+
+  fun setAllowMirroring(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("allow_mirroring", on).apply()
+
+  /** Advertised mirroring resolution: "auto" (the real panel size) or `WxH`. */
+  fun resolution(c: Context): String = prefs(c).getString("resolution", "auto") ?: "auto"
+
+  fun setResolution(c: Context, v: String) = prefs(c).edit().putString("resolution", v).apply()
+
+  /** Bring [AirPlayActivity] to the front when a *video* session starts. */
+  fun showOnConnect(c: Context): Boolean = prefs(c).getBoolean("show_on_connect", true)
+
+  fun setShowOnConnect(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("show_on_connect", on).apply()
+
+  /** Immutable snapshot, so the settings domain renders through the generic on-device list. */
+  data class Settings(
+      val enabled: Boolean = false,
+      val requirePin: Boolean = false,
+      val allowMirroring: Boolean = true,
+      val resolution: String = "auto",
+      val showOnConnect: Boolean = true,
+  )
+
+  fun load(c: Context): Settings =
+      Settings(
+          enabled = isEnabled(c),
+          requirePin = requirePin(c),
+          allowMirroring = allowMirroring(c),
+          resolution = resolution(c),
+          showOnConnect = showOnConnect(c),
+      )
+
+  /**
+   * This config as the module's typed options.
+   *
+   * `launchOnConnect` is pinned OFF regardless of [showOnConnect]: the module launches the surface
+   * Activity at TCP connect, before the session's kind is known, which would tear the screensaver
+   * down for an audio-only stream. [AirPlayControl] launches [AirPlayActivity] itself once a real
+   * video session is confirmed, and gates that on [showOnConnect].
+   */
+  fun options(c: Context): AirPlayOptions {
+    val s = load(c)
+    return AirPlayOptions(
+        deviceName = FleetConfig.name(c),
+        requirePin = s.requirePin,
+        allowMirroring = s.allowMirroring,
+        // "auto" means "advertise the real panel resolution"; a fixed WxH overrides it.
+        autoResolution = s.resolution.equals("auto", ignoreCase = true),
+        resolution = s.resolution,
+        launchOnConnect = false,
+    )
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/AirPlayControl.kt
+++ b/app/src/main/java/com/immortal/launcher/AirPlayControl.kt
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.media.AudioManager
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.util.Log
+import com.immortal.airplay.AIRPLAY_HANDOVER_GRACE_MS
+import com.immortal.airplay.AirPlayEngine
+import com.immortal.airplay.AirPlayOptions
+import com.immortal.airplay.AirPlaySession
+import com.immortal.airplay.sessionFlow
+import io.github.jqssun.airplay.service.AirPlayService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Immortal's runtime wiring for the `:airplay` receiver: bring it up to match [AirPlayConfig], and
+ * react to what a session turns out to be.
+ *
+ * The module needs no service of its own here — `AirPlayService` merges in from the library — so
+ * this is only the two things a *launcher* has to decide that a receiver app doesn't:
+ *
+ *  - **When to put a surface on screen.** The module offers to launch the host's surface Activity
+ *    at TCP connect, but the session's kind isn't known yet: an audio-only stream would tear the
+ *    screensaver down for nothing. So [AirPlayConfig.options] pins `launchOnConnect` off and the
+ *    watcher below raises [AirPlayActivity] only once mirroring or AirPlay video is genuinely live.
+ *  - **Who owns the speakers.** Multi-room (Snapcast) and an AirPlay audio session both want them.
+ *    The live AirPlay session wins for its duration and hands back when it ends.
+ *
+ * Both need someone watching the running service, which is what [SessionWatcher] is. As the home
+ * app our process is effectively persistent, so a binding held for as long as the receiver runs
+ * costs nothing — the same reasoning as the runtime receivers in [ImmortalApp].
+ */
+object AirPlayControl {
+  private const val TAG = "ImmortalAirPlay"
+
+  /**
+   * The main thread, which everything here runs on.
+   *
+   * Callers arrive on whatever thread applied a setting — the phone remote's HTTP worker as much as
+   * the UI — while the service's own state changes and the binder callbacks are already on main.
+   * One thread for the lot is what keeps [started] and [lastStarted] describing the same server:
+   * `startServer` reads the prefs and reaches RUNNING inside a single main-thread message, so an
+   * apply can no longer slip between a start's settings and the state that confirms them. Always
+   * posted, never run inline, so requests take effect in the order they were issued.
+   */
+  private val main = Handler(Looper.getMainLooper())
+
+  private fun onMain(block: () -> Unit) {
+    main.post(block)
+  }
+
+  /**
+   * The options the *running* server was started with, so [applyConfig] can skip a no-op restart.
+   * Not an optimisation: a restart re-inits the native stack on the main thread and drops any live
+   * session, and both pairing surfaces re-apply the config every time they open.
+   *
+   * Written from the server's own state by [SessionWatcher] — [started] the moment it reports
+   * RUNNING, null on anything else — and cleared by [stop]. Latching it optimistically at the call
+   * site is what made a failed start unrecoverable: every later apply matched a config that was
+   * never actually running, skipped, and left the receiver down behind a UI saying it was on.
+   */
+  private var lastStarted: AirPlayOptions? = null
+
+  /** The options the last start/restart was issued with — [lastStarted] once the server confirms. */
+  private var started: AirPlayOptions? = null
+
+  /** The config a restart has already been retried for, so a miss costs one extra attempt, not a loop. */
+  private var retried: AirPlayOptions? = null
+
+  /** Long enough for whatever made the bind time out to have passed. */
+  private const val RECONFIGURE_RETRY_MS = 5_000L
+
+  /**
+   * Whether this device can run the receiver at all (arm64 + the native library present). Loads the
+   * native stack to find out, so only call it where the receiver is about to start anyway.
+   */
+  fun isSupported(): Boolean = AirPlayEngine.isSupported()
+
+  /** The same question for a UI gate, cheap enough for a composable. */
+  fun isProbablySupported(): Boolean = AirPlayEngine.isProbablySupported()
+
+  /**
+   * Bring the receiver up if the user turned it on. No-op otherwise, so [ImmortalApp] and
+   * [BootReceiver] can call it unconditionally — mirroring [FleetAgentService.ensureRunning].
+   */
+  fun ensureRunning(context: Context) = onMain { ensureRunningNow(context.applicationContext) }
+
+  private fun ensureRunningNow(c: Context) {
+    if (!AirPlayConfig.isEnabled(c) || !isSupported()) return
+    runCatching {
+          // The service reads its settings on start, so persist them first.
+          val options = AirPlayConfig.options(c)
+          options.applyTo(c)
+          started = options
+          // A refused start leaves nothing to watch.
+          if (AirPlayEngine.start(c)) SessionWatcher.attach(c)
+        }
+        .onFailure { Log.w(TAG, "ensureRunning failed", it) }
+  }
+
+  /**
+   * Make the running receiver match [AirPlayConfig] — start it, restart it with new settings, or
+   * stop it. The settings domain's `onApplied` hook, so a change from the on-device screen and one
+   * pushed from the phone remote take effect the same way.
+   */
+  fun applyConfig(context: Context) = onMain { applyConfigNow(context.applicationContext) }
+
+  private fun applyConfigNow(c: Context) {
+    // The cheap gate, not [isSupported]: every settings apply lands here — a rename pushed from the
+    // phone remote included — and this now runs on the main thread, which is not where a launcher
+    // should be dlopening the native stack. The paths below that actually start something check the
+    // real thing.
+    if (!isProbablySupported()) return
+    if (!AirPlayConfig.isEnabled(c)) {
+      stopNow(c)
+      return
+    }
+    val options = AirPlayConfig.options(c)
+    // `lastStarted == null` means no server is confirmed running with a config — either this
+    // process has not brought one up yet or the last attempt failed — and a plain start covers
+    // both. Keying that on the service's own state is safe because [SessionWatcher] holds an
+    // AUTO_CREATE binding for the receiver's lifetime: the stopSelf inside a settings restart
+    // cannot destroy a bound service, so the instance that reports RUNNING again is the same one.
+    if (lastStarted == null) {
+      retried = null
+      ensureRunningNow(c)
+      return
+    }
+    // Config unchanged — leave the running server alone (the common path from both pair surfaces).
+    if (options == lastStarted) {
+      retried = null
+      return
+    }
+    // Restart to pick up the change. Nothing may follow: reconfigure is asynchronous and re-issues
+    // the foreground start itself, so a second start here would race its stopSelf and get the
+    // process killed for not calling startForeground in time.
+    started = options
+    AirPlayEngine.reconfigure(c, options, running = true) { applied ->
+      if (applied) {
+        retried = null
+        return@reconfigure
+      }
+      // The restart never reached the instance: the old settings are still running, and the server
+      // never left RUNNING, so there is no state change to notice that by. Put [started] back to
+      // what the server actually has — otherwise the next RUNNING edge, from a reconnect or an
+      // unrelated restart, would latch a config it never took and skip every apply after it. Unless
+      // a later apply has moved on already, in which case that one owns the field.
+      if (started == options) started = lastStarted
+      // Nothing else will re-drive this: the prefs already hold the new value, so the disagreement
+      // is invisible to every later comparison, and a rename is a one-shot action. One retry, once
+      // per config, so a receiver that is simply gone doesn't get poked forever.
+      if (retried == options) {
+        Log.w(TAG, "reconfigure did not reach the receiver; giving up until the next change")
+        return@reconfigure
+      }
+      Log.w(TAG, "reconfigure did not reach the receiver; retrying once")
+      retried = options
+      main.postDelayed({ applyConfigNow(c) }, RECONFIGURE_RETRY_MS)
+    }
+  }
+
+  /** Stop the receiver and drop its mDNS advertisement. Safe when it isn't running. */
+  fun stop(context: Context) = onMain { stopNow(context.applicationContext) }
+
+  private fun stopNow(c: Context) {
+    // Asynchronous: it stops the service outright, then reaches the live instance through a bind of
+    // its own to stop the server inside it. Either half is enough — if dropping our binding below
+    // destroys the service before that bind is answered, its onDestroy stops the server anyway.
+    runCatching { AirPlayEngine.stop(c) }.onFailure { Log.w(TAG, "stop failed", it) }
+    // Both, or the watcher's last emission on the way down could re-latch what we just cleared.
+    started = null
+    lastStarted = null
+    retried = null
+    SessionWatcher.detach(c)
+  }
+
+  /**
+   * Bound to the running [AirPlayService] for as long as the receiver is up, translating its
+   * session state into the two host decisions described on [AirPlayControl], and reporting back
+   * what the server is actually doing.
+   *
+   * Main thread throughout: its collectors and binder callbacks land there, and [attach]/[detach]
+   * are only ever reached from the hop above.
+   */
+  private object SessionWatcher : ServiceConnection {
+    private var service: AirPlayService? = null
+    private var scope: CoroutineScope? = null
+    /** Registered with the system, not connected to an instance — only [detach] may clear it. */
+    private var bound = false
+    /** Kept so a disconnect can release what we were holding without a live service to ask. */
+    private var appContext: Context? = null
+    /** Rising-edge latches — a session state is a level, and both reactions are edge-triggered. */
+    private var videoRaised = false
+    private var audioOwned = false
+    /** Pending hand-back of the speakers, cancelled if the session comes back within the grace. */
+    private var releaseJob: Job? = null
+
+    /** Ignored focus changes: we don't pause the sender, we just claim the output. */
+    private val focusListener = AudioManager.OnAudioFocusChangeListener {}
+
+    fun attach(context: Context) {
+      if (bound) return
+      val c = context.applicationContext
+      appContext = c
+      // AUTO_CREATE (not a passive bind), always reached just after start() so creation is wanted:
+      // a passive bind fails while the service is still starting, and would keep holding the old
+      // instance across a settings restart (stopServer calls stopSelf). [detach] releases it.
+      bound =
+          runCatching {
+                c.bindService(Intent(c, AirPlayService::class.java), this, Context.BIND_AUTO_CREATE)
+              }
+              .getOrDefault(false)
+    }
+
+    fun detach(context: Context) {
+      val c = context.applicationContext
+      if (bound) runCatching { c.unbindService(this) }
+      bound = false
+      release(c)
+    }
+
+    override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+      val svc = (binder as? AirPlayService.LocalBinder)?.service ?: return
+      service = svc
+      val ctx = appContext ?: return
+      val s = CoroutineScope(Dispatchers.Main.immediate)
+      scope = s
+      s.launch { svc.sessionFlow().collect { onSession(ctx, it) } }
+      s.launch {
+        // The only writer of [lastStarted]: a start that failed (port taken, native init) or a
+        // server that stopped leaves it null, so the next apply retries instead of matching a config
+        // nothing is running. Reading the state rather than trusting the start call also covers the
+        // failure repeating — a second ERROR is not an event, but never reaching RUNNING is.
+        svc.serverState.collect {
+          lastStarted = if (it == AirPlayService.ServerState.RUNNING) started else null
+        }
+      }
+    }
+
+    override fun onServiceDisconnected(name: ComponentName?) {
+      // The service process died. Drop what we held on its behalf, but leave `bound` alone: the
+      // binding survives a disconnect and the system reconnects us through it. Clearing it would
+      // leave [detach] nothing to unbind, so the AUTO_CREATE binding would keep recreating the
+      // service — still advertising over mDNS — after the user turned AirPlay off.
+      appContext?.let { release(it) }
+    }
+
+    private fun onSession(c: Context, s: AirPlaySession) {
+      // Video: raise the surface once, on the way in. The Activity owns its own dismissal — it has
+      // to survive the mirroring -> AirPlay-video handover, during which both flags are briefly
+      // false and a level-triggered teardown would read as a disconnect.
+      val video = s.connected && s.video
+      if (video && !videoRaised && AirPlayConfig.showOnConnect(c)) {
+        runCatching {
+              ScreenControl.wake(c)
+              c.startActivity(
+                  Intent(c, AirPlayActivity::class.java)
+                      .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT))
+            }
+            .onFailure { Log.w(TAG, "failed to raise the AirPlay surface", it) }
+      }
+      videoRaised = video
+
+      // Audio: any live session owns the speakers, mirroring and AirPlay video included — those
+      // carry sound too, and leaving multi-room running under them plays two streams at once.
+      if (s.connected && (s.audioOnly || s.video)) {
+        disarmRelease()
+        setAudioOwned(c, true)
+      } else {
+        armRelease(c)
+      }
+    }
+
+    /**
+     * Hand the speakers back, but not during a handover. Mirroring → AirPlay video passes through a
+     * state with neither flag set, and releasing there would stop and immediately respawn the
+     * Snapcast relay — an audible gap in a session that never actually ended. Same reasoning, and
+     * the same delay, as [AirPlayActivity]'s close.
+     */
+    private fun armRelease(c: Context) {
+      if (!audioOwned || releaseJob != null) return
+      releaseJob =
+          scope?.launch {
+            delay(AIRPLAY_HANDOVER_GRACE_MS)
+            releaseJob = null
+            setAudioOwned(c, false)
+          }
+    }
+
+    private fun disarmRelease() {
+      releaseJob?.cancel()
+      releaseJob = null
+    }
+
+    /**
+     * Take or hand back the speakers. Multi-room's Snapcast player and an AirPlay session would
+     * otherwise play over each other: the relay is stopped so the now-playing card follows the live
+     * stream, and audio focus asks any other local player to get out of the way.
+     */
+    private fun setAudioOwned(c: Context, owned: Boolean) {
+      if (owned == audioOwned) return
+      audioOwned = owned
+      val am = c.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+      runCatching {
+            if (owned) {
+              // The pre-26 form on purpose: it is still honoured on API 26+, and every Portal is
+              // API 28/29 — one call beats a version fork for a single transient claim.
+              @Suppress("DEPRECATION")
+              am?.requestAudioFocus(focusListener, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN)
+              c.stopService(Intent(c, MultiRoomService::class.java))
+            } else {
+              @Suppress("DEPRECATION") am?.abandonAudioFocus(focusListener)
+              // Restores the relay only if multi-room is still configured; a no-op otherwise.
+              MultiRoomService.sync(c)
+            }
+          }
+          .onFailure { Log.w(TAG, "audio ownership change failed", it) }
+    }
+
+    private fun release(c: Context) {
+      // Cancelling the scope takes any armed release with it, so hand the speakers back here.
+      disarmRelease()
+      scope?.cancel()
+      scope = null
+      service = null
+      videoRaised = false
+      setAudioOwned(c, false)
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/AirPlayPairActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/AirPlayPairActivity.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Activity
+import android.content.Context
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.settings.SettingsDomains
+import com.immortal.launcher.ui.theme.SampleAppTheme
+import org.json.JSONObject
+
+/**
+ * "Stream from your iPhone" — turns the AirPlay receiver on and shows what to look for in Control
+ * Center, rendering the `airplay` settings domain below the how-to card.
+ *
+ * Opening it opts in (like [RemotePairActivity] for the phone remote), but only once on entry so
+ * the toggle below still turns it back off. No QR code: a sender finds the Portal over mDNS, so what
+ * the user needs is just the name to pick — [FleetConfig.name].
+ */
+class AirPlayPairActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    if (AirPlayControl.isSupported()) enableAirPlay(this)
+    setContent { SampleAppTheme(darkTheme = true) { AirPlayPairScreen() } }
+  }
+}
+
+/**
+ * Turn the receiver on and start it. Mirrors [enableRemoteAndMintPin] — reaching a pairing surface
+ * is itself the "yes, I want this". Shared with the home-header quick-connect modal.
+ */
+fun enableAirPlay(context: Context) {
+  AirPlayConfig.setEnabled(context, true)
+  AirPlayControl.applyConfig(context)
+}
+
+@Composable
+private fun AirPlayPairScreen() {
+  val context = LocalContext.current
+  val activity = context as? Activity
+  val supported = remember { AirPlayControl.isSupported() }
+  var settings by remember { mutableStateOf(AirPlayConfig.load(context)) }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Color(0xFF111111))
+              .onPreviewKeyEvent { e ->
+                if (e.key == Key.Back) {
+                  if (e.type == KeyEventType.KeyUp) activity?.finish()
+                  true
+                } else false
+              }
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 40.dp),
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+  ) {
+    Text("Stream from your iPhone", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+    Text(
+        "Play music through this Portal's speakers, or put your iPhone, iPad or Mac screen on it — " +
+            "over the same Wi-Fi, with nothing to install.",
+        color = Color(0xFF9A9A9A),
+        fontSize = 16.sp,
+    )
+    Spacer(Modifier.size(8.dp))
+
+    if (!supported) {
+      AirPlayUnsupportedCard()
+    } else {
+      if (settings.enabled) AirPlayPairCard(FleetConfig.name(context), settings.requirePin)
+
+      // Everything else renders from the `airplay` registry domain — the same specs the phone
+      // remote uses, applied through the domain so its onApplied (restart the receiver with the new
+      // settings) fires here too. "pairing" is the NavSpec back into this very screen.
+      SettingsList(SettingsDomains.airplay, settings, exclude = setOf("pairing")) { k, v ->
+        SettingsDomains.airplay.apply(context, JSONObject().put(k, v))
+        settings = AirPlayConfig.load(context)
+      }
+    }
+
+    Spacer(Modifier.size(8.dp))
+    PairDoneButton { activity?.finish() }
+  }
+}
+
+/**
+ * The "here's what to tap" card: the two Control Center routes and the name to pick. Shared with the
+ * home-header quick-connect modal so the two surfaces can't drift.
+ */
+@Composable
+fun AirPlayPairCard(deviceName: String, requirePin: Boolean, modifier: Modifier = Modifier) {
+  Surface(color = Color(0xFF1C1C1E), shape = RoundedCornerShape(18.dp), modifier = modifier.fillMaxWidth()) {
+    Column(modifier = Modifier.fillMaxWidth().padding(24.dp)) {
+      Step("1", "Open Control Center on your iPhone, iPad or Mac.")
+      Step("2", "Tap AirPlay to send music, or Screen Mirroring to send the screen.")
+      Step("3", "Pick this Portal from the list:")
+      Surface(
+          color = Color(0xFF2A2A2C),
+          shape = RoundedCornerShape(12.dp),
+          modifier = Modifier.padding(start = 34.dp, top = 10.dp),
+      ) {
+        Text(
+            deviceName,
+            color = Color.White,
+            fontSize = 26.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp),
+        )
+      }
+      Text(
+          "This is the Portal's device name — rename it from the phone remote and AirPlay follows.",
+          color = Color(0xFF7C7C7C),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(start = 34.dp, top = 8.dp),
+      )
+      if (requirePin) {
+        Text(
+            "A code appears on this Portal when your phone connects — type it into the phone to " +
+                "allow the connection.",
+            color = Color(0xFFD8C08A),
+            fontSize = 14.sp,
+            modifier = Modifier.padding(top = 18.dp),
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun Step(n: String, text: String) {
+  Row(modifier = Modifier.fillMaxWidth().padding(top = 8.dp), verticalAlignment = Alignment.Top) {
+    Text(n, color = Color(0xFF7C7C7C), fontSize = 17.sp, modifier = Modifier.width(34.dp))
+    Text(text, color = Color(0xFFDADADA), fontSize = 17.sp)
+  }
+}
+
+/**
+ * Shown instead of the card on a device with no native library. The build filters it to arm64 (every
+ * Portal is), so in practice this is only ever seen on an emulator.
+ */
+@Composable
+private fun AirPlayUnsupportedCard(modifier: Modifier = Modifier) {
+  Surface(color = Color(0xFF1C1C1E), shape = RoundedCornerShape(18.dp), modifier = modifier.fillMaxWidth()) {
+    Text(
+        "AirPlay isn't available on this device.",
+        color = Color(0xFFE0A0A0),
+        fontSize = 17.sp,
+        modifier = Modifier.padding(20.dp),
+    )
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/BootReceiver.kt
+++ b/app/src/main/java/com/immortal/launcher/BootReceiver.kt
@@ -30,6 +30,10 @@ class BootReceiver : BroadcastReceiver() {
       FleetAgentService.ensureRunning(context)
       // Reconnect the Home Assistant MQTT publisher (no-op unless configured).
       MqttService.sync(context)
+      // Bring the AirPlay receiver back up (no-op unless the user turned it on). ImmortalApp does
+      // this too, but only once our process starts — this is what makes the Portal discoverable
+      // again straight after a power-cycle.
+      AirPlayControl.ensureRunning(context)
       // (Re)launch apps that can't restart themselves (e.g. the MA/Sendspin player,
       // which has no boot receiver). Wait a few seconds first so WiFi is up for their
       // first connect, then hand the screen back to our home so the Portal doesn't sit

--- a/app/src/main/java/com/immortal/launcher/DreamPolicy.kt
+++ b/app/src/main/java/com/immortal/launcher/DreamPolicy.kt
@@ -69,6 +69,17 @@ object DreamPolicy {
   @Volatile var inStockHandoff: Boolean = false
 
   /**
+   * Set by a full-screen Activity that owns the display for as long as it is up — currently
+   * [AirPlayActivity] during a cast. The dream stops the moment such an Activity comes forward,
+   * which is a genuine REDREAM (someone is here), so the presence verdict below stays honest; but
+   * relaunching the holding photo frame would drop it straight over the top of the cast.
+   *
+   * Deliberately in-memory only, unlike [bridgeAt]: the flag is meaningless without the Activity
+   * that set it, so a process restart clearing it is the correct behaviour.
+   */
+  @Volatile var suppressFrame: Boolean = false
+
+  /**
    * Called from [ImmortalApp.onCreate] to restore bridge state after a process restart.
    * Without this, a new process spawned for a dream-service invocation sees default
    * (zeroed) values and classifies the dream stop as REDREAM, relaunching the photo
@@ -177,6 +188,10 @@ object DreamPolicy {
     // companion). SUPPRESSED (a Calls handoff) leaves presence untouched.
     PresenceHub.onDreamStopped(context, verdict)
     if (verdict != DreamStopVerdict.REDREAM) return
+    if (suppressFrame) {
+      Log.i(TAG, "frame relaunch suppressed; a full-screen owner is up")
+      return
+    }
     // Inside the overnight window the SleepScheduler owns the screen. In dark mode, relaunching the
     // frame would wake the screen just to blank it again — a flash every time a stray sibling/system
     // dream cycles overnight (issue #73). Let the scheduler re-blank in place instead.

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -1422,6 +1422,11 @@ private fun HeaderBar(onScreensaver: () -> Unit) {
   var pairUrl by remember { mutableStateOf<String?>(null) }
   var pairPin by remember { mutableStateOf<String?>(null) }
 
+  // Same idea for AirPlay: turn the receiver on and show which name to pick in Control Center.
+  // The glyph is hidden entirely where the native library can't load (arm64-only build).
+  var showAirPlay by remember { mutableStateOf(false) }
+  val airPlaySupported = remember { AirPlayControl.isProbablySupported() }
+
   // Layout: the big clock anchors the left; the weather and date stack on the
   // right, right-aligned, so the header reads as a balanced pair of blocks. The
   // clock and the right-hand stack are centred against each other.
@@ -1463,6 +1468,22 @@ private fun HeaderBar(onScreensaver: () -> Unit) {
             },
     ) {
       Box(contentAlignment = Alignment.Center) { RemoteGlyph() }
+    }
+    // AirPlay — the other "use your phone with this Portal" affordance: turn the receiver on
+    // (if off) and show the name to pick in Control Center.
+    if (airPlaySupported) {
+      Spacer(Modifier.size(14.dp))
+      Surface(
+          color = Color(0x33FFFFFF),
+          shape = androidx.compose.foundation.shape.CircleShape,
+          modifier =
+              Modifier.size(56.dp).tvFocusable(androidx.compose.foundation.shape.CircleShape) {
+                enableAirPlay(context)
+                showAirPlay = true
+              },
+      ) {
+        Box(contentAlignment = Alignment.Center) { AirPlayGlyph() }
+      }
     }
     // "Hey" button — push-to-talk for the active assistant. The launcher stays
     // dumb: it just broadcasts the trigger; Millennium owns assistant selection,
@@ -1531,6 +1552,26 @@ private fun HeaderBar(onScreensaver: () -> Unit) {
           RemotePairCard(pairUrl, pairPin)
           Spacer(Modifier.size(16.dp))
           PairDoneButton { showPair = false }
+        }
+      }
+    }
+  }
+
+  if (showAirPlay) {
+    androidx.compose.ui.window.Dialog(onDismissRequest = { showAirPlay = false }) {
+      Surface(color = Color(0xFF101012), shape = androidx.compose.foundation.shape.RoundedCornerShape(20.dp)) {
+        Column(modifier = Modifier.padding(20.dp)) {
+          Text("Stream from your iPhone", color = Color.White, fontSize = 20.sp, fontWeight = FontWeight.SemiBold)
+          Text(
+              "AirPlay is on. Pick this Portal in Control Center on a phone, tablet or Mac on the " +
+                  "same Wi-Fi.",
+              color = Color(0xFF9A9A9A),
+              fontSize = 13.sp,
+              modifier = Modifier.padding(top = 4.dp, bottom = 14.dp),
+          )
+          AirPlayPairCard(FleetConfig.name(context), AirPlayConfig.requirePin(context))
+          Spacer(Modifier.size(16.dp))
+          PairDoneButton { showAirPlay = false }
         }
       }
     }
@@ -1877,6 +1918,41 @@ private fun RemoteGlyph() {
     // Speaker slit near the top, home dot near the bottom.
     drawLine(Color.White, Offset(w * 0.44f, w * 0.22f), Offset(w * 0.56f, w * 0.22f), strokeWidth = s)
     drawCircle(color = Color.White, radius = w * 0.045f, center = Offset(w * 0.5f, w * 0.67f))
+  }
+}
+
+/**
+ * White line-art AirPlay glyph for the header "stream from your iPhone" button — Apple's own mark:
+ * a screen outline with a triangle rising into it from below.
+ */
+@Composable
+private fun AirPlayGlyph() {
+  Canvas(modifier = Modifier.size(28.dp)) {
+    val w = size.minDimension
+    val s = w * 0.08f
+    val stroke =
+        Stroke(
+            width = s,
+            cap = androidx.compose.ui.graphics.StrokeCap.Round,
+            join = androidx.compose.ui.graphics.StrokeJoin.Round,
+        )
+    // Screen: an open-bottomed rounded rect, so the triangle reads as sitting in its mouth.
+    drawRoundRect(
+        color = Color.White,
+        topLeft = Offset(w * 0.14f, w * 0.16f),
+        size = Size(w * 0.72f, w * 0.50f),
+        cornerRadius = CornerRadius(w * 0.08f, w * 0.08f),
+        style = stroke,
+    )
+    // Triangle, apex up, centred under the screen.
+    val path =
+        androidx.compose.ui.graphics.Path().apply {
+          moveTo(w * 0.50f, w * 0.56f)
+          lineTo(w * 0.74f, w * 0.88f)
+          lineTo(w * 0.26f, w * 0.88f)
+          close()
+        }
+    drawPath(path, color = Color.White, style = stroke)
   }
 }
 

--- a/app/src/main/java/com/immortal/launcher/ImmortalApp.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalApp.kt
@@ -12,6 +12,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import com.immortal.airplay.AirPlayHost
 
 /**
  * Process-wide hooks. As the home app our process is effectively persistent, so a
@@ -80,5 +81,11 @@ class ImmortalApp : Application() {
     // Publish this Portal to Home Assistant over MQTT if the user configured a broker
     // (no-op otherwise). Off by default.
     MqttService.sync(this)
+
+    // AirPlay receiver: tell the module which Activity hosts a cast, then bring it up if the
+    // user turned it on (no-op otherwise). The host Activity has to be registered before the
+    // service can start — it's also the target of the receiver's notification tap.
+    AirPlayHost.surfaceActivity = AirPlayActivity::class.java
+    AirPlayControl.ensureRunning(this)
   }
 }

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -183,6 +183,8 @@ private fun ImmortalSettingsScreen() {
 
       RemoteNavRow()
 
+      AirPlayNavRow()
+
       FeatureSettingsNavRow(
           "Sounds", "Chimes & spoken time",
           "Hourly chime, spoken time, golden-hour tone, quiet hours") {
@@ -686,6 +688,41 @@ private fun RemoteNavRow() {
         Text("Control from your phone", color = Color.White, fontSize = 17.sp)
         Text(
             if (RemotePairing.isEnabled(context)) "On — pair a phone as a remote" else "Off",
+            color = Color(0xFF9A9A9A),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 2.dp),
+        )
+      }
+      Text("›", color = Color(0xFF7C7C7C), fontSize = 26.sp)
+    }
+  }
+}
+
+/**
+ * Opens the AirPlay screen ([AirPlayPairActivity]); shows on/off at a glance. Sits in the same
+ * "Remote" section as [RemoteNavRow] — both are "use your phone with this Portal". Hidden outright
+ * on a device with no native library (arm64-only build, so emulators).
+ */
+@Composable
+private fun AirPlayNavRow() {
+  val context = LocalContext.current
+  if (!AirPlayControl.isProbablySupported()) return
+  Card {
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
+                .tvFocusableRow {
+                  runCatching {
+                    context.startActivity(Intent(context, AirPlayPairActivity::class.java))
+                  }
+                }
+                .padding(18.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Column(modifier = Modifier.weight(1f)) {
+        Text("Stream from your iPhone", color = Color.White, fontSize = 17.sp)
+        Text(
+            if (AirPlayConfig.isEnabled(context)) "On — AirPlay audio and screen mirroring" else "Off",
             color = Color(0xFF9A9A9A),
             fontSize = 13.sp,
             modifier = Modifier.padding(top = 2.dp),

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -8,6 +8,9 @@
 package com.immortal.launcher.settings
 
 import android.content.Context
+import com.immortal.launcher.AirPlayConfig
+import com.immortal.launcher.AirPlayControl
+import com.immortal.launcher.AirPlayPairActivity
 import com.immortal.launcher.CalendarFeed
 import com.immortal.launcher.CalendarUrlEntryActivity
 import com.immortal.launcher.SunriseConfig
@@ -758,6 +761,12 @@ object SettingsDomains {
                       help = "Shown in the phone remote and in Home Assistant.",
                   ),
               ),
+          onApplied = { c, keys ->
+            // The AirPlay receiver advertises under this name (it has no name of its own, by
+            // design), so a rename has to re-register mDNS or the Portal keeps showing up in
+            // Control Center under the old one. No-op when AirPlay is off or unchanged.
+            if ("name" in keys) AirPlayControl.applyConfig(c)
+          },
       )
 
   /** Every registered domain. */
@@ -1188,6 +1197,91 @@ object SettingsDomains {
           defaults = { WelcomeConfig.Settings() },
       )
 
+  /**
+   * The AirPlay receiver ([AirPlayConfig]) — stream audio or a screen from an iPhone/iPad/Mac.
+   *
+   * The advertised name is deliberately absent: it's [FleetConfig.name], owned by the `fleet`
+   * domain, so there's no second name to drift. Everything past the master toggle is gated on it,
+   * and the whole domain hides on a device with no native library — the build filters it to arm64,
+   * so that's emulators only, but a settings screen offering a feature that cannot start is worse
+   * than one that doesn't mention it.
+   *
+   * Restarting the receiver so a change takes effect belongs in [onApplied], fired once per batch,
+   * so a push from the phone remote re-applies exactly like the on-device screen.
+   */
+  val airplay: SettingsDomain<AirPlayConfig.Settings> =
+      SettingsDomain(
+          id = "airplay",
+          title = "AirPlay",
+          load = AirPlayConfig::load,
+          specs =
+              listOf(
+                  BoolSpec(
+                      "enabled",
+                      "Stream from your iPhone",
+                      get = { it.enabled },
+                      set = AirPlayConfig::setEnabled,
+                      help =
+                          "Let an iPhone, iPad or Mac on this Wi-Fi play music through the Portal's " +
+                              "speakers, or put its screen on the Portal.",
+                      visible = { _, _ -> AirPlayControl.isProbablySupported() }),
+                  NavSpec(
+                      "pairing",
+                      "How to connect",
+                      value = { c, _ -> FleetConfig.name(c) },
+                      activity = AirPlayPairActivity::class.java,
+                      help = "What to tap in Control Center, and the name to pick.",
+                      visible = { _, s -> s.enabled && AirPlayControl.isProbablySupported() }),
+                  BoolSpec(
+                      "allowMirroring",
+                      "Allow screen mirroring",
+                      get = { it.allowMirroring },
+                      set = AirPlayConfig::setAllowMirroring,
+                      help = "Off leaves an audio-only speaker — the Portal stops offering Screen Mirroring.",
+                      visible = { _, s -> s.enabled && AirPlayControl.isProbablySupported() }),
+                  BoolSpec(
+                      "showOnConnect",
+                      "Show the screen when casting starts",
+                      get = { it.showOnConnect },
+                      set = AirPlayConfig::setShowOnConnect,
+                      help =
+                          "Bring the cast to the front automatically. Music never interrupts the " +
+                              "screensaver either way.",
+                      visible = { _, s -> s.enabled && s.allowMirroring && AirPlayControl.isProbablySupported() }),
+                  BoolSpec(
+                      "requirePin",
+                      "Ask for a code",
+                      get = { it.requirePin },
+                      set = AirPlayConfig::setRequirePin,
+                      help =
+                          "Show a code on the Portal that has to be typed into the phone before it " +
+                              "can connect.",
+                      visible = { _, s -> s.enabled && AirPlayControl.isProbablySupported() }),
+                  // Advertised mirroring resolution. "auto" = the Portal's real panel size, which is
+                  // what a sender should normally match; the fixed options exist for a sender that
+                  // negotiates badly with an unusual panel. Free-text WxH would be an inline string
+                  // the on-device renderer can't edit, so it's an enum on both surfaces.
+                  EnumSpec(
+                      "resolution",
+                      "Mirroring resolution",
+                      get = { it.resolution },
+                      set = AirPlayConfig::setResolution,
+                      options =
+                          listOf(
+                              "auto" to "Match the Portal",
+                              "1920x1080" to "1080p",
+                              "1280x720" to "720p"),
+                      coerce = { v ->
+                        v.takeIf { it in setOf("auto", "1920x1080", "1280x720") }
+                      },
+                      visible = { _, s -> s.enabled && s.allowMirroring && AirPlayControl.isProbablySupported() }),
+              ),
+          defaults = { AirPlayConfig.Settings() },
+          onApplied = { c, _ -> AirPlayControl.applyConfig(c) },
+      )
+
   val all: List<SettingsDomain<*>> =
-      listOf(screensaver, calendar, immortal, mqtt, quickbar, fleet, chime, digitalclock, welcome, sunrise)
+      listOf(
+          screensaver, calendar, immortal, mqtt, quickbar, fleet, chime, digitalclock, welcome,
+          sunrise, airplay)
 }

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -236,6 +236,38 @@ class SettingsDomainTest {
   }
 
   @Test
+  fun airplayRegistry_coversEveryPersistedField_orExplicitlyAccountsForIt() {
+    // Same tripwire as the other snapshot-backed domains: a new AirPlayConfig.Settings field that
+    // nobody specs would silently never appear on-device or on the phone remote. `pairing` is a
+    // NavSpec (the how-to-connect screen), so it holds no value of its own and isn't listed here —
+    // every persisted field must be bound by a value spec.
+    val fields =
+        com.immortal.launcher.AirPlayConfig.Settings::class.java.declaredFields
+            .filter { !java.lang.reflect.Modifier.isStatic(it.modifiers) }
+            .map { it.name }
+            .toSet()
+    val specKeys = SettingsDomains.airplay.specs.map { it.key }.toSet()
+    val uncovered = fields - specKeys
+    assertTrue(
+        "AirPlayConfig.Settings has persisted fields neither in the registry nor accounted for: $uncovered",
+        uncovered.isEmpty())
+  }
+
+  @Test
+  fun airplayResolution_rejectsValuesOutsideItsOptions() {
+    // The resolution enum writes straight to prefs, and the module parses the stored string by
+    // splitting on a literal "x" — a garbage value pushed from the remote would take the foreground
+    // service down on every start attempt. AirPlayOptions sanitises as the last line of defence;
+    // this coercer is the first, and keeps the applied-key set truthful.
+    val spec = SettingsDomains.airplay.specs.first { it.key == "resolution" } as EnumSpec<*>
+    spec.options.forEach { (value, _) ->
+      assertEquals("resolution must accept its own option '$value'", value, spec.coerce(value))
+    }
+    assertNull("resolution must skip an unrecognised value", spec.coerce("1920X1080"))
+    assertNull("resolution must skip an unrecognised value", spec.coerce("not-a-real-value"))
+  }
+
+  @Test
   fun allDomains_sectionKeysMatchRealSpecs() {
     SettingsRegistry.domains.forEach { dom ->
       val specKeys = dom.specs.map { it.key }.toSet()
@@ -261,6 +293,7 @@ class SettingsDomainTest {
             SettingsDomains.digitalclock to emptySet(),
             SettingsDomains.welcome to emptySet(),
             SettingsDomains.sunrise to emptySet(),
+            SettingsDomains.airplay to setOf("pairing"),
         )
     rendered.forEach { (dom, exclude) ->
       val blank =
@@ -410,6 +443,7 @@ class SettingsDomainTest {
             "WelcomeConfig",
             "SunriseConfig",
             "QuickBarConfig",
+            "AirPlayConfig",
             // Context-typed domains (no aggregate Settings class); pinned by their own tests above.
             "MqttConfig",
             "FleetConfig",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,5 +8,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
   alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.android.library) apply false // :airplay
   alias(libs.plugins.kotlin.compose) apply false
 }

--- a/docs/features/airplay.md
+++ b/docs/features/airplay.md
@@ -1,0 +1,91 @@
+# AirPlay — stream from your iPhone
+
+Turn the Portal into an AirPlay 2 receiver: play music through its speakers, or put an iPhone,
+iPad or Mac screen on it. Nothing to install on the phone — it appears in Control Center like an
+Apple TV or a HomePod.
+
+Off by default. Turn it on from **Immortal Settings → Remote → Stream from your iPhone**, or with
+the AirPlay glyph in the home-screen header (one tap enables it and shows the name to pick).
+
+## What works
+
+| Mode | How it looks on the phone | What the Portal does |
+|---|---|---|
+| **Audio** | Control Center → AirPlay | Plays through the speakers. Stays headless — the screensaver keeps running and the track shows on the now-playing card and the home mini-player. |
+| **Screen mirroring** | Control Center → Screen Mirroring | Full-screen on the Portal. |
+| **AirPlay video** | Play a video after mirroring (YouTube, TV, …) | The sender hands over a stream URL instead of mirroring it. Noticeably better quality, and the phone is free to do something else. |
+
+The mirroring → video handover happens mid-session and is meant to be invisible; see
+`AirPlayActivity` for why that needs one persistent surface rather than two.
+
+## The name it advertises
+
+Whatever the Portal's **device name** is — the same one the phone remote and Home Assistant show.
+There is deliberately no separate AirPlay name to drift. Rename the Portal from the phone remote
+and the AirPlay entry follows immediately (it re-registers mDNS).
+
+## Settings
+
+All of them render on-device *and* on the phone remote from one definition (the `airplay` settings
+domain):
+
+- **Stream from your iPhone** — the master toggle.
+- **Allow screen mirroring** — off leaves an audio-only speaker.
+- **Show the screen when casting starts** — bring the cast to the front automatically. Audio-only
+  streams never interrupt the screensaver either way.
+- **Ask for a code** — show a PIN on the Portal that must be typed into the phone.
+- **Mirroring resolution** — set a fixed size instead of matching the Portal, if a sender
+  negotiates badly with the panel.
+
+!!! note "Gen-2 Portal: the decoder can hiccup during YouTube ads (recovers on its own)"
+
+    A YouTube pre-roll ad makes the sender restart the video decoder several times in a few seconds
+    (mirror → video → mirror, repeatedly). On a gen-2 Portal (`omni`) the Qualcomm decoder
+    occasionally faults under that churn:
+
+    ```
+    OMX-VDEC-1080P: OMX_COMPONENT_GENERATE_HARDWARE_ERROR
+    ACodec [OMX.qcom.video.decoder.{avc|hevc}] ERROR(0x80001009)
+    VideoRenderer: Codec error, resetting
+    ```
+
+    `VideoRenderer` catches it and resets, so it self-heals — in testing the transition still
+    completed and the picture came back. It is **not codec-specific**: it was reproduced on the
+    H.264 (`avc`) decoder with H.265 turned off, so turning H.265 off does *not* prevent it. It is a
+    decoder-level quirk of the gen-2 silicon under rapid restart, not something the receiver
+    controls. A gen-1 Portal+ (`aloha`) has not shown it. Upstream PR #22 (robust video session-end
+    detection) is the most relevant fix to watch.
+
+Changing any of them restarts the receiver in place (~100 ms), which drops a session in progress.
+
+## Audio and multi-room
+
+Multi-room (Snapcast) and an AirPlay audio session both want the speakers, so the live AirPlay
+session takes them for its duration: the multi-room now-playing relay stops and Immortal holds
+audio focus. Both are handed back when the session ends.
+
+## Notes and limits
+
+- **arm64 only.** The native library is built for `arm64-v8a`, which is every Portal. On anything
+  else the feature hides itself rather than offering something that cannot start.
+- **Ports.** The receiver listens on **7000**. Don't run a second AirPlay receiver app alongside it.
+- **After a reboot** it comes back on its own (`BootReceiver`). Installing and immediately rebooting
+  can miss it — the package is still being optimised when `BOOT_COMPLETED` goes out; a second
+  reboot with the package settled works.
+- **APK cost** ≈ 8 MB (the native stack, statically linked).
+
+## Licensing — read before releasing
+
+The receiver is vendored from [jqssun/android-airplay-server](https://github.com/jqssun/android-airplay-server)
+and links **GPL-3.0** code that is not optional (the FairPlay handshake). Any APK bundling it is
+GPL-3.0 as a whole, while Immortal is MIT. **Do not cut a release containing the `:airplay` module
+until that is resolved** — the `TODO(licensing)` marker at the top of `airplay/build.gradle.kts` is
+the tripwire. Dev and debug builds only.
+
+## Source
+
+`AirPlayConfig` (settings), `AirPlayControl` (runtime — when to raise a surface, who owns the
+speakers), `AirPlayActivity` (the cast surface), `AirPlayPairActivity` (the how-to-connect screen),
+and the `airplay` domain in `SettingsDomains.kt`. The receiver itself is the `:airplay` module —
+read [`airplay/UPSTREAM.md`](https://github.com/starbright-lab/immortal/blob/main/airplay/UPSTREAM.md)
+before touching anything under `airplay/src/main/`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,9 @@
 
 [versions]
 agp = "9.2.1"
-coreKtx = "1.10.1"
+# >= 1.12 is required by :airplay (the typed ServiceCompat.startForeground overload its
+# foreground service uses); 1.15.0 is what the module was verified against upstream.
+coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
@@ -15,6 +17,23 @@ kotlin = "2.2.10"
 composeBom = "2026.02.01"
 camerax = "1.4.0"
 exifinterface = "1.3.7"
+# One media3 version for the whole APK. The :airplay module needs 1.11.0-beta01 (AirPlay video /
+# HLS, the DACP player, the downloader); the screensaver media cache ([VideoTranscoder]) used to
+# pin 1.5.1. Gradle resolves a single version per module group anyway, so this is declared once
+# here rather than being reached silently by conflict resolution — see docs.
+#
+# VideoTranscoder came along for the ride, and two Transformer defaults changed under it: 1.6.0
+# generates HDR static metadata in DefaultEncoderFactory, and 1.10.0 switched the default muxer to
+# InAppMp4Muxer (the platform MediaMuxer no longer writes the output). Its API surface is unchanged
+# and compiles clean, but the derivative files it produces are written by different code than
+# before, so a moved pin here wants a screensaver video played from cache on a real Portal.
+media3 = "1.11.0-beta01"
+# :airplay — lifecycle-service (its LifecycleService base) and androidx.media (MediaSessionCompat).
+lifecycle = "2.8.7"
+androidxMedia = "1.7.0"
+coroutines = "1.9.0"
+# :airplay — low-latency audio output; AAudio on API 27+, so every Portal.
+oboe = "1.9.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -37,6 +56,19 @@ androidx-camera-camera2 = { group = "androidx.camera", name = "camera-camera2", 
 androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
 androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "camerax" }
 
+# Screensaver media cache: on-device downscale/transcode ([VideoTranscoder]).
+media3-transformer = { group = "androidx.media3", name = "media3-transformer", version.ref = "media3" }
+media3-effect = { group = "androidx.media3", name = "media3-effect", version.ref = "media3" }
+media3-common = { group = "androidx.media3", name = "media3-common", version.ref = "media3" }
+# :airplay only.
+media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
+media3-exoplayer-hls = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3" }
+androidx-lifecycle-service = { group = "androidx.lifecycle", name = "lifecycle-service", version.ref = "lifecycle" }
+androidx-media = { group = "androidx.media", name = "media", version.ref = "androidxMedia" }
+kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+oboe = { group = "com.google.oboe", name = "oboe", version.ref = "oboe" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - Smart home (Home Assistant / MQTT): features/smart-home.md
       - Fleet management: features/fleet.md
       - Phone remote: features/remote.md
+      - AirPlay: features/airplay.md
       - Portal TV: features/portal-tv.md
   - How-to guides:
       - Installing apps & app stores: guides/installing-apps.md

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,3 +32,8 @@ dependencyResolutionManagement {
 rootProject.name = "Portal Sample App"
 
 include(":app")
+
+// AirPlay 2 receiver (audio, screen mirroring, AirPlay video). Vendored from
+// jqssun/android-airplay-server — see airplay/UPSTREAM.md before touching anything under
+// airplay/src/main/. NOTE the licensing tripwire at the top of airplay/build.gradle.kts.
+include(":airplay")


### PR DESCRIPTION
Hey @starbrightlab ,

This PR implements a new feature: **AirPlay 2 receiver** — audio streaming, screen mirroring, and AirPlay video (HLS handoff, so a cast of e.g. YouTube hands over a video URL rather than mirroring pixels) for iOS/iPadOS/macOS devices. The Portal appears in Control Center like an Apple TV or HomePod, with optional PIN pairing and now-playing / transport control (DACP) from the sender.

It was tested mirroring Spotify and YouTube on Portal Gen2 and Portal+ Gen1. It relies on **android-airplay-server** (https://github.com/jqssun/android-airplay-server), vendored under `airplay/` with a single local patch and a sync script (`airplay/UPSTREAM.md` documents the vendor line).

It is tested to work with iOS but is a large feature, which affects:

- **A new `:airplay` Gradle module** bundling a native stack (UxPlay + OpenSSL + libplist + FFmpeg via JNI/CMake, arm64-only) and its four submodules — so the build now needs the NDK to configure.
- **App-wide dependency bumps** to satisfy the module: `media3` 1.5.1 → 1.11.0-beta01 and `androidx.core` 1.10.1 → 1.15.0, plus lifecycle/coroutines. media3 is shared with the screensaver's `VideoTranscoder`, so that path moves onto the newer (beta) media3 too — worth a look on real hardware.
- **A new foreground service + launcher surfaces** (`AirPlayActivity`, pairing flow), wired in the same "opt-in from a pairing screen" style as the phone remote.
- **Speaker / multi-room ownership** — a live AirPlay session takes the speakers and hands them back, so it coordinates with the Snapcast multi-room relay.

Care should be taken with the licensing — you have an MIT License but this uses **GNU GPL-3.0** (the vendored FairPlay/UxPlay native code), and I don't want to push a licensing change to you. There's a tripwire comment in `airplay/build.gradle.kts` about not cutting a public self-updating release that bundles it; it is **not** enforced in the build, so that would need a real gate before any release includes `:airplay`.

I have further built this feature into a standalone application, but it really belongs in Immortal, similar to remote control via phone.

Please take your time to review this work and decide if and/or how you want to port or land it.
