### PR TITLE
Add Synology Photos shared albums for Screensaver (LAN, public shares)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/AlbumUrlEntryActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/AlbumUrlEntryActivity.kt
@@ -78,7 +78,7 @@ private fun AlbumUrlEntryScreen(onSave: (String) -> Unit, onCancel: () -> Unit) 
           fontWeight = FontWeight.SemiBold,
       )
       Text(
-          "Paste a public link from iCloud Shared Albums or Google Photos. " +
+          "Paste a public link from iCloud Shared Albums, Google Photos, or Synology Photos. " +
               "Make sure it's shared as \"anyone with the link\" — Immortal can't sign in.",
           color = Color(0xFF9A9A9A),
           fontSize = 16.sp,
@@ -100,7 +100,8 @@ private fun AlbumUrlEntryScreen(onSave: (String) -> Unit, onCancel: () -> Unit) 
 
       Text(
           when {
-            trimmed.isEmpty() -> "Examples: iCloud Shared Album, Google Photos shared album."
+            trimmed.isEmpty() ->
+                "Examples: iCloud Shared Album, Google Photos, or Synology Photos."
             supported -> "Looks like a $provider link."
             else -> "That doesn't look like a supported share link yet."
           },
@@ -161,7 +162,8 @@ private fun AlbumUrlEntryScreen(onSave: (String) -> Unit, onCancel: () -> Unit) 
           "• iPhone Photos → a Shared Album you own → people/share button → " +
               "Share Link → Copy Link (works with the current " +
               "photos.icloud.com/shared/album/… links).\n" +
-              "• Google Photos → album → Share → \"Get link\" (anyone with the link can view).",
+              "• Google Photos → album → Share → \"Get link\" (anyone with the link can view).\n" +
+              "• Synology Photos → album → Share → enable share link → Public.",
           color = Color(0xFF8A8A8A),
           fontSize = 13.sp,
           modifier = Modifier.padding(start = 4.dp),

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -59,8 +59,8 @@ private const val SHERPA_VOICE_PARAM = "sherpa_voice_name"
  *    blank even with no network or a third-party outage. See [fetchWebPhoto].
  *  - **folder** — photos and videos from a folder the user picked (internal, SD, or
  *    a USB-C drive), read through the Storage Access Framework.
- *  - **url** — a public share link to an iCloud Shared Album or a Google Photos
- *    shared album. Fetched once on start; the screensaver rotates through the
+ *  - **url** — a public share link to an iCloud Shared Album, Google Photos, or
+ *    Synology Photos album. Fetched once on start; the screensaver rotates through the
  *    returned direct image URLs and silently falls back to the default feed if the
  *    album can't be resolved.
  *
@@ -148,7 +148,7 @@ class PhotoFrameController(
   // callback can tell it's been superseded and bow out.
   private var gen = 0
 
-  // Remote playback state (iCloud / Google Photos shared albums, or an Immich server).
+  // Remote playback state (shared albums, or an Immich server).
   private var remoteMode = false
   private var remoteUrls: List<String> = emptyList()
   private var remoteIndex = -1
@@ -336,7 +336,7 @@ class PhotoFrameController(
           ui.post {
             if (urls.isNotEmpty()) {
               remoteUrls = if (source.shuffle) urls.shuffled() else urls
-              remoteHeaders = emptyMap()
+              remoteHeaders = album?.headers.orEmpty()
               remoteMode = true
               remoteIndex = -1
               remoteFailStreak = 0
@@ -1202,7 +1202,7 @@ class PhotoFrameController(
     }
   }
 
-  // --- remote album playback (iCloud / Google Photos public shares) -----------
+  // --- remote album playback (public shared albums) ---------------------------
   private val remoteTick =
       object : Runnable {
         override fun run() {
@@ -1225,6 +1225,7 @@ class PhotoFrameController(
             ui.post {
               if (remoteMode && urls.isNotEmpty()) {
                 remoteUrls = urls
+                remoteHeaders = fresh?.headers.orEmpty()
                 if (remoteIndex >= remoteUrls.size) remoteIndex = -1
                 remoteFailStreak = 0
               }
@@ -1386,6 +1387,7 @@ class PhotoFrameController(
         if (!remoteMode) return@post // raced with a source change / startWeb()
         if (urls.isNotEmpty()) {
           remoteUrls = if (settings.shuffle) urls.shuffled() else urls
+          remoteHeaders = fresh?.headers.orEmpty()
           remoteIndex = -1
           remoteFailStreak = 0
           advanceRemote(+1)

--- a/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
@@ -7,10 +7,10 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 /**
- * Fetch direct image URLs from a public iCloud Shared Album or Google Photos shared
- * album link — no account or API key, only links the owner marked "anyone with the
- * link can view". On any failure [fetch] returns null and the caller falls back to
- * the default web feed so the photo frame is never blank.
+ * Fetch direct image URLs from a public iCloud Shared Album, Google Photos, or
+ * Synology Photos shared-album link — no account or API key, only links the owner
+ * marked "anyone with the link can view". On any failure [fetch] returns null and
+ * the caller falls back to the default web feed so the photo frame is never blank.
  *
  * iCloud comes in two flavours, both supported here:
  *  - **Legacy "Shared Streams"** — `www.icloud.com/sharedalbum/#TOKEN` (token in the
@@ -22,17 +22,22 @@ import org.json.JSONObject
  */
 object RemoteAlbum {
 
-  data class Album(val title: String?, val photoUrls: List<String>)
+  data class Album(
+      val title: String?,
+      val photoUrls: List<String>,
+      val headers: Map<String, String> = emptyMap(),
+  )
 
   fun isSupported(url: String): Boolean {
     val u = url.trim()
-    return isIcloud(u) || isGooglePhotos(u)
+    return isIcloud(u) || isGooglePhotos(u) || isSynologyPhotos(u)
   }
 
   fun providerName(url: String): String =
       when {
         isIcloud(url) -> "iCloud Shared Album"
         isGooglePhotos(url) -> "Google Photos"
+        isSynologyPhotos(url) -> "Synology Photos"
         else -> "Shared album"
       }
 
@@ -52,6 +57,8 @@ object RemoteAlbum {
       url.contains("photos.app.goo.gl", ignoreCase = true) ||
           url.contains("photos.google.com/share/", ignoreCase = true)
 
+  fun isSynologyPhotos(url: String): Boolean = synologyShare(url) != null
+
   fun fetch(shareUrl: String, screenW: Int = 1920, screenH: Int = 1080): Album? {
     val url = shareUrl.trim()
     return runCatching {
@@ -59,6 +66,7 @@ object RemoteAlbum {
             isIcloudCloudKit(url) -> fetchIcloudCloudKit(url, screenW, screenH)
             isIcloudLegacy(url) -> fetchIcloud(url, screenW, screenH)
             isGooglePhotos(url) -> fetchGoogle(url, screenW, screenH)
+            isSynologyPhotos(url) -> fetchSynology(url)
             else -> null
           }
         }
@@ -391,6 +399,160 @@ object RemoteAlbum {
     return m.groupValues[1].substringBefore(" - Google Photos").trim().ifBlank { null }
   }
 
+  // --- Synology Photos public shares -----------------------------------------
+
+  private const val SYNO_PAGE_SIZE = 500
+  private const val SYNO_MAX_PAGES = 100
+
+  /**
+   * Synology's public viewer uses the same private WebAPI as the Photos web app:
+   * opening `/mo/sharing/<passphrase>` mints a `sharing_sid` cookie, then album and
+   * item metadata are JSON calls under `/mo/sharing/webapi/entry.cgi`. Thumbnail
+   * responses require that cookie too, so it is returned in [Album.headers].
+   */
+  private fun fetchSynology(url: String): Album? {
+    val share = synologyShare(url) ?: return null
+    val landing = httpGetResponse(url) ?: return null
+    val cookie = synologySharingCookie(landing.setCookies) ?: return null
+    val headers = mapOf("Cookie" to cookie)
+
+    val albumJson =
+        synologyGet(
+            share.apiUrl,
+            "SYNO.Foto.Browse.Album",
+            4,
+            "get",
+            share.passphrase,
+            headers,
+            mapOf("additional" to """["sharing_info","flex_section","provider_count"]"""),
+        ) ?: return null
+    val album =
+        JSONObject(albumJson)
+            .optJSONObject("data")
+            ?.optJSONArray("list")
+            ?.optJSONObject(0) ?: return null
+    val title = album.optString("name", "").ifBlank { null }
+    val sortBy = album.optString("sort_by", "takentime").ifBlank { "takentime" }
+    val sortDirection = album.optString("sort_direction", "asc").ifBlank { "asc" }
+
+    val out = ArrayList<String>()
+    var offset = 0
+    var pages = 0
+    do {
+      val body =
+          synologyGet(
+              share.apiUrl,
+              "SYNO.Foto.Browse.Item",
+              1,
+              "list",
+              share.passphrase,
+              headers,
+              mapOf(
+                  "offset" to offset.toString(),
+                  "limit" to SYNO_PAGE_SIZE.toString(),
+                  "sort_by" to jsonString(sortBy),
+                  "sort_direction" to jsonString(sortDirection),
+                  "additional" to """["thumbnail"]""",
+              ),
+          ) ?: break
+      val items = JSONObject(body).optJSONObject("data")?.optJSONArray("list") ?: break
+      for (i in 0 until items.length()) {
+        val item = items.optJSONObject(i) ?: continue
+        if (item.optString("type") == "video") continue
+        val thumb = item.optJSONObject("additional")?.optJSONObject("thumbnail") ?: continue
+        val unitId = thumb.optLong("unit_id", 0L)
+        val cacheKey = thumb.optString("cache_key", "")
+        if (unitId <= 0L || cacheKey.isEmpty()) continue
+        out.add(synologyThumbnailUrl(share.apiUrl, share.passphrase, unitId, cacheKey))
+      }
+      offset += items.length()
+      pages++
+    } while (items.length() == SYNO_PAGE_SIZE && pages < SYNO_MAX_PAGES)
+
+    return Album(title, out, headers)
+  }
+
+  internal data class SynologyShare(val apiUrl: String, val passphrase: String)
+
+  internal fun synologyShare(spec: String): SynologyShare? {
+    val parsed = runCatching { URL(spec.trim()) }.getOrNull() ?: return null
+    if (parsed.protocol != "http" && parsed.protocol != "https") return null
+    val marker = "/mo/sharing/"
+    val idx = parsed.path.indexOf(marker, ignoreCase = true)
+    if (idx < 0) return null
+    val token = parsed.path.substring(idx + marker.length).substringBefore('/').trim()
+    if (token.isEmpty()) return null
+    val basePath = parsed.path.substring(0, idx + marker.length)
+    val port = if (parsed.port >= 0) ":${parsed.port}" else ""
+    return SynologyShare(
+        "${parsed.protocol}://${parsed.host}$port${basePath}webapi/entry.cgi",
+        token,
+    )
+  }
+
+  internal fun synologySharingCookie(setCookies: List<String>): String? =
+      setCookies
+          .asSequence()
+          .map { it.substringBefore(';').trim() }
+          .firstOrNull { it.startsWith("sharing_sid=") && it.length > "sharing_sid=".length }
+
+  internal fun synologyThumbnailUrl(
+      apiUrl: String,
+      passphrase: String,
+      unitId: Long,
+      cacheKey: String,
+  ): String =
+      buildUrl(
+          apiUrl,
+          linkedMapOf(
+              "id" to unitId.toString(),
+              "cache_key" to jsonString(cacheKey),
+              "type" to jsonString("unit"),
+              "size" to jsonString("xl"),
+              "passphrase" to jsonString(passphrase),
+              "api" to jsonString("SYNO.Foto.Thumbnail"),
+              "method" to jsonString("get"),
+              "version" to "2",
+              "_sharing_id" to jsonString(passphrase),
+          ),
+      )
+
+  private fun synologyGet(
+      apiUrl: String,
+      api: String,
+      version: Int,
+      method: String,
+      passphrase: String,
+      headers: Map<String, String>,
+      params: Map<String, String>,
+  ): String? {
+    val all =
+        linkedMapOf(
+            "api" to jsonString(api),
+            "version" to version.toString(),
+            "method" to jsonString(method),
+            "_sharing_id" to jsonString(passphrase),
+            "passphrase" to jsonString(passphrase),
+        )
+    all.putAll(params)
+    val response = httpGetResponse(buildUrl(apiUrl, all), headers) ?: return null
+    val json = runCatching { JSONObject(response.body) }.getOrNull() ?: return null
+    return if (json.optBoolean("success")) response.body else null
+  }
+
+  private fun jsonString(value: String): String = JSONObject.quote(value)
+
+  private fun buildUrl(base: String, params: Map<String, String>): String =
+      buildString {
+        append(base).append('?')
+        params.entries.forEachIndexed { idx, (key, value) ->
+          if (idx > 0) append('&')
+          append(URLEncoder.encode(key, "UTF-8"))
+          append('=')
+          append(URLEncoder.encode(value, "UTF-8"))
+        }
+      }
+
   private const val USER_AGENT =
       "Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 (KHTML, like Gecko) " +
           "Chrome/120.0.0.0 Safari/537.36 PortalPhotoFrame/1.0"
@@ -419,13 +581,32 @@ object RemoteAlbum {
   }
 
   private fun httpGet(spec: String): String? {
+    return httpGetResponse(spec)?.body
+  }
+
+  private data class HttpResponse(val body: String, val setCookies: List<String>)
+
+  private fun httpGetResponse(
+      spec: String,
+      headers: Map<String, String> = emptyMap(),
+  ): HttpResponse? {
     val c = URL(spec).openConnection() as HttpURLConnection
     c.connectTimeout = 8000
     c.readTimeout = 10000
     c.instanceFollowRedirects = true
     c.setRequestProperty("User-Agent", USER_AGENT)
     c.setRequestProperty("Accept-Language", "en-US,en;q=0.9")
-    return runCatching { c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) } }.getOrNull()
+    headers.forEach { (key, value) -> c.setRequestProperty(key, value) }
+    return runCatching {
+          val body = c.inputStream.use { it.readBytes().toString(Charsets.UTF_8) }
+          val cookies =
+              c.headerFields.entries
+                  .filter { (key, _) -> key.equals("Set-Cookie", ignoreCase = true) }
+                  .flatMap { it.value.orEmpty() }
+          HttpResponse(body, cookies)
+        }
+        .getOrNull()
+        .also { runCatching { c.disconnect() } }
   }
 
   private fun postJson(spec: String, body: String): String? {

--- a/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteHtml.kt
@@ -278,7 +278,7 @@ object RemoteHtml {
           <div class=srcf id=f_smb><input id=smbHost placeholder="Host or IP"><input id=smbShare placeholder="Share name"><input id=smbPath placeholder="Folder path (optional)"><input id=smbUser placeholder="Username (optional)"><input id=smbPass type=password placeholder="Password (optional)"></div>
           <div class=srcf id=f_dav><input id=davUrl placeholder="WebDAV URL"><input id=davUser placeholder="Username (optional)"><input id=davPass type=password placeholder="Password (optional)"></div>
           <div class=srcf id=f_web><input id=webUrl placeholder="Web page URL"></div>
-          <div class=srcf id=f_album><input id=albumUrl placeholder="iCloud or Google Photos share link"></div>
+          <div class=srcf id=f_album><input id=albumUrl placeholder="iCloud, Google, or Synology Photos share link"></div>
           <button class=primary onclick=saveSources()>Save</button>
           <div id=srcErr class=err></div>
         </div>

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -31,7 +31,7 @@ enum class FrameMode {
  * The default source is Immortal's built-in photo feed; the user can instead point
  * the screensaver at a local folder of photos/videos — including one on a USB-C or
  * SD card plugged into the Portal (any folder reachable through the system file
- * picker) — or paste a public share link from iCloud or Google Photos. If the
+ * picker) — or paste a public share link from iCloud, Google Photos, or Synology Photos. If the
  * chosen source can't be read (e.g. the drive is unplugged, the album was unshared)
  * the screensaver falls back to the default feed, so it's never blank.
  */

--- a/app/src/main/java/com/immortal/launcher/ScreensaverSourcesActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverSourcesActivity.kt
@@ -296,7 +296,7 @@ private fun folderSubtitle(usesFolder: Boolean, name: String?, count: Int?): Str
 
 private fun albumUrlSubtitle(usesUrl: Boolean, url: String?): String =
     when {
-      !usesUrl -> "Paste a public iCloud or Google Photos share link."
+      !usesUrl -> "Paste a public iCloud, Google Photos, or Synology Photos share link."
       url.isNullOrBlank() -> "No link yet — tap to paste one."
       else -> "${RemoteAlbum.providerName(url)} — ${shortUrl(url)}"
     }

--- a/app/src/test/java/com/immortal/launcher/RemoteAlbumTest.kt
+++ b/app/src/test/java/com/immortal/launcher/RemoteAlbumTest.kt
@@ -15,6 +15,7 @@ class RemoteAlbumTest {
     assertTrue(RemoteAlbum.isSupported("https://photos.icloud.com/shared/album/037SP6pgkQQ_LNS48MIYBgiTQ"))
     assertTrue(RemoteAlbum.isSupported("https://photos.app.goo.gl/abcd1234"))
     assertTrue(RemoteAlbum.isSupported("https://photos.google.com/share/AF1Qa1b2c3d"))
+    assertTrue(RemoteAlbum.isSupported("https://nas.example:5001/mo/sharing/8S5GDsCVN"))
     assertFalse(RemoteAlbum.isSupported("https://example.com/album/123"))
     assertFalse(RemoteAlbum.isSupported(""))
   }
@@ -28,7 +29,46 @@ class RemoteAlbumTest {
         "iCloud Shared Album",
         RemoteAlbum.providerName("https://photos.icloud.com/shared/album/037SP6pgkQQ_LNS48MIYBgiTQ"))
     assertEquals("Google Photos", RemoteAlbum.providerName("https://photos.app.goo.gl/x"))
+    assertEquals(
+        "Synology Photos",
+        RemoteAlbum.providerName("https://nas.example:5001/mo/sharing/8S5GDsCVN"))
     assertEquals("Shared album", RemoteAlbum.providerName("https://example.com"))
+  }
+
+  @Test
+  fun synologyShare_extractsTokenAndPreservesPhotosBasePath() {
+    val share =
+        RemoteAlbum.synologyShare(
+            "https://nas.example:5001/photos/mo/sharing/8S5GDsCVN?ignored=true")
+    assertEquals("8S5GDsCVN", share?.passphrase)
+    assertEquals(
+        "https://nas.example:5001/photos/mo/sharing/webapi/entry.cgi",
+        share?.apiUrl)
+    assertNull(RemoteAlbum.synologyShare("https://nas.example:5001/photos/album/8S5GDsCVN"))
+  }
+
+  @Test
+  fun synologySharingCookie_keepsOnlySessionPair() {
+    assertEquals(
+        "sharing_sid=abc123",
+        RemoteAlbum.synologySharingCookie(
+            listOf("other=x; Path=/", "sharing_sid=abc123; Path=/; Secure")))
+    assertNull(RemoteAlbum.synologySharingCookie(listOf("other=x; Path=/")))
+  }
+
+  @Test
+  fun synologyThumbnailUrl_containsQuotedWebApiParameters() {
+    val url =
+        RemoteAlbum.synologyThumbnailUrl(
+            "https://nas.example/mo/sharing/webapi/entry.cgi",
+            "share key",
+            296,
+            "296_123",
+        )
+    assertTrue(url.contains("api=%22SYNO.Foto.Thumbnail%22"))
+    assertTrue(url.contains("passphrase=%22share+key%22"))
+    assertTrue(url.contains("cache_key=%22296_123%22"))
+    assertTrue(url.contains("size=%22xl%22"))
   }
 
   @Test

--- a/docs/features/screensaver.md
+++ b/docs/features/screensaver.md
@@ -38,6 +38,8 @@ you don't type URLs and credentials on the Portal:
 | --- | --- |
 | Your own folder | Photos **and** videos from the device's own storage. EXIF rotation is honoured. |
 | iCloud shared album | Paste a shared-album link (supports Apple's newer CloudKit link format). |
+| Google Photos | Paste a public shared-album link. |
+| Synology Photos | Paste a public album share link. For a local HTTPS address, the NAS certificate must be trusted by the Portal. |
 | [Immich](https://immich.app/) | A self-hosted photo library. Photos **and** videos (with "Play videos" on), from an album or the whole library. |
 | Network share (SMB) | A file server on your LAN. |
 | WebDAV | Any WebDAV server. |


### PR DESCRIPTION
## Purpose

Add support for using public Synology Photos shared albums as an Immortal screensaver photo source.

This allows Synology users to create a public album share link in Synology Photos, paste that link into Immortal, and display the album locally on a Portal without requiring a Synology account, API key, or NAS credentials.

## What changed

### Synology Photos integration

`RemoteAlbum` now:

- Recognizes Synology Photos links using the `/mo/sharing/<token>` format.
- Supports NAS addresses with custom ports and reverse-proxy path prefixes.
- Opens the public sharing page to obtain Synology’s required `sharing_sid` session cookie.
- Fetches album metadata through `SYNO.Foto.Browse.Album`.
- Fetches album contents through the paginated `SYNO.Foto.Browse.Item` API.
- Preserves the album’s configured sort order.
- Generates `xl` JPEG preview URLs through `SYNO.Foto.Thumbnail`.
- Passes the sharing cookie when downloading images.
- Refreshes the sharing cookie together with the album contents.
- Excludes video entries from the initial implementation.
- Supports JPEG previews generated by Synology for HEIC and Live Photo entries.

The existing shared-album abstraction remains in use; no separate Synology-specific photo-source subsystem was introduced.

### Screensaver playback

The shared-album result can now include HTTP request headers. `PhotoFrameController` carries these headers through initial playback, scheduled album refreshes, and retry/re-resolution flows.

Existing iCloud and Google Photos behavior remains unchanged.

### User interface and documentation

The shared-album setup screens and phone remote now identify Synology Photos as a supported provider. Setup instructions and screensaver documentation were updated accordingly.

Local HTTPS NAS installations require a certificate trusted by the Portal. TLS certificate validation is not disabled by this change.

## Files changed

- `app/src/main/java/com/immortal/launcher/RemoteAlbum.kt`
  - Synology link detection, API access, pagination, cookie handling, and thumbnail URL generation.
  - Adds optional request headers to shared-album results.

- `app/src/main/java/com/immortal/launcher/PhotoFrameController.kt`
  - Applies and refreshes shared-album request headers during playback.

- `app/src/test/java/com/immortal/launcher/RemoteAlbumTest.kt`
  - Adds coverage for Synology link recognition, token and API-path extraction, cookie parsing, provider identification, and thumbnail URL generation.

- `app/src/main/java/com/immortal/launcher/AlbumUrlEntryActivity.kt`
  - Adds Synology Photos to the shared-album setup text and instructions.

- `app/src/main/java/com/immortal/launcher/ScreensaverSourcesActivity.kt`
  - Updates the photo-source summary text.

- `app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt`
  - Updates source documentation to include Synology Photos.

- `app/src/main/java/com/immortal/launcher/RemoteHtml.kt`
  - Updates the phone remote’s shared-album input placeholder.

- `docs/features/screensaver.md`
  - Documents Synology Photos support and the trusted-certificate requirement.

No new production source files or dependencies were added.

## Testing

The implementation was tested at a single site with the following setup:

- Device: Facebook Portal+ 2nd generation
- Android version: Android 10 / API 29
- Portal OS release: 1.47.4
- Build and deployment host: macOS
- NAS: Synology DS1821+
- DSM: 7.3.2-86009 Update 4
- Synology Photos: 1.9.1-10928

Validation performed:

- Inspected a live public Synology Photos share and verified the album, item-list, cookie, and thumbnail request flow.
- Retrieved album metadata and paginated photo entries from the NAS.
- Retrieved JPEG thumbnails using the generated URLs and required sharing cookie.
- Ran the full debug unit-test suite successfully.
- Built the debug APK successfully on macOS.
- Installed the debug APK over USB-C/ADB alongside the production Immortal installation.
- Launched and verified the debug application on the Portal+.
- Repeated the complete test/build/install/launch workflow using a local deployment script.

## Scope and limitations

- This initial implementation supports public, non-password-protected Synology Photos album links.
- Video playback from Synology Photos is not included.
- Testing has currently been performed against one NAS, one Synology Photos version, and one Portal model.
- Private or self-signed HTTPS certificates must already be trusted by the Portal.
- The integration uses Synology Photos’ web application APIs, which are not documented as a stable public API and may require adjustment if Synology changes them.

This patch was created with support from OpenAI ChatGPT work.