### PR TITLE
RemoteAlbum: a failed later page can no longer discard the whole album (#175 hardening)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
@@ -130,28 +130,32 @@ object RemoteAlbum {
     }
     if (guids.isEmpty()) return Album(title, emptyList())
 
-    // webasseturls caps each response at ~25 items, so page through.
+    // webasseturls caps each response at ~25 items, so page through. Each batch is
+    // contained: one bad response (transport error, unexpected body) skips only its 25
+    // photos instead of throwing away the whole album (issue #175 hardening).
     val urlByChecksum = HashMap<String, String>(guids.size)
     guids.chunked(25).forEach { batch ->
-      val body =
-          buildString {
-            append("{\"photoGuids\":[")
-            batch.forEachIndexed { idx, g ->
-              if (idx > 0) append(',')
-              append('"').append(g).append('"')
+      runCatching {
+        val body =
+            buildString {
+              append("{\"photoGuids\":[")
+              batch.forEachIndexed { idx, g ->
+                if (idx > 0) append(',')
+                append('"').append(g).append('"')
+              }
+              append("]}")
             }
-            append("]}")
+        val resp = postJson("$base/webasseturls", body) ?: return@runCatching
+        val items = JSONObject(resp).optJSONObject("items") ?: return@runCatching
+        val keys = items.keys()
+        while (keys.hasNext()) {
+          val checksum = keys.next()
+          val o = items.optJSONObject(checksum) ?: continue
+          val loc = o.optString("url_location", "")
+          val path = o.optString("url_path", "")
+          if (loc.isNotEmpty() && path.isNotEmpty()) {
+            urlByChecksum[checksum] = "https://$loc$path"
           }
-      val resp = postJson("$base/webasseturls", body) ?: return@forEach
-      val items = JSONObject(resp).optJSONObject("items") ?: return@forEach
-      val keys = items.keys()
-      while (keys.hasNext()) {
-        val checksum = keys.next()
-        val o = items.optJSONObject(checksum) ?: continue
-        val loc = o.optString("url_location", "")
-        val path = o.optString("url_path", "")
-        if (loc.isNotEmpty() && path.isNotEmpty()) {
-          urlByChecksum[checksum] = "https://$loc$path"
         }
       }
     }
@@ -290,35 +294,47 @@ object RemoteAlbum {
     var pages = 0
     do {
       val m = marker // local for a stable smart-cast
-      val query =
-          JSONObject()
-              .put("recordType", CK_RECORD_TYPE)
-              .put(
-                  "filterBy",
-                  JSONArray().put(
-                      JSONObject()
-                          .put("fieldName", "direction")
-                          .put("comparator", "EQUALS")
-                          .put(
-                              "fieldValue",
-                              JSONObject().put("value", "DESCENDING").put("type", "STRING"))))
-      val payload =
-          JSONObject()
-              .put("query", query)
-              .put("zoneID", zoneId)
-              .put("resultsLimit", CK_PAGE_SIZE)
-              .apply { if (m != null) put("continuationMarker", m) }
-      val resp = postJson(queryUrl, payload.toString()) ?: break
-      val obj = JSONObject(resp)
-      val records: JSONArray = obj.optJSONArray("records") ?: break
-      for (i in 0 until records.length()) {
-        val rec = records.optJSONObject(i) ?: continue
-        if (rec.optString("recordType") != "CPLMaster") continue
-        val fields = rec.optJSONObject("fields") ?: continue
-        if (!isCloudKitImage(fields)) continue
-        pickBestCloudKitAsset(fields, screenW, screenH)?.let { out.add(it) }
-      }
-      marker = obj.optString("continuationMarker", "").ifBlank { null }
+      // A later page must never cost the photos already collected: records come as
+      // CPLAsset+CPLMaster PAIRS, so one [CK_PAGE_SIZE] page is only ~100 photos and a
+      // >100-photo album (issue #175) always crosses at least one page boundary. Any
+      // failure here — transport, an error body that isn't the expected JSON shape —
+      // degrades to a shorter album, not a throw that nukes the whole fetch.
+      val page =
+          runCatching {
+                val query =
+                    JSONObject()
+                        .put("recordType", CK_RECORD_TYPE)
+                        .put(
+                            "filterBy",
+                            JSONArray().put(
+                                JSONObject()
+                                    .put("fieldName", "direction")
+                                    .put("comparator", "EQUALS")
+                                    .put(
+                                        "fieldValue",
+                                        JSONObject().put("value", "DESCENDING").put("type", "STRING"))))
+                val payload =
+                    JSONObject()
+                        .put("query", query)
+                        .put("zoneID", zoneId)
+                        .put("resultsLimit", CK_PAGE_SIZE)
+                        .apply { if (m != null) put("continuationMarker", m) }
+                val resp = postJson(queryUrl, payload.toString()) ?: return@runCatching null
+                val obj = JSONObject(resp)
+                val records: JSONArray = obj.optJSONArray("records") ?: return@runCatching null
+                val pageUrls = ArrayList<String>()
+                for (i in 0 until records.length()) {
+                  val rec = records.optJSONObject(i) ?: continue
+                  if (rec.optString("recordType") != "CPLMaster") continue
+                  val fields = rec.optJSONObject("fields") ?: continue
+                  if (!isCloudKitImage(fields)) continue
+                  pickBestCloudKitAsset(fields, screenW, screenH)?.let { pageUrls.add(it) }
+                }
+                pageUrls to obj.optString("continuationMarker", "").ifBlank { null }
+              }
+              .getOrNull() ?: break
+      out.addAll(page.first)
+      marker = page.second
       pages++
     } while (marker != null && pages < CK_MAX_PAGES)
 
@@ -394,7 +410,9 @@ object RemoteAlbum {
     val maxPages = 100 // Cap to 100 pages (~10,000 photos) for memory/network safety
 
     while (!token.isNullOrBlank() && !albumKey.isNullOrBlank() && page < maxPages) {
-      val rpcBody = fetchGoogleBatchRpc(albumKey, token) ?: break
+      // Contained per page: a failed continuation fetch keeps the photos already found
+      // rather than propagating out of the crawl (issue #175 hardening).
+      val rpcBody = runCatching { fetchGoogleBatchRpc(albumKey, token!!) }.getOrNull() ?: break
       val prevSize = seen.size
       LH3_REGEX.findAll(rpcBody).forEach { m ->
         val u = m.value
@@ -496,24 +514,31 @@ object RemoteAlbum {
     val out = ArrayList<String>()
     var offset = 0
     var pages = 0
+    var lastPageLen: Int
     do {
-      val body =
-          synologyGet(
-              share.apiUrl,
-              "SYNO.Foto.Browse.Item",
-              1,
-              "list",
-              share.passphrase,
-              headers,
-              mapOf(
-                  "offset" to offset.toString(),
-                  "limit" to SYNO_PAGE_SIZE.toString(),
-                  "sort_by" to jsonString(sortBy),
-                  "sort_direction" to jsonString(sortDirection),
-                  "additional" to """["thumbnail"]""",
-              ),
-          ) ?: break
-      val items = JSONObject(body).optJSONObject("data")?.optJSONArray("list") ?: break
+      // Contained per page, like the other providers: a failed or malformed later page
+      // keeps the photos already collected (issue #175 hardening).
+      val items =
+          runCatching {
+                val body =
+                    synologyGet(
+                        share.apiUrl,
+                        "SYNO.Foto.Browse.Item",
+                        1,
+                        "list",
+                        share.passphrase,
+                        headers,
+                        mapOf(
+                            "offset" to offset.toString(),
+                            "limit" to SYNO_PAGE_SIZE.toString(),
+                            "sort_by" to jsonString(sortBy),
+                            "sort_direction" to jsonString(sortDirection),
+                            "additional" to """["thumbnail"]""",
+                        ),
+                    ) ?: return@runCatching null
+                JSONObject(body).optJSONObject("data")?.optJSONArray("list")
+              }
+              .getOrNull() ?: break
       for (i in 0 until items.length()) {
         val item = items.optJSONObject(i) ?: continue
         if (item.optString("type") == "video") continue
@@ -523,9 +548,10 @@ object RemoteAlbum {
         if (unitId <= 0L || cacheKey.isEmpty()) continue
         out.add(synologyThumbnailUrl(share.apiUrl, share.passphrase, unitId, cacheKey))
       }
-      offset += items.length()
+      lastPageLen = items.length()
+      offset += lastPageLen
       pages++
-    } while (items.length() == SYNO_PAGE_SIZE && pages < SYNO_MAX_PAGES)
+    } while (lastPageLen == SYNO_PAGE_SIZE && pages < SYNO_MAX_PAGES)
 
     return Album(title, out, headers)
   }


### PR DESCRIPTION
## What

Every shared-album provider paginates, and every one ran its paging loop bare inside `fetch()`'s single top-level `runCatching`. An exception on a later page (an error body that isn't the expected JSON shape, a transport hiccup mid-crawl) threw away everything already collected and dropped the screensaver to the default feed.

That failure shape matches #175 exactly: a CloudKit query page is 200 records, but records arrive as CPLAsset+CPLMaster pairs, so one page is ~100 photos and a >100-photo album always crosses a page boundary. If the continuation query fails, the user goes from "would have seen 100 photos" to "sees the default feed".

Each provider now contains failures at its paging granularity, degrading to a shorter album instead of none:

- iCloud CloudKit: per page (query + parse + collect)
- iCloud legacy: per 25-photo `webasseturls` batch
- Google Photos: per continuation RPC
- Synology: per `SYNO.Foto.Browse.Item` page

## What this does NOT do

This is the defensive half of #175. The root cause (why the CloudKit continuation fails) still needs a >100-photo repro album to pin down; a live-harness setup for that is ready, and the issue stays open.

## Testing

- Full unit suite green.
- Verified against a real legacy iCloud shared album via a JVM harness driving the actual `RemoteAlbum.fetch`: all photos returned, behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)