### PR TITLE
Weather: manual location setting with city search (fixes #177)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -361,6 +361,15 @@
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- City search for the weather-location override, reachable from the
+             "Weather location" row in Immortal settings (issue #177). -->
+        <activity
+            android:name=".WeatherLocationActivity"
+            android:exported="false"
+            android:label="Weather location"
+            android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.SampleApp" />
+
         <!-- One-field form for pasting a public iCalendar (.ics) feed link from Google
              Calendar or Apple iCloud, reachable from the "Calendar" section in
              screensaver settings. -->

--- a/app/src/main/java/com/immortal/launcher/Weather.kt
+++ b/app/src/main/java/com/immortal/launcher/Weather.kt
@@ -10,6 +10,7 @@ package com.immortal.launcher
 import android.content.Context
 import java.net.HttpURLConnection
 import java.net.URL
+import java.net.URLEncoder
 import java.text.SimpleDateFormat
 import java.util.Locale
 import kotlin.math.roundToInt
@@ -55,6 +56,12 @@ object Weather {
   /** Cached lat/lon, or a fresh geolocation (cached on success). Also caches the city name. */
   private fun location(context: Context): Pair<Double, Double>? {
     val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    // A manually chosen location always wins (issue #177): IP geolocation often lands on
+    // the ISP's city, and because the first answer is cached forever, a wrong first
+    // answer used to be permanent with no way to correct it.
+    prefs.getString("manual_lat", null)?.toDoubleOrNull()?.let { la ->
+      prefs.getString("manual_lon", null)?.toDoubleOrNull()?.let { lo -> return la to lo }
+    }
     prefs.getString("lat", null)?.toDoubleOrNull()?.let { la ->
       prefs.getString("lon", null)?.toDoubleOrNull()?.let { lo -> return la to lo }
     }
@@ -109,9 +116,92 @@ object Weather {
           }
           .getOrNull()
 
-  /** Last known city name (empty until geolocation has succeeded once). */
-  fun cachedCity(context: Context): String =
-      context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getString("city", "") ?: ""
+  /** Last known city name (empty until geolocation has succeeded once). A manual
+   * location's place name wins, matching [location]'s precedence. */
+  fun cachedCity(context: Context): String {
+    val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    manualPlace(context)?.let { return it.substringBefore(',') }
+    return prefs.getString("city", "") ?: ""
+  }
+
+  // --- manual location override (issue #177) ----------------------------------
+
+  /** A geocoding match from Open-Meteo's keyless search endpoint. [label] is e.g.
+   * "Boston, Massachusetts, US". */
+  data class Place(val name: String, val region: String, val lat: Double, val lon: Double) {
+    val label: String
+      get() = if (region.isBlank()) name else "$name, $region"
+  }
+
+  /** The manually chosen place label, or null when the location is auto-detected. */
+  fun manualPlace(context: Context): String? {
+    val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+    if (prefs.getString("manual_lat", null)?.toDoubleOrNull() == null) return null
+    return prefs.getString("manual_city", null)?.ifBlank { null }
+  }
+
+  fun setManualLocation(context: Context, place: Place) {
+    context
+        .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        .edit()
+        .putString("manual_lat", place.lat.toString())
+        .putString("manual_lon", place.lon.toString())
+        .putString("manual_city", place.label)
+        .apply()
+  }
+
+  /** Back to automatic: drops the manual choice AND the cached IP result, so the next
+   * weather refresh re-detects from scratch instead of reviving a stale first answer. */
+  fun redetectAutomatically(context: Context) {
+    context
+        .getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        .edit()
+        .remove("manual_lat")
+        .remove("manual_lon")
+        .remove("manual_city")
+        .remove("lat")
+        .remove("lon")
+        .remove("city")
+        .apply()
+  }
+
+  /** Row label for the settings screen: the manual place, the detected city, or a hint. */
+  fun locationLabel(context: Context): String {
+    manualPlace(context)?.let { return it }
+    val auto =
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).getString("city", "").orEmpty()
+    return if (auto.isNotBlank()) "Auto: $auto" else "Automatic (from your internet connection)"
+  }
+
+  /** Search Open-Meteo's keyless geocoder for a city. Blocking; call off the main thread. */
+  fun searchPlaces(query: String): List<Place> =
+      runCatching {
+            parseGeocoding(
+                httpGet(
+                    "https://geocoding-api.open-meteo.com/v1/search?name=" +
+                        URLEncoder.encode(query, "UTF-8") +
+                        "&count=8&language=en&format=json"))
+          }
+          .getOrDefault(emptyList())
+
+  /** Pure parse of an Open-Meteo geocoding response (unit-tested). */
+  internal fun parseGeocoding(json: String): List<Place> {
+    val results = JSONObject(json).optJSONArray("results") ?: return emptyList()
+    val out = ArrayList<Place>(results.length())
+    for (i in 0 until results.length()) {
+      val r = results.optJSONObject(i) ?: continue
+      val name = r.optString("name", "")
+      val la = r.optDouble("latitude", Double.NaN)
+      val lo = r.optDouble("longitude", Double.NaN)
+      if (name.isBlank() || la.isNaN() || lo.isNaN()) continue
+      val region =
+          listOf(r.optString("admin1", ""), r.optString("country_code", ""))
+              .filter { it.isNotBlank() }
+              .joinToString(", ")
+      out.add(Place(name, region, la, lo))
+    }
+    return out
+  }
 
   /** Current conditions for the redesigned weather widget: city, rounded temp, and weather code. */
   data class Current(val city: String, val temp: Int, val code: Int)

--- a/app/src/main/java/com/immortal/launcher/WeatherLocationActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/WeatherLocationActivity.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.ui.theme.SampleAppTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * City picker for the weather location (issue #177). IP geolocation often lands on the
+ * ISP's city and the first answer is cached forever, so this screen lets the user
+ * search Open-Meteo's keyless geocoder and pin the location — or wipe the cache and
+ * re-detect automatically.
+ */
+class WeatherLocationActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { WeatherLocationScreen(onDone = { finish() }) } }
+  }
+}
+
+@Composable
+private fun WeatherLocationScreen(onDone: () -> Unit) {
+  val context = LocalContext.current
+  val scope = rememberCoroutineScope()
+  var query by remember { mutableStateOf("") }
+  var results by remember { mutableStateOf<List<Weather.Place>>(emptyList()) }
+  var searching by remember { mutableStateOf(false) }
+  var searched by remember { mutableStateOf(false) }
+  var detecting by remember { mutableStateOf(false) }
+  var currentLabel by remember { mutableStateOf(Weather.locationLabel(context)) }
+
+  fun runSearch() {
+    val q = query.trim()
+    if (q.isEmpty() || searching) return
+    searching = true
+    scope.launch(Dispatchers.IO) {
+      val found = Weather.searchPlaces(q)
+      withContext(Dispatchers.Main) {
+        results = found
+        searching = false
+        searched = true
+      }
+    }
+  }
+
+  BackHandler { onDone() }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp)) {
+      Text(
+          "Weather location",
+          color = Color.White,
+          fontSize = 34.sp,
+          fontWeight = FontWeight.SemiBold,
+      )
+      Text(
+          "Used for the weather, forecast, sunrise & sunset times, and ISS passes. " +
+              "Automatic detection uses your internet connection, which can be off by a city " +
+              "or two — search for your city below to pin it.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+
+      Spacer(Modifier.heightIn(min = 18.dp))
+
+      Text(
+          "Current: $currentLabel",
+          color = Color(0xFFBBBBBB),
+          fontSize = 15.sp,
+          fontWeight = FontWeight.SemiBold,
+          modifier = Modifier.padding(start = 4.dp),
+      )
+
+      Spacer(Modifier.heightIn(min = 18.dp))
+
+      OutlinedTextField(
+          value = query,
+          onValueChange = { query = it },
+          placeholder = { Text("City name, e.g. Boston", color = Color(0xFF777777)) },
+          singleLine = true,
+          modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
+          shape = RoundedCornerShape(14.dp),
+      )
+
+      Spacer(Modifier.heightIn(min = 12.dp))
+
+      Surface(
+          color = if (query.trim().isNotEmpty()) Color(0xFF2E6BE6) else Color(0xFF2A2A2C),
+          shape = RoundedCornerShape(16.dp),
+          modifier =
+              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                runSearch()
+              },
+      ) {
+        Text(
+            if (searching) "Searching…" else "Search",
+            color = if (query.trim().isNotEmpty()) Color.White else Color(0xFF777777),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 16.dp).fillMaxWidth(),
+        )
+      }
+
+      if (searched && results.isEmpty() && !searching) {
+        Text(
+            "No matches — try just the city name, without state or country.",
+            color = Color(0xFFE89090),
+            fontSize = 13.sp,
+            modifier = Modifier.padding(top = 10.dp, start = 4.dp),
+        )
+      }
+
+      results.forEach { place ->
+        Spacer(Modifier.heightIn(min = 10.dp))
+        Surface(
+            color = Color(0xFF1C1C1E),
+            shape = RoundedCornerShape(16.dp),
+            modifier =
+                Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                  Weather.setManualLocation(context, place)
+                  onDone()
+                },
+        ) {
+          Text(
+              place.label,
+              color = Color.White,
+              fontSize = 16.sp,
+              modifier = Modifier.padding(vertical = 14.dp, horizontal = 18.dp).fillMaxWidth(),
+          )
+        }
+      }
+
+      Spacer(Modifier.heightIn(min = 26.dp))
+
+      Surface(
+          color = Color(0xFF1C1C1E),
+          shape = RoundedCornerShape(16.dp),
+          modifier =
+              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                if (!detecting) {
+                  detecting = true
+                  Weather.redetectAutomatically(context)
+                  currentLabel = "Detecting…"
+                  scope.launch(Dispatchers.IO) {
+                    Weather.coordinates(context) // re-resolves and re-caches from scratch
+                    withContext(Dispatchers.Main) {
+                      currentLabel = Weather.locationLabel(context)
+                      detecting = false
+                    }
+                  }
+                }
+              },
+      ) {
+        Text(
+            "Detect automatically instead",
+            color = Color(0xFFDDDDDD),
+            fontSize = 16.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 14.dp).fillMaxWidth(),
+        )
+      }
+
+      Spacer(Modifier.heightIn(min = 12.dp))
+
+      Surface(
+          color = Color(0xFF1C1C1E),
+          shape = RoundedCornerShape(16.dp),
+          modifier =
+              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                onDone()
+              },
+      ) {
+        Text(
+            "Done",
+            color = Color(0xFFDDDDDD),
+            fontSize = 16.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 14.dp).fillMaxWidth(),
+        )
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -33,6 +33,8 @@ import com.immortal.launcher.MqttService
 import com.immortal.launcher.MultiRoomService
 import com.immortal.launcher.QuickBar
 import com.immortal.launcher.QuickBarConfig
+import com.immortal.launcher.Weather
+import com.immortal.launcher.WeatherLocationActivity
 import com.immortal.launcher.ScreensaverConfig
 import com.immortal.launcher.SettingsGuard
 import org.json.JSONArray
@@ -506,6 +508,15 @@ object SettingsDomains {
                               ImmortalSettings.UNIT_C to "Celsius"),
                       coerce = oneOf(ImmortalSettings.UNIT_AUTO, ImmortalSettings.UNIT_F, ImmortalSettings.UNIT_C),
                       help = "Auto follows your Portal's language & region setting."),
+                  NavSpec(
+                      "weatherLocation",
+                      "Weather location",
+                      value = { c, _ -> Weather.locationLabel(c) },
+                      activity = WeatherLocationActivity::class.java,
+                      help =
+                          "Where the weather, forecast, and sunrise times come from. Automatic " +
+                              "detection uses your internet connection, which can be off by a " +
+                              "city or two - set it manually if the forecast looks wrong."),
                   EnumSpec(
                       "tileSize",
                       "App tile size",

--- a/app/src/test/java/com/immortal/launcher/WeatherTest.kt
+++ b/app/src/test/java/com/immortal/launcher/WeatherTest.kt
@@ -135,4 +135,42 @@ class WeatherTest {
     val c = Weather.forecastUrl(1.5, -2.25, fahrenheit = false)
     assertTrue(c.contains("temperature_unit=celsius"))
   }
+
+  // --- geocoding search (manual weather location, issue #177) ---------------
+
+  @Test
+  fun `geocoding parse extracts name, region and coordinates`() {
+    val json =
+        """{"results":[
+             {"name":"Boston","latitude":42.35843,"longitude":-71.05977,
+              "country_code":"US","admin1":"Massachusetts"},
+             {"name":"Boston","latitude":52.97633,"longitude":-0.02664,
+              "country_code":"GB","admin1":"England"}
+           ]}"""
+    val places = Weather.parseGeocoding(json)
+    assertEquals(2, places.size)
+    assertEquals("Boston", places[0].name)
+    assertEquals("Boston, Massachusetts, US", places[0].label)
+    assertEquals(42.35843, places[0].lat, 1e-9)
+    assertEquals(-71.05977, places[0].lon, 1e-9)
+    assertEquals("Boston, England, GB", places[1].label)
+  }
+
+  @Test
+  fun `geocoding parse survives missing region fields and skips broken entries`() {
+    val json =
+        """{"results":[
+             {"name":"Springfield","latitude":39.8,"longitude":-89.6},
+             {"name":"","latitude":1.0,"longitude":1.0},
+             {"name":"NoCoords"}
+           ]}"""
+    val places = Weather.parseGeocoding(json)
+    assertEquals(1, places.size)
+    assertEquals("Springfield", places[0].label) // no region -> bare name, no dangling comma
+  }
+
+  @Test
+  fun `geocoding parse returns empty on a no-results or malformed body`() {
+    assertTrue(Weather.parseGeocoding("""{"generationtime_ms":0.5}""").isEmpty())
+  }
 }

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -17,7 +17,9 @@ and is fully navigable by remote on the [Portal TV](portal-tv.md).
 
 ## Header
 
-- **Clock / date / weather** — weather is keyless (Open-Meteo + IP geolocation).
+- **Clock / date / weather** — weather is keyless (Open-Meteo + IP geolocation). If the
+  detected location is wrong, pin it manually under **Settings → Weather location**
+  (city search, also keyless).
 - **Now-playing mini-player** — a compact cover-art + play/pause control that appears whenever
   something is playing on the device, sourced from the device's own media session
   (`NowPlayingHub`). It stays out of the way when nothing's playing. See


### PR DESCRIPTION
## Problem (issue #177)

Weather location comes from IP geolocation, resolved once and cached forever, with no override and no refresh. When the ISP's exit node geolocates to the wrong city (common), the weather chip, forecast widget, sunrise/sunset times, and ISS passes are all permanently wrong with nothing the user can do about it.

## Fix

- **Manual override in `Weather`**: `manual_lat/lon/city` in the existing `immortal_weather` prefs, taking precedence over the auto cache in `location()` and `cachedCity()`. `redetectAutomatically()` clears both the override and the cached IP answer, so re-detection starts from scratch instead of reviving a stale first answer.
- **City search** via Open-Meteo's keyless geocoding API (consistent with the house no-keys rule). The response parse is pure and covered by three new unit tests.
- **`WeatherLocationActivity`**: search field, tappable result rows ("Boston, Massachusetts, US"), a "Detect automatically instead" action that re-resolves and shows what it found, and Done. Mirrors the `AlbumUrlEntryActivity` look and the `tvFocusable` interaction pattern.
- **Registry**: a `NavSpec` row ("Weather location") in the `immortal` domain next to the temperature unit, showing the pinned place or "Auto: <city>" as its value. No persisted registry fields added (NavSpec navigates only), so the domain tripwires are untouched.

## Testing

- Full unit suite green, including the new geocoding parse tests.
- Geocoding endpoint verified live (Boston -> US + GB matches with the expected fields).
- Needs an on-device pass: search flow, pinning a city, re-detect, and that the weather chip/forecast pick up the new coordinates on their next refresh.

Fixes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)