### PR TITLE
MQTT audio: fix mic_mute desync + gate volume/speaker on fixed-volume devices

### DIFF
--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -488,12 +488,7 @@ class MqttPublisher(private val appContext: Context) {
 
   private fun publishSpeakerMute() {
     val c = client ?: return
-    val muted =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-          audio.isStreamMute(AudioManager.STREAM_MUSIC)
-        } else {
-          audio.getStreamVolume(AudioManager.STREAM_MUSIC) == 0
-        }
+    val muted = audio.isStreamMute(AudioManager.STREAM_MUSIC)
     c.publish("$base/speaker_mute/state", if (muted) "ON" else "OFF", retain = true)
   }
 

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -294,8 +294,12 @@ class MqttPublisher(private val appContext: Context) {
             publishSpeakerMute()
           }
           "mic_mute" -> {
-            audio.isMicrophoneMute = payload.trim().equals("ON", ignoreCase = true)
-            publishMicMute()
+            val on = payload.trim().equals("ON", ignoreCase = true)
+            audio.isMicrophoneMute = on
+            // Echo the commanded state. isMicrophoneMute lags a set by one call,
+            // so re-reading it here desyncs the HA switch (mutes only every
+            // other press).
+            publishMicMute(on)
           }
           "notify" -> handleNotify(payload)
           // Show the photo frame on demand — the same surface the launcher's header
@@ -493,9 +497,9 @@ class MqttPublisher(private val appContext: Context) {
     c.publish("$base/speaker_mute/state", if (muted) "ON" else "OFF", retain = true)
   }
 
-  private fun publishMicMute() {
+  private fun publishMicMute(muted: Boolean = audio.isMicrophoneMute) {
     val c = client ?: return
-    c.publish("$base/mic_mute/state", if (audio.isMicrophoneMute) "ON" else "OFF", retain = true)
+    c.publish("$base/mic_mute/state", if (muted) "ON" else "OFF", retain = true)
   }
 
   private fun readBatteryPresent(): Boolean {

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -464,8 +464,12 @@ class MqttPublisher(private val appContext: Context) {
   }
 
   private fun publishAudioState() {
-    publishMediaVolume()
-    publishSpeakerMute()
+    // Volume/speaker state is only meaningful where the stream isn't fixed;
+    // on the Portal TV those entities aren't published (see publishDiscovery).
+    if (!audio.isVolumeFixed) {
+      publishMediaVolume()
+      publishSpeakerMute()
+    }
     publishMicMute()
   }
 
@@ -522,18 +526,32 @@ class MqttPublisher(private val appContext: Context) {
     button(c, "media_play_pause", "Play / pause", icon = "mdi:play-pause")
     button(c, "media_next", "Next track", icon = "mdi:skip-next")
     button(c, "media_previous", "Previous track", icon = "mdi:skip-previous")
-    numberEntity(
-        c,
-        "media_volume",
-        "Media volume",
-        icon = "mdi:volume-high",
-        min = 0,
-        max = audio.getStreamMaxVolume(AudioManager.STREAM_MUSIC),
-        step = 1,
-    )
-    switchEntity(c, "speaker_mute", "Speaker mute", icon = "mdi:volume-off")
-    button(c, "volume_up", "Volume up", icon = "mdi:volume-plus")
-    button(c, "volume_down", "Volume down", icon = "mdi:volume-minus")
+    // Volume and speaker mute act on STREAM_MUSIC, which only works on Portals
+    // that own their speakers (Portal, Portal+, Go, Mini). On the Portal TV
+    // audio goes out over HDMI at a fixed volume and the real volume path is an
+    // IR blaster reachable only via system key events, so these entities can't
+    // do anything there. Publish them only where the stream isn't fixed.
+    if (!audio.isVolumeFixed) {
+      numberEntity(
+          c,
+          "media_volume",
+          "Media volume",
+          icon = "mdi:volume-high",
+          min = 0,
+          max = audio.getStreamMaxVolume(AudioManager.STREAM_MUSIC),
+          step = 1,
+      )
+      switchEntity(c, "speaker_mute", "Speaker mute", icon = "mdi:volume-off")
+      button(c, "volume_up", "Volume up", icon = "mdi:volume-plus")
+      button(c, "volume_down", "Volume down", icon = "mdi:volume-minus")
+    } else {
+      // Fixed-volume device (Portal TV / HDMI): clear these in case an earlier
+      // version published them, so they don't orphan in Home Assistant.
+      publishConfig(c, "number", "media_volume", null)
+      publishConfig(c, "switch", "speaker_mute", null)
+      publishConfig(c, "button", "volume_up", null)
+      publishConfig(c, "button", "volume_down", null)
+    }
     switchEntity(c, "mic_mute", "Microphone mute", icon = "mdi:microphone-off")
 
     button(c, "go_home", "Home", icon = "mdi:home")

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -11,6 +11,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.net.Uri
 import android.os.BatteryManager
@@ -296,9 +297,9 @@ class MqttPublisher(private val appContext: Context) {
           "mic_mute" -> {
             val on = payload.trim().equals("ON", ignoreCase = true)
             audio.isMicrophoneMute = on
-            // Echo the commanded state. isMicrophoneMute lags a set by one call,
-            // so re-reading it here desyncs the HA switch (mutes only every
-            // other press).
+            // Echo the commanded state. isMicrophoneMute can return stale state
+            // right after a set, so re-reading it here desyncs the HA switch
+            // (mutes only every other press).
             publishMicMute(on)
           }
           "notify" -> handleNotify(payload)
@@ -467,10 +468,29 @@ class MqttPublisher(private val appContext: Context) {
     client?.publish("$base/ip/state", currentIp().ifBlank { "unknown" }, retain = true)
   }
 
+  /**
+   * True when changing STREAM_MUSIC volume audibly does something on this device.
+   *
+   * The obvious gate, [AudioManager.isVolumeFixed], returns false on the Portal TV (verified on
+   * ripley via dumpsys: mUseFixedVolume=false), so it can't carry this decision alone. What
+   * actually happens there: setStreamVolume moves the STREAM_MUSIC index (and reads back
+   * correctly), but HDMI output plays at full scale whatever the index says, and
+   * adjustStreamVolume from an app is silently dropped by the firmware — the identical call from
+   * an adb shell works. The audible volume path is the IR blaster to the TV, reachable only from
+   * system volume-key events an app can't inject. So treat any device with an HDMI output as
+   * fixed-volume: tablet Portals (Portal, Portal+, Go, Mini) have none, the Portal TV always has
+   * one. isVolumeFixed stays OR-ed in for any firmware that does report fixed volume honestly.
+   */
+  private fun volumeIsControllable(): Boolean =
+      !audio.isVolumeFixed &&
+          audio.getDevices(AudioManager.GET_DEVICES_OUTPUTS).none {
+            it.type == AudioDeviceInfo.TYPE_HDMI
+          }
+
   private fun publishAudioState() {
-    // Volume/speaker state is only meaningful where the stream isn't fixed;
+    // Volume/speaker state is only meaningful where volume changes are audible;
     // on the Portal TV those entities aren't published (see publishDiscovery).
-    if (!audio.isVolumeFixed) {
+    if (volumeIsControllable()) {
       publishMediaVolume()
       publishSpeakerMute()
     }
@@ -526,11 +546,11 @@ class MqttPublisher(private val appContext: Context) {
     button(c, "media_next", "Next track", icon = "mdi:skip-next")
     button(c, "media_previous", "Previous track", icon = "mdi:skip-previous")
     // Volume and speaker mute act on STREAM_MUSIC, which only works on Portals
-    // that own their speakers (Portal, Portal+, Go, Mini). On the Portal TV
-    // audio goes out over HDMI at a fixed volume and the real volume path is an
-    // IR blaster reachable only via system key events, so these entities can't
-    // do anything there. Publish them only where the stream isn't fixed.
-    if (!audio.isVolumeFixed) {
+    // that own their speakers (Portal, Portal+, Go, Mini). On the Portal TV the
+    // index is writable but inaudible — HDMI plays at full scale regardless, and
+    // the app-side adjust path is dropped by the firmware (see
+    // volumeIsControllable). Publish these only where volume changes are audible.
+    if (volumeIsControllable()) {
       numberEntity(
           c,
           "media_volume",


### PR DESCRIPTION
Follow-up fixes to the MQTT audio controls (#179), from testing on a Portal TV. **Related to #183** (does not close it — see below).

1. **mic_mute muted only every other press.** The handler set the mute then re-read `isMicrophoneMute` to report state, but that getter can return stale state right after a set — so the published state was a press behind, HA desynced, and sent a redundant no-op command every other press. Now it echoes the commanded value (`publishMicMute` takes the intended state; still defaults to the live getter for the initial/periodic publish, where the value has settled).

2. **Media volume, speaker mute, and volume up/down do nothing audible on the Portal TV.** Verified over USB adb on ripley — and the mechanism is different from what this PR first claimed:
   - `isVolumeFixed()` returns **false** (`mUseFixedVolume=false`, and plain HDMI 0x400 isn't in `mFixedVolumeDevices=0x2c1800`), so the original gate would never have fired.
   - `setStreamVolume` **works** from an app: the STREAM_MUSIC index moves and reads back correctly. That's why HA showed values like 10 and 18 rather than pinned-at-max.
   - The index is **inaudible**: with music playing, flipping it 2 → 16 → 10 changed nothing. HDMI output plays at full scale; loudness belongs to the TV, reached over the IR blaster from system volume-key events an app can't inject.
   - `adjustStreamVolume` is **dropped for app callers**: AudioService logs the calls from `com.immortal.launcher` and ignores them, while the identical call from an adb shell moves the index. That kills volume_up / volume_down and speaker_mute (`ADJUST_MUTE`) specifically.

   The four entities are still useless on the Portal TV and hiding them is still right, but the gate is now "this device has an HDMI output" (`getDevices(GET_DEVICES_OUTPUTS)` contains `TYPE_HDMI`), OR-ed with `isVolumeFixed()` for firmware that reports fixed volume honestly. Tablet Portals have no HDMI output, so they keep all four entities; previously-published discovery configs are cleared on gated devices so they don't orphan in HA.

3. **Removed the dead pre-M branch in `publishSpeakerMute()`** — `isStreamMute()` exists since API 23 and minSdk is 24, so the fallback was unreachable. (The minor cleanup from #183.)

`mic_mute` works on every Portal and is unaffected by the gate.

**Relation to #183 (why "related", not "closes"):**
- Point 2 (mic-mute semantics): confirmed on-device that software `setMicrophoneMute` *does* control the mic — muted a live Zoom Rooms call — so the entity should stay, not be dropped. The hardware privacy switch is decoupled and unobservable from an unprivileged app (see the issue thread).
- Point 1 (stale state on local changes): not addressed for tablet Portals (no `VOLUME_CHANGED_ACTION` receiver yet); moot on the Portal TV since the volume entities are gated off.
- Point 3: dead-code branch removed here. The `FLAG_SHOW_UI` vs `0` consistency is a deliberate call left for you.
