### PR TITLE
RemoteAlbum: 30s read timeout for album-metadata calls (fixes #175)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteAlbum.kt
@@ -177,7 +177,7 @@ object RemoteAlbum {
         URL("https://$firstGuess/$token/sharedstreams/webstream").openConnection()
             as HttpURLConnection
     c.connectTimeout = 8000
-    c.readTimeout = 8000
+    c.readTimeout = SLOW_READ_TIMEOUT_MS // a correct partition guess makes THIS the slow webstream call
     c.requestMethod = "POST"
     c.doOutput = true
     c.setRequestProperty("Content-Type", "application/json")
@@ -454,7 +454,7 @@ object RemoteAlbum {
   private fun postForm(spec: String, body: String): String? {
     val c = URL(spec).openConnection() as HttpURLConnection
     c.connectTimeout = 8000
-    c.readTimeout = 10000
+    c.readTimeout = SLOW_READ_TIMEOUT_MS
     c.requestMethod = "POST"
     c.doOutput = true
     c.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
@@ -637,6 +637,14 @@ object RemoteAlbum {
         }
       }
 
+  // Read timeout for album-metadata calls. Apple's legacy webstream endpoint takes ~14s
+  // (measured, consistently) to BUILD its response for a 116-photo album — the response
+  // itself is small; the server is slow — and Google's continuation RPC behaves the same
+  // way on very large albums. A 10s read timeout was exactly the ">100 photos kills the
+  // album" bug (issue #175): the fetch died waiting, not paging. connectTimeout stays
+  // short, so dead hosts still fail fast; this only extends patience once connected.
+  private const val SLOW_READ_TIMEOUT_MS = 30_000
+
   private const val USER_AGENT =
       "Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 (KHTML, like Gecko) " +
           "Chrome/120.0.0.0 Safari/537.36 PortalPhotoFrame/1.0"
@@ -676,7 +684,7 @@ object RemoteAlbum {
   ): HttpResponse? {
     val c = URL(spec).openConnection() as HttpURLConnection
     c.connectTimeout = 8000
-    c.readTimeout = 10000
+    c.readTimeout = SLOW_READ_TIMEOUT_MS
     c.instanceFollowRedirects = true
     c.setRequestProperty("User-Agent", USER_AGENT)
     c.setRequestProperty("Accept-Language", "en-US,en;q=0.9")
@@ -696,7 +704,7 @@ object RemoteAlbum {
   private fun postJson(spec: String, body: String): String? {
     val c = URL(spec).openConnection() as HttpURLConnection
     c.connectTimeout = 8000
-    c.readTimeout = 10000
+    c.readTimeout = SLOW_READ_TIMEOUT_MS
     c.requestMethod = "POST"
     c.doOutput = true
     c.setRequestProperty("Content-Type", "application/json")


### PR DESCRIPTION
## Root cause (reproduced against the reporter's real album)

The #175 reporter provided a 116-photo test album. Driving the real `RemoteAlbum.fetch` against it from a JVM harness reproduced the total failure, and step-through instrumentation found the cause: **Apple's legacy webstream endpoint takes ~14 seconds to build its response for a 116-photo album** (measured, consistent across HTTP/1.1 and HTTP/2; the response is only 68KB, the server is just slow). `postJson`'s read timeout was 10s, so the fetch died waiting, returned null, and the screensaver fell back to the default feed.

So ">100 photos kills the album" was never a page boundary. It's the album size at which Apple's response generation crosses 10 seconds.

## Fix

A `SLOW_READ_TIMEOUT_MS = 30_000` read timeout at the four album-metadata sites: `resolveIcloudHost` (a correct partition guess makes it the slow webstream call itself), `postJson` (webstream / webasseturls / CloudKit queries), `postForm` (Google's continuation RPC), and `httpGetResponse` (album HTML / Synology). `connectTimeout` stays at 8s, so unreachable hosts still fail fast; only patience once connected is extended.

The `postForm` bump very plausibly also fixes the "still only ~30 photos" field report on #155: the Google continuation RPC shares the same 10s timeout, and with #186's hardening a timed-out page 2 keeps exactly page 1's ~30 photos, which is what @grither describes.

## Testing

- End-to-end against the live repro album: fetch returns the full 116 photos with valid CDN URLs.
- Full unit suite green.

Fixes #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)