### PR TITLE
Screensaver: fill mode fills again - portraits crop instead of letterboxing (fixes #188)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -756,10 +756,19 @@ class PhotoFrameController(
 
   private fun applyFit() {
     // Video gets the same choice via [applyVideoFit], sized per-clip once its dimensions are known.
+    // BOTH layers, not just the current one: the incoming layer keeps whatever scale type it was
+    // last given, so applying to one layer left every second photo on the old mode after a
+    // fit/fill toggle (part of issue #188's "the setting does nothing").
     val isFit = settings.fit == ScreensaverConfig.FIT_FIT
-    photo.scaleType =
-        if (isFit) ImageView.ScaleType.FIT_CENTER
-        else ImageView.ScaleType.CENTER_CROP
+    val scale = if (isFit) ImageView.ScaleType.FIT_CENTER else ImageView.ScaleType.CENTER_CROP
+    if (this::layerA.isInitialized) {
+      layerA.photo.scaleType = scale
+      layerB.photo.scaleType = scale
+      if (!isFit) {
+        layerA.blurPhoto.visibility = View.GONE
+        layerB.blurPhoto.visibility = View.GONE
+      }
+    }
     blurPhoto.visibility = if (isFit) View.VISIBLE else View.GONE
   }
 
@@ -1594,7 +1603,13 @@ class PhotoFrameController(
     }
 
     val isPortrait = displayBmp.height > displayBmp.width
-    val isFitMode = isPortrait || settings.fit == ScreensaverConfig.FIT_FIT
+    // The user's fit/fill choice applies to EVERY photo (issue #188). 1.65 forced portraits
+    // into the blurred letterbox even on "fill", which read as a regression on landscape
+    // panels (portraits stopped cropping to full-screen) and doubly so on portrait-mounted
+    // panels (where a portrait photo fills natively). The blurred letterbox belongs to fit
+    // mode only; the aspect math below is orientation-generic, so a portrait panel needs no
+    // special case.
+    val isFitMode = settings.fit == ScreensaverConfig.FIT_FIT
 
     val containerLp = targetLayer.frameContainer.layoutParams as FrameLayout.LayoutParams
     val displayMetrics = context.resources.displayMetrics


### PR DESCRIPTION
## Problem (issue #188, two reporters)

1.65's portrait handling (#168) computed `isFitMode = isPortrait || fit == FIT`, forcing every portrait photo into the blurred letterbox regardless of the user's fit/fill setting. On landscape panels, portraits stopped cropping to full screen on "fill" (the pre-1.65 behaviour). On portrait-mounted panels it was doubly wrong: a portrait photo fills a portrait screen natively, yet still got blurred top/bottom bars.

A second, compounding bug: `applyFit()` only set the scale type on the *current* layer of the new dual-layer crossfade, so after a fit/fill toggle every second photo kept the old mode. Together these read as "the setting does nothing".

## Fix

- `show()`: `isFitMode` follows the setting alone. The blurred letterbox is fit mode's rendering; fill crops, as it always did. The fit-mode aspect math compares image ratio to screen ratio, so portrait-mounted panels are handled with no special case.
- `applyFit()`: applies the scale type (and blur hiding on fill) to **both** layers.

The `cropVertical` opt-in from #168 is untouched and still applies on top of fill.

## Testing

- Unit suite green.
- Needs an on-device pass: (1) fill + portrait photo on a landscape panel crops full-screen; (2) fit mode keeps the blurred letterbox; (3) a fit/fill toggle mid-session affects every subsequent photo, not every second one; (4) a portrait-mounted panel fills edge to edge on fill.

Fixes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)