### PR TITLE
QuickBar: the Recents square only shows with the system bar (fixes #190)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/QuickBar.kt
+++ b/app/src/main/java/com/immortal/launcher/QuickBar.kt
@@ -115,7 +115,12 @@ object QuickBar {
     // Gate the cluster on its own setting; show only when enabled AND (always-show or bar shown).
     val visible = QuickBarConfig.isEnabled(ctx) && (QuickBarConfig.alwaysShow(ctx) || barVisible)
     switcherView?.visibility = if (visible) View.VISIBLE else View.GONE
-    recentsView?.visibility = if (visible) View.VISIBLE else View.GONE
+    // The Recents square is positioned beside the system bar's Back/Home pair, so it only makes
+    // sense WHILE that bar is on screen — always-show floated it over whatever sat at its fixed
+    // offset, e.g. the launcher's own header icons (issue #190). Also per-setting (issue #182).
+    val recentsVisible =
+        QuickBarConfig.isEnabled(ctx) && barVisible && QuickBarConfig.showSystemRecents(ctx)
+    recentsView?.visibility = if (recentsVisible) View.VISIBLE else View.GONE
   }
 
   private fun statusBarHeight(ctx: Context): Int {

--- a/app/src/main/java/com/immortal/launcher/QuickBarConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/QuickBarConfig.kt
@@ -28,8 +28,23 @@ object QuickBarConfig {
   fun setAlwaysShow(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("always_show", on).apply()
 
-  /** Immutable snapshot, so the settings domain renders through the generic on-device list. */
-  data class Settings(val enabled: Boolean = false, val alwaysShow: Boolean = false)
+  /** The Android Recents square beside the system Back/Home pair (issue #182 gate). */
+  fun showSystemRecents(c: Context): Boolean = prefs(c).getBoolean("show_system_recents", true)
 
-  fun load(c: Context): Settings = Settings(enabled = isEnabled(c), alwaysShow = alwaysShow(c))
+  fun setShowSystemRecents(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("show_system_recents", on).apply()
+
+  /** Immutable snapshot, so the settings domain renders through the generic on-device list. */
+  data class Settings(
+      val enabled: Boolean = false,
+      val alwaysShow: Boolean = false,
+      val showSystemRecents: Boolean = true,
+  )
+
+  fun load(c: Context): Settings =
+      Settings(
+          enabled = isEnabled(c),
+          alwaysShow = alwaysShow(c),
+          showSystemRecents = showSystemRecents(c),
+      )
 }

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -731,6 +731,15 @@ object SettingsDomains {
                       set = QuickBarConfig::setAlwaysShow,
                       help = "On: always visible. Off: only while the system top bar is revealed.",
                       visible = { _, s -> s.enabled }),
+                  BoolSpec(
+                      "showSystemRecents",
+                      "Android Recents button",
+                      get = { it.showSystemRecents },
+                      set = QuickBarConfig::setShowSystemRecents,
+                      help =
+                          "Adds an Android Recents square beside the system bar's Back and Home " +
+                              "buttons while that bar is revealed.",
+                      visible = { _, s -> s.enabled }),
               ),
           defaults = { QuickBarConfig.Settings() },
           onApplied = { c, _ ->


### PR DESCRIPTION
## Problem (issue #190)

The Android Recents overlay from #180 sits at a fixed 224dp offset, positioned beside the system bar's Back/Home pair. Its visibility followed the whole cluster's rule, so with "always show" enabled it floated at that offset permanently - over whatever was underneath. On the reporter's panel that was the launcher's own header icons next to the clock (the #190 screenshot shows the pill stacked on the photo/remote icons).

## Fix

- `refresh()`: the Recents square now requires the system bar to actually be on screen (`barVisible`), regardless of always-show. Without the bar there is no Back/Home pair to sit beside. The centered app-switcher pill keeps its existing always-show behaviour.
- The #182 setting gate: a `showSystemRecents` `BoolSpec` (default on) in the `quickbar` domain bound to `QuickBarConfig`, so the button can be disabled outright on-device or from the phone remote. The domain's field/spec tripwire covers the new field.

The remaining half of #182 (the 224dp offset across models) stays open, but the offset is now only ever visible alongside the real bar, where #180 verified it on Gen 1.

## Testing

- Unit suite green (including the quickbar registry tripwire with the new field).
- Needs an on-device pass: header icons unobstructed in normal use; swipe the system bar down and the Recents square appears beside Back/Home; toggle the new setting off and it stays gone.

Fixes #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)