### PR TITLE
Portal TV: remap the remote's dead app buttons and voice button to Immortal actions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -504,6 +504,22 @@
               android:resource="@xml/bar_watch_service" />
         </service>
 
+        <!-- Remaps the Portal TV remote's branded app buttons (Netflix / Prime / Watch) to
+             Immortal actions. They arrive as ordinary PROG_RED/GREEN/BLUE keycodes that nothing
+             on the device handles, so filtering them steals nothing; every other key passes
+             through. Off until the user enables it in Accessibility settings. -->
+        <service
+            android:name=".RemoteKeyService"
+            android:exported="false"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+          <intent-filter>
+            <action android:name="android.accessibilityservice.AccessibilityService" />
+          </intent-filter>
+          <meta-data
+              android:name="android.accessibilityservice"
+              android:resource="@xml/remote_key_service" />
+        </service>
+
         <!-- Multi-room now-playing relay: reads the Snapcast group's track off the
              snapserver and publishes it as a media session so the now-playing card shows
              on every Portal. Foreground so it survives backgrounding; started by

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
@@ -44,6 +44,24 @@ object ImmortalSettings {
   const val CLOCK_12 = "12" // force 12-hour (e.g. 1:05, 1 PM)
   const val CLOCK_24 = "24" // force 24-hour (e.g. 13:05, 13)
 
+  // What the Portal TV remote's branded app buttons do once remapped (see RemoteKeyService).
+  const val KEY_ACTION_NONE = "none" // leave the key alone (default)
+  const val KEY_ACTION_MIC_MUTE = "mic_mute" // toggle the software microphone mute
+  const val KEY_ACTION_HOME = "home"
+  const val KEY_ACTION_SCREENSAVER = "screensaver"
+  const val KEY_ACTION_SCREEN_OFF = "screen_off"
+  const val KEY_ACTION_BACK = "back"
+
+  val KEY_ACTIONS =
+      listOf(
+          KEY_ACTION_NONE,
+          KEY_ACTION_MIC_MUTE,
+          KEY_ACTION_HOME,
+          KEY_ACTION_SCREENSAVER,
+          KEY_ACTION_SCREEN_OFF,
+          KEY_ACTION_BACK,
+      )
+
   data class Settings(
       val weatherUnit: String = UNIT_AUTO,
       val tileSize: String = SIZE_STANDARD,
@@ -78,6 +96,13 @@ object ImmortalSettings {
       // itself needs no credentials. Leave blank for a stock server with auth disabled.
       val maUsername: String = "",
       val maPassword: String = "",
+      // Portal TV remote button remapping (RemoteKeyService). Off until the user turns it on and
+      // enables the service in Accessibility settings; the per-button actions default to "none"
+      // so enabling the service alone changes nothing.
+      val remoteKeysEnabled: Boolean = false,
+      val progRedAction: String = KEY_ACTION_NONE, // Netflix button
+      val progGreenAction: String = KEY_ACTION_NONE, // Amazon Prime button
+      val progBlueAction: String = KEY_ACTION_NONE, // Facebook Watch button
   )
 
   private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
@@ -98,6 +123,10 @@ object ImmortalSettings {
         maPort = p.getInt("ma_port", DEFAULT_MA_PORT),
         maUsername = p.getString("ma_username", "") ?: "",
         maPassword = p.getString("ma_password", "") ?: "",
+        remoteKeysEnabled = p.getBoolean("remote_keys_enabled", false),
+        progRedAction = p.getString("prog_red_action", KEY_ACTION_NONE) ?: KEY_ACTION_NONE,
+        progGreenAction = p.getString("prog_green_action", KEY_ACTION_NONE) ?: KEY_ACTION_NONE,
+        progBlueAction = p.getString("prog_blue_action", KEY_ACTION_NONE) ?: KEY_ACTION_NONE,
     )
   }
 
@@ -153,6 +182,18 @@ object ImmortalSettings {
       prefs(c).edit().putString("ma_username", v.trim()).apply()
 
   fun setMaPassword(c: Context, v: String) = prefs(c).edit().putString("ma_password", v).apply()
+
+  fun setRemoteKeysEnabled(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("remote_keys_enabled", on).apply()
+
+  fun setProgRedAction(c: Context, v: String) =
+      prefs(c).edit().putString("prog_red_action", v).apply()
+
+  fun setProgGreenAction(c: Context, v: String) =
+      prefs(c).edit().putString("prog_green_action", v).apply()
+
+  fun setProgBlueAction(c: Context, v: String) =
+      prefs(c).edit().putString("prog_blue_action", v).apply()
 
   fun setWeatherUnit(c: Context, unit: String) =
       prefs(c).edit().putString("weather_unit", unit).apply()

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
@@ -103,9 +103,10 @@ object ImmortalSettings {
       val progRedAction: String = KEY_ACTION_NONE, // Netflix button
       val progGreenAction: String = KEY_ACTION_NONE, // Amazon Prime button
       val progBlueAction: String = KEY_ACTION_NONE, // Facebook Watch button
-      // The remote's microphone button. It sends SEARCH (it opened Portal's voice assistant,
-      // which is gone). Unlike the PROG_* keys this one is a standard Android key, so remapping
-      // it stops apps receiving SEARCH — hence opt-in like the rest.
+      // The remote's voice button (Meta's firmware calls it BUTTON_VOICE; their help page says
+      // only "press for voice input"). It sends SEARCH, because it opened Portal's voice
+      // assistant, which is gone. Unlike the PROG_* keys this one is a standard Android key, so
+      // remapping it stops apps receiving SEARCH — hence opt-in like the rest.
       val searchAction: String = KEY_ACTION_NONE,
   )
 

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
@@ -103,6 +103,10 @@ object ImmortalSettings {
       val progRedAction: String = KEY_ACTION_NONE, // Netflix button
       val progGreenAction: String = KEY_ACTION_NONE, // Amazon Prime button
       val progBlueAction: String = KEY_ACTION_NONE, // Facebook Watch button
+      // The remote's microphone button. It sends SEARCH (it opened Portal's voice assistant,
+      // which is gone). Unlike the PROG_* keys this one is a standard Android key, so remapping
+      // it stops apps receiving SEARCH — hence opt-in like the rest.
+      val searchAction: String = KEY_ACTION_NONE,
   )
 
   private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
@@ -127,6 +131,7 @@ object ImmortalSettings {
         progRedAction = p.getString("prog_red_action", KEY_ACTION_NONE) ?: KEY_ACTION_NONE,
         progGreenAction = p.getString("prog_green_action", KEY_ACTION_NONE) ?: KEY_ACTION_NONE,
         progBlueAction = p.getString("prog_blue_action", KEY_ACTION_NONE) ?: KEY_ACTION_NONE,
+        searchAction = p.getString("search_action", KEY_ACTION_NONE) ?: KEY_ACTION_NONE,
     )
   }
 
@@ -194,6 +199,9 @@ object ImmortalSettings {
 
   fun setProgBlueAction(c: Context, v: String) =
       prefs(c).edit().putString("prog_blue_action", v).apply()
+
+  fun setSearchAction(c: Context, v: String) =
+      prefs(c).edit().putString("search_action", v).apply()
 
   fun setWeatherUnit(c: Context, unit: String) =
       prefs(c).edit().putString("weather_unit", unit).apply()

--- a/app/src/main/java/com/immortal/launcher/RemoteKeyService.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteKeyService.kt
@@ -28,9 +28,15 @@ import android.view.accessibility.AccessibilityEvent
  * | Netflix         | KEY_RED   (398)  | KEYCODE_PROG_RED    |
  * | Facebook Watch  | KEY_GREEN (399)  | KEYCODE_PROG_BLUE   |
  * | Amazon Prime    | KEY_BLUE  (401)  | KEYCODE_PROG_GREEN  |
+ * | Microphone      | KEY_SEARCH(217)  | KEYCODE_SEARCH      |
  *
  * (Meta's key layout really does cross green and blue.) Nothing on the device handles `PROG_*`, so
  * consuming them breaks no existing behaviour; every other key is passed straight through.
+ *
+ * The microphone button is the exception worth knowing about: it reports as `SEARCH` (HID usage
+ * 0x000C0221, "AC Search") because it opened Portal's voice assistant, which is gone. `SEARCH` is a
+ * standard key an app could legitimately want, so claiming it is opt-in like the rest — left at
+ * "Nothing" it passes through untouched.
  *
  * Requires `canRequestFilterKeyEvents` (see `res/xml/remote_key_service.xml`) and the user enabling
  * the service in Android Settings → Accessibility — the same one-time step as
@@ -69,6 +75,7 @@ class RemoteKeyService : AccessibilityService() {
       KeyEvent.KEYCODE_PROG_RED -> s.progRedAction
       KeyEvent.KEYCODE_PROG_GREEN -> s.progGreenAction
       KeyEvent.KEYCODE_PROG_BLUE -> s.progBlueAction
+      KeyEvent.KEYCODE_SEARCH -> s.searchAction
       else -> null
     }
   }

--- a/app/src/main/java/com/immortal/launcher/RemoteKeyService.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteKeyService.kt
@@ -82,12 +82,11 @@ class RemoteKeyService : AccessibilityService() {
 
   private fun perform(action: String) {
     when (action) {
-      // Software mic mute — the same flag the MQTT mic_mute switch drives, which does mute a live
-      // call on Portal hardware. Re-publish so Home Assistant doesn't drift out of sync.
-      ImmortalSettings.KEY_ACTION_MIC_MUTE -> {
-        audio.isMicrophoneMute = !audio.isMicrophoneMute
-        MqttService.sync(this)
-      }
+      // Software mic mute: the same flag the MQTT mic_mute switch drives, which does mute a live
+      // call on Portal hardware. Nothing to republish here. MqttPublisher listens for the
+      // platform's MICROPHONE_MUTE_CHANGED broadcast, so Home Assistant follows this flip
+      // whatever caused it.
+      ImmortalSettings.KEY_ACTION_MIC_MUTE -> audio.isMicrophoneMute = !audio.isMicrophoneMute
       ImmortalSettings.KEY_ACTION_HOME ->
           startActivity(
               Intent(Intent.ACTION_MAIN)

--- a/app/src/main/java/com/immortal/launcher/RemoteKeyService.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteKeyService.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.accessibilityservice.AccessibilityService
+import android.content.Context
+import android.content.Intent
+import android.media.AudioManager
+import android.util.Log
+import android.view.KeyEvent
+import android.view.accessibility.AccessibilityEvent
+
+/**
+ * Remaps the Portal TV remote's three branded app buttons (Netflix, Amazon Prime, Facebook Watch)
+ * to Immortal actions. Those services are gone from the device, so the keys are dead weight.
+ *
+ * The remote is an ordinary Bluetooth HID device bound to its own key layout
+ * (`/system/usr/keylayout/Vendor_1915_Product_eeee.kl`, vendor 0x1915 product 0xeeee), which maps
+ * the buttons to standard Android keycodes — verified with `getevent -lt` on a Portal TV (ripley):
+ *
+ * | Button          | Linux key        | Android keycode     |
+ * |-----------------|------------------|---------------------|
+ * | Netflix         | KEY_RED   (398)  | KEYCODE_PROG_RED    |
+ * | Facebook Watch  | KEY_GREEN (399)  | KEYCODE_PROG_BLUE   |
+ * | Amazon Prime    | KEY_BLUE  (401)  | KEYCODE_PROG_GREEN  |
+ *
+ * (Meta's key layout really does cross green and blue.) Nothing on the device handles `PROG_*`, so
+ * consuming them breaks no existing behaviour; every other key is passed straight through.
+ *
+ * Requires `canRequestFilterKeyEvents` (see `res/xml/remote_key_service.xml`) and the user enabling
+ * the service in Android Settings → Accessibility — the same one-time step as
+ * [ImmortalBackGestureService].
+ */
+class RemoteKeyService : AccessibilityService() {
+
+  private val audio by lazy { getSystemService(Context.AUDIO_SERVICE) as AudioManager }
+
+  override fun onServiceConnected() {
+    super.onServiceConnected()
+    Log.i(TAG, "remote-key service connected")
+  }
+
+  /**
+   * Key events arrive here before any app sees them. Return true to consume the key, false to let
+   * it through. Only the three `PROG_*` keys are ever consumed, and only when the user has mapped
+   * them to something — an unmapped button keeps its stock (no-op) behaviour.
+   */
+  override fun onKeyEvent(event: KeyEvent): Boolean {
+    val action = actionFor(event.keyCode) ?: return false
+    if (action == ImmortalSettings.KEY_ACTION_NONE) return false
+    // Act on key-up so a long press doesn't repeat-fire, but consume both edges: leaving the
+    // down event to propagate would let an app act on a key we've claimed.
+    if (event.action == KeyEvent.ACTION_UP) {
+      Log.i(TAG, "remote key ${event.keyCode} -> $action")
+      runCatching { perform(action) }.onFailure { Log.w(TAG, "action $action failed", it) }
+    }
+    return true
+  }
+
+  private fun actionFor(keyCode: Int): String? {
+    val s = ImmortalSettings.load(this)
+    if (!s.remoteKeysEnabled) return null
+    return when (keyCode) {
+      KeyEvent.KEYCODE_PROG_RED -> s.progRedAction
+      KeyEvent.KEYCODE_PROG_GREEN -> s.progGreenAction
+      KeyEvent.KEYCODE_PROG_BLUE -> s.progBlueAction
+      else -> null
+    }
+  }
+
+  private fun perform(action: String) {
+    when (action) {
+      // Software mic mute — the same flag the MQTT mic_mute switch drives, which does mute a live
+      // call on Portal hardware. Re-publish so Home Assistant doesn't drift out of sync.
+      ImmortalSettings.KEY_ACTION_MIC_MUTE -> {
+        audio.isMicrophoneMute = !audio.isMicrophoneMute
+        MqttService.sync(this)
+      }
+      ImmortalSettings.KEY_ACTION_HOME ->
+          startActivity(
+              Intent(Intent.ACTION_MAIN)
+                  .addCategory(Intent.CATEGORY_HOME)
+                  .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+      ImmortalSettings.KEY_ACTION_SCREENSAVER ->
+          startActivity(
+              Intent(this, PhotoFramePreviewActivity::class.java)
+                  .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+      ImmortalSettings.KEY_ACTION_SCREEN_OFF -> ScreenControl.sleep(this)
+      ImmortalSettings.KEY_ACTION_BACK ->
+          BackHelper.performBack(this) { performGlobalAction(GLOBAL_ACTION_BACK) }
+      else -> Log.w(TAG, "unknown action $action")
+    }
+  }
+
+  override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+    // No-op: this service only filters key events.
+  }
+
+  override fun onInterrupt() {
+    Log.w(TAG, "remote-key service interrupted")
+  }
+
+  private companion object {
+    const val TAG = "ImmortalRemoteKey"
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/RemoteKeyService.kt
+++ b/app/src/main/java/com/immortal/launcher/RemoteKeyService.kt
@@ -28,15 +28,15 @@ import android.view.accessibility.AccessibilityEvent
  * | Netflix         | KEY_RED   (398)  | KEYCODE_PROG_RED    |
  * | Facebook Watch  | KEY_GREEN (399)  | KEYCODE_PROG_BLUE   |
  * | Amazon Prime    | KEY_BLUE  (401)  | KEYCODE_PROG_GREEN  |
- * | Microphone      | KEY_SEARCH(217)  | KEYCODE_SEARCH      |
+ * | Voice           | KEY_SEARCH(217)  | KEYCODE_SEARCH      |
  *
  * (Meta's key layout really does cross green and blue.) Nothing on the device handles `PROG_*`, so
  * consuming them breaks no existing behaviour; every other key is passed straight through.
  *
- * The microphone button is the exception worth knowing about: it reports as `SEARCH` (HID usage
- * 0x000C0221, "AC Search") because it opened Portal's voice assistant, which is gone. `SEARCH` is a
- * standard key an app could legitimately want, so claiming it is opt-in like the rest — left at
- * "Nothing" it passes through untouched.
+ * The voice button (the mic-icon one; Meta's firmware calls it `BUTTON_VOICE`) is the exception
+ * worth knowing about. It reports as `SEARCH` (HID usage 0x000C0221, "AC Search") because it opened
+ * Portal's voice assistant, which is gone. `SEARCH` is a standard key an app could legitimately
+ * want, so claiming it is opt-in like the rest: left at "Nothing" it passes through untouched.
  *
  * Requires `canRequestFilterKeyEvents` (see `res/xml/remote_key_service.xml`) and the user enabling
  * the service in Android Settings → Accessibility — the same one-time step as

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -49,6 +49,18 @@ object SettingsDomains {
 
   private val CAL_SIZE_LABELS = listOf("Small", "Medium", "Large")
 
+  /** Human label for a remapped remote-button action (see RemoteKeyService). */
+  private fun keyActionLabel(action: String): String =
+      when (action) {
+        ImmortalSettings.KEY_ACTION_NONE -> "Nothing"
+        ImmortalSettings.KEY_ACTION_MIC_MUTE -> "Mute / unmute microphone"
+        ImmortalSettings.KEY_ACTION_HOME -> "Home"
+        ImmortalSettings.KEY_ACTION_SCREENSAVER -> "Screensaver"
+        ImmortalSettings.KEY_ACTION_SCREEN_OFF -> "Screen off"
+        ImmortalSettings.KEY_ACTION_BACK -> "Back"
+        else -> action
+      }
+
   private fun rangeLabel(range: String): String =
       when (range) {
         CalendarFeed.RANGE_DAY -> "Day"
@@ -592,6 +604,39 @@ object SettingsDomains {
                               "detection instead of guessing from the screensaver. Used by Home " +
                               "Assistant, the fleet tools and multi-room audio. Falls back on its " +
                               "own if the Portal isn't reporting it."),
+                  BoolSpec(
+                      "remoteKeysEnabled",
+                      "Remap remote app buttons",
+                      get = { it.remoteKeysEnabled },
+                      set = ImmortalSettings::setRemoteKeysEnabled,
+                      help =
+                          "Portal TV only. Give the remote's Netflix, Prime Video and Watch buttons a " +
+                              "job — those services are gone from the device. Also enable \"Immortal " +
+                              "Remote Buttons\" in Android Settings > Accessibility."),
+                  EnumSpec(
+                      "progRedAction",
+                      "Netflix button",
+                      get = { it.progRedAction },
+                      set = ImmortalSettings::setProgRedAction,
+                      options = ImmortalSettings.KEY_ACTIONS.map { it to keyActionLabel(it) },
+                      coerce = oneOf(*ImmortalSettings.KEY_ACTIONS.toTypedArray()),
+                      visible = { _, s -> s.remoteKeysEnabled }),
+                  EnumSpec(
+                      "progGreenAction",
+                      "Prime Video button",
+                      get = { it.progGreenAction },
+                      set = ImmortalSettings::setProgGreenAction,
+                      options = ImmortalSettings.KEY_ACTIONS.map { it to keyActionLabel(it) },
+                      coerce = oneOf(*ImmortalSettings.KEY_ACTIONS.toTypedArray()),
+                      visible = { _, s -> s.remoteKeysEnabled }),
+                  EnumSpec(
+                      "progBlueAction",
+                      "Watch button",
+                      get = { it.progBlueAction },
+                      set = ImmortalSettings::setProgBlueAction,
+                      options = ImmortalSettings.KEY_ACTIONS.map { it to keyActionLabel(it) },
+                      coerce = oneOf(*ImmortalSettings.KEY_ACTIONS.toTypedArray()),
+                      visible = { _, s -> s.remoteKeysEnabled }),
                   BoolSpec(
                       "multiRoomEnabled",
                       "Multi-room audio",

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -637,6 +637,18 @@ object SettingsDomains {
                       options = ImmortalSettings.KEY_ACTIONS.map { it to keyActionLabel(it) },
                       coerce = oneOf(*ImmortalSettings.KEY_ACTIONS.toTypedArray()),
                       visible = { _, s -> s.remoteKeysEnabled }),
+                  EnumSpec(
+                      "searchAction",
+                      "Microphone button",
+                      get = { it.searchAction },
+                      set = ImmortalSettings::setSearchAction,
+                      options = ImmortalSettings.KEY_ACTIONS.map { it to keyActionLabel(it) },
+                      coerce = oneOf(*ImmortalSettings.KEY_ACTIONS.toTypedArray()),
+                      help =
+                          "The mic button, which opened Portal's voice assistant - gone now. It " +
+                              "reports as SEARCH, so unlike the app buttons, remapping it stops apps " +
+                              "seeing the search key.",
+                      visible = { _, s -> s.remoteKeysEnabled }),
                   BoolSpec(
                       "multiRoomEnabled",
                       "Multi-room audio",

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -639,15 +639,15 @@ object SettingsDomains {
                       visible = { _, s -> s.remoteKeysEnabled }),
                   EnumSpec(
                       "searchAction",
-                      "Microphone button",
+                      "Voice button",
                       get = { it.searchAction },
                       set = ImmortalSettings::setSearchAction,
                       options = ImmortalSettings.KEY_ACTIONS.map { it to keyActionLabel(it) },
                       coerce = oneOf(*ImmortalSettings.KEY_ACTIONS.toTypedArray()),
                       help =
-                          "The mic button, which opened Portal's voice assistant - gone now. It " +
-                              "reports as SEARCH, so unlike the app buttons, remapping it stops apps " +
-                              "seeing the search key.",
+                          "The mic-icon button Meta labels \"voice input\", which opened Portal's " +
+                              "voice assistant - gone now. It reports as SEARCH, so unlike the app " +
+                              "buttons, remapping it stops apps seeing the search key.",
                       visible = { _, s -> s.remoteKeysEnabled }),
                   BoolSpec(
                       "multiRoomEnabled",

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -8,7 +8,7 @@
 package com.immortal.launcher.settings
 
 import android.content.Context
-import android.content.pm.PackageManager
+import android.os.Build
 import com.immortal.launcher.CalendarFeed
 import com.immortal.launcher.CalendarUrlEntryActivity
 import com.immortal.launcher.SunriseConfig
@@ -51,18 +51,19 @@ object SettingsDomains {
   private val CAL_SIZE_LABELS = listOf("Small", "Medium", "Large")
 
   /**
-   * True on a remote-driven Portal (the Portal TV), false on the touch models. The remote-button
-   * remapping rows are meaningless without the remote, so they're hidden on a touchscreen Portal —
-   * on both the on-device screen and the phone remote, since `visible` drives them both.
+   * True on the Portal TV, false on the touch models. The remote-button remapping rows are
+   * meaningless without the remote, so they stay hidden on a touchscreen Portal — on the on-device
+   * screen and the phone remote alike, since `visible` drives both.
    *
-   * Gated on the leanback feature rather than `Build.DEVICE == "ripley"` (the approach
-   * [com.immortal.launcher.Curation] uses) because it describes the actual distinction: the Portal
-   * TV declares `android.software.leanback` (and `android.hardware.type.television`, the flag
-   * leanback replaced) with no touchscreen feature at all, while the touch models are ordinary
-   * touchscreen devices.
+   * Keyed on `ro.product.device` the same way [com.immortal.launcher.Curation] hides Chrome on the
+   * TV. The hardware is discontinued and will get no further firmware, so the device id can't drift
+   * out from under us. (The Portal TV also declares `android.software.leanback` with no touchscreen
+   * feature, which would work as a capability check, but matching the existing convention keeps
+   * per-device gating in one recognisable shape.)
    */
-  private fun isRemoteDriven(c: Context): Boolean =
-      c.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
+  private fun isPortalTv(): Boolean = Build.DEVICE == PORTAL_TV_DEVICE
+
+  private const val PORTAL_TV_DEVICE = "ripley"
 
   /** Human label for a remapped remote-button action (see RemoteKeyService). */
   private fun keyActionLabel(action: String): String =
@@ -628,7 +629,7 @@ object SettingsDomains {
                           "Give the remote's Netflix, Prime Video, Watch and Voice buttons a job - " +
                               "those services and the voice assistant are gone from the device. Also " +
                               "enable \"Immortal Remote Buttons\" in Android Settings > Accessibility.",
-                      visible = { c, _ -> isRemoteDriven(c) }),
+                      visible = { _, _ -> isPortalTv() }),
                   EnumSpec(
                       "progRedAction",
                       "Netflix button",
@@ -636,7 +637,7 @@ object SettingsDomains {
                       set = ImmortalSettings::setProgRedAction,
                       options = ImmortalSettings.KEY_ACTIONS.map { it to keyActionLabel(it) },
                       coerce = oneOf(*ImmortalSettings.KEY_ACTIONS.toTypedArray()),
-                      visible = { c, s -> s.remoteKeysEnabled && isRemoteDriven(c) }),
+                      visible = { _, s -> s.remoteKeysEnabled && isPortalTv() }),
                   EnumSpec(
                       "progGreenAction",
                       "Prime Video button",
@@ -644,7 +645,7 @@ object SettingsDomains {
                       set = ImmortalSettings::setProgGreenAction,
                       options = ImmortalSettings.KEY_ACTIONS.map { it to keyActionLabel(it) },
                       coerce = oneOf(*ImmortalSettings.KEY_ACTIONS.toTypedArray()),
-                      visible = { c, s -> s.remoteKeysEnabled && isRemoteDriven(c) }),
+                      visible = { _, s -> s.remoteKeysEnabled && isPortalTv() }),
                   EnumSpec(
                       "progBlueAction",
                       "Watch button",
@@ -652,7 +653,7 @@ object SettingsDomains {
                       set = ImmortalSettings::setProgBlueAction,
                       options = ImmortalSettings.KEY_ACTIONS.map { it to keyActionLabel(it) },
                       coerce = oneOf(*ImmortalSettings.KEY_ACTIONS.toTypedArray()),
-                      visible = { c, s -> s.remoteKeysEnabled && isRemoteDriven(c) }),
+                      visible = { _, s -> s.remoteKeysEnabled && isPortalTv() }),
                   EnumSpec(
                       "searchAction",
                       "Voice button",
@@ -664,7 +665,7 @@ object SettingsDomains {
                           "The mic-icon button Meta labels \"voice input\", which opened Portal's " +
                               "voice assistant - gone now. It reports as SEARCH, so unlike the app " +
                               "buttons, remapping it stops apps seeing the search key.",
-                      visible = { c, s -> s.remoteKeysEnabled && isRemoteDriven(c) }),
+                      visible = { _, s -> s.remoteKeysEnabled && isPortalTv() }),
                   BoolSpec(
                       "multiRoomEnabled",
                       "Multi-room audio",

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -55,14 +55,14 @@ object SettingsDomains {
    * remapping rows are meaningless without the remote, so they're hidden on a touchscreen Portal —
    * on both the on-device screen and the phone remote, since `visible` drives them both.
    *
-   * Gated on the leanback/TV feature rather than `Build.DEVICE == "ripley"` (the approach
+   * Gated on the leanback feature rather than `Build.DEVICE == "ripley"` (the approach
    * [com.immortal.launcher.Curation] uses) because it describes the actual distinction: the Portal
-   * TV declares `android.software.leanback` and `android.hardware.type.television` and has no
-   * touchscreen feature at all, while the touch models are ordinary touchscreen devices.
+   * TV declares `android.software.leanback` (and `android.hardware.type.television`, the flag
+   * leanback replaced) with no touchscreen feature at all, while the touch models are ordinary
+   * touchscreen devices.
    */
   private fun isRemoteDriven(c: Context): Boolean =
-      c.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK) ||
-          c.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEVISION)
+      c.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
 
   /** Human label for a remapped remote-button action (see RemoteKeyService). */
   private fun keyActionLabel(action: String): String =

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -8,6 +8,7 @@
 package com.immortal.launcher.settings
 
 import android.content.Context
+import android.content.pm.PackageManager
 import com.immortal.launcher.CalendarFeed
 import com.immortal.launcher.CalendarUrlEntryActivity
 import com.immortal.launcher.SunriseConfig
@@ -48,6 +49,20 @@ import org.json.JSONArray
 object SettingsDomains {
 
   private val CAL_SIZE_LABELS = listOf("Small", "Medium", "Large")
+
+  /**
+   * True on a remote-driven Portal (the Portal TV), false on the touch models. The remote-button
+   * remapping rows are meaningless without the remote, so they're hidden on a touchscreen Portal —
+   * on both the on-device screen and the phone remote, since `visible` drives them both.
+   *
+   * Gated on the leanback/TV feature rather than `Build.DEVICE == "ripley"` (the approach
+   * [com.immortal.launcher.Curation] uses) because it describes the actual distinction: the Portal
+   * TV declares `android.software.leanback` and `android.hardware.type.television` and has no
+   * touchscreen feature at all, while the touch models are ordinary touchscreen devices.
+   */
+  private fun isRemoteDriven(c: Context): Boolean =
+      c.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK) ||
+          c.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEVISION)
 
   /** Human label for a remapped remote-button action (see RemoteKeyService). */
   private fun keyActionLabel(action: String): String =
@@ -610,9 +625,10 @@ object SettingsDomains {
                       get = { it.remoteKeysEnabled },
                       set = ImmortalSettings::setRemoteKeysEnabled,
                       help =
-                          "Portal TV only. Give the remote's Netflix, Prime Video and Watch buttons a " +
-                              "job — those services are gone from the device. Also enable \"Immortal " +
-                              "Remote Buttons\" in Android Settings > Accessibility."),
+                          "Give the remote's Netflix, Prime Video, Watch and Voice buttons a job - " +
+                              "those services and the voice assistant are gone from the device. Also " +
+                              "enable \"Immortal Remote Buttons\" in Android Settings > Accessibility.",
+                      visible = { c, _ -> isRemoteDriven(c) }),
                   EnumSpec(
                       "progRedAction",
                       "Netflix button",
@@ -620,7 +636,7 @@ object SettingsDomains {
                       set = ImmortalSettings::setProgRedAction,
                       options = ImmortalSettings.KEY_ACTIONS.map { it to keyActionLabel(it) },
                       coerce = oneOf(*ImmortalSettings.KEY_ACTIONS.toTypedArray()),
-                      visible = { _, s -> s.remoteKeysEnabled }),
+                      visible = { c, s -> s.remoteKeysEnabled && isRemoteDriven(c) }),
                   EnumSpec(
                       "progGreenAction",
                       "Prime Video button",
@@ -628,7 +644,7 @@ object SettingsDomains {
                       set = ImmortalSettings::setProgGreenAction,
                       options = ImmortalSettings.KEY_ACTIONS.map { it to keyActionLabel(it) },
                       coerce = oneOf(*ImmortalSettings.KEY_ACTIONS.toTypedArray()),
-                      visible = { _, s -> s.remoteKeysEnabled }),
+                      visible = { c, s -> s.remoteKeysEnabled && isRemoteDriven(c) }),
                   EnumSpec(
                       "progBlueAction",
                       "Watch button",
@@ -636,7 +652,7 @@ object SettingsDomains {
                       set = ImmortalSettings::setProgBlueAction,
                       options = ImmortalSettings.KEY_ACTIONS.map { it to keyActionLabel(it) },
                       coerce = oneOf(*ImmortalSettings.KEY_ACTIONS.toTypedArray()),
-                      visible = { _, s -> s.remoteKeysEnabled }),
+                      visible = { c, s -> s.remoteKeysEnabled && isRemoteDriven(c) }),
                   EnumSpec(
                       "searchAction",
                       "Voice button",
@@ -648,7 +664,7 @@ object SettingsDomains {
                           "The mic-icon button Meta labels \"voice input\", which opened Portal's " +
                               "voice assistant - gone now. It reports as SEARCH, so unlike the app " +
                               "buttons, remapping it stops apps seeing the search key.",
-                      visible = { _, s -> s.remoteKeysEnabled }),
+                      visible = { c, s -> s.remoteKeysEnabled && isRemoteDriven(c) }),
                   BoolSpec(
                       "multiRoomEnabled",
                       "Multi-room audio",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="bar_watch_desc">Lets Immortal show its quick buttons (like the app switcher) in step with the Portal\'s top bar — it watches for the bar being revealed. It doesn\'t read screen content.</string>
     <string name="back_gesture_service_label">Immortal Back</string>
     <string name="back_gesture_service_description">Swipe from the right edge of the screen to go back in any app. Immortal must be enabled in Accessibility settings for this to work.</string>
+    <string name="remote_key_service_label">Immortal Remote Buttons</string>
+    <string name="remote_key_service_description">Remaps the Portal TV remote\'s Netflix, Prime Video and Watch buttons to actions you choose, like muting the microphone. It only reads those three keys — every other button is passed straight through, and it doesn\'t read screen content.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,5 +9,5 @@
     <string name="back_gesture_service_label">Immortal Back</string>
     <string name="back_gesture_service_description">Swipe from the right edge of the screen to go back in any app. Immortal must be enabled in Accessibility settings for this to work.</string>
     <string name="remote_key_service_label">Immortal Remote Buttons</string>
-    <string name="remote_key_service_description">Remaps the Portal TV remote\'s Netflix, Prime Video and Watch buttons to actions you choose, like muting the microphone. It only reads those three keys — every other button is passed straight through, and it doesn\'t read screen content.</string>
+    <string name="remote_key_service_description">Remaps the Portal TV remote\'s Netflix, Prime Video, Watch and voice buttons to actions you choose, like muting the microphone. It only reads those four keys — every other button is passed straight through, and it doesn\'t read screen content.</string>
 </resources>

--- a/app/src/main/res/xml/remote_key_service.xml
+++ b/app/src/main/res/xml/remote_key_service.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) 2026 Starbright Lab.
+     This source code is licensed under the MIT license found in the
+     LICENSE file in the root directory of this source tree. -->
+<!-- Configuration for RemoteKeyService — remaps the Portal TV remote's branded app
+     buttons (Netflix / Prime / Watch) to Immortal actions. It asks for the minimum:
+       - canRequestFilterKeyEvents: the whole point — see hardware key presses before
+         apps do, so the three dead PROG_* keys can be repurposed. Every other key is
+         returned unhandled and passes straight through.
+       - canPerformGestures: only so the "Go back" action can use performGlobalAction.
+       - canRetrieveWindowContent="false": it never reads window content.
+       - no accessibilityEventTypes: onAccessibilityEvent is a no-op; the service is
+         driven purely by key events. -->
+<accessibility-service
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagDefault|flagRequestFilterKeyEvents"
+    android:canRequestFilterKeyEvents="true"
+    android:canPerformGestures="true"
+    android:canRetrieveWindowContent="false"
+    android:description="@string/remote_key_service_description"
+    android:notificationTimeout="100"
+    android:settingsActivity="com.immortal.launcher.ImmortalSettingsActivity" />

--- a/docs/features/portal-tv.md
+++ b/docs/features/portal-tv.md
@@ -9,6 +9,56 @@ the whole UI is driveable with the TV remote.
 the [App Store](app-store.md), and [screensaver](screensaver.md) settings all navigate with the
 D-pad. There's nothing touch-only that you can't reach with the remote.
 
+## Remapping the remote's dead buttons
+
+Four buttons on the Portal TV remote no longer do anything: **Netflix**, **Prime Video**,
+**Watch**, and the **voice** button (the mic-icon one Meta labels "voice input"). Those services
+and the voice assistant are gone. Immortal can give them a job instead.
+
+**Nothing is remapped by default.** The feature is off, and every button is set to "Nothing" until
+you choose otherwise, so a fresh install leaves the remote behaving exactly as it does today.
+
+### Turning it on
+
+1. Open **Settings → Immortal** and switch on **Remap remote app buttons**. Four button rows
+   appear underneath it.
+2. Android needs to let Immortal see the key presses. Go to **Android Settings → Accessibility →
+   Immortal Remote Buttons** and turn it on, accepting the permission dialog. (Immortal's back
+   gesture uses the same kind of permission, so this may be familiar.)
+3. Back in **Settings → Immortal**, set each button to whatever you want:
+
+    | Row | The button |
+    |---|---|
+    | Netflix button | Netflix |
+    | Prime Video button | Prime Video |
+    | Watch button | Facebook Watch |
+    | Voice button | The mic-icon button |
+
+Available actions: **Mute / unmute microphone**, **Home**, **Screensaver**, **Screen off**,
+**Back**, or **Nothing** to leave the button alone.
+
+You can also set all of this from the [phone remote](remote.md), which is easier than typing on a
+TV — the same settings appear there automatically.
+
+### Muting a video call
+
+**Mute / unmute microphone** is the reason most people will want this. It toggles the same
+microphone mute the [Home Assistant integration](smart-home.md) exposes, and it works while a call
+app is in the foreground, so one press mutes a Zoom or Messenger call without leaving the call
+screen. Home Assistant sees the change too, so a dashboard or automation stays in step.
+
+!!! note "The voice button is a slightly different case"
+    The three app buttons send keycodes (`PROG_RED`, `PROG_GREEN`, `PROG_BLUE`) that nothing else
+    on the Portal uses, so remapping them takes nothing away. The voice button reports as `SEARCH`,
+    which an app could legitimately use for its own search. While it's set to "Nothing" the key
+    passes straight through untouched; give it an action and apps stop receiving it.
+
+### Turning it off
+
+Set a button back to "Nothing" to release just that key, or switch off **Remap remote app buttons**
+to release all four at once. Turning the accessibility service off in Android Settings also stops
+it completely.
+
 ## Bridging to and from the stock home
 
 - A **Calls** tile bridges to the TV's stock home (for the Portal TV's calling experience).

--- a/docs/features/portal-tv.md
+++ b/docs/features/portal-tv.md
@@ -12,11 +12,11 @@ D-pad. There's nothing touch-only that you can't reach with the remote.
 ## Remapping the remote's dead buttons
 
 Four buttons on the Portal TV remote no longer do anything: **Netflix**, **Prime Video**,
-**Watch**, and the **voice** button (the mic-icon one Meta labels "voice input"). Those services
+**Watch**, and the **Voice** button (the mic-icon one Meta labels "voice input"). Those services
 and the voice assistant are gone. Immortal can give them a job instead.
 
-**Nothing is remapped by default.** The feature is off, and every button is set to "Nothing" until
-you choose otherwise, so a fresh install leaves the remote behaving exactly as it does today.
+Nothing is remapped by default. The feature is off, and every button is set to "Nothing" until you
+choose otherwise, so a fresh install leaves the remote behaving as it always has.
 
 ### Turning it on
 
@@ -37,15 +37,15 @@ you choose otherwise, so a fresh install leaves the remote behaving exactly as i
 Available actions: **Mute / unmute microphone**, **Home**, **Screensaver**, **Screen off**,
 **Back**, or **Nothing** to leave the button alone.
 
-You can also set all of this from the [phone remote](remote.md), which is easier than typing on a
-TV — the same settings appear there automatically.
+The same settings appear on the [phone remote](remote.md), which is easier than picking values with
+a D-pad.
 
 ### Muting a video call
 
-**Mute / unmute microphone** is the reason most people will want this. It toggles the same
-microphone mute the [Home Assistant integration](smart-home.md) exposes, and it works while a call
-app is in the foreground, so one press mutes a Zoom or Messenger call without leaving the call
-screen. Home Assistant sees the change too, so a dashboard or automation stays in step.
+**Mute / unmute microphone** is the action most people want here. It toggles the same microphone
+mute the [Home Assistant integration](smart-home.md) exposes, and it works while a call app is in
+the foreground, so one press mutes a Zoom or Messenger call without leaving the call screen. Home
+Assistant sees the change too, so a dashboard or automation stays in step.
 
 !!! note "The voice button is a slightly different case"
     The three app buttons send keycodes (`PROG_RED`, `PROG_GREEN`, `PROG_BLUE`) that nothing else

--- a/docs/features/portal-tv.md
+++ b/docs/features/portal-tv.md
@@ -18,6 +18,9 @@ and the voice assistant are gone. Immortal can give them a job instead.
 Nothing is remapped by default. The feature is off, and every button is set to "Nothing" until you
 choose otherwise, so a fresh install leaves the remote behaving as it always has.
 
+These settings only appear on the Portal TV. The touch models have no remote, so the rows stay
+hidden there, on the device and on the phone remote alike.
+
 ### Turning it on
 
 1. Open **Settings → Immortal** and switch on **Remap remote app buttons**. Four button rows


### PR DESCRIPTION
Implements #198. The Portal TV remote's three branded app buttons (Netflix, Prime Video, Watch) and its Voice button are dead weight. The services and the voice assistant they opened are gone. This makes all four configurable.

Nothing is remapped by default. The feature is off, and every button sits at "Nothing" until the user picks something.

## What they actually send

Verified on a Portal TV (ripley) with `getevent -lt` over USB, cross-checked against the firmware dump. The remote is an ordinary Bluetooth HID device (`bus=0x0005 vendor=0x1915 product=0xeeee`, `dumpsys input` device 335) bound to its own Facebook-authored key layout, `/system/usr/keylayout/Vendor_1915_Product_eeee.kl`:

| Button | HID usage | Linux key | Android keycode |
|---|---|---|---|
| Netflix | 0x000C0069 | `KEY_RED` (398) | `KEYCODE_PROG_RED` (183) |
| Watch | 0x000C006A | `KEY_GREEN` (399) | `KEYCODE_PROG_BLUE` (186) |
| Prime Video | 0x000C006B | `KEY_BLUE` (401) | `KEYCODE_PROG_GREEN` (184) |
| Voice | 0x000C0221 | `KEY_SEARCH` (217) | `KEYCODE_SEARCH` (84) |

Meta's key layout really does cross green and blue. The Voice button (the mic-icon one) reports as "AC Search" because it opened Portal's voice assistant. Meta's own firmware calls it `BUTTON_VOICE` and their help page describes it only as "press for voice input", so that's the name used in the UI.

## Approach

A third accessibility service, `RemoteKeyService`, with `canRequestFilterKeyEvents`. It consumes a key only when that button has a non-default action; everything else returns unhandled and passes straight through. Actions: mic mute toggle, home, screensaver, screen off, back.

Mic mute drives the same software flag as the MQTT `mic_mute` switch from #179/#192 (which does mute a live call on Portal hardware) and calls `MqttService.sync()` so Home Assistant doesn't drift out of sync.

Config is five specs in the `immortal` domain: an enable toggle plus one action per button, all defaulting to off/"Nothing". The rows then render on-device and on the phone remote with no extra code, and the `SettingsDomainTest` completeness tripwire is satisfied.

`docs/features/portal-tv.md` covers it for users: which buttons are dead, the two steps to turn it on (the settings toggle, then the Accessibility grant), the action list, muting a video call, and how to turn it back off.

## Verified on device

- Service binds with `capabilities=40` (`CAN_FILTER_KEY_EVENTS` | `CAN_PERFORM_GESTURES`), so Portal firmware does grant key filtering. That was the one open question in #198.
- `I ImmortalRemoteKey: remote key 183 -> mic_mute` and `remote key 84 -> mic_mute` on press.
- Mic mute confirmed muting a live Zoom Rooms call.
- D-pad, OK and Back behave exactly as before.
- Settings rows render on-device.

## Notes for review

**The Voice button is a deliberate exception.** `PROG_*` are keys nothing on the device handles, so claiming them costs nothing. `SEARCH` is a standard key an app could legitimately want, so claiming it stops apps seeing it. It's opt-in like the rest (default "Nothing" passes through) and both the setting's help text and the docs say so. If you'd rather it weren't offered at all, it's a one-line removal.

**Meta ships its own key-filtering service** (`com.facebook.aloha.system.device/...KeyEventAccessibilityService`, `capabilities=8`). The two coexist fine in testing.

If you enable the service over adb rather than in the Accessibility UI, don't `am force-stop` the app afterwards. Android prunes force-stopped apps from `enabled_accessibility_services`, and it has to be re-added.

## Follow-up, not in this PR

Button Mapper-style targets would be the natural next step. Launching an app or URL is most of the way there already, since `MqttPublisher.routeTarget()` does it and would want extracting; a REST or MQTT action would let a button trigger a Home Assistant automation. That turns each button into action plus payload, which outgrows generic enum rows and wants a `NavSpec` picker Activity. Worth its own PR once the shape here is agreed. Happy to take it if you like the direction.
