### PR TITLE
feat(screensaver): add blurBackground setting for solid black sidebars (closes #199)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -769,7 +769,7 @@ class PhotoFrameController(
         layerB.blurPhoto.visibility = View.GONE
       }
     }
-    blurPhoto.visibility = if (isFit) View.VISIBLE else View.GONE
+    blurPhoto.visibility = if (isFit && settings.blurBackground) View.VISIBLE else View.GONE
   }
 
   /**
@@ -1634,9 +1634,13 @@ class PhotoFrameController(
       containerLp.gravity = Gravity.CENTER
       targetLayer.frameContainer.layoutParams = containerLp
 
-      runCatching {
-        val blurred = createBlurredBackground(displayBmp)
-        targetLayer.blurPhoto.setImageBitmap(blurred)
+      if (settings.blurBackground) {
+        runCatching {
+          val blurred = createBlurredBackground(displayBmp)
+          targetLayer.blurPhoto.setImageBitmap(blurred)
+        }
+      } else {
+        targetLayer.blurPhoto.setImageDrawable(null)
       }
     } else {
       containerLp.width = MATCH
@@ -1649,7 +1653,7 @@ class PhotoFrameController(
 
     // Prepare incoming layer at 0 alpha and bring to front
     targetLayer.blurPhoto.alpha = 0f
-    targetLayer.blurPhoto.visibility = if (isFitMode) View.VISIBLE else View.GONE
+    targetLayer.blurPhoto.visibility = if (isFitMode && settings.blurBackground) View.VISIBLE else View.GONE
 
     targetLayer.frameContainer.alpha = 0f
     targetLayer.frameContainer.visibility = View.VISIBLE

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -215,6 +215,9 @@ object ScreensaverConfig {
       val dismissHaDashboard: String? = null,
       // Crop vertical (portrait) photos by ~20% (top & bottom) so they look less tall/panoramic.
       val cropVertical: Boolean = false,
+      // Fill letterbox sidebars in fit mode with a blurred copy of the photo. On by default.
+      // Turn off to show clean solid black bars (issue #199).
+      val blurBackground: Boolean = true,
   ) {
     /** True when the idle screen-off timeout is active. */
     val idleSleepOn: Boolean
@@ -316,11 +319,15 @@ object ScreensaverConfig {
         dismissAppComponent = p.getString("dismiss_app_component", null),
         dismissHaDashboard = p.getString("dismiss_ha_dashboard", null),
         cropVertical = p.getBoolean("crop_vertical", false),
+        blurBackground = p.getBoolean("blur_background", true),
     )
   }
 
   fun setCropVertical(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("crop_vertical", on).apply()
+
+  fun setBlurBackground(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("blur_background", on).apply()
 
   fun setSoundscape(c: Context, s: String) = prefs(c).edit().putString("soundscape", s).apply()
 

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -263,6 +263,12 @@ object SettingsDomains {
                       get = { it.cropVertical },
                       set = ScreensaverConfig::setCropVertical,
                       help = "Trims ~20% off the top and bottom of portrait photos so they look less tall and narrow."),
+                  BoolSpec(
+                      "blurBackground",
+                      "Blur photo background",
+                      get = { it.blurBackground },
+                      set = ScreensaverConfig::setBlurBackground,
+                      help = "Fills letterbox sidebars in fit mode with a blurred copy of the photo instead of solid black."),
                   // On-device cache: only meaningful for a network source that re-fetches the same
                   // assets every loop (Immich / WebDAV). Hidden for a local folder or the built-in
                   // feed, where there's nothing to save a round-trip on.


### PR DESCRIPTION
Adds a `blurBackground` toggle setting to the screensaver (on by default) so users can choose between letterbox background blur or clean solid black bars (closes #199).

### What it does:
- **`ScreensaverConfig` & `SettingsDomains`**: Adds `blurBackground` (boolean, defaults `true`) exposed to both on-device settings and remote.
- **`PhotoFrameController`**: When `blurBackground` is `false`, hides `blurPhoto` and skips blur CPU calculation, leaving solid black sidebars behind fit/portrait photos.
- Tested and verified on physical Meta Portal hardware.