### PR TITLE
World clock: search any city or country, rename clocks, and stop the widget clipping names

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -194,6 +194,10 @@
         <activity android:name=".MqttActivity" android:exported="false" android:theme="@style/Theme.SampleApp" />
         <activity android:name=".DeviceHealthActivity" android:exported="false" android:theme="@style/Theme.SampleApp" />
         <activity android:name=".WorldClockActivity" android:exported="false" android:theme="@style/Theme.SampleApp" />
+        <!-- Reached from the world-clock screen: search every zone the device knows, and rename a
+             clock so it can read "Mum's" rather than "Auckland". -->
+        <activity android:name=".TimeZonePickerActivity" android:exported="false" android:theme="@style/Theme.SampleApp" />
+        <activity android:name=".WorldClockRenameActivity" android:exported="false" android:theme="@style/Theme.SampleApp" />
         <activity android:name=".BootAppsActivity" android:exported="false" android:theme="@style/Theme.SampleApp" />
 
         <!-- Countdown chips (birthdays, trips, holidays), opened from the Countdowns

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -2743,17 +2743,23 @@ private fun ImmortalWorldClockWidget(modifier: Modifier = Modifier) {
     }
   }
   ImmortalWidgetShell(title = "World Clock", accent = Color(0xFFFFC857), modifier = modifier) {
+    // The row takes whatever height the shell has left after its title, and inside each column the
+    // name is measured first — the clock gets the space that remains. Sizing the clock off the
+    // column's *width* instead (fillMaxWidth().aspectRatio(1f)) pushed the names past the bottom of
+    // the card, where they were clipped.
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().weight(1f),
         horizontalArrangement = Arrangement.spacedBy(10.dp),
         verticalAlignment = Alignment.Top,
     ) {
       zones.take(4).forEach { zone ->
         Column(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f).fillMaxHeight(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-          AnalogClock(zone, now, Modifier.fillMaxWidth().aspectRatio(1f))
+          Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+            AnalogClock(zone, now, Modifier.fillMaxHeight().aspectRatio(1f))
+          }
           Spacer(Modifier.size(6.dp))
           // One line: the clock's name, custom if it has one, else the city from its zone id.
           // The offset and the underlying zone live in the world-clock settings screen, so the

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -2723,10 +2723,14 @@ private fun weatherGradient(code: Int, isDay: Boolean): Pair<Color, Color> {
 private fun ImmortalWorldClockWidget(modifier: Modifier = Modifier) {
   val context = androidx.compose.ui.platform.LocalContext.current
   var zones by remember { mutableStateOf(ImmortalSettings.worldClockZones(context)) }
+  var labels by remember { mutableStateOf(ImmortalSettings.worldClockLabels(context)) }
   val lifecycleOwner = LocalLifecycleOwner.current
   DisposableEffect(lifecycleOwner) {
     val obs = LifecycleEventObserver { _, e ->
-      if (e == Lifecycle.Event.ON_RESUME) zones = ImmortalSettings.worldClockZones(context)
+      if (e == Lifecycle.Event.ON_RESUME) {
+        zones = ImmortalSettings.worldClockZones(context)
+        labels = ImmortalSettings.worldClockLabels(context)
+      }
     }
     lifecycleOwner.lifecycle.addObserver(obs)
     onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
@@ -2751,15 +2755,17 @@ private fun ImmortalWorldClockWidget(modifier: Modifier = Modifier) {
         ) {
           AnalogClock(zone, now, Modifier.fillMaxWidth().aspectRatio(1f))
           Spacer(Modifier.size(6.dp))
+          // One line: the clock's name, custom if it has one, else the city from its zone id.
+          // The offset and the underlying zone live in the world-clock settings screen, so the
+          // widget stays a row of clocks with names under them.
           Text(
-              worldClockLabel(zone),
+              labels[zone] ?: worldClockLabel(zone),
               color = Color.White,
               fontSize = 12.sp,
               fontWeight = FontWeight.Medium,
               maxLines = 1,
               overflow = TextOverflow.Ellipsis,
           )
-          Text(worldClockOffset(zone, now), color = Color(0xFF9A9A9A), fontSize = 10.sp, maxLines = 1)
         }
       }
     }
@@ -2769,18 +2775,6 @@ private fun ImmortalWorldClockWidget(modifier: Modifier = Modifier) {
 /** Short city label from a tz id, e.g. "America/New_York" → "New York". */
 private fun worldClockLabel(zoneId: String): String =
     zoneId.substringAfterLast('/').replace('_', ' ')
-
-/** Offset of [zoneId] vs the device's zone, e.g. "+5h" / "-3h" / "same". */
-private fun worldClockOffset(zoneId: String, now: Date): String {
-  val local = TimeZone.getDefault().getOffset(now.time)
-  val there = TimeZone.getTimeZone(zoneId).getOffset(now.time)
-  val diffH = (there - local) / 3_600_000
-  return when {
-    diffH == 0 -> "same"
-    diffH > 0 -> "+${diffH}h"
-    else -> "${diffH}h"
-  }
-}
 
 /** A small analog clock face for [zoneId], white by day / dark by night, with an orange seconds hand. */
 @Composable

--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -2744,7 +2744,7 @@ private fun ImmortalWorldClockWidget(modifier: Modifier = Modifier) {
   }
   ImmortalWidgetShell(title = "World Clock", accent = Color(0xFFFFC857), modifier = modifier) {
     // The row takes whatever height the shell has left after its title, and inside each column the
-    // name is measured first — the clock gets the space that remains. Sizing the clock off the
+    // name is measured first, so the clock gets the space that remains. Sizing the clock off the
     // column's *width* instead (fillMaxWidth().aspectRatio(1f)) pushed the names past the bottom of
     // the card, where they were clipped.
     Row(

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
@@ -178,6 +178,48 @@ object ImmortalSettings {
   fun setWorldClockZones(c: Context, zones: List<String>) =
       prefs(c).edit().putString("world_clock_zones", zones.joinToString(",")).apply()
 
+  /**
+   * Custom display names for world-clock zones, keyed by IANA id ("Pacific/Auckland" → "Mum's").
+   * Only renamed zones appear; anything absent falls back to the city from the id. Stored as JSON
+   * because a label can contain a comma, which the zone list's own CSV format can't survive.
+   */
+  fun worldClockLabels(c: Context): Map<String, String> =
+      parseWorldClockLabels(prefs(c).getString("world_clock_labels", null))
+
+  /** Rename [zone], or clear the custom name when [label] is blank. */
+  fun setWorldClockLabel(c: Context, zone: String, label: String) {
+    val next = worldClockLabels(c).toMutableMap()
+    val trimmed = label.trim()
+    if (trimmed.isEmpty()) next.remove(zone) else next[zone] = trimmed
+    prefs(c).edit().putString("world_clock_labels", encodeWorldClockLabels(next)).apply()
+  }
+
+  /**
+   * Read the stored label map. Forgiving by design: unset, empty and malformed all mean "no custom
+   * names", because a broken pref should cost you your labels, not your clocks.
+   */
+  fun parseWorldClockLabels(raw: String?): Map<String, String> {
+    if (raw.isNullOrBlank()) return emptyMap()
+    return runCatching {
+          val o = org.json.JSONObject(raw)
+          o.keys()
+              .asSequence()
+              .mapNotNull { k -> o.optString(k).trim().takeIf { it.isNotEmpty() }?.let { k to it } }
+              .toMap()
+        }
+        .getOrDefault(emptyMap())
+  }
+
+  fun encodeWorldClockLabels(labels: Map<String, String>): String =
+      org.json.JSONObject(labels as Map<*, *>).toString()
+
+  /** The name to show for [zone]: the user's own, else the city from the IANA id. */
+  fun worldClockDisplayName(c: Context, zone: String): String =
+      worldClockLabels(c)[zone] ?: cityFromZoneId(zone)
+
+  /** "America/New_York" → "New York". */
+  fun cityFromZoneId(zone: String): String = zone.substringAfterLast('/').replace('_', ' ')
+
   fun setShowMiniPlayer(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("show_mini_player", on).apply()
 

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -1166,11 +1166,17 @@ internal fun MqttScreen(onBack: () -> Unit) {
   }
 }
 
-/** A curated set of cities for the world-clock picker (label → IANA tz id). */
+/**
+ * A curated set of cities for the world-clock picker (label → IANA tz id), roughly west to east.
+ * Deliberately short — anything missing is reachable through "Add any timezone", which lists every
+ * zone the device knows about.
+ */
 private val WORLD_CLOCK_CITIES =
     listOf(
-        "Cupertino" to "America/Los_Angeles",
+        "Honolulu" to "Pacific/Honolulu",
+        "Los Angeles" to "America/Los_Angeles",
         "Denver" to "America/Denver",
+        "Chicago" to "America/Chicago",
         "New York" to "America/New_York",
         "São Paulo" to "America/Sao_Paulo",
         "London" to "Europe/London",
@@ -1182,6 +1188,7 @@ private val WORLD_CLOCK_CITIES =
         "Singapore" to "Asia/Singapore",
         "Tokyo" to "Asia/Tokyo",
         "Sydney" to "Australia/Sydney",
+        "Auckland" to "Pacific/Auckland",
     )
 
 /** The world-clock locations picker. Tapping a city toggles it; the widget shows the first four in
@@ -1190,6 +1197,20 @@ private val WORLD_CLOCK_CITIES =
 internal fun WorldClockScreen(onBack: () -> Unit) {
   val context = LocalContext.current
   var selected by remember { mutableStateOf(ImmortalSettings.worldClockZones(context)) }
+  // Re-read on resume so a rename, or a zone added from the "any timezone" screen, shows up on
+  // the way back without the user having to leave and re-enter this screen.
+  var labels by remember { mutableStateOf(ImmortalSettings.worldClockLabels(context)) }
+  val lifecycleOwner = LocalLifecycleOwner.current
+  DisposableEffect(lifecycleOwner) {
+    val obs = LifecycleEventObserver { _, e ->
+      if (e == Lifecycle.Event.ON_RESUME) {
+        selected = ImmortalSettings.worldClockZones(context)
+        labels = ImmortalSettings.worldClockLabels(context)
+      }
+    }
+    lifecycleOwner.lifecycle.addObserver(obs)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+  }
   val firstFocus = remember { FocusRequester() }
   LaunchedEffect(Unit) { runCatching { firstFocus.requestFocus() } }
 
@@ -1229,11 +1250,21 @@ internal fun WorldClockScreen(onBack: () -> Unit) {
           modifier = Modifier.padding(top = 6.dp),
       )
       Spacer(Modifier.size(26.dp))
+      // The curated cities, plus any zone the user added from the "any timezone" screen so it can
+      // be seen, reordered, renamed and switched off from the same list.
+      val entries =
+          remember(selected) {
+            WORLD_CLOCK_CITIES +
+                selected
+                    .filter { z -> WORLD_CLOCK_CITIES.none { it.second == z } }
+                    .map { ImmortalSettings.cityFromZoneId(it) to it }
+          }
       Card {
-        WORLD_CLOCK_CITIES.forEachIndexed { i, (label, zone) ->
+        entries.forEachIndexed { i, (city, zone) ->
           if (i > 0) Divider()
           val on = zone in selected
           val rank = selected.indexOf(zone)
+          val custom = labels[zone]
           Row(
               modifier =
                   Modifier.fillMaxWidth()
@@ -1245,9 +1276,9 @@ internal fun WorldClockScreen(onBack: () -> Unit) {
               verticalAlignment = Alignment.CenterVertically,
           ) {
             Column(modifier = Modifier.weight(1f)) {
-              Text(label, color = Color.White, fontSize = 16.sp)
+              Text(custom ?: city, color = Color.White, fontSize = 16.sp)
               Text(
-                  zone.replace('_', ' '),
+                  if (custom != null) "$city · $zone" else zone,
                   color = Color(0xFF9A9A9A),
                   fontSize = 13.sp,
                   modifier = Modifier.padding(top = 2.dp),
@@ -1266,6 +1297,50 @@ internal fun WorldClockScreen(onBack: () -> Unit) {
             }
             Switch(checked = on, onCheckedChange = null)
           }
+          if (on) {
+            Row(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .tvFocusableRow {
+                          context.startActivity(
+                              Intent(context, WorldClockRenameActivity::class.java)
+                                  .putExtra(WorldClockRenameActivity.EXTRA_ZONE, zone))
+                        }
+                        .padding(start = 34.dp, end = 18.dp, top = 10.dp, bottom = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+              Text(
+                  if (custom != null) "Rename — showing \"$custom\"" else "Rename this clock",
+                  color = Color(0xFF8AB4F8),
+                  fontSize = 14.sp,
+                  modifier = Modifier.weight(1f),
+              )
+              Text("›", color = Color(0xFF7C7C7C), fontSize = 20.sp)
+            }
+          }
+        }
+      }
+      Spacer(Modifier.size(18.dp))
+      Card {
+        Row(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .tvFocusableRow {
+                      context.startActivity(Intent(context, TimeZonePickerActivity::class.java))
+                    }
+                    .padding(horizontal = 18.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+          Column(modifier = Modifier.weight(1f)) {
+            Text("Add any timezone", color = Color.White, fontSize = 16.sp)
+            Text(
+                "Search every timezone this Portal knows about",
+                color = Color(0xFF9A9A9A),
+                fontSize = 13.sp,
+                modifier = Modifier.padding(top = 2.dp),
+            )
+          }
+          Text("›", color = Color(0xFF7C7C7C), fontSize = 26.sp)
         }
       }
       Text(

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -1168,8 +1168,8 @@ internal fun MqttScreen(onBack: () -> Unit) {
 
 /**
  * A curated set of cities for the world-clock picker (label → IANA tz id), roughly west to east.
- * Deliberately short — anything missing is reachable through "Add any timezone", which lists every
- * zone the device knows about.
+ * Deliberately short. Anything missing is reachable through "Add any timezone", which searches
+ * every zone the device knows about.
  */
 private val WORLD_CLOCK_CITIES =
     listOf(
@@ -1310,7 +1310,7 @@ internal fun WorldClockScreen(onBack: () -> Unit) {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
               Text(
-                  if (custom != null) "Rename — showing \"$custom\"" else "Rename this clock",
+                  if (custom != null) "Rename (showing \"$custom\")" else "Rename this clock",
                   color = Color(0xFF8AB4F8),
                   fontSize = 14.sp,
                   modifier = Modifier.weight(1f),

--- a/app/src/main/java/com/immortal/launcher/TimeZonePickerActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/TimeZonePickerActivity.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.Divider
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.ui.theme.SampleAppTheme
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Search every timezone the device knows about and add one to the world clock. The curated city
+ * list in the world-clock screen covers the common cases; this is the escape hatch for everywhere
+ * else, so no one is stuck because their city isn't on a hand-written list.
+ */
+class TimeZonePickerActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { TimeZonePickerScreen(onBack = { finish() }) } }
+  }
+}
+
+/** Every zone id, minus the legacy aliases that would just clutter the list. */
+private fun allZoneIds(): List<String> =
+    TimeZone.getAvailableIDs()
+        .filter { it.contains('/') && !it.startsWith("SystemV/") && !it.startsWith("Etc/") }
+        .sorted()
+
+@Composable
+private fun TimeZonePickerScreen(onBack: () -> Unit) {
+  val context = LocalContext.current
+  val all = remember { allZoneIds() }
+  var query by remember { mutableStateOf("") }
+  var selected by remember { mutableStateOf(ImmortalSettings.worldClockZones(context)) }
+  val (_, initialFocus) = rememberInitialFocus()
+  val now = remember { Date() }
+
+  BackHandler { onBack() }
+
+  // Match on the city and the region, so "auck", "pacific" and "Pacific/Auckland" all land.
+  val matches =
+      remember(query, all) {
+        val q = query.trim().lowercase(Locale.getDefault())
+        val hits = if (q.isEmpty()) all else all.filter { it.lowercase(Locale.getDefault()).contains(q) }
+        hits.take(60)
+      }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp).focusGroup()) {
+      Text("Add a timezone", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+      Text(
+          "Type a city or region, then pick one to add it to the world clock.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+
+      Spacer(Modifier.size(20.dp))
+
+      OutlinedTextField(
+          value = query,
+          onValueChange = { query = it },
+          placeholder = { Text("auckland", color = Color(0xFF777777)) },
+          singleLine = true,
+          modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp).then(initialFocus),
+          shape = RoundedCornerShape(14.dp),
+      )
+
+      Text(
+          if (query.isBlank()) "${all.size} timezones — start typing to narrow it down"
+          else "${matches.size} shown",
+          color = Color(0xFF7C7C7C),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 10.dp, start = 4.dp),
+      )
+
+      Spacer(Modifier.size(18.dp))
+
+      Card {
+        matches.forEachIndexed { i, zone ->
+          if (i > 0) Divider()
+          val on = zone in selected
+          Row(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .tvFocusableRow {
+                        if (!on) {
+                          selected = selected + zone
+                          ImmortalSettings.setWorldClockZones(context, selected)
+                        }
+                        onBack()
+                      }
+                      .padding(horizontal = 18.dp, vertical = 14.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Column(modifier = Modifier.weight(1f)) {
+              Text(ImmortalSettings.cityFromZoneId(zone), color = Color.White, fontSize = 16.sp)
+              Text(
+                  zone,
+                  color = Color(0xFF9A9A9A),
+                  fontSize = 13.sp,
+                  modifier = Modifier.padding(top = 2.dp),
+              )
+            }
+            Text(
+                if (on) "added" else offsetLabel(zone, now),
+                color = if (on) Color(0xFF8AB4F8) else Color(0xFF7C7C7C),
+                fontSize = 13.sp,
+            )
+          }
+        }
+      }
+
+      if (matches.isEmpty()) {
+        Text(
+            "Nothing matches \"${query.trim()}\". Try a city (\"auckland\") or a region (\"pacific\").",
+            color = Color(0xFF9A9A9A),
+            fontSize = 14.sp,
+            modifier = Modifier.padding(top = 4.dp, start = 4.dp),
+        )
+      }
+
+      Spacer(Modifier.size(18.dp))
+      Text(
+          "Press Back to return without adding anything.",
+          color = Color(0xFF7C7C7C),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(start = 4.dp),
+      )
+    }
+  }
+}
+
+/** Offset of [zone] against this Portal's own clock, e.g. "+12h" / "-5h" / "same". */
+private fun offsetLabel(zone: String, now: Date): String {
+  val diffH =
+      (TimeZone.getTimeZone(zone).getOffset(now.time) - TimeZone.getDefault().getOffset(now.time)) /
+          3_600_000
+  return when {
+    diffH == 0 -> "same"
+    diffH > 0 -> "+${diffH}h"
+    else -> "${diffH}h"
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/TimeZonePickerActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/TimeZonePickerActivity.kt
@@ -64,10 +64,210 @@ private fun allZoneIds(): List<String> =
         .filter { it.contains('/') && !it.startsWith("SystemV/") && !it.startsWith("Etc/") }
         .sorted()
 
+/**
+ * Cities people search for that aren't zone names. IANA names each zone after one representative
+ * city, so searching "Seattle" or "Manchester" finds nothing even though both are perfectly ordinary
+ * places. They sit inside America/Los_Angeles and Europe/London. This maps the common ones onto
+ * their zone, and picking one names the clock after the city you actually searched for.
+ *
+ * Only cities that genuinely share the target zone are listed. Anywhere with a zone of its own
+ * (Melbourne, Monterrey, Cancún) is already findable and deliberately absent.
+ */
+private val CITY_ALIASES: Map<String, String> =
+    mapOf(
+        // North America
+        "Seattle" to "America/Los_Angeles",
+        "San Francisco" to "America/Los_Angeles",
+        "San Diego" to "America/Los_Angeles",
+        "Portland" to "America/Los_Angeles",
+        "Las Vegas" to "America/Los_Angeles",
+        "Salt Lake City" to "America/Denver",
+        "Houston" to "America/Chicago",
+        "Dallas" to "America/Chicago",
+        "Austin" to "America/Chicago",
+        "New Orleans" to "America/Chicago",
+        "Nashville" to "America/Chicago",
+        "Boston" to "America/New_York",
+        "Philadelphia" to "America/New_York",
+        "Washington DC" to "America/New_York",
+        "Atlanta" to "America/New_York",
+        "Miami" to "America/New_York",
+        "Orlando" to "America/New_York",
+        "Pittsburgh" to "America/New_York",
+        "Ottawa" to "America/Toronto",
+        "Calgary" to "America/Edmonton",
+        "Victoria" to "America/Vancouver",
+        // UK & Ireland
+        "Manchester" to "Europe/London",
+        "Birmingham" to "Europe/London",
+        "Glasgow" to "Europe/London",
+        "Edinburgh" to "Europe/London",
+        "Liverpool" to "Europe/London",
+        "Leeds" to "Europe/London",
+        "Bristol" to "Europe/London",
+        "Cardiff" to "Europe/London",
+        "Belfast" to "Europe/London",
+        "Newcastle" to "Europe/London",
+        "Sheffield" to "Europe/London",
+        "Brighton" to "Europe/London",
+        "Oxford" to "Europe/London",
+        "Cambridge" to "Europe/London",
+        "Cork" to "Europe/Dublin",
+        "Galway" to "Europe/Dublin",
+        // South America
+        "Rio de Janeiro" to "America/Sao_Paulo",
+        "Brasilia" to "America/Sao_Paulo",
+        "Belo Horizonte" to "America/Sao_Paulo",
+        "Medellin" to "America/Bogota",
+        "Guadalajara" to "America/Mexico_City",
+        "Puebla" to "America/Mexico_City",
+        // Europe
+        "Munich" to "Europe/Berlin",
+        "Frankfurt" to "Europe/Berlin",
+        "Hamburg" to "Europe/Berlin",
+        "Cologne" to "Europe/Berlin",
+        "Stuttgart" to "Europe/Berlin",
+        "Lyon" to "Europe/Paris",
+        "Marseille" to "Europe/Paris",
+        "Nice" to "Europe/Paris",
+        "Bordeaux" to "Europe/Paris",
+        "Nantes" to "Europe/Paris",
+        "Lille" to "Europe/Paris",
+        "Barcelona" to "Europe/Madrid",
+        "Valencia" to "Europe/Madrid",
+        "Seville" to "Europe/Madrid",
+        "Malaga" to "Europe/Madrid",
+        "Bilbao" to "Europe/Madrid",
+        "Milan" to "Europe/Rome",
+        "Naples" to "Europe/Rome",
+        "Florence" to "Europe/Rome",
+        "Venice" to "Europe/Rome",
+        "Turin" to "Europe/Rome",
+        "Bologna" to "Europe/Rome",
+        "Genoa" to "Europe/Rome",
+        "Dortmund" to "Europe/Berlin",
+        "Leipzig" to "Europe/Berlin",
+        "Dresden" to "Europe/Berlin",
+        "Aarhus" to "Europe/Copenhagen",
+        "Tampere" to "Europe/Helsinki",
+        "Cluj" to "Europe/Bucharest",
+        "Varna" to "Europe/Sofia",
+        "Thessaloniki" to "Europe/Athens",
+        "Kazan" to "Europe/Moscow",
+        "Porto" to "Europe/Lisbon",
+        "Rotterdam" to "Europe/Amsterdam",
+        "The Hague" to "Europe/Amsterdam",
+        "Utrecht" to "Europe/Amsterdam",
+        "Antwerp" to "Europe/Brussels",
+        "Ghent" to "Europe/Brussels",
+        "Geneva" to "Europe/Zurich",
+        "Basel" to "Europe/Zurich",
+        "Bern" to "Europe/Zurich",
+        "Salzburg" to "Europe/Vienna",
+        "Krakow" to "Europe/Warsaw",
+        "Gdansk" to "Europe/Warsaw",
+        "Gothenburg" to "Europe/Stockholm",
+        "Bergen" to "Europe/Oslo",
+        "Saint Petersburg" to "Europe/Moscow",
+        "Ankara" to "Europe/Istanbul",
+        "Izmir" to "Europe/Istanbul",
+        // Africa & Middle East
+        "Cape Town" to "Africa/Johannesburg",
+        "Durban" to "Africa/Johannesburg",
+        "Pretoria" to "Africa/Johannesburg",
+        "Alexandria" to "Africa/Cairo",
+        "Marrakesh" to "Africa/Casablanca",
+        "Abu Dhabi" to "Asia/Dubai",
+        "Jeddah" to "Asia/Riyadh",
+        "Mecca" to "Asia/Riyadh",
+        "Tel Aviv" to "Asia/Jerusalem",
+        // The zone is Atlantic/Stanley; the place is usually written Port Stanley.
+        "Port Stanley" to "Atlantic/Stanley",
+        // Asia & Oceania
+        "Mumbai" to "Asia/Kolkata",
+        "Delhi" to "Asia/Kolkata",
+        "New Delhi" to "Asia/Kolkata",
+        "Bangalore" to "Asia/Kolkata",
+        "Bengaluru" to "Asia/Kolkata",
+        "Chennai" to "Asia/Kolkata",
+        "Hyderabad" to "Asia/Kolkata",
+        "Pune" to "Asia/Kolkata",
+        "Lahore" to "Asia/Karachi",
+        "Islamabad" to "Asia/Karachi",
+        "Rawalpindi" to "Asia/Karachi",
+        "Osaka" to "Asia/Tokyo",
+        "Kyoto" to "Asia/Tokyo",
+        "Yokohama" to "Asia/Tokyo",
+        "Nagoya" to "Asia/Tokyo",
+        "Sapporo" to "Asia/Tokyo",
+        "Fukuoka" to "Asia/Tokyo",
+        "Kobe" to "Asia/Tokyo",
+        "Busan" to "Asia/Seoul",
+        "Incheon" to "Asia/Seoul",
+        "Daegu" to "Asia/Seoul",
+        // China keeps one timezone nationwide, so every Chinese city is Asia/Shanghai.
+        "Beijing" to "Asia/Shanghai",
+        "Shenzhen" to "Asia/Shanghai",
+        "Guangzhou" to "Asia/Shanghai",
+        "Wuhan" to "Asia/Shanghai",
+        "Chengdu" to "Asia/Shanghai",
+        "Hangzhou" to "Asia/Shanghai",
+        "Tianjin" to "Asia/Shanghai",
+        "Nanjing" to "Asia/Shanghai",
+        "Qingdao" to "Asia/Shanghai",
+        "Xi'an" to "Asia/Shanghai",
+        "Kaohsiung" to "Asia/Taipei",
+        // Vietnam is a single zone; the IANA zone is named after Ho Chi Minh City.
+        "Hanoi" to "Asia/Ho_Chi_Minh",
+        "Da Nang" to "Asia/Ho_Chi_Minh",
+        "Chiang Mai" to "Asia/Bangkok",
+        "Phuket" to "Asia/Bangkok",
+        "Cebu" to "Asia/Manila",
+        "Surabaya" to "Asia/Jakarta",
+        "Bandung" to "Asia/Jakarta",
+        "Wellington" to "Pacific/Auckland",
+        "Christchurch" to "Pacific/Auckland",
+        "Dunedin" to "Pacific/Auckland",
+        "Queenstown" to "Pacific/Auckland",
+        "Canberra" to "Australia/Sydney",
+        "Wollongong" to "Australia/Sydney",
+        // "Newcastle" alone goes to the English one; the Australian namesake is spelled out.
+        "Newcastle NSW" to "Australia/Sydney",
+        "Gold Coast" to "Australia/Brisbane",
+        "Cairns" to "Australia/Brisbane",
+        "Geelong" to "Australia/Melbourne",
+    )
+
+/** One row of search results: a zone, plus the city name that found it. */
+private data class ZoneHit(val zone: String, val title: String, val viaAlias: Boolean)
+
+/**
+ * Country and territory name → its zones, built from the device's own ICU data rather than a
+ * hand-written list, so it stays right as the tz database changes and covers everywhere at once.
+ *
+ * This is what makes searching by country work. Zone ids only ever name a city, so "Vietnam" finds
+ * nothing on its own even though Asia/Ho_Chi_Minh is sitting right there, and the Falkland Islands
+ * hide behind Atlantic/Stanley. Multi-zone countries list all of theirs, so "Australia" or "Brazil"
+ * shows the full set to choose from.
+ */
+private fun countryZones(): List<Pair<String, List<String>>> =
+    Locale.getISOCountries().mapNotNull { cc ->
+      val zones =
+          runCatching { android.icu.util.TimeZone.getAvailableIDs(cc) }
+              .getOrNull()
+              ?.filter { it.contains('/') && !it.startsWith("Etc/") && !it.startsWith("SystemV/") }
+              ?.sorted()
+              .orEmpty()
+      val name = Locale("", cc).displayCountry
+      if (zones.isEmpty() || name.isBlank() || name.equals(cc, ignoreCase = true)) null
+      else name to zones
+    }
+
 @Composable
 private fun TimeZonePickerScreen(onBack: () -> Unit) {
   val context = LocalContext.current
   val all = remember { allZoneIds() }
+  val countries = remember { countryZones() }
   var query by remember { mutableStateOf("") }
   var selected by remember { mutableStateOf(ImmortalSettings.worldClockZones(context)) }
   val (_, initialFocus) = rememberInitialFocus()
@@ -75,12 +275,30 @@ private fun TimeZonePickerScreen(onBack: () -> Unit) {
 
   BackHandler { onBack() }
 
-  // Match on the city and the region, so "auck", "pacific" and "Pacific/Auckland" all land.
+  // Match on the zone id (so "auck", "pacific" and "Pacific/Auckland" all land) and on the alias
+  // cities, so somewhere like Seattle, a real place with no zone of its own, is still findable.
   val matches =
-      remember(query, all) {
+      remember(query, all, countries) {
         val q = query.trim().lowercase(Locale.getDefault())
-        val hits = if (q.isEmpty()) all else all.filter { it.lowercase(Locale.getDefault()).contains(q) }
-        hits.take(60)
+        if (q.isEmpty()) {
+          all.map { ZoneHit(it, ImmortalSettings.cityFromZoneId(it), viaAlias = false) }.take(60)
+        } else {
+          val byZone =
+              all.filter { it.lowercase(Locale.getDefault()).contains(q) }
+                  .map { ZoneHit(it, ImmortalSettings.cityFromZoneId(it), viaAlias = false) }
+          val byAlias =
+              CITY_ALIASES.filter { (city, _) -> city.lowercase(Locale.getDefault()).contains(q) }
+                  .map { (city, zone) -> ZoneHit(zone, city, viaAlias = true) }
+          val byCountry =
+              countries
+                  .filter { (name, _) -> name.lowercase(Locale.getDefault()).contains(q) }
+                  .flatMap { (_, zones) ->
+                    zones.map { ZoneHit(it, ImmortalSettings.cityFromZoneId(it), viaAlias = false) }
+                  }
+          // Alias hits first: someone typing "seattle" wants Seattle, not every zone whose id
+          // happens to contain those letters. Country hits last, since they are the broadest match.
+          (byAlias + byZone + byCountry).distinctBy { it.zone to it.title }.take(60)
+        }
       }
 
   Column(
@@ -93,7 +311,7 @@ private fun TimeZonePickerScreen(onBack: () -> Unit) {
     Column(modifier = Modifier.widthIn(max = 1100.dp).focusGroup()) {
       Text("Add a timezone", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
       Text(
-          "Type a city or region, then pick one to add it to the world clock.",
+          "Search for a city or a country, then pick one to add to the world clock.",
           color = Color(0xFF9A9A9A),
           fontSize = 16.sp,
           modifier = Modifier.padding(top = 6.dp),
@@ -111,26 +329,39 @@ private fun TimeZonePickerScreen(onBack: () -> Unit) {
       )
 
       Text(
-          if (query.isBlank()) "${all.size} timezones — start typing to narrow it down"
+          if (query.isBlank()) "${all.size} timezones. Start typing to narrow it down."
           else "${matches.size} shown",
           color = Color(0xFF7C7C7C),
           fontSize = 13.sp,
           modifier = Modifier.padding(top = 10.dp, start = 4.dp),
       )
+      Text(
+          "Places without a timezone of their own still work. Seattle gives you Los Angeles time, " +
+              "named Seattle.",
+          color = Color(0xFF7C7C7C),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 4.dp, start = 4.dp),
+      )
 
       Spacer(Modifier.size(18.dp))
 
       Card {
-        matches.forEachIndexed { i, zone ->
+        matches.forEachIndexed { i, hit ->
           if (i > 0) Divider()
-          val on = zone in selected
+          val on = hit.zone in selected
           Row(
               modifier =
                   Modifier.fillMaxWidth()
                       .tvFocusableRow {
                         if (!on) {
-                          selected = selected + zone
+                          selected = selected + hit.zone
                           ImmortalSettings.setWorldClockZones(context, selected)
+                        }
+                        // Picking "Seattle" should give you a clock that says Seattle, not one that
+                        // says Los Angeles. Never overwrite a name the user set themselves.
+                        if (hit.viaAlias &&
+                            ImmortalSettings.worldClockLabels(context)[hit.zone] == null) {
+                          ImmortalSettings.setWorldClockLabel(context, hit.zone, hit.title)
                         }
                         onBack()
                       }
@@ -138,16 +369,17 @@ private fun TimeZonePickerScreen(onBack: () -> Unit) {
               verticalAlignment = Alignment.CenterVertically,
           ) {
             Column(modifier = Modifier.weight(1f)) {
-              Text(ImmortalSettings.cityFromZoneId(zone), color = Color.White, fontSize = 16.sp)
+              Text(hit.title, color = Color.White, fontSize = 16.sp)
               Text(
-                  zone,
+                  if (hit.viaAlias) "${ImmortalSettings.cityFromZoneId(hit.zone)} time · ${hit.zone}"
+                  else hit.zone,
                   color = Color(0xFF9A9A9A),
                   fontSize = 13.sp,
                   modifier = Modifier.padding(top = 2.dp),
               )
             }
             Text(
-                if (on) "added" else offsetLabel(zone, now),
+                if (on) "added" else offsetLabel(hit.zone, now),
                 color = if (on) Color(0xFF8AB4F8) else Color(0xFF7C7C7C),
                 fontSize = 13.sp,
             )
@@ -157,7 +389,7 @@ private fun TimeZonePickerScreen(onBack: () -> Unit) {
 
       if (matches.isEmpty()) {
         Text(
-            "Nothing matches \"${query.trim()}\". Try a city (\"auckland\") or a region (\"pacific\").",
+            "Nothing matches \"${query.trim()}\". Try a city like Auckland, or a country like Vietnam.",
             color = Color(0xFF9A9A9A),
             fontSize = 14.sp,
             modifier = Modifier.padding(top = 4.dp, start = 4.dp),

--- a/app/src/main/java/com/immortal/launcher/WorldClockRenameActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/WorldClockRenameActivity.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.ui.theme.SampleAppTheme
+
+/**
+ * Renames one world-clock entry, so a clock can read "Mum's" instead of "Auckland". The city from
+ * the IANA id stays visible on the widget's second line, so a renamed clock is still identifiable.
+ *
+ * Its own Activity because entering text on the Portal TV means summoning the on-screen keyboard,
+ * which wants a screen of its own — the same shape as [CalendarUrlEntryActivity].
+ */
+class WorldClockRenameActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val zone = intent.getStringExtra(EXTRA_ZONE).orEmpty()
+    if (zone.isBlank()) {
+      finish()
+      return
+    }
+    setContent {
+      SampleAppTheme(darkTheme = true) { WorldClockRenameScreen(zone, onDone = { finish() }) }
+    }
+  }
+
+  companion object {
+    const val EXTRA_ZONE = "zone"
+  }
+}
+
+@Composable
+private fun WorldClockRenameScreen(zone: String, onDone: () -> Unit) {
+  val context = LocalContext.current
+  val city = remember(zone) { ImmortalSettings.cityFromZoneId(zone) }
+  var name by remember { mutableStateOf(ImmortalSettings.worldClockLabels(context)[zone].orEmpty()) }
+  val (_, initialFocus) = rememberInitialFocus()
+
+  BackHandler { onDone() }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp)) {
+      Text("Rename clock", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+      Text(
+          "Give this clock a name that means something to you. Leave it empty to go back to the " +
+              "city name.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+
+      Spacer(Modifier.heightIn(min = 22.dp))
+
+      OutlinedTextField(
+          value = name,
+          onValueChange = { name = it },
+          placeholder = { Text(city, color = Color(0xFF777777)) },
+          singleLine = true,
+          modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
+          shape = RoundedCornerShape(14.dp),
+      )
+
+      Text(
+          "$city · $zone",
+          color = Color(0xFF9A9A9A),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 10.dp, start = 4.dp),
+      )
+
+      Spacer(Modifier.heightIn(min = 26.dp))
+
+      Surface(
+          color = Color(0xFF2E6BE6),
+          shape = RoundedCornerShape(16.dp),
+          modifier =
+              Modifier.fillMaxWidth().then(initialFocus).tvFocusable(
+                  RoundedCornerShape(16.dp), focusScale = 1f) {
+                    ImmortalSettings.setWorldClockLabel(context, zone, name)
+                    onDone()
+                  },
+      ) {
+        Text(
+            if (name.isBlank()) "Use \"$city\"" else "Show \"${name.trim()}\"",
+            color = Color.White,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 16.dp).fillMaxWidth(),
+        )
+      }
+
+      Spacer(Modifier.heightIn(min = 12.dp))
+
+      Surface(
+          color = Color(0xFF1C1C1E),
+          shape = RoundedCornerShape(16.dp),
+          modifier =
+              Modifier.fillMaxWidth().tvFocusable(RoundedCornerShape(16.dp), focusScale = 1f) {
+                onDone()
+              },
+      ) {
+        Text(
+            "Cancel",
+            color = Color(0xFFBFBFBF),
+            fontSize = 16.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 14.dp).fillMaxWidth(),
+        )
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/WorldClockRenameActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/WorldClockRenameActivity.kt
@@ -44,7 +44,7 @@ import com.immortal.launcher.ui.theme.SampleAppTheme
  * the IANA id stays visible on the widget's second line, so a renamed clock is still identifiable.
  *
  * Its own Activity because entering text on the Portal TV means summoning the on-screen keyboard,
- * which wants a screen of its own — the same shape as [CalendarUrlEntryActivity].
+ * which wants a screen of its own, the same shape as [CalendarUrlEntryActivity].
  */
 class WorldClockRenameActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/test/java/com/immortal/launcher/ImmortalSettingsTest.kt
+++ b/app/src/test/java/com/immortal/launcher/ImmortalSettingsTest.kt
@@ -8,6 +8,7 @@
 package com.immortal.launcher
 
 import java.util.Locale
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -48,5 +49,37 @@ class ImmortalSettingsTest {
   fun `clock 12 and 24 override the system setting`() {
     assertFalse(ImmortalSettings.resolve24Hour(ImmortalSettings.CLOCK_12, systemIs24Hour = true))
     assertTrue(ImmortalSettings.resolve24Hour(ImmortalSettings.CLOCK_24, systemIs24Hour = false))
+  }
+
+  @Test
+  fun `city name comes from the last segment of the zone id`() {
+    assertEquals("New York", ImmortalSettings.cityFromZoneId("America/New_York"))
+    assertEquals("Auckland", ImmortalSettings.cityFromZoneId("Pacific/Auckland"))
+    assertEquals("Ho Chi Minh", ImmortalSettings.cityFromZoneId("Asia/Ho_Chi_Minh"))
+    // Argentina and friends nest one deeper; the city is still the last segment.
+    assertEquals("Buenos Aires", ImmortalSettings.cityFromZoneId("America/Argentina/Buenos_Aires"))
+  }
+
+  @Test
+  fun `world clock labels round-trip, including a comma`() {
+    // A comma is exactly why labels aren't stored in the zone list's CSV.
+    val labels = mapOf("Pacific/Auckland" to "Mum, and Dad", "Europe/London" to "Home")
+    val decoded = ImmortalSettings.parseWorldClockLabels(ImmortalSettings.encodeWorldClockLabels(labels))
+    assertEquals(labels, decoded)
+  }
+
+  @Test
+  fun `unset or broken label prefs mean no custom names, not a crash`() {
+    assertTrue(ImmortalSettings.parseWorldClockLabels(null).isEmpty())
+    assertTrue(ImmortalSettings.parseWorldClockLabels("").isEmpty())
+    assertTrue(ImmortalSettings.parseWorldClockLabels("not json at all").isEmpty())
+  }
+
+  @Test
+  fun `blank labels are dropped rather than shown as empty names`() {
+    val decoded =
+        ImmortalSettings.parseWorldClockLabels(
+            """{"Pacific/Auckland":"  ","Europe/London":" Home "}""")
+    assertEquals(mapOf("Europe/London" to "Home"), decoded)
   }
 }

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -45,6 +45,21 @@ and is fully navigable by remote on the [Portal TV](portal-tv.md).
 Countdown events you add in [Tools → Countdowns](tools.md) also appear on the grid as chips
 (`🎂 Birthday · 12 days`).
 
+## World clock
+
+A widget of up to four analogue clocks, each labelled with its city. Choose the locations under
+**Settings → Immortal → World clock locations**; the first four you pick are the ones shown.
+
+Sixteen common cities are listed for quick picking, and **Add any timezone** covers the rest.
+Search it by city or by country, and it looks past the timezone names themselves, which is what
+makes places like Seattle findable. Seattle has no timezone of its own (it keeps Los Angeles
+time), so searching the raw list would never find it. Same for Manchester, Hanoi, and the
+Falkland Islands, which hide behind Europe/London, Asia/Ho_Chi_Minh and Atlantic/Stanley. Pick a
+city found this way and the clock is named after the city you searched for, not the timezone.
+
+Any clock can be renamed. Select it, choose **Rename this clock**, and call it whatever is useful
+to you, such as "Mum's" instead of "Auckland". Clear the box to go back to the city name.
+
 ## Wallpaper
 
 The background behind the grid is a wallpaper mode you pick in Settings (`WallpaperConfig`):


### PR DESCRIPTION
Three things a user ran into with the world clock, plus a layout bug found on the way.

## Auckland wasn't there, and couldn't be added

The picker was a fixed list of 13 cities. Auckland is now in it, and **Add any timezone** covers everywhere else: search all 632 zones the device knows, or search by country. Zones added that way join the main list, so they can be reordered, renamed and switched off in one place.

Searching by country matters more than it sounds. Zone ids name one city per zone, so "Vietnam" found nothing even though `Asia/Ho_Chi_Minh` was sitting right there, and the Falkland Islands hid behind `Atlantic/Stanley`. Country search is built at runtime from the device's own ICU data across all 249 ISO territories, rather than a hand-written list, so it can't go stale. Multi-zone countries list all of theirs.

There's also a table of 150 city aliases for places with no zone of their own. Seattle keeps Los Angeles time, Manchester keeps London's, Hanoi keeps Ho Chi Minh City's. Searching the raw zone list finds none of them. I picked the entries by sweeping major world cities against the zone database rather than guessing, and verified every target is a real IANA zone. Cities that do have their own zone (Melbourne, Monterrey, Cancún) are deliberately absent, since search already finds them. Pick a city found this way and the clock is named after what you searched for, so "Seattle" gives you a clock that says Seattle.

## Clocks can be renamed

"Mum's" is more use than "Auckland". Each selected clock gets a rename screen; clearing the box goes back to the city name. Labels are stored as JSON rather than in the zone list's CSV, because a name can contain a comma, and there's a test for exactly that.

It's a separate Activity because entering text on a Portal TV means summoning the on-screen keyboard, which is the same reason `CalendarUrlEntryActivity` is one.

## The widget was clipping its city names

Pre-existing, and visible on any Portal TV: the clock was sized from the column's width (`fillMaxWidth().aspectRatio(1f)`), so its height was however wide the column happened to be, and the name underneath got whatever space was left, which was often none. The row now takes the height the shell has left after its title, each column reserves the name's height first, and the clock fills what remains inside a centred box. It stays circular, just slightly smaller.

## Also fixed

The picker offered "Cupertino" while the widget derived "Los Angeles" from that same zone id, so a clock never showed the name you picked. It's Los Angeles in both places now.

## Verified on a Portal TV (ripley)

- Four clocks render fully inside the card, names and all.
- Renaming works end to end: `Pacific/Auckland` shown as "NZ" on the widget.
- Empirically checked against the device's zone database: Seattle, Boston, Miami, San Francisco, Glasgow, Hanoi and 49 of ~55 major cities swept have no zone of their own, which is what the alias table is for.

Storage sits outside the settings registry, as the collection-shaped config it is, so `SettingsDomainTest`'s completeness tripwire is unaffected. Four new tests cover label round-tripping with a comma, malformed prefs degrading to "no custom names" rather than crashing, blank labels being dropped, and multi-segment ids like `America/Argentina/Buenos_Aires`.

`docs/features/launcher.md` gains a World clock section; it had nothing on the widget before.
