### PR TITLE
Fix the flaky stopClosesTheListeningPort test

### DIFF
--- a/app/src/test/java/com/immortal/launcher/FleetHttpServerSocketTest.kt
+++ b/app/src/test/java/com/immortal/launcher/FleetHttpServerSocketTest.kt
@@ -12,7 +12,6 @@ import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.net.Socket
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -126,9 +125,18 @@ class FleetHttpServerSocketTest {
     val server = serverOn(port) { FleetHttpServer.Response(200, """{"ok":true}""") }
     assertEquals("HTTP/1.1 200 OK", ok(port))
     server.stop()
-    assertNotNull(
-        "expected connect to fail after stop()",
-        runCatching { connect(port).close() }.exceptionOrNull(),
-    )
+    // Prove the port was released by binding it ourselves: if stop() had left the listener open,
+    // this throws BindException.
+    //
+    // The obvious alternative — assert that a fresh connect() fails — is the same claim but it
+    // races, and it flaked on CI while passing locally every time. Once stop() frees the port the
+    // OS is free to hand that number to anything else asking for an ephemeral port, including
+    // another test in this suite calling freePort(). If something else binds it first, the connect
+    // succeeds and the test fails while stop() did its job perfectly.
+    ServerSocket().use { probe ->
+      probe.reuseAddress = true
+      probe.bind(InetSocketAddress(InetAddress.getByName("127.0.0.1"), port))
+      assertTrue("stop() should release the listening port", probe.isBound)
+    }
   }
 }


### PR DESCRIPTION
`FleetHttpServerSocketTest.stopClosesTheListeningPort` fails intermittently on CI while passing locally every time. It failed on the first run of #200, and twice in a row on #203, in both cases on branches that go nowhere near the fleet HTTP server. It also cost a `ci: re-trigger` commit back on #192.

## Why it flakes

```kotlin
server.stop()
assertNotNull(
    "expected connect to fail after stop()",
    runCatching { connect(port).close() }.exceptionOrNull(),
)
```

The claim is right: after `stop()`, nothing should be listening. The check is racy. Once `stop()` frees the port, the OS may hand that number straight back out to anything asking for an ephemeral port, including another test in this suite calling `freePort()`. If something else binds it first, the `connect()` succeeds, `exceptionOrNull()` is null, and the test fails while `stop()` did its job perfectly. A loaded CI runner with more concurrent tests makes that far more likely than a quiet laptop, which matches what we see.

## The fix

Bind the port instead of connecting to it. If `stop()` had left the listener open, `bind` throws `BindException`. Same claim, no dependence on what the OS does with the port afterwards.

```kotlin
ServerSocket().use { probe ->
  probe.reuseAddress = true
  probe.bind(InetSocketAddress(InetAddress.getByName("127.0.0.1"), port))
  assertTrue("stop() should release the listening port", probe.isBound)
}
```

## Verified it still catches the bug it's for

A test that can't fail is worse than a flaky one, so I checked it by mutation: with `stop()` temporarily changed to skip `server.close()`, the test fails as it should. Restored afterwards, and this PR touches only the test file.

Full suite passes locally.
