### PR TITLE
Home Assistant: real presence, and ambient sensor entities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,8 @@ The Kotlin package is flat; files are grouped by name prefix:
   `FleetConfig`, `FleetFs`, `FleetDiag`, `FleetCalendar`, `FleetScreensaver`
 - **Multi-room audio / now playing:** `MultiRoom*`, `NowPlaying*`, `Snapcast*`, `Ma*`,
   `MediaSession*`, `MediaNotificationListenerService`
-- **Smart home (MQTT):** `Mqtt*`
+- **Smart home (MQTT):** `Mqtt*`; ambient sensor entities `AmbientSensors`; presence read from
+  Meta's own detector `PortalPresence` (feeds `PresenceHub`)
 - **Remote / Portal TV:** `Remote*`, `TvFocus`
 - **Boot / lifecycle:** `ImmortalApp`, `BootReceiver`, `BootLaunch`, `Sleep*`, `ScreenControl`
 - **Settings (the registry — read [Settings infrastructure](#settings-infrastructure) before

--- a/app/src/main/java/com/immortal/launcher/AmbientSensors.kt
+++ b/app/src/main/java/com/immortal/launcher/AmbientSensors.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.util.Log
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.abs
+
+/**
+ * An ambient sensor the Portal may or may not physically have, and how it should look in Home
+ * Assistant. Everything is auto-detected: a Portal without the hardware simply never publishes
+ * that entity, so nothing promises a reading the device can't take.
+ *
+ * @param key MQTT object id (the topic segment and the HA `unique_id` suffix).
+ * @param minDelta smallest change worth a message — below this the value is sensor noise.
+ */
+enum class AmbientKind(
+    val key: String,
+    val title: String,
+    val sensorType: Int,
+    val deviceClass: String,
+    val unit: String,
+    val decimals: Int,
+    val minDelta: Double,
+) {
+  TEMPERATURE("temperature", "Temperature", Sensor.TYPE_AMBIENT_TEMPERATURE, "temperature", "°C", 1, 0.1),
+  ILLUMINANCE("illuminance", "Ambient light", Sensor.TYPE_LIGHT, "illuminance", "lx", 0, 1.0),
+  HUMIDITY("humidity", "Humidity", Sensor.TYPE_RELATIVE_HUMIDITY, "humidity", "%", 0, 1.0),
+  PRESSURE("pressure", "Pressure", Sensor.TYPE_PRESSURE, "pressure", "hPa", 1, 0.2),
+}
+
+/**
+ * When a new reading is worth putting on the wire, and how it's rendered. Pure — no Android, no
+ * clock of its own — so the rate limiting is unit-tested rather than eyeballed on a device.
+ */
+object AmbientPolicy {
+  /** Ordinary cadence: a drifting value gets at most one message per this interval. */
+  const val MIN_INTERVAL_MS = 20_000L
+
+  /** Floor for the big-change fast path, so a flickering sensor still can't flood the broker. */
+  const val FAST_MIN_MS = 2_000L
+
+  /** A change this many times [AmbientKind.minDelta] is an event, not drift (a light switch). */
+  const val BIG_CHANGE_FACTOR = 10
+
+  /**
+   * True when [next] should be published. The first reading always goes out; after that a value
+   * must have moved by at least [minDelta] AND waited out [MIN_INTERVAL_MS] — unless it moved a
+   * lot, which is exactly the case an automation is waiting on (someone turned the lights on),
+   * so that jumps the queue down to [FAST_MIN_MS].
+   */
+  fun shouldPublish(
+      prev: Double?,
+      next: Double,
+      lastPublishMs: Long,
+      nowMs: Long,
+      minDelta: Double,
+  ): Boolean {
+    if (prev == null) return true
+    val delta = abs(next - prev)
+    if (delta < minDelta) return false
+    val elapsed = nowMs - lastPublishMs
+    if (elapsed >= MIN_INTERVAL_MS) return true
+    return delta >= minDelta * BIG_CHANGE_FACTOR && elapsed >= FAST_MIN_MS
+  }
+
+  /**
+   * Render for MQTT. Locale.US is load-bearing: a device in a comma-decimal locale would
+   * otherwise publish "21,4", which Home Assistant reads as a non-numeric state.
+   */
+  fun format(value: Double, decimals: Int): String =
+      String.format(Locale.US, "%.${decimals}f", value)
+
+  /**
+   * Apply the user's temperature calibration. An ambient sensor sitting inside a powered device
+   * reads its own waste heat, so it runs warm by a few degrees — a fixed offset is how you get
+   * it to agree with a thermometer in the same room.
+   */
+  fun calibrate(celsius: Double, offsetC: Int): Double = celsius + offsetC
+}
+
+/**
+ * Publishes the Portal's ambient sensors to whoever is listening — in practice [MqttPublisher],
+ * which owns this object's lifetime and only runs it while a broker is connected, so an
+ * un-configured device pays nothing for it.
+ *
+ * Readings are throttled by [AmbientPolicy] rather than forwarded raw: `TYPE_LIGHT` in
+ * particular fires continuously, and one MQTT message per sensor event would bury the broker in
+ * noise nobody automates on.
+ *
+ * @param onValue called with the object key and the formatted state, on the sensor thread.
+ */
+class AmbientSensors(
+    private val appContext: Context,
+    private val onValue: (AmbientKind, String) -> Unit,
+) : SensorEventListener {
+
+  private val manager by lazy {
+    appContext.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+  }
+  // Concurrent: readings arrive on the sensor thread while start()/stop() clear these from the
+  // publisher's worker (or the main thread, on teardown).
+  private val lastValue = ConcurrentHashMap<AmbientKind, Double>()
+  private val lastPublishMs = ConcurrentHashMap<AmbientKind, Long>()
+  @Volatile private var running = false
+
+  /** The kinds this Portal actually has hardware for, in enum order. */
+  fun available(): List<AmbientKind> {
+    val m = manager ?: return emptyList()
+    return AmbientKind.values().filter {
+      runCatching { m.getDefaultSensor(it.sensorType) != null }.getOrDefault(false)
+    }
+  }
+
+  /**
+   * Start listening to every available sensor. Registration itself delivers the current reading
+   * for on-change sensors, so the first values land without waiting for the room to change.
+   */
+  fun start() {
+    if (running) return
+    val m = manager ?: return
+    val kinds = available()
+    if (kinds.isEmpty()) {
+      Log.i(TAG, "no ambient sensors on this Portal")
+      return
+    }
+    running = true
+    lastValue.clear()
+    lastPublishMs.clear()
+    kinds.forEach { kind ->
+      val sensor = runCatching { m.getDefaultSensor(kind.sensorType) }.getOrNull() ?: return@forEach
+      runCatching { m.registerListener(this, sensor, SensorManager.SENSOR_DELAY_NORMAL) }
+          .onFailure { Log.w(TAG, "couldn't register ${kind.key}", it) }
+    }
+    Log.i(TAG, "ambient sensors started: ${kinds.joinToString { it.key }}")
+  }
+
+  fun stop() {
+    if (!running) return
+    running = false
+    runCatching { manager?.unregisterListener(this) }
+    lastValue.clear()
+    lastPublishMs.clear()
+    Log.i(TAG, "ambient sensors stopped")
+  }
+
+  override fun onSensorChanged(event: SensorEvent) {
+    if (!running) return
+    val kind = AmbientKind.values().firstOrNull { it.sensorType == event.sensor.type } ?: return
+    val raw = event.values.firstOrNull()?.toDouble() ?: return
+    if (raw.isNaN() || raw.isInfinite()) return
+    val value =
+        if (kind == AmbientKind.TEMPERATURE) {
+          AmbientPolicy.calibrate(raw, MqttConfig.tempOffset(appContext))
+        } else {
+          raw
+        }
+    val now = System.currentTimeMillis()
+    if (!AmbientPolicy.shouldPublish(
+        lastValue[kind], value, lastPublishMs[kind] ?: 0L, now, kind.minDelta)) {
+      return
+    }
+    lastValue[kind] = value
+    lastPublishMs[kind] = now
+    runCatching { onValue(kind, AmbientPolicy.format(value, kind.decimals)) }
+        .onFailure { Log.w(TAG, "publishing ${kind.key} failed", it) }
+  }
+
+  override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+
+  private companion object {
+    const val TAG = "ImmortalSensors"
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -711,6 +711,9 @@ internal fun MqttScreen(onBack: () -> Unit) {
   var pass by remember { mutableStateOf(MqttConfig.password(context)) }
   var useTls by remember { mutableStateOf(MqttConfig.useTls(context)) }
   var validateCert by remember { mutableStateOf(MqttConfig.validateCert(context)) }
+  var portalPresence by remember { mutableStateOf(MqttConfig.portalPresence(context)) }
+  var ambientSensors by remember { mutableStateOf(MqttConfig.ambientSensors(context)) }
+  var tempOffset by remember { mutableStateOf(MqttConfig.tempOffset(context)) }
   // MqttStatus is a plain holder updated off the main thread, so poll it for live
   // "Connecting… → Connected" feedback (Compose won't recompose on its writes).
   var status by remember { mutableStateOf(MqttStatus.text) }
@@ -736,6 +739,17 @@ internal fun MqttScreen(onBack: () -> Unit) {
     MqttConfig.setUseTls(context, useTls)
     MqttConfig.setValidateCert(context, validateCert)
     MqttService.sync(context)
+  }
+
+  /**
+   * The sensor toggles are read by the running publisher rather than only at connect time, so
+   * they apply with `reconfigure` — a plain sync would no-op against a service already running.
+   */
+  fun applySensors() {
+    MqttConfig.setPortalPresence(context, portalPresence)
+    MqttConfig.setAmbientSensors(context, ambientSensors)
+    MqttConfig.setTempOffset(context, tempOffset)
+    MqttService.sync(context, reconfigure = true)
   }
 
   Column(
@@ -959,6 +973,81 @@ internal fun MqttScreen(onBack: () -> Unit) {
               fontSize = 13.sp,
               modifier = Modifier.padding(start = 18.dp, end = 18.dp, top = 12.dp, bottom = 16.dp),
           )
+        }
+      }
+      if (enabled) {
+        Spacer(Modifier.size(26.dp))
+        SectionLabel("Sensors")
+        Card {
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Column(modifier = Modifier.weight(1f)) {
+              Text("Use the Portal's own detector", color = Color.White, fontSize = 15.sp)
+              Text(
+                  "Report presence from Meta's own camera detection instead of guessing from " +
+                      "the screensaver. Falls back on its own if the Portal isn't reporting it.",
+                  color = Color(0xFF9A9A9A),
+                  fontSize = 13.sp,
+                  modifier = Modifier.padding(top = 2.dp),
+              )
+            }
+            Segmented(
+                options = listOf("Off" to "off", "On" to "on"),
+                selected = if (portalPresence) "on" else "off",
+                onSelect = {
+                  portalPresence = it == "on"
+                  applySensors()
+                },
+            )
+          }
+          Divider()
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Column(modifier = Modifier.weight(1f)) {
+              Text("Ambient sensors", color = Color.White, fontSize = 15.sp)
+              Text(
+                  "Publish this Portal's ambient sensors (temperature, light) to Home Assistant. " +
+                      "Only sensors this model actually has will appear.",
+                  color = Color(0xFF9A9A9A),
+                  fontSize = 13.sp,
+                  modifier = Modifier.padding(top = 2.dp),
+              )
+            }
+            Segmented(
+                options = listOf("Off" to "off", "On" to "on"),
+                selected = if (ambientSensors) "on" else "off",
+                onSelect = {
+                  ambientSensors = it == "on"
+                  applySensors()
+                },
+            )
+          }
+          if (ambientSensors) {
+            Divider()
+            Stepper(
+                label = "Temperature offset",
+                valueText = "${if (tempOffset > 0) "+" else ""}$tempOffset °C",
+                onMinus = {
+                  tempOffset = (tempOffset - 1).coerceAtLeast(MqttConfig.TEMP_OFFSET_MIN)
+                  applySensors()
+                },
+                onPlus = {
+                  tempOffset = (tempOffset + 1).coerceAtMost(MqttConfig.TEMP_OFFSET_MAX)
+                  applySensors()
+                },
+            )
+            Text(
+                "Correct the temperature reading. A sensor inside a powered device reads its own " +
+                    "heat, so it usually runs a few degrees warm.",
+                color = Color(0xFF7C7C7C),
+                fontSize = 13.sp,
+                modifier = Modifier.padding(start = 18.dp, end = 18.dp, bottom = 14.dp),
+            )
+          }
         }
       }
       Text(

--- a/app/src/main/java/com/immortal/launcher/MqttConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttConfig.kt
@@ -23,6 +23,8 @@ object MqttConfig {
   private const val PREFS = "mqtt_publisher"
   const val DEFAULT_PORT = 1883
   const val DEFAULT_TLS_PORT = 8883
+  const val TEMP_OFFSET_MIN = -20
+  const val TEMP_OFFSET_MAX = 20
 
   private fun prefs(c: Context) = c.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
@@ -61,6 +63,32 @@ object MqttConfig {
 
   fun setValidateCert(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("validate_cert", on).apply()
+
+  /**
+   * Publish the presence sensor from Meta's own camera detector ([PortalPresenceMonitor]) rather
+   * than the dream/sleep proxy. On by default: it needs no permission the provisioning kit
+   * doesn't already grant, and it degrades to the proxy on its own when the log stays quiet.
+   */
+  fun portalPresence(c: Context): Boolean = prefs(c).getBoolean("portal_presence", true)
+
+  fun setPortalPresence(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("portal_presence", on).apply()
+
+  /** Publish the Portal's ambient sensors (temperature, light, …) as Home Assistant entities. */
+  fun ambientSensors(c: Context): Boolean = prefs(c).getBoolean("ambient_sensors", true)
+
+  fun setAmbientSensors(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("ambient_sensors", on).apply()
+
+  /**
+   * Calibration for the ambient temperature sensor, in whole °C. A sensor inside a powered
+   * device reads its own waste heat, so the raw value runs warm; this is how you make it agree
+   * with a thermometer in the same room.
+   */
+  fun tempOffset(c: Context): Int = prefs(c).getInt("temp_offset", 0)
+
+  fun setTempOffset(c: Context, v: Int) =
+      prefs(c).edit().putInt("temp_offset", v.coerceIn(TEMP_OFFSET_MIN, TEMP_OFFSET_MAX)).apply()
 
   /** True once a broker host is set — the publisher stays idle until then. */
   fun isConfigured(c: Context): Boolean = host(c).isNotBlank()

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -54,6 +54,21 @@ class MqttPublisher(private val appContext: Context) {
   private val base = "immortal/$id"
   private val audio by lazy { appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager }
 
+  /**
+   * The Portal's ambient sensors, and Meta's own presence detector. Both are owned by the
+   * publisher rather than the app: they exist to feed Home Assistant, so they run exactly while
+   * a broker is connected and cost an un-configured device nothing. (The presence monitor also
+   * improves [PresenceHub] for the screensaver as a side effect, for as long as it's running.)
+   */
+  private val ambient by lazy {
+    AmbientSensors(appContext) { kind, value ->
+      client?.publish("$base/${kind.key}/state", value, retain = true)
+    }
+  }
+  private val portalPresence by lazy {
+    PortalPresenceMonitor(appContext) { PresenceHub.onPortalPresence(appContext, it) }
+  }
+
   private val presenceListener = PresenceHub.Listener { st -> runCatching { publishPresence(st) } }
   private val nowPlayingListener = NowPlayingHub.Listener { st -> runCatching { publishMedia(st) } }
   private var batteryReceiver: BroadcastReceiver? = null
@@ -105,6 +120,35 @@ class MqttPublisher(private val appContext: Context) {
     worker?.interrupt()
     worker = null
     MqttStatus.text = "Off"
+  }
+
+  /**
+   * Re-read the feature toggles and republish, without dropping the broker connection. Called
+   * when the user changes a sensor/presence setting: [MqttService.sync] alone would not do it,
+   * because starting an already-running service re-enters `onStartCommand` and touches nothing.
+   *
+   * The sensors are restarted rather than left alone so that a changed temperature offset shows
+   * up at once — re-registering replays each sensor's current reading — instead of waiting for
+   * the room to move.
+   */
+  fun reconfigure() {
+    val c = client ?: return
+    Thread {
+          runCatching {
+                if (MqttConfig.portalPresence(appContext)) portalPresence.start()
+                else portalPresence.stop()
+                ambient.stop()
+                if (MqttConfig.ambientSensors(appContext)) ambient.start()
+                publishDiscovery(c)
+                publishPresence(PresenceHub.current)
+              }
+              .onFailure { Log.w(TAG, "reconfigure failed", it) }
+        }
+        .apply {
+          isDaemon = true
+          name = "mqtt-reconfigure"
+          start()
+        }
   }
 
   // --- connection lifecycle ---------------------------------------------------
@@ -227,9 +271,13 @@ class MqttPublisher(private val appContext: Context) {
     publishScreen()
     publishIp()
     publishAudioState()
+    if (MqttConfig.portalPresence(appContext)) portalPresence.start()
+    if (MqttConfig.ambientSensors(appContext)) ambient.start()
   }
 
   private fun detach() {
+    runCatching { portalPresence.stop() }
+    runCatching { ambient.stop() }
     runCatching { PresenceHub.removeListener(presenceListener) }
     runCatching { NowPlayingHub.removeListener(nowPlayingListener) }
     batteryReceiver?.let { r -> runCatching { appContext.unregisterReceiver(r) } }
@@ -408,13 +456,25 @@ class MqttPublisher(private val appContext: Context) {
         "$base/presence/attributes",
         JSONObject()
             .put("confident", st.confident)
-            .put("source", if (st.presence == Presence.UNKNOWN) "screen" else "proxy")
+            .put("source", presenceSource(st))
             .put("raw", st.presence.name.lowercase())
             .toString(),
         retain = true,
     )
     publishScreen()
   }
+
+  /**
+   * How much to trust the presence entity, for the `source` attribute: `portal` is Meta's own
+   * camera detector (direct observation), `proxy` the dream/sleep inference, and `screen` the
+   * last-resort "is the panel on" fallback used while the proxy has no reading at all.
+   */
+  private fun presenceSource(st: PresenceState): String =
+      when {
+        st.source == PresenceSource.PORTAL -> "portal"
+        st.presence == Presence.UNKNOWN -> "screen"
+        else -> "proxy"
+      }
 
   /**
    * Publish the screen-state sensor from the LIVE display state. immortal's PresenceHub
@@ -539,6 +599,25 @@ class MqttPublisher(private val appContext: Context) {
       binarySensor(c, "charging", "Charging", deviceClass = "battery_charging")
     }
 
+    // Ambient sensors, auto-detected. A Portal without the hardware never advertises the entity;
+    // one that has it but with the feature switched off gets its retained config cleared, so a
+    // previously-published entity doesn't linger in HA as "unavailable".
+    val ambientKinds = if (MqttConfig.ambientSensors(appContext)) ambient.available() else emptyList()
+    AmbientKind.values().forEach { kind ->
+      if (kind in ambientKinds) {
+        sensor(
+            c,
+            kind.key,
+            kind.title,
+            deviceClass = kind.deviceClass,
+            unit = kind.unit,
+            stateClass = "measurement",
+        )
+      } else {
+        publishConfig(c, "sensor", kind.key, null)
+      }
+    }
+
     sensor(c, "media_state", "Media", icon = "mdi:music")
     sensor(c, "media_title", "Media title", icon = "mdi:music-note")
     sensor(c, "media_artist", "Media artist", icon = "mdi:account-music")
@@ -607,7 +686,7 @@ class MqttPublisher(private val appContext: Context) {
           "button" to "identify",
           "sensor" to "ip",
           "button" to "screen_off", // legacy (pre-1.41)
-      )
+      ) + AmbientKind.values().map { "sensor" to it.key }
 
   /** Remove this device's entities from HA by clearing their retained discovery configs. */
   private fun clearDiscovery(c: MqttClient) {

--- a/app/src/main/java/com/immortal/launcher/MqttService.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttService.kt
@@ -35,7 +35,12 @@ class MqttService : Service() {
     publisher = MqttPublisher(applicationContext).also { it.start() }
   }
 
-  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_STICKY
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    // Starting an already-running service only re-enters here, so a settings change needs an
+    // explicit nudge to reach the live publisher — [sync] with reconfigure = true sends it.
+    if (intent?.action == ACTION_RECONFIGURE) runCatching { publisher?.reconfigure() }
+    return START_STICKY
+  }
 
   override fun onBind(intent: Intent?): IBinder? = null
 
@@ -72,10 +77,18 @@ class MqttService : Service() {
   companion object {
     private const val CHANNEL = "mqtt_publisher"
     private const val NOTIF_ID = 4712
+    private const val ACTION_RECONFIGURE = "com.immortal.launcher.MQTT_RECONFIGURE"
 
-    /** Start the publisher when enabled+configured, stop it otherwise. Safe to call repeatedly. */
-    fun sync(context: Context) {
+    /**
+     * Start the publisher when enabled+configured, stop it otherwise. Safe to call repeatedly.
+     *
+     * Pass [reconfigure] when a setting the publisher reads at runtime has changed (sensors,
+     * presence source, temperature offset) so a service that's ALREADY running re-reads it and
+     * republishes; without it the change would only take effect on the next reconnect.
+     */
+    fun sync(context: Context, reconfigure: Boolean = false) {
       val intent = Intent(context, MqttService::class.java)
+      if (reconfigure) intent.action = ACTION_RECONFIGURE
       if (MqttConfig.isEnabled(context) && MqttConfig.isConfigured(context)) {
         if (Build.VERSION.SDK_INT >= 26) context.startForegroundService(intent)
         else context.startService(intent)

--- a/app/src/main/java/com/immortal/launcher/PortalPresence.kt
+++ b/app/src/main/java/com/immortal/launcher/PortalPresence.kt
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+
+/**
+ * Reads Meta's OWN camera presence detection, by tailing the system log.
+ *
+ * The permission that would let us ask the platform directly is signature-gated and stays shut
+ * (see [PresenceHub] and `docs/limitations.md`) — but the detector is chatty. Portal's
+ * `PresenceManager` (Aloha) logs a heartbeat roughly every 30s **only while it sees a person**,
+ * and goes quiet when the room empties. So the signal isn't the text of the line, it's the
+ * *liveness* of the beat: recent beats mean someone is there, a gap means the room emptied.
+ *
+ * This gives the presence sensor a real reading instead of [PresenceHub]'s dream/sleep proxy,
+ * and it keeps working while the frame is pinned on — exactly the case the proxy calls
+ * `confident = false`, because a held screen never times out and hides the empty-room transition.
+ *
+ * Needs `READ_LOGS`, which is a *development* permission the provisioning kit already grants for
+ * the fleet agent's `/logcat` endpoint ([FleetDiag]) — so on a provisioned Portal this costs no
+ * new permission. Without it we simply never start, and the proxy stays in charge.
+ *
+ * **Silence is not absence.** Until a first beat is seen the verdict is `null`, not "absent" —
+ * on hardware or a firmware build where these tags never appear (or where the grant is missing),
+ * reporting an empty room forever would be worse than saying nothing and letting the proxy
+ * answer. Only once the detector has proven it talks do gaps start meaning "nobody here".
+ */
+object PortalPresenceLog {
+  /** A beat whose own timestamp is older than this is backlog, not news — logcat replays. */
+  const val FRESH_MS = 45_000L
+
+  /** Declare the room empty once the newest beat is older than this (~30s beat + margin). */
+  const val ABSENT_MS = 50_000L
+
+  /** How often the verdict is re-evaluated against the clock. */
+  const val CHECK_MS = 10_000L
+
+  /** Portal's presence service. Everything it logs is about presence — the tag IS the signal. */
+  const val TAG_PRESENCE = "PresenceManager"
+
+  /** The camera service. It logs presence among other things, so its lines need the text test. */
+  const val TAG_CAMERA = "aloha.CameraServiceController"
+
+  /** The log tags to follow, in `logcat -s` form. */
+  val TAG_FILTERS = arrayOf("$TAG_PRESENCE:I", "$TAG_CAMERA:I")
+
+  /**
+   * Epoch millis of a presence heartbeat line (`logcat -v epoch`), or null when the line isn't
+   * one.
+   *
+   * The message is tested separately from the tag, which matters more than it looks: every line
+   * from `PresenceManager` contains the string "presence" in its *tag*, so testing the whole line
+   * would accept anything that tag ever logs. Lines from the presence service count on the tag
+   * alone; lines from the camera service, which logs plenty that isn't about presence, have to
+   * say so in the message.
+   */
+  fun beatEpochMs(line: String): Long? {
+    val epoch = line.trimStart().substringBefore(' ').toDoubleOrNull() ?: return null
+    if (epoch <= 0.0) return null
+    // "<epoch>  <pid>  <tid> <level> <Tag>: <message>"
+    val head = line.substringBefore(": ", missingDelimiterValue = "")
+    if (head.isEmpty()) return null
+    val message = line.substringAfter(": ", missingDelimiterValue = "")
+    val fromPresenceService = head.trimEnd().endsWith(TAG_PRESENCE)
+    if (!fromPresenceService && !message.contains("presence", ignoreCase = true)) return null
+    return (epoch * 1000).toLong()
+  }
+
+  /**
+   * True when a beat stamped [beatEpochMs] is recent enough to count as live rather than the
+   * backlog logcat dumps on attach. A beat slightly in the future (clock jitter between the log
+   * writer and us) counts as fresh.
+   */
+  fun isFreshBeat(beatEpochMs: Long, nowMs: Long): Boolean = (nowMs - beatEpochMs) < FRESH_MS
+
+  /**
+   * The presence verdict: true = someone's here, false = room empty, **null = don't know yet**
+   * (no beat has ever been seen, so the detector may simply not be talking on this device).
+   */
+  fun verdict(lastBeatMs: Long, nowMs: Long): Boolean? =
+      when {
+        lastBeatMs <= 0L -> null
+        nowMs - lastBeatMs < ABSENT_MS -> true
+        else -> false
+      }
+}
+
+/**
+ * Runs [PortalPresenceLog] against a live `logcat` process and reports transitions to
+ * [PresenceHub]. Owns two daemon threads — one blocked on the log stream, one on a timer that
+ * ages the last beat out — mirroring the shape of [MqttPublisher]'s worker/pinger pair.
+ */
+class PortalPresenceMonitor(
+    private val appContext: Context,
+    private val onPresence: (Boolean?) -> Unit,
+) {
+  @Volatile private var running = false
+  @Volatile private var lastBeatMs = 0L
+  @Volatile private var reported: Boolean? = null
+  private var process: Process? = null
+  private var reader: Thread? = null
+  private var checkThread: HandlerThread? = null
+  private var checkHandler: Handler? = null
+
+  /** True when `READ_LOGS` is granted — i.e. when this monitor can do anything at all. */
+  fun canRead(): Boolean =
+      runCatching {
+            appContext.checkSelfPermission(android.Manifest.permission.READ_LOGS) ==
+                PackageManager.PERMISSION_GRANTED
+          }
+          .getOrDefault(false)
+
+  /** Start tailing. Returns false when the permission is missing (the proxy stays in charge). */
+  fun start(): Boolean {
+    if (running) return true
+    if (!canRead()) {
+      Log.i(TAG, "READ_LOGS not granted; leaving presence to the dream proxy")
+      return false
+    }
+    running = true
+    lastBeatMs = 0L
+    reported = null
+    val t = HandlerThread("portal-presence-check").apply { start() }
+    checkThread = t
+    checkHandler = Handler(t.looper).also { it.post(checkTick) }
+    reader = Thread(::readLoop, "portal-presence-log").apply { isDaemon = true; start() }
+    Log.i(TAG, "portal presence monitor started")
+    return true
+  }
+
+  /** Stop tailing and hand presence back to the proxy (reports null, not "absent"). */
+  fun stop() {
+    if (!running) return
+    running = false
+    checkHandler?.removeCallbacks(checkTick)
+    checkHandler = null
+    runCatching { checkThread?.quitSafely() }
+    checkThread = null
+    runCatching { process?.destroy() }
+    process = null
+    reader?.interrupt()
+    reader = null
+    if (reported != null) {
+      reported = null
+      runCatching { onPresence(null) }
+    }
+    Log.i(TAG, "portal presence monitor stopped")
+  }
+
+  /**
+   * Block on `logcat`, stamping [lastBeatMs] for every fresh heartbeat. If the process dies
+   * (the log daemon restarts, or someone runs `logcat -c`) this re-spawns it while we're still
+   * running, so a transient failure doesn't silently end presence for the rest of the session.
+   */
+  private fun readLoop() {
+    while (running) {
+      runCatching {
+            // -v epoch prefixes each line with a Unix timestamp we can age-check.
+            val p =
+                ProcessBuilder(listOf("logcat", "-v", "epoch", "-s") + PortalPresenceLog.TAG_FILTERS)
+                    .redirectErrorStream(true)
+                    .start()
+            process = p
+            p.inputStream.bufferedReader().use { r ->
+              while (running) {
+                val line = r.readLine() ?: break
+                val beat = PortalPresenceLog.beatEpochMs(line) ?: continue
+                if (PortalPresenceLog.isFreshBeat(beat, System.currentTimeMillis())) {
+                  lastBeatMs = System.currentTimeMillis()
+                }
+              }
+            }
+          }
+          .onFailure { if (running) Log.w(TAG, "presence log reader stopped: ${it.message}") }
+      runCatching { process?.destroy() }
+      process = null
+      // runCatching: stop() interrupts this thread, and an uncaught InterruptedException
+      // here would reach the crash handler on an ordinary teardown.
+      if (running) runCatching { Thread.sleep(RESPAWN_MS) }
+    }
+  }
+
+  private val checkTick =
+      object : Runnable {
+        override fun run() {
+          if (!running) return
+          val next = PortalPresenceLog.verdict(lastBeatMs, System.currentTimeMillis())
+          if (next != reported) {
+            reported = next
+            Log.i(TAG, "portal presence -> ${next ?: "unknown"}")
+            runCatching { onPresence(next) }
+          }
+          checkHandler?.postDelayed(this, PortalPresenceLog.CHECK_MS)
+        }
+      }
+
+  private companion object {
+    const val TAG = "ImmortalPresence"
+    const val RESPAWN_MS = 5_000L
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/PresenceState.kt
+++ b/app/src/main/java/com/immortal/launcher/PresenceState.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.CopyOnWriteArrayList
  * One source of truth for "is someone here, and what's the screen doing" — shared by the
  * photo-frame screensaver (in-process) and the Snapcast music companion (cross-process).
  *
- * Why this exists: the Portal won't let an unprivileged app read Meta's presence signal
+ * Why this exists: the Portal won't let an unprivileged app *ask* for Meta's presence signal
  * (it's front-camera CV behind a platform-signature permission — see docs/design/multi-room-audio.md),
  * but the system's own dream/sleep lifecycle is DERIVED from that signal, and we DO receive
  * it. So the dream coming up means "someone's around"; the device sleeping at a screen
@@ -27,10 +27,16 @@ import java.util.concurrent.CopyOnWriteArrayList
  * [PresenceState] that both the screensaver and the music react to, instead of each guessing
  * from raw screen on/off and drifting apart.
  *
- * The honest caveat lives in one field: [PresenceState.confident]. It's false exactly when the
- * frame is pinned on (Always-on mode), because a held screen never times out, so the
- * empty-room transition is hidden and presence is genuinely UNKNOWN. Consumers read that as
- * "fall back to Home Assistant or the manual override."
+ * That proxy is the floor, not the ceiling. [PortalPresenceMonitor] reads the same detector's
+ * heartbeat out of the system log and, whenever it's talking, its verdict OVERRIDES the proxy
+ * (see [onPortalPresence]) — which is what [PresenceState.source] reports. The proxy remains the
+ * fallback for devices without the `READ_LOGS` grant, or where those log tags never appear.
+ *
+ * The honest caveat lives in one field: [PresenceState.confident]. On the proxy it's false
+ * exactly when the frame is pinned on (Always-on mode), because a held screen never times out,
+ * so the empty-room transition is hidden and presence is genuinely UNKNOWN. Consumers read that
+ * as "fall back to Home Assistant or the manual override." A reading sourced from the Portal's
+ * own detector is always confident — it watches the room, not the screen.
  */
 
 enum class Presence {
@@ -51,18 +57,28 @@ enum class ScreenState {
   OFF,
 }
 
+/** Where a [PresenceState.presence] reading came from — see [PresenceHub.onPortalPresence]. */
+enum class PresenceSource {
+  /** Meta's own camera detector, read off the system log. Direct observation of the room. */
+  PORTAL,
+  /** The dream/sleep lifecycle proxy — inferred, and blind while the frame is pinned on. */
+  PROXY,
+}
+
 /**
  * Immutable snapshot of the shared signal.
  *
  * @param confident false when the Always-on frame masks the proxy → treat [presence] as
  *   advisory only and defer to an authoritative source (HA occupancy / manual override).
  * @param sinceMs wall-clock millis when this state began (for grace-period timing downstream).
+ * @param source which detector produced [presence]; [PresenceSource.PORTAL] outranks the proxy.
  */
 data class PresenceState(
     val presence: Presence,
     val screen: ScreenState,
     val confident: Boolean,
     val sinceMs: Long,
+    val source: PresenceSource = PresenceSource.PROXY,
 )
 
 /**
@@ -122,6 +138,7 @@ object PresenceHub {
   const val EXTRA_SCREEN = "screen" // ScreenState.name
   const val EXTRA_CONFIDENT = "confident" // Boolean
   const val EXTRA_SINCE_MS = "sinceMs" // Long
+  const val EXTRA_SOURCE = "source" // PresenceSource.name
 
   fun interface Listener {
     fun onPresenceChanged(state: PresenceState)
@@ -129,6 +146,19 @@ object PresenceHub {
 
   private val listeners = CopyOnWriteArrayList<Listener>()
   private var app: Context? = null
+
+  /**
+   * Meta's own detector's latest verdict, or null when it isn't talking (no `READ_LOGS`, tags
+   * absent, or the monitor is off). Non-null overrides the proxy in [set].
+   */
+  @Volatile private var portalPresence: Boolean? = null
+
+  /**
+   * The proxy's own last opinion, kept separately from [current] so that when the Portal
+   * detector drops out we fall back to what the dream lifecycle last said rather than freezing
+   * on the override's value.
+   */
+  @Volatile private var proxyPresence: Presence = Presence.UNKNOWN
 
   @Volatile
   var current: PresenceState = PresenceState(Presence.UNKNOWN, ScreenState.OFF, confident = false, sinceMs = 0L)
@@ -197,6 +227,17 @@ object PresenceHub {
         DreamStopVerdict.SUPPRESSED -> Unit // a call handoff — presence is unknowable here
       }
 
+  /**
+   * A verdict from Meta's own detector ([PortalPresenceMonitor]): true present, false empty, or
+   * null when it has nothing to say. Non-null takes precedence over the dream/sleep proxy for as
+   * long as it lasts; null hands control straight back, re-deriving from the proxy's last word.
+   */
+  fun onPortalPresence(c: Context, present: Boolean?) {
+    if (portalPresence == present) return
+    portalPresence = present
+    set(proxyPresence, current.screen, isConfident(c), c)
+  }
+
   /** Screen blanked outside the dream path (our own lockNow, power button). */
   private fun onScreenOff(c: Context) {
     // If we were confidently following the proxy, a screen-off means the room emptied or the
@@ -227,13 +268,30 @@ object PresenceHub {
   }
 
   private fun set(presence: Presence, screen: ScreenState, confident: Boolean, context: Context) {
-    val next = PresenceState(presence, screen, confident, System.currentTimeMillis())
+    proxyPresence = presence
+    // Meta's detector outranks the proxy whenever it's talking: it watches the room directly, so
+    // it stays right in the very case the proxy is blind to — a pinned frame that never times out.
+    val portal = portalPresence
+    val next =
+        PresenceState(
+            presence = if (portal == null) presence else if (portal) Presence.PRESENT else Presence.ABSENT,
+            screen = screen,
+            confident = if (portal == null) confident else true,
+            sinceMs = System.currentTimeMillis(),
+            source = if (portal == null) PresenceSource.PROXY else PresenceSource.PORTAL,
+        )
     val prev = current
-    if (prev.presence == next.presence && prev.screen == next.screen && prev.confident == next.confident) {
+    if (prev.presence == next.presence &&
+        prev.screen == next.screen &&
+        prev.confident == next.confident &&
+        prev.source == next.source) {
       return // no meaningful change; don't churn listeners/broadcasts
     }
     current = next
-    Log.i(TAG, "presence ${prev.presence}/${prev.screen} -> ${next.presence}/${next.screen} confident=${next.confident}")
+    Log.i(
+        TAG,
+        "presence ${prev.presence}/${prev.screen} -> ${next.presence}/${next.screen} " +
+            "confident=${next.confident} source=${next.source}")
     listeners.forEach { runCatching { it.onPresenceChanged(next) } }
     publish(context, next)
   }
@@ -246,7 +304,8 @@ object PresenceHub {
               .putExtra(EXTRA_PRESENCE, state.presence.name)
               .putExtra(EXTRA_SCREEN, state.screen.name)
               .putExtra(EXTRA_CONFIDENT, state.confident)
-              .putExtra(EXTRA_SINCE_MS, state.sinceMs))
+              .putExtra(EXTRA_SINCE_MS, state.sinceMs)
+              .putExtra(EXTRA_SOURCE, state.source.name))
     }
         .onFailure { Log.w(TAG, "presence broadcast failed", it) }
   }

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -694,6 +694,37 @@ object SettingsDomains {
                       get = { MqttConfig.validateCert(it) },
                       set = MqttConfig::setValidateCert,
                       visible = { c, _ -> MqttConfig.isEnabled(c) && MqttConfig.useTls(c) }),
+                  BoolSpec(
+                      "portalPresence",
+                      "Use the Portal's own detector",
+                      get = { MqttConfig.portalPresence(it) },
+                      set = MqttConfig::setPortalPresence,
+                      help =
+                          "Report presence from Meta's own camera detection instead of guessing " +
+                              "from the screensaver. Falls back on its own if the Portal isn't " +
+                              "reporting it.",
+                      visible = { c, _ -> MqttConfig.isEnabled(c) }),
+                  BoolSpec(
+                      "ambientSensors",
+                      "Ambient sensors",
+                      get = { MqttConfig.ambientSensors(it) },
+                      set = MqttConfig::setAmbientSensors,
+                      help =
+                          "Publish this Portal's ambient sensors (temperature, light) to Home " +
+                              "Assistant. Only sensors this model actually has will appear.",
+                      visible = { c, _ -> MqttConfig.isEnabled(c) }),
+                  IntSpec(
+                      "tempOffset",
+                      "Temperature offset",
+                      get = { MqttConfig.tempOffset(it) },
+                      set = MqttConfig::setTempOffset,
+                      min = MqttConfig.TEMP_OFFSET_MIN,
+                      max = MqttConfig.TEMP_OFFSET_MAX,
+                      format = { "${if (it > 0) "+" else ""}$it °C" },
+                      help =
+                          "Correct the temperature reading. A sensor inside a powered device " +
+                              "reads its own heat, so it usually runs a few degrees warm.",
+                      visible = { c, _ -> MqttConfig.isEnabled(c) && MqttConfig.ambientSensors(c) }),
               ),
           sections =
               mapOf(
@@ -702,7 +733,10 @@ object SettingsDomains {
                   "username" to "Broker",
                   "password" to "Broker",
                   "useTls" to "Security",
-                  "validateCert" to "Security"),
+                  "validateCert" to "Security",
+                  "portalPresence" to "Sensors",
+                  "ambientSensors" to "Sensors",
+                  "tempOffset" to "Sensors"),
           onApplied = { c, keys ->
             // TLS<->port convenience hop, lifted out of the bespoke on-device screen so the phone
             // remote gets it too (it didn't before — a real drift): flipping TLS moves the port to
@@ -713,7 +747,10 @@ object SettingsDomains {
               if (tls && port == MqttConfig.DEFAULT_PORT) MqttConfig.setPort(c, MqttConfig.DEFAULT_TLS_PORT)
               else if (!tls && port == MqttConfig.DEFAULT_TLS_PORT) MqttConfig.setPort(c, MqttConfig.DEFAULT_PORT)
             }
-            MqttService.sync(c)
+            // These are read by the running publisher, not just at connect time, so tell it to
+            // re-read them — a plain sync() would no-op against an already-running service.
+            val live = keys.any { it in setOf("portalPresence", "ambientSensors", "tempOffset") }
+            MqttService.sync(c, reconfigure = live)
           },
       )
 

--- a/app/src/test/java/com/immortal/launcher/AmbientPolicyTest.kt
+++ b/app/src/test/java/com/immortal/launcher/AmbientPolicyTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Rate limiting and rendering for the ambient sensor entities. */
+class AmbientPolicyTest {
+
+  private val now = 1_760_000_000_000L
+  private val delta = AmbientKind.TEMPERATURE.minDelta
+
+  @Test
+  fun `the first reading always publishes`() {
+    assertTrue(AmbientPolicy.shouldPublish(null, 21.4, 0L, now, delta))
+  }
+
+  @Test
+  fun `sensor noise below the threshold is dropped`() {
+    assertFalse(
+        AmbientPolicy.shouldPublish(21.4, 21.42, now - AmbientPolicy.MIN_INTERVAL_MS, now, delta))
+  }
+
+  @Test
+  fun `a real change waits out the interval`() {
+    assertFalse(AmbientPolicy.shouldPublish(21.4, 22.0, now - 5_000L, now, delta))
+    assertTrue(
+        AmbientPolicy.shouldPublish(21.4, 22.0, now - AmbientPolicy.MIN_INTERVAL_MS, now, delta))
+  }
+
+  @Test
+  fun `a big jump jumps the queue`() {
+    // Someone switching a lamp on is the event an automation is waiting for — it shouldn't sit
+    // in the rate limiter for twenty seconds.
+    val lux = AmbientKind.ILLUMINANCE.minDelta
+    assertTrue(
+        AmbientPolicy.shouldPublish(5.0, 400.0, now - AmbientPolicy.FAST_MIN_MS, now, lux))
+  }
+
+  @Test
+  fun `even a big jump can't publish faster than the floor`() {
+    val lux = AmbientKind.ILLUMINANCE.minDelta
+    assertFalse(AmbientPolicy.shouldPublish(5.0, 400.0, now - 100L, now, lux))
+  }
+
+  @Test
+  fun `values render with a dot decimal whatever the device locale`() {
+    // A comma-decimal locale would publish "21,4", which Home Assistant reads as non-numeric.
+    val original = Locale.getDefault()
+    try {
+      Locale.setDefault(Locale.GERMANY)
+      assertEquals("21.4", AmbientPolicy.format(21.44, decimals = 1))
+      assertEquals("415", AmbientPolicy.format(414.6, decimals = 0))
+    } finally {
+      Locale.setDefault(original)
+    }
+  }
+
+  @Test
+  fun `the temperature offset shifts the reading`() {
+    assertEquals(19.5, AmbientPolicy.calibrate(21.5, offsetC = -2), 0.0001)
+    assertEquals(21.5, AmbientPolicy.calibrate(21.5, offsetC = 0), 0.0001)
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/PortalPresenceLogTest.kt
+++ b/app/src/test/java/com/immortal/launcher/PortalPresenceLogTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The log-tailing presence reader. Background: Portal's own `PresenceManager` beats about every
+ * 30s while it sees a person and goes quiet when the room empties, so the signal is the beat's
+ * liveness rather than anything it says.
+ */
+class PortalPresenceLogTest {
+
+  private val now = 1_760_000_000_000L
+
+  private fun line(
+      epochSeconds: String,
+      text: String = "presence detected",
+      tag: String = PortalPresenceLog.TAG_PRESENCE,
+  ) = "$epochSeconds  1234  1234 I $tag: $text"
+
+  @Test
+  fun `a heartbeat line yields its own timestamp`() {
+    assertEquals(1_760_000_000_123L, PortalPresenceLog.beatEpochMs(line("1760000000.123")))
+  }
+
+  @Test
+  fun `anything the presence service logs counts as a beat`() {
+    // The tag is the signal: PresenceManager only runs while it's watching for people, so its
+    // heartbeat is "it said something", not any particular wording we'd be guessing at.
+    assertEquals(
+        1_760_000_000_123L, PortalPresenceLog.beatEpochMs(line("1760000000.123", "still tracking")))
+  }
+
+  @Test
+  fun `camera-service lines only count when they're about presence`() {
+    // This tag logs plenty that has nothing to do with anyone being in the room.
+    assertNull(
+        PortalPresenceLog.beatEpochMs(
+            line("1760000000.123", "opened camera 0", tag = PortalPresenceLog.TAG_CAMERA)))
+    assertEquals(
+        1_760_000_000_123L,
+        PortalPresenceLog.beatEpochMs(
+            line("1760000000.123", "presence: true", tag = PortalPresenceLog.TAG_CAMERA)))
+  }
+
+  @Test
+  fun `the tag's own name doesn't satisfy the message test`() {
+    // "PresenceManager" contains "presence", so testing the whole line rather than the message
+    // would quietly accept every line from any tag whose NAME mentions presence.
+    assertNull(
+        PortalPresenceLog.beatEpochMs(
+            line("1760000000.123", "opened camera 0", tag = "PresenceManagerCamera")))
+  }
+
+  @Test
+  fun `malformed lines are ignored rather than throwing`() {
+    assertNull(PortalPresenceLog.beatEpochMs("not-a-timestamp I PresenceManager: presence"))
+    assertNull(PortalPresenceLog.beatEpochMs(""))
+    assertNull(PortalPresenceLog.beatEpochMs(line("0.0")))
+    assertNull(PortalPresenceLog.beatEpochMs("1760000000.123 no-tag-separator"))
+  }
+
+  @Test
+  fun `the startup backlog doesn't count as a live beat`() {
+    // logcat replays history on attach; an hour-old beat must not read as someone in the room.
+    assertFalse(PortalPresenceLog.isFreshBeat(now - 3_600_000L, now))
+    assertTrue(PortalPresenceLog.isFreshBeat(now - 1_000L, now))
+  }
+
+  @Test
+  fun `a beat stamped slightly in the future is still fresh`() {
+    // The log writer and we read the same clock, but not at the same instant.
+    assertTrue(PortalPresenceLog.isFreshBeat(now + 500L, now))
+  }
+
+  @Test
+  fun `silence before the first beat is unknown, not absent`() {
+    // The safety property: on a device where these tags never appear (or without READ_LOGS),
+    // reporting an empty room forever would be worse than deferring to the dream proxy.
+    assertNull(PortalPresenceLog.verdict(lastBeatMs = 0L, nowMs = now))
+  }
+
+  @Test
+  fun `a recent beat means present, and a gap means the room emptied`() {
+    assertEquals(true, PortalPresenceLog.verdict(now - 30_000L, now))
+    assertEquals(false, PortalPresenceLog.verdict(now - 60_000L, now))
+  }
+
+  @Test
+  fun `one missed beat is tolerated before declaring absence`() {
+    // Beats land ~30s apart, so the absence window has to clear a single dropped one.
+    assertTrue(PortalPresenceLog.ABSENT_MS > 30_000L)
+    assertEquals(true, PortalPresenceLog.verdict(now - (PortalPresenceLog.ABSENT_MS - 1), now))
+    assertEquals(false, PortalPresenceLog.verdict(now - PortalPresenceLog.ABSENT_MS, now))
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -356,7 +356,17 @@ class SettingsDomainTest {
     // tripwire to enumerate. Pin the spec-key set: a new MqttConfig setting forces a conscious update
     // here (and a spec) rather than silently shipping with no remote/registry exposure.
     assertEquals(
-        setOf("enabled", "host", "port", "username", "password", "useTls", "validateCert"),
+        setOf(
+            "enabled",
+            "host",
+            "port",
+            "username",
+            "password",
+            "useTls",
+            "validateCert",
+            "portalPresence",
+            "ambientSensors",
+            "tempOffset"),
         SettingsDomains.mqtt.specs.map { it.key }.toSet())
   }
 

--- a/docs/features/smart-home.md
+++ b/docs/features/smart-home.md
@@ -8,9 +8,67 @@ as something you can see and control.
 
 The publisher reuses the state Immortal already holds and surfaces it to Home Assistant:
 
-- **Presence** and **screen** state (`PresenceHub`).
+- **Presence** and **screen** state (`PresenceHub`) — see [Presence](#presence) below.
+- **Ambient sensors** — temperature and light, where the model has them. See
+  [Ambient sensors](#ambient-sensors).
 - **Now-playing** media (`NowPlayingHub`) — see [Multi-room audio](multi-room-audio.md).
 - **Battery** (on models that have one).
+- **IP address** (a diagnostic sensor).
+
+## Presence
+
+The **Presence** entity reads Meta's own camera detection. Portal's presence service logs a
+heartbeat about every 30 seconds *while it can see someone*, and goes quiet when the room
+empties — so Immortal tails the system log and reports presence from whether that beat is still
+arriving (`PortalPresenceMonitor`). It's the real signal, not an inference, and it keeps working
+while the photo frame is pinned on.
+
+This needs the `READ_LOGS` permission, which the [provisioning kit](../provisioning.md) already
+grants for the fleet agent — so on a provisioned Portal there's nothing to do. If your Portal was
+set up before that grant existed, re-run the provisioner.
+
+Where the detector can't be read — no grant, or a Portal that doesn't log it — the entity falls
+back to inferring presence from the screensaver's dream/sleep lifecycle. The entity's
+`source` attribute says which you're getting:
+
+| `source` | Meaning |
+| --- | --- |
+| `portal` | Meta's own camera detection. Direct observation of the room. |
+| `proxy` | Inferred from the dream/sleep lifecycle. Blind while the frame is pinned on — see the `confident` attribute. |
+| `screen` | Last resort: whether the panel is on. Used only before the proxy has seen a transition. |
+
+Silence is never read as an empty room: until a first heartbeat arrives the log reader says
+nothing at all and the proxy stays in charge, so a Portal that never reports presence doesn't sit
+in Home Assistant claiming the room is permanently empty.
+
+Turn it off with **Use the Portal's own detector** under Settings → Home Assistant (MQTT) to go
+back to the proxy.
+
+## Ambient sensors
+
+Immortal publishes the Portal's ambient sensors as Home Assistant entities:
+
+| Entity | Unit | Notes |
+| --- | --- | --- |
+| Temperature | °C | Has a calibration offset — see below. |
+| Ambient light | lx | |
+| Humidity | % | Only if the model has the hardware. |
+| Pressure | hPa | Only if the model has the hardware. |
+
+**Sensors are auto-detected**, so only the ones your Portal physically has ever appear — no entity
+is advertised for hardware that isn't there, and switching the feature off clears the entities from
+Home Assistant rather than leaving them behind as "unavailable".
+
+!!! tip "Calibrate the temperature"
+    A temperature sensor inside a powered device reads its own waste heat, so it runs a few degrees
+    warm. Put a thermometer next to the Portal, then set **Temperature offset** (Settings → Home
+    Assistant (MQTT)) to the difference — it applies immediately, without waiting for the room to
+    change.
+
+Readings are rate-limited rather than forwarded raw: a value has to move by a meaningful amount and
+wait out an interval before it's published, so a twitchy light sensor doesn't bury the broker. A
+large jump — someone switching a lamp on — skips most of that wait, because that's the event an
+automation is actually waiting for.
 
 ## What it can control
 

--- a/docs/guides/home-assistant.md
+++ b/docs/guides/home-assistant.md
@@ -6,15 +6,34 @@ Discovery**, so the device appears automatically — no YAML. For the overview, 
 
 ## What you get in Home Assistant
 
-Immortal publishes the state it already tracks, and accepts the one command this hardware can
-honour:
+The Portal arrives as one device with everything below. Entities that depend on hardware only
+appear where the hardware exists.
 
-| Entity | Direction | Notes |
-| --- | --- | --- |
-| Presence | state | Inferred from the Portal's dream/sleep lifecycle (see [limitations](../limitations.md)). |
-| Screen on/off | **state + control** | Wake or sleep the display from an automation (uses the screen-off device admin). |
-| Now-playing media | state | The device's current track — see [now-playing](../features/multi-room-audio.md). |
-| Battery | state | On models that have one (Portal Go). |
+**Sensors**
+
+| Entity | Notes |
+| --- | --- |
+| Presence | Meta's own camera detection, read off the system log — see [presence](../features/smart-home.md#presence). Falls back to the screensaver-lifecycle proxy; the `source` attribute says which. |
+| Screen state | `off` / `dreaming` / `interactive`. |
+| Temperature | Ambient temperature, with a calibration offset. Only on models with the sensor. |
+| Ambient light | Illuminance in lux. Only on models with the sensor. |
+| Humidity, Pressure | Only on models with the sensor. |
+| Media, Media title, Media artist | The current track — see [now-playing](../features/multi-room-audio.md). |
+| Battery, Charging | On models that have a battery (Portal Go). |
+| IP address | Diagnostic. |
+
+**Controls**
+
+| Entity | Notes |
+| --- | --- |
+| Screen | Wake or sleep the display (uses the screen-off device admin). |
+| Play / pause, Next track, Previous track | Transport for whatever is playing. |
+| Media volume, Speaker mute, Volume up / down | Hidden on Portal TV, where volume changes are inaudible. |
+| Microphone mute | |
+| Home, Screensaver | Go to the launcher, or show the photo frame. |
+| Open | Send the Portal to a URL, an installed app, or a Home Assistant dashboard path. |
+| Notify | Push a toast with optional image, sound and tap target — see [notifications](../features/smart-home.md#notifications). |
+| Identify | Pop a toast naming the device, for finding which Portal is which. |
 
 The Portal registers with a stable per-device id, so it survives broker reinstalls but stays unique
 across a fleet. Its **device name is shared with the [fleet agent](../features/fleet.md)**, so a
@@ -64,9 +83,10 @@ automation:
 
 (Entity names follow your Portal's device name; check **Settings → Devices** for the exact ids.)
 
-!!! info "On the roadmap: deeper MQTT security"
-    Today the publisher supports broker **username/password** auth. Additional MQTT security options
-    are **in testing** and not yet in a released build — this page will be updated when they ship.
+!!! info "TLS"
+    As well as broker username/password, the publisher can wrap the connection in **TLS** (turn on
+    *Use TLS* and set the port, conventionally `8883`). Certificate and hostname validation is on by
+    default; turn it off only for a self-signed broker on a network you trust.
 
 ## Troubleshooting
 
@@ -74,3 +94,9 @@ automation:
   host/port/login on the Portal are correct; watch the status line for a connection error.
 - **Screen control does nothing** — the screen-off **device admin** must be granted (the
   [provisioning kit](../provisioning.md) does this; you can also enable it in Immortal settings).
+- **Presence says `proxy`, not `portal`** — the log-reading detector needs the `READ_LOGS`
+  permission. The provisioning kit grants it, so re-run the provisioner on a Portal set up before
+  that grant existed.
+- **No temperature entity** — not every Portal has an ambient temperature sensor. Entities are only
+  advertised for hardware the device actually reports, so a missing one means the sensor isn't
+  there.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -29,9 +29,19 @@ storage stack doesn't bind it, so it doesn't appear as a folder. Put
 [screensaver photos](features/screensaver.md) on the device's own storage instead (e.g. copy
 them across while it's plugged into your computer), or use a network/self-hosted photo source.
 
-## Can't read Meta's presence signal directly
+## Can't *ask* for Meta's presence signal
 
 The Portal won't let an unprivileged app read Meta's camera-based presence detection — it's
-front-camera computer vision behind a platform-signature permission. Immortal instead infers
-presence from the system's own dream/sleep lifecycle, which *is* derived from that signal. See
-the [multi-room design notes](design/multi-room-audio.md) for how this is used.
+front-camera computer vision behind a platform-signature permission, and that door stays shut.
+
+Immortal gets at it another way. Portal's own detector logs a heartbeat roughly every 30 seconds
+**while it sees someone**, and goes quiet when the room empties, so Immortal tails the system log
+and reads presence from whether that beat is still arriving. That needs the `READ_LOGS` permission,
+which the [provisioning kit](provisioning.md) already grants, and it powers the **Presence** entity
+in the [Home Assistant integration](features/smart-home.md#presence).
+
+Where that isn't available — no `READ_LOGS` grant, or a Portal whose firmware doesn't log it —
+Immortal falls back to inferring presence from the system's own dream/sleep lifecycle, which *is*
+derived from the same signal. That fallback can't see the room while the photo frame is pinned on
+(a held screen never times out), which is what the `confident` attribute reports. See the
+[multi-room design notes](design/multi-room-audio.md) for how this is used.


### PR DESCRIPTION
Presence stops being a guess, and the Portal's ambient sensors reach Home Assistant.

## Presence from Meta's own detector

The permission that would let us *ask* the platform for Meta's camera presence detection is signature-gated and stays shut. But the detector is chatty: `PresenceManager` logs a heartbeat about every 30s **while it sees someone**, and goes quiet when the room empties. `PortalPresenceMonitor` tails that and reports the beat's *liveness*.

So the **Presence** entity is now direct observation rather than inference — and it keeps working while the photo frame is pinned on, which is exactly the case the dream/sleep proxy is structurally blind to (a held screen never times out, so the empty-room transition is hidden).

`PresenceHub` gained an authoritative override: whenever the detector is talking its verdict outranks the proxy and is always `confident`. The entity's `source` attribute reports which detector answered — `portal`, `proxy`, or `screen`.

**No new permission.** `READ_LOGS` is already declared and already granted by both provisioners for the fleet agent's `/logcat` endpoint, so a provisioned Portal needs nothing new.

**Silence is never read as an empty room.** Until a first beat arrives the verdict is `null` and the proxy stays in charge — a device that never logs presence (missing grant, different firmware) must not sit in Home Assistant claiming the room is permanently empty. That property is what the tests pin hardest.

## Ambient sensors

New sensor entities: **Temperature**, **Ambient light**, and **Humidity** / **Pressure** where the hardware exists.

- **Auto-detected** — no entity is advertised for hardware the model doesn't have, and switching the feature off clears the retained discovery configs rather than orphaning entities as "unavailable".
- **Temperature calibration offset** (−20…+20 °C), because a sensor inside a powered device reads its own waste heat. Changing it republishes at once instead of waiting for the room to move.
- **Rate-limited**, not forwarded raw — `TYPE_LIGHT` fires continuously. A large jump skips most of the wait, since a lamp coming on is the event an automation is waiting for.
- Values format via `Locale.US`; a comma-decimal device would otherwise publish `21,4`, which HA reads as a non-numeric state.

## Notes for review

- Both features run **only while a broker is connected**, so an un-configured device pays nothing. The trade-off: the improved presence reaches the screensaver only while the HA integration is on. Straightforward to lift into `ImmortalApp` later if that's preferred.
- Added `MqttService.sync(reconfigure = true)`. These settings are read by the *running* publisher, and a plain `sync()` can't reach it — starting an already-running service only re-enters `onStartCommand` and touches nothing. This is the same class of gap as the mic-mute re-publish in #200.
- The log filter has a subtlety worth a look: testing the whole line for "presence" is a no-op, because every line from `PresenceManager` contains "presence" *in its tag*. Lines from the presence service therefore count on the tag alone; camera-service lines must say so in the message.
- Settings live in the existing `mqtt` domain, so the phone remote gets them free; the bespoke on-device `MqttScreen` renders them by hand as that screen already does (it can't use `SettingsList` — Context-as-snapshot, per the documented warning in `SettingsDomains`).

## Docs

- `limitations.md` no longer claims the signal is unreachable — it distinguishes "can't ask for it" from "can't get it".
- The HA guide's entity table had drifted badly (4 rows against ~22 published) and now lists what's actually there, plus presence/sensor troubleshooting.
- Replaced the guide's stale "deeper MQTT security is on the roadmap" note — TLS with certificate validation has shipped.

## Testing

- `./gradlew :app:testDebugUnitTest` — **323 pass, 0 fail** (17 new across `PortalPresenceLogTest` and `AmbientPolicyTest`, covering the parser, the unknown-until-proven property, the absence window, rate limiting, and locale-independent formatting).
- `./gradlew :app:assembleDebug` — builds.
- The `mqttRegistry_specKeysArePinned` tripwire fired on the new settings and was updated deliberately, as intended.
- Not yet verified on real hardware: the log tags come from a third-party project's on-device verification, not my own. Worth a smoke test on a Portal that the `source` attribute reads `portal` and that Temperature appears where expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013opfPDdDg37KZRo4LMYerM

---
_Generated by [Claude Code](https://claude.ai/code/session_013opfPDdDg37KZRo4LMYerM)_