### PR TITLE
Fix folder creation: the dwell could never arm

### DIFF
--- a/app/src/main/java/com/immortal/launcher/HomeActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeActivity.kt
@@ -657,6 +657,9 @@ private fun LauncherScreen(
   var foldCandidate by remember { mutableStateOf<String?>(null) }
   var foldTarget by remember { mutableStateOf<String?>(null) }
   var moveTick by remember { mutableStateOf(0) }
+  // Where the current dwell started. Movement within HomeFold.TOLERANCE_DP of this doesn't count
+  // as the user moving on, so a resting finger's jitter can't keep restarting the timer.
+  var dwellAnchor by remember { mutableStateOf<Offset?>(null) }
 
   fun persist() = UserLayout.save(context, assignments.toMap())
   fun replaceAssignments(next: Map<String, String>) {
@@ -716,6 +719,7 @@ private fun LauncherScreen(
     if (!editMode) editMode = true
     dragKey = key
     dragPos = clampToGrid(win)
+    dwellAnchor = dragPos
     dragOriginalSlots = gridSlots
   }
   fun moveTileDrag(amount: Offset) {
@@ -730,34 +734,52 @@ private fun LauncherScreen(
           dragPos.x < bounds.left + width * 0.14f -> -1
           else -> 0
         }
-    // Any movement restarts the dwell timer and drops the fold highlight; only a pause re-arms it.
-    moveTick++
-    foldTarget = null
-    val src = dragKey ?: return
-    val tgtIdx = targetSlotAt(dragPos)
-    if (tgtIdx == null) {
-      foldCandidate = null
-      return
+    // Real movement restarts the dwell timer and drops the fold highlight; only a pause re-arms
+    // it. "Real" is the operative word: pointer changes are reported for a single pixel, so
+    // restarting on every sample meant a held finger's tremor reset the timer forever and a fold
+    // could never arm. See HomeFold.movedEnough.
+    val tolerancePx =
+        with(context.resources.displayMetrics) { HomeFold.TOLERANCE_DP * density }
+    val anchor = dwellAnchor
+    if (HomeFold.movedEnough(anchor?.x, anchor?.y, dragPos.x, dragPos.y, tolerancePx)) {
+      dwellAnchor = dragPos
+      moveTick++
+      foldTarget = null
     }
-    val tgt = gridSlots.getOrNull(tgtIdx)
+    val src = dragKey ?: return
     // Dwell-to-fold: remember the app we're passing directly over so a pause here can arm a new
-    // folder. Anything else under the finger (folder, widget, built-in, blank) clears the candidate.
-    foldCandidate = if (src.startsWith(APP_KEY) && tgt != null && tgt.startsWith(APP_KEY)) tgt else null
+    // folder. Anything else under the finger (folder, widget, built-in, blank) clears the
+    // candidate — but the gutter BETWEEN tiles doesn't, since it hit-tests as nothing and says
+    // nothing about intent. Clearing there is what broke folder creation.
+    val tgtIdx = targetSlotAt(dragPos)
+    foldCandidate =
+        HomeFold.nextCandidate(src, tgtIdx, tgtIdx?.let { gridSlots.getOrNull(it) }, foldCandidate)
     // Do not mutate the grid during pointer movement. The old live-swap behaviour could process
     // dozens of overlapping targets in one gesture and visually scramble the desktop. A single
     // deterministic swap is committed in endTileDrag only after a valid drop.
+  }
+  /**
+   * Commit an armed dwell-to-fold, if there is one, and report whether it took. Shared by the
+   * normal drop AND the cancel path: the Portal reports a cancel for a brief finger-off-screen,
+   * and discarding a fold the user already held a second for is indistinguishable from "folders
+   * don't work".
+   */
+  fun commitArmedFold(src: String?): Boolean {
+    val armed = foldTarget
+    if (src == null || armed == null || !HomeFold.canFold(src, armed)) return false
+    // Restore the pre-drag slots; the reconcile effect removes both apps and adds the named
+    // folder tile once the name overlay is confirmed.
+    dragOriginalSlots?.let { gridSlots = it }
+    UserLayout.saveGridSlots(context, gridSlots)
+    pendingPair = src.removePrefix(APP_KEY) to armed.removePrefix(APP_KEY)
+    return true
   }
   fun endTileDrag() {
     edgeDir = 0
     val src = dragKey
     if (src != null) {
-      val armed = foldTarget
-      if (src.startsWith(APP_KEY) && armed != null && armed.startsWith(APP_KEY) && armed != src) {
-        // Dwell-to-fold: the app rested on another app — make a folder from the pair. Restore the
-        // pre-drag slots; the reconcile effect removes both apps and adds the named folder tile.
-        dragOriginalSlots?.let { gridSlots = it }
-        UserLayout.saveGridSlots(context, gridSlots)
-        pendingPair = src.removePrefix(APP_KEY) to armed.removePrefix(APP_KEY)
+      if (commitArmedFold(src)) {
+        // Folded — nothing else to do with this drop.
       } else {
         val tgtIdx = targetSlotAt(dragPos)
         val tgt = tgtIdx?.let { gridSlots.getOrNull(it) }
@@ -780,15 +802,19 @@ private fun LauncherScreen(
     dragOriginalSlots = null
     foldTarget = null
     foldCandidate = null
+    dwellAnchor = null
   }
   fun cancelTileDrag() {
     // A cancelled gesture is transactional: restore the exact pre-drag layout and persist nothing.
+    // The exception is an armed fold, which survives — see commitArmedFold.
     edgeDir = 0
-    dragOriginalSlots?.let { gridSlots = it }
+    val src = dragKey
+    if (!commitArmedFold(src)) dragOriginalSlots?.let { gridSlots = it }
     dragKey = null
     dragOriginalSlots = null
     foldTarget = null
     foldCandidate = null
+    dwellAnchor = null
   }
   // Debounced page flip while a drag rests against a screen edge.
   LaunchedEffect(edgeDir) {
@@ -804,12 +830,14 @@ private fun LauncherScreen(
   // Dwell-to-fold: if a dragged app rests over another app for a beat, arm folder creation so the
   // release makes a folder (a quick pass-through just reorders). moveTick restarts this on every
   // movement, so the delay only completes once the finger holds still over the candidate.
-  LaunchedEffect(moveTick, dragKey) {
+  // Keyed on foldCandidate as well as moveTick: now that jitter no longer ticks moveTick, picking
+  // up a candidate can be the only thing that happens, and the timer still has to start then.
+  LaunchedEffect(moveTick, dragKey, foldCandidate) {
     val src = dragKey ?: return@LaunchedEffect
-    if (!src.startsWith(APP_KEY) || foldCandidate == null) return@LaunchedEffect
-    delay(FOLD_DWELL_MS)
-    val cand = foldCandidate
-    if (dragKey == src && cand != null && cand.startsWith(APP_KEY) && gridSlots.contains(cand)) {
+    val cand = foldCandidate ?: return@LaunchedEffect
+    if (!HomeFold.canFold(src, cand)) return@LaunchedEffect
+    delay(HomeFold.DWELL_MS)
+    if (dragKey == src && foldCandidate == cand && gridSlots.contains(cand)) {
       foldTarget = cand
     }
   }
@@ -1322,11 +1350,10 @@ private fun SlideToStop(onStop: () -> Unit) {
   }
 }
 
-private const val APP_KEY = "app:"
-private const val FOLDER_KEY = "folder:"
+private const val APP_KEY = HomeFold.APP_KEY
+private const val FOLDER_KEY = HomeFold.FOLDER_KEY
 private const val WIDGET_KEY = "widget-tile:"
 // How long a dragged app must rest over another app before the drop makes a folder (dwell-to-fold).
-private const val FOLD_DWELL_MS = 1000L
 private const val BUILTIN_CALLS = "builtin:calls"
 private const val BUILTIN_STORE = "builtin:store"
 private const val BUILTIN_TOOLS = "builtin:tools"

--- a/app/src/main/java/com/immortal/launcher/HomeFold.kt
+++ b/app/src/main/java/com/immortal/launcher/HomeFold.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import kotlin.math.hypot
+
+/**
+ * Dwell-to-fold: the rules deciding when dragging one app onto another makes a folder, as opposed
+ * to just reordering the grid. Pure — no Compose, no Android — because this is the part that has
+ * regressed twice ([HomeActivity] owns only the state plumbing around it).
+ *
+ * The interaction: drag an app over another app, hold still for [DWELL_MS], and the target
+ * highlights; releasing then folds the pair. A quick pass-through reorders instead.
+ *
+ * Two properties matter more than they look, and both are what broke last time:
+ *
+ *  - **A gap between tiles is "no news", not "cancel".** The home grid spaces its tiles apart, and
+ *    those gutters belong to no slot, so a finger crossing one hit-tests as nothing. Treating that
+ *    as "the user left the app" cleared the pending target — and since the dwell timer only
+ *    restarts on movement, which is exactly what stops when someone holds still to fold, the fold
+ *    could then never arm at all. See [keepCandidate].
+ *  - **A resting finger still jitters.** Pointer changes are reported for a single pixel, so a
+ *    dwell that restarts on *any* movement never completes on a capacitive panel. Movement has to
+ *    clear [TOLERANCE_DP] before it counts as the user moving on. See [movedEnough].
+ */
+object HomeFold {
+  /** Tile-key prefixes. Canonical here so the pure rules can read a key without Compose. */
+  const val APP_KEY = "app:"
+  const val FOLDER_KEY = "folder:"
+
+  /** How long an app must rest over another before releasing folds instead of reorders. */
+  const val DWELL_MS = 1000L
+
+  /** Movement under this (in dp) is hand tremor, not the user moving to another tile. */
+  const val TOLERANCE_DP = 12f
+
+  /**
+   * True when the pointer has moved far enough from where the dwell started to count as real
+   * movement, restarting the timer. Null [anchorX]/[anchorY] means no dwell is in progress yet.
+   */
+  fun movedEnough(
+      anchorX: Float?,
+      anchorY: Float?,
+      x: Float,
+      y: Float,
+      tolerancePx: Float,
+  ): Boolean {
+    if (anchorX == null || anchorY == null) return true
+    return hypot(x - anchorX, y - anchorY) > tolerancePx
+  }
+
+  /**
+   * The fold candidate after a pointer sample: the app a pause would fold with, or null for none.
+   *
+   * [slotIndexUnderPointer] null means the finger is in the gutter between tiles, which hit-tests
+   * as nothing. That says nothing about intent, so [current] is kept — clearing it there is the
+   * regression this function exists to prevent.
+   */
+  fun nextCandidate(
+      dragged: String,
+      slotIndexUnderPointer: Int?,
+      tileUnderPointer: String?,
+      current: String?,
+  ): String? =
+      if (slotIndexUnderPointer == null) current
+      else candidateFor(dragged, tileUnderPointer)
+
+  /**
+   * The app a pause here could fold with, or null if this tile isn't a fold target. Only
+   * app-on-app folds; a folder, widget, built-in, blank slot, or the dragged tile's own slot all
+   * clear the candidate.
+   */
+  fun candidateFor(dragged: String, tileUnderPointer: String?): String? =
+      if (dragged.startsWith(APP_KEY) &&
+          tileUnderPointer != null &&
+          tileUnderPointer.startsWith(APP_KEY) &&
+          tileUnderPointer != dragged) {
+        tileUnderPointer
+      } else {
+        null
+      }
+
+  /** True when an armed target can actually become a folder with [dragged]. */
+  fun canFold(dragged: String?, armed: String?): Boolean =
+      dragged != null &&
+          armed != null &&
+          dragged.startsWith(APP_KEY) &&
+          armed.startsWith(APP_KEY) &&
+          armed != dragged
+}

--- a/app/src/test/java/com/immortal/launcher/HomeFoldTest.kt
+++ b/app/src/test/java/com/immortal/launcher/HomeFoldTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Dwell-to-fold, the rules behind "drag one app onto another to make a folder". This has regressed
+ * twice — once by losing the interaction outright, once by making it unarmable — so the two
+ * properties that broke it are pinned here rather than left to a device to discover.
+ */
+class HomeFoldTest {
+
+  private val a = "app:com.example.a"
+  private val b = "app:com.example.b"
+  private val folder = "folder:Games"
+  private val widget = "widget-tile:clock"
+
+  // --- the gutter between tiles ---------------------------------------------
+
+  @Test
+  fun `a sample in the gutter between tiles keeps the candidate`() {
+    // THE regression: the grid spaces its tiles apart, so a finger between them hit-tests as no
+    // slot at all. Clearing the candidate there left the dwell with nothing to arm — and the
+    // timer only restarts on movement, which is exactly what stops when you hold still to fold.
+    assertEquals(b, HomeFold.nextCandidate(a, slotIndexUnderPointer = null, tileUnderPointer = null, current = b))
+  }
+
+  @Test
+  fun `landing on another app makes it the candidate`() {
+    assertEquals(b, HomeFold.nextCandidate(a, slotIndexUnderPointer = 4, tileUnderPointer = b, current = null))
+  }
+
+  @Test
+  fun `moving onto something that isn't an app clears the candidate`() {
+    // A real slot under the finger IS news, unlike the gutter: the user moved off the app.
+    assertNull(HomeFold.nextCandidate(a, slotIndexUnderPointer = 4, tileUnderPointer = folder, current = b))
+    assertNull(HomeFold.nextCandidate(a, slotIndexUnderPointer = 4, tileUnderPointer = widget, current = b))
+    // A blank slot is a slot, so it clears too.
+    assertNull(HomeFold.nextCandidate(a, slotIndexUnderPointer = 4, tileUnderPointer = null, current = b))
+  }
+
+  @Test
+  fun `an app can't be a fold candidate with itself`() {
+    assertNull(HomeFold.nextCandidate(a, slotIndexUnderPointer = 4, tileUnderPointer = a, current = null))
+  }
+
+  @Test
+  fun `dragging a folder or widget never picks up a candidate`() {
+    assertNull(HomeFold.nextCandidate(folder, slotIndexUnderPointer = 4, tileUnderPointer = b, current = null))
+    assertNull(HomeFold.nextCandidate(widget, slotIndexUnderPointer = 4, tileUnderPointer = b, current = null))
+  }
+
+  // --- movement tolerance ----------------------------------------------------
+
+  @Test
+  fun `a resting finger's jitter is not movement`() {
+    // Pointer changes are reported for a single pixel. Without tolerance the dwell timer restarts
+    // forever and the fold can never arm on real hardware.
+    assertFalse(HomeFold.movedEnough(100f, 100f, 101f, 102f, tolerancePx = 24f))
+  }
+
+  @Test
+  fun `moving to another tile is movement`() {
+    assertTrue(HomeFold.movedEnough(100f, 100f, 160f, 100f, tolerancePx = 24f))
+  }
+
+  @Test
+  fun `tolerance is a radius, not per-axis`() {
+    // 18 across and 18 down is 25.5 away — over a 24 tolerance, even though neither axis is.
+    assertTrue(HomeFold.movedEnough(100f, 100f, 118f, 118f, tolerancePx = 24f))
+  }
+
+  @Test
+  fun `with no anchor yet, anything counts as movement`() {
+    assertTrue(HomeFold.movedEnough(null, null, 10f, 10f, tolerancePx = 24f))
+  }
+
+  // --- what may actually fold ------------------------------------------------
+
+  @Test
+  fun `only app-on-app, and never with itself`() {
+    assertTrue(HomeFold.canFold(a, b))
+    assertFalse(HomeFold.canFold(a, a))
+    assertFalse(HomeFold.canFold(a, folder))
+    assertFalse(HomeFold.canFold(folder, b))
+    assertFalse(HomeFold.canFold(a, null))
+    assertFalse(HomeFold.canFold(null, b))
+  }
+}

--- a/docs/features/launcher.md
+++ b/docs/features/launcher.md
@@ -11,8 +11,10 @@ and is fully navigable by remote on the [Portal TV](portal-tv.md).
 ## The grid
 
 - **App grid** — your installed apps, fullscreen.
-- **Folders** — in Manage mode, drag one app onto another to make a folder. Name them, rename
-  them, and drag apps back out, just like a phone.
+- **Folders** — in Manage mode, drag one app onto another and **hold it there for a second**: the
+  app underneath outlines in white to show it's ready, and releasing makes a folder. Passing
+  straight over an app without pausing just reorders the grid instead. Name folders, rename them,
+  and drag apps back out, just like a phone.
 - **Manage mode** — remove apps (tap the ✕) and organise the grid.
 
 ## Header


### PR DESCRIPTION
Dragging one app onto another to make a folder has been unreliable to the point of looking removed. The whole path is still there — `pendingPair`, the Name-folder overlay, `HomeLayoutModel.createFolder`, the white highlight — but the dwell that arms it almost never completed.

Two causes, both from the transactional-drag rewrite (#181) meeting the dwell introduced in #134.

## 1. The gutter between tiles cleared the candidate

The home grid spaces its tiles apart (`spacedBy(16.dp)` / `spacedBy(20.dp)`), and slot bounds are the tile rects — so a finger in the gap hit-tests as **no slot at all**. #181 added:

```kotlin
val tgtIdx = targetSlotAt(dragPos)
if (tgtIdx == null) {
  foldCandidate = null   // ← treats the gutter as "the user left"
  return
}
```

Arming only happens in `LaunchedEffect(moveTick, dragKey)`, which bails when `foldCandidate == null` and only re-runs **when the finger moves again** — which is precisely what stops when someone holds still to fold. So one sample in a gutter, or resting slightly between two tiles, made the fold unarmable for the rest of the gesture.

Before #181 this was masked: the null case was `?: return` (no clear), and live-swapping kept the candidate sticky.

The gutter is now "no news" and the candidate survives it.

## 2. The dwell restarted on any movement at all

`moveTick++` and `foldTarget = null` ran on every pointer sample, unconditionally. `drag()` reports a change for a single pixel, and a finger resting on a capacitive panel jitters continuously — so the one-second timer was forever being reset, and an already-armed highlight was dropped.

Movement now has to clear a **12dp radius** from where the dwell started before it counts as the user moving on. The comparison is against the dwell anchor rather than the previous sample, so a slow continuous drag still ticks correctly every 12dp.

The arming effect is also keyed on `foldCandidate` now: with jitter no longer ticking `moveTick`, picking up a candidate can be the only thing that happens, and the timer still has to start then.

## 3. An armed fold now survives a cancel

#181 changed `cancelTileDrag` from committing to reverting. The comment it deleted explained why that mattered: *"a brief finger-off-screen (which the OS reports as a cancel) never snaps everything back."* A cancel discarded the armed `foldTarget` **and** snapped the layout back — indistinguishable from the feature not working. `commitArmedFold` is now shared by both the drop and the cancel path.

## Structure

The rules move into `HomeFold` — pure, no Compose, no Android — because this is the part that has now regressed twice. `HomeActivity` keeps only the state plumbing. Both failure modes are pinned by name in `HomeFoldTest`:

- `a sample in the gutter between tiles keeps the candidate`
- `a resting finger's jitter is not movement`

`APP_KEY` / `FOLDER_KEY` now have a single home in `HomeFold` rather than being duplicated.

## Docs

`docs/features/launcher.md` said "drag one app onto another to make a folder" with no mention of the hold, so even a working build didn't match what users were told. It now describes the hold and the white outline.

## Testing

- `./gradlew :app:testDebugUnitTest` — **333 pass, 0 fail** (10 new in `HomeFoldTest`).
- `./gradlew :app:assembleDebug` — builds.
- Not verified on hardware: the jitter magnitude and the 12dp tolerance are reasoned from the gesture code, not measured on a panel. Worth confirming on a Portal that a normal hold now shows the white outline within a second, and that ordinary reordering still feels unchanged.

The 1s dwell is kept as-is. Now that arming is reliable it may feel long — easy to lower `HomeFold.DWELL_MS`, but it's the guard against accidental folds when someone pauses mid-reorder, so I left the semantics alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013opfPDdDg37KZRo4LMYerM

---
_Generated by [Claude Code](https://claude.ai/code/session_013opfPDdDg37KZRo4LMYerM)_