### PR TITLE
Presence: run the detector app-wide, not just for Home Assistant

### DIFF
--- a/app/src/main/java/com/immortal/launcher/FleetRoutes.kt
+++ b/app/src/main/java/com/immortal/launcher/FleetRoutes.kt
@@ -91,7 +91,11 @@ class FleetRoutes(private val context: Context) {
                 JSONObject()
                     .put("presence", p.presence.name)
                     .put("screen", p.screen.name)
-                    .put("confident", p.confident))
+                    .put("confident", p.confident)
+                    // Which detector answered: "PORTAL" is Meta's own camera detection, "PROXY"
+                    // the dream/sleep inference. Without it a fleet operator can't tell a real
+                    // reading from an inferred one.
+                    .put("source", p.source.name))
             .put(
                 "install",
                 JSONObject()

--- a/app/src/main/java/com/immortal/launcher/ImmortalApp.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalApp.kt
@@ -37,6 +37,10 @@ class ImmortalApp : Application() {
     // (broadcast). DREAMING_STOPPED stays here because it also drives the frame relaunch, and
     // we feed its verdict into the hub from DreamPolicy.
     PresenceHub.init(this)
+    // Meta's own camera detector, read off the system log. Overrides the dream/sleep proxy above
+    // whenever it's talking, so every PresenceHub reader gets the real signal — not just Home
+    // Assistant. No-op without the READ_LOGS grant or with the setting off.
+    PortalPresenceDetector.sync(this)
     // Read the device's native media session (whatever's playing) into NowPlayingHub
     // for the screensaver card + header mini-player. Dormant until our notification
     // listener is enabled — done at provisioning (`cmd notification allow_listener`);

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
@@ -52,6 +52,12 @@ object ImmortalSettings {
       // Mini-player in the home header (cover art + controls), shown only while
       // something is actually playing. Defaults on — useful to everyone, unobtrusive.
       val showMiniPlayer: Boolean = true,
+      // Read presence from Meta's own camera detector (PortalPresenceMonitor) rather than
+      // inferring it from the screensaver's dream/sleep lifecycle. App-wide, not Home
+      // Assistant-specific: the fleet agent and the multi-room companion read the same
+      // PresenceHub. On by default — it needs no permission provisioning doesn't already
+      // grant, and falls back to the proxy on its own when the detector stays quiet.
+      val portalPresence: Boolean = true,
       // Hide the system status bar (immersive). Default on — the clean wall-frame look,
       // and what provisioning seeds; swipe from the top still reveals it transiently.
       val hideStatusBar: Boolean = true,
@@ -84,6 +90,7 @@ object ImmortalSettings {
         weatherWidget = p.getString("weather_widget", WIDGET_OFF) ?: WIDGET_OFF,
         clockFormat = p.getString("clock_format", CLOCK_AUTO) ?: CLOCK_AUTO,
         showMiniPlayer = p.getBoolean("show_mini_player", true),
+        portalPresence = p.getBoolean("portal_presence", true),
         hideStatusBar = p.getBoolean("hide_status_bar", true),
         constrainPageWidth = p.getBoolean("constrain_page_width", false),
         multiRoomEnabled = p.getBoolean("multiroom_enabled", false),
@@ -93,6 +100,11 @@ object ImmortalSettings {
         maPassword = p.getString("ma_password", "") ?: "",
     )
   }
+
+  fun portalPresence(c: Context): Boolean = prefs(c).getBoolean("portal_presence", true)
+
+  fun setPortalPresence(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("portal_presence", on).apply()
 
   fun multiRoomEnabled(c: Context): Boolean = prefs(c).getBoolean("multiroom_enabled", false)
 

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -711,7 +711,6 @@ internal fun MqttScreen(onBack: () -> Unit) {
   var pass by remember { mutableStateOf(MqttConfig.password(context)) }
   var useTls by remember { mutableStateOf(MqttConfig.useTls(context)) }
   var validateCert by remember { mutableStateOf(MqttConfig.validateCert(context)) }
-  var portalPresence by remember { mutableStateOf(MqttConfig.portalPresence(context)) }
   var ambientSensors by remember { mutableStateOf(MqttConfig.ambientSensors(context)) }
   var tempOffset by remember { mutableStateOf(MqttConfig.tempOffset(context)) }
   // MqttStatus is a plain holder updated off the main thread, so poll it for live
@@ -746,7 +745,6 @@ internal fun MqttScreen(onBack: () -> Unit) {
    * they apply with `reconfigure` — a plain sync would no-op against a service already running.
    */
   fun applySensors() {
-    MqttConfig.setPortalPresence(context, portalPresence)
     MqttConfig.setAmbientSensors(context, ambientSensors)
     MqttConfig.setTempOffset(context, tempOffset)
     MqttService.sync(context, reconfigure = true)
@@ -979,30 +977,6 @@ internal fun MqttScreen(onBack: () -> Unit) {
         Spacer(Modifier.size(26.dp))
         SectionLabel("Sensors")
         Card {
-          Row(
-              modifier = Modifier.fillMaxWidth().padding(18.dp),
-              verticalAlignment = Alignment.CenterVertically,
-          ) {
-            Column(modifier = Modifier.weight(1f)) {
-              Text("Use the Portal's own detector", color = Color.White, fontSize = 15.sp)
-              Text(
-                  "Report presence from Meta's own camera detection instead of guessing from " +
-                      "the screensaver. Falls back on its own if the Portal isn't reporting it.",
-                  color = Color(0xFF9A9A9A),
-                  fontSize = 13.sp,
-                  modifier = Modifier.padding(top = 2.dp),
-              )
-            }
-            Segmented(
-                options = listOf("Off" to "off", "On" to "on"),
-                selected = if (portalPresence) "on" else "off",
-                onSelect = {
-                  portalPresence = it == "on"
-                  applySensors()
-                },
-            )
-          }
-          Divider()
           Row(
               modifier = Modifier.fillMaxWidth().padding(18.dp),
               verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/immortal/launcher/MqttConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttConfig.kt
@@ -64,16 +64,6 @@ object MqttConfig {
   fun setValidateCert(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("validate_cert", on).apply()
 
-  /**
-   * Publish the presence sensor from Meta's own camera detector ([PortalPresenceMonitor]) rather
-   * than the dream/sleep proxy. On by default: it needs no permission the provisioning kit
-   * doesn't already grant, and it degrades to the proxy on its own when the log stays quiet.
-   */
-  fun portalPresence(c: Context): Boolean = prefs(c).getBoolean("portal_presence", true)
-
-  fun setPortalPresence(c: Context, on: Boolean) =
-      prefs(c).edit().putBoolean("portal_presence", on).apply()
-
   /** Publish the Portal's ambient sensors (temperature, light, …) as Home Assistant entities. */
   fun ambientSensors(c: Context): Boolean = prefs(c).getBoolean("ambient_sensors", true)
 

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -55,18 +55,15 @@ class MqttPublisher(private val appContext: Context) {
   private val audio by lazy { appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager }
 
   /**
-   * The Portal's ambient sensors, and Meta's own presence detector. Both are owned by the
-   * publisher rather than the app: they exist to feed Home Assistant, so they run exactly while
-   * a broker is connected and cost an un-configured device nothing. (The presence monitor also
-   * improves [PresenceHub] for the screensaver as a side effect, for as long as it's running.)
+   * The Portal's ambient sensors. Owned by the publisher rather than the app because they exist
+   * only to feed Home Assistant entities: they run exactly while a broker is connected, and cost
+   * an un-configured device nothing. (Presence is the opposite case — every [PresenceHub] reader
+   * wants it — so that one lives in [PortalPresenceDetector], app-wide.)
    */
   private val ambient by lazy {
     AmbientSensors(appContext) { kind, value ->
       client?.publish("$base/${kind.key}/state", value, retain = true)
     }
-  }
-  private val portalPresence by lazy {
-    PortalPresenceMonitor(appContext) { PresenceHub.onPortalPresence(appContext, it) }
   }
 
   private val presenceListener = PresenceHub.Listener { st -> runCatching { publishPresence(st) } }
@@ -135,8 +132,6 @@ class MqttPublisher(private val appContext: Context) {
     val c = client ?: return
     Thread {
           runCatching {
-                if (MqttConfig.portalPresence(appContext)) portalPresence.start()
-                else portalPresence.stop()
                 ambient.stop()
                 if (MqttConfig.ambientSensors(appContext)) ambient.start()
                 publishDiscovery(c)
@@ -271,12 +266,10 @@ class MqttPublisher(private val appContext: Context) {
     publishScreen()
     publishIp()
     publishAudioState()
-    if (MqttConfig.portalPresence(appContext)) portalPresence.start()
     if (MqttConfig.ambientSensors(appContext)) ambient.start()
   }
 
   private fun detach() {
-    runCatching { portalPresence.stop() }
     runCatching { ambient.stop() }
     runCatching { PresenceHub.removeListener(presenceListener) }
     runCatching { NowPlayingHub.removeListener(nowPlayingListener) }

--- a/app/src/main/java/com/immortal/launcher/PortalPresence.kt
+++ b/app/src/main/java/com/immortal/launcher/PortalPresence.kt
@@ -96,6 +96,34 @@ object PortalPresenceLog {
 }
 
 /**
+ * Owns the one [PortalPresenceMonitor] for the process, so presence improves for everything that
+ * reads [PresenceHub] — the Home Assistant entity, the fleet agent's `/info`, and the multi-room
+ * companion — rather than only while a broker happens to be connected.
+ *
+ * Started from [ImmortalApp] and re-synced when the setting changes. [sync] is the whole API:
+ * call it, and the monitor runs iff the user wants it (and `READ_LOGS` allows it).
+ */
+object PortalPresenceDetector {
+  private var monitor: PortalPresenceMonitor? = null
+
+  /** Start or stop the detector to match the setting. Safe to call repeatedly. */
+  @Synchronized
+  fun sync(context: Context) {
+    val app = context.applicationContext
+    if (!ImmortalSettings.portalPresence(app)) {
+      monitor?.stop()
+      monitor = null
+      return
+    }
+    if (monitor != null) return
+    val m = PortalPresenceMonitor(app) { PresenceHub.onPortalPresence(app, it) }
+    // start() returns false without READ_LOGS; drop the instance so a later sync retries (the
+    // grant can arrive between runs, when the provisioning kit is re-run).
+    if (m.start()) monitor = m
+  }
+}
+
+/**
  * Runs [PortalPresenceLog] against a live `logcat` process and reports transitions to
  * [PresenceHub]. Owns two daemon threads — one blocked on the log stream, one on a timer that
  * ages the last beat out — mirroring the shape of [MqttPublisher]'s worker/pinger pair.

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -24,6 +24,7 @@ import com.immortal.launcher.FleetConfig
 import com.immortal.launcher.FleetScreensaver
 import com.immortal.launcher.FrameMode
 import com.immortal.launcher.PhotoFramePreviewActivity
+import com.immortal.launcher.PortalPresenceDetector
 import com.immortal.launcher.ScreensaverDismiss
 import com.immortal.launcher.ScreensaverDismissAppActivity
 import com.immortal.launcher.ScreensaverSourcesActivity
@@ -576,6 +577,16 @@ object SettingsDomains {
                       help =
                           "Cap the home screen width on large landscape displays instead of filling the whole panel. Off by default."),
                   BoolSpec(
+                      "portalPresence",
+                      "Use the Portal's own detector",
+                      get = { it.portalPresence },
+                      set = ImmortalSettings::setPortalPresence,
+                      help =
+                          "Detect whether anyone's in the room using the Portal's own camera " +
+                              "detection instead of guessing from the screensaver. Used by Home " +
+                              "Assistant, the fleet tools and multi-room audio. Falls back on its " +
+                              "own if the Portal isn't reporting it."),
+                  BoolSpec(
                       "multiRoomEnabled",
                       "Multi-room audio",
                       get = { it.multiRoomEnabled },
@@ -619,6 +630,7 @@ object SettingsDomains {
                   "hideStatusBar" to "Home screen",
                   "constrainPageWidth" to "Home screen",
                   "clockFormat" to "Clock",
+                  "portalPresence" to "Presence",
                   "multiRoomEnabled" to "Audio",
                   "snapcastHost" to "Audio",
                   "maPort" to "Audio",
@@ -627,6 +639,7 @@ object SettingsDomains {
           defaults = { ImmortalSettings.Settings() },
           onApplied = { c, keys ->
             if ("hideStatusBar" in keys) SettingsGuard.applyStatusBar(c)
+            if ("portalPresence" in keys) PortalPresenceDetector.sync(c)
             if (keys.any { it in setOf("multiRoomEnabled", "snapcastHost", "maPort", "maUsername", "maPassword") })
                 MultiRoomService.sync(c)
           },
@@ -695,16 +708,6 @@ object SettingsDomains {
                       set = MqttConfig::setValidateCert,
                       visible = { c, _ -> MqttConfig.isEnabled(c) && MqttConfig.useTls(c) }),
                   BoolSpec(
-                      "portalPresence",
-                      "Use the Portal's own detector",
-                      get = { MqttConfig.portalPresence(it) },
-                      set = MqttConfig::setPortalPresence,
-                      help =
-                          "Report presence from Meta's own camera detection instead of guessing " +
-                              "from the screensaver. Falls back on its own if the Portal isn't " +
-                              "reporting it.",
-                      visible = { c, _ -> MqttConfig.isEnabled(c) }),
-                  BoolSpec(
                       "ambientSensors",
                       "Ambient sensors",
                       get = { MqttConfig.ambientSensors(it) },
@@ -734,7 +737,6 @@ object SettingsDomains {
                   "password" to "Broker",
                   "useTls" to "Security",
                   "validateCert" to "Security",
-                  "portalPresence" to "Sensors",
                   "ambientSensors" to "Sensors",
                   "tempOffset" to "Sensors"),
           onApplied = { c, keys ->
@@ -749,7 +751,7 @@ object SettingsDomains {
             }
             // These are read by the running publisher, not just at connect time, so tell it to
             // re-read them — a plain sync() would no-op against an already-running service.
-            val live = keys.any { it in setOf("portalPresence", "ambientSensors", "tempOffset") }
+            val live = keys.any { it in setOf("ambientSensors", "tempOffset") }
             MqttService.sync(c, reconfigure = live)
           },
       )

--- a/app/src/test/java/com/immortal/launcher/FleetHttpServerSocketTest.kt
+++ b/app/src/test/java/com/immortal/launcher/FleetHttpServerSocketTest.kt
@@ -125,18 +125,40 @@ class FleetHttpServerSocketTest {
     val server = serverOn(port) { FleetHttpServer.Response(200, """{"ok":true}""") }
     assertEquals("HTTP/1.1 200 OK", ok(port))
     server.stop()
-    // Prove the port was released by binding it ourselves: if stop() had left the listener open,
-    // this throws BindException.
+    // Prove the port was released by binding it ourselves — but give the OS a moment to get
+    // there, because "bindable" is not instantaneous and asserting it once is a coin flip.
     //
-    // The obvious alternative — assert that a fresh connect() fails — is the same claim but it
-    // races, and it flaked on CI while passing locally every time. Once stop() frees the port the
-    // OS is free to hand that number to anything else asking for an ephemeral port, including
-    // another test in this suite calling freePort(). If something else binds it first, the connect
-    // succeeds and the test fails while stop() did its job perfectly.
-    ServerSocket().use { probe ->
-      probe.reuseAddress = true
-      probe.bind(InetSocketAddress(InetAddress.getByName("127.0.0.1"), port))
-      assertTrue("stop() should release the listening port", probe.isBound)
+    // Asserting that a fresh connect() fails is the same claim and races the other way: once the
+    // port is free the OS may hand that number to anything asking for an ephemeral one, including
+    // another test calling freePort(), and then the connect succeeds while stop() did its job.
+    //
+    // Binding is the right claim, but stop() closes the LISTENING socket while the connection the
+    // request above accepted is still winding down (pool.shutdownNow() interrupts the pool, it
+    // doesn't close accepted sockets), so for a moment the port can still be unbindable. Retrying
+    // to a deadline keeps the assertion honest — a leaked listener never becomes bindable and
+    // still fails — without failing on the wind-down. Measured at ~44% failure without this.
+    assertTrue(
+        "stop() should release the listening port",
+        awaitBindable(port, timeoutMs = 5_000),
+    )
+  }
+
+  /** True once [port] can be bound, retrying until [timeoutMs] elapses. */
+  private fun awaitBindable(port: Int, timeoutMs: Long): Boolean {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (true) {
+      val bound =
+          runCatching {
+                ServerSocket().use { probe ->
+                  probe.reuseAddress = true
+                  probe.bind(InetSocketAddress(InetAddress.getByName("127.0.0.1"), port))
+                  probe.isBound
+                }
+              }
+              .getOrDefault(false)
+      if (bound) return true
+      if (System.currentTimeMillis() >= deadline) return false
+      Thread.sleep(50)
     }
   }
 }

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -364,7 +364,6 @@ class SettingsDomainTest {
             "password",
             "useTls",
             "validateCert",
-            "portalPresence",
             "ambientSensors",
             "tempOffset"),
         SettingsDomains.mqtt.specs.map { it.key }.toSet())

--- a/docs/design/multi-room-audio.md
+++ b/docs/design/multi-room-audio.md
@@ -162,7 +162,7 @@ precise about *where* the occupancy signal comes from. There are two viable sour
 **Portal-local proxy** (good enough for the common case, free) and **Home Assistant occupancy
 sensors** (authoritative, decoupled) — and one that's genuinely closed to us.
 
-### What's closed: reading Meta's presence directly
+### What's closed: *asking* for Meta's presence directly
 
 We tore apart the native `Photos_superframe.apk` (and the `aloha-gen1` system dump) to settle
 this. Meta's presence is **front-camera computer vision**, not a discrete sensor:
@@ -184,8 +184,21 @@ Access is **platform-signature-gated**. The provider/service require
 presence; an unprivileged, non-root third-party app **cannot** — directly. That part of the
 old `DreamPolicy` comment was right.
 
-What was *overstated* was concluding presence is therefore unachievable. We can't read Meta's
-signal, but we already receive events **derived** from it, and that's enough for the baseline.
+What was *overstated* was concluding presence is therefore unachievable. Two ways round it, and
+we now use both:
+
+- **The detector talks even though it won't answer.** `PresenceManager` (Aloha) logs a heartbeat
+  roughly every 30s *while it sees a person*, and goes quiet when the room empties. Tailing that
+  with `READ_LOGS` — a development permission the provisioning kit already grants for the fleet
+  agent — gives the real signal, liveness-of-beat rather than any API. That's
+  `PortalPresenceMonitor`, owned app-wide by `PortalPresenceDetector`, and its verdict overrides
+  the proxy below in `PresenceHub` whenever it's talking. `PresenceState.source` reports which
+  answered.
+- **The events derived from it.** The proxy below, which remains the fallback for devices without
+  the grant, or where those log tags never appear.
+
+So the signature gate is real and unchanged — nothing here reads the provider or the CV service.
+What it gates is the *interface*, not the information.
 
 ### What's open: the presence-derived proxy (Portal-local, free)
 

--- a/docs/features/smart-home.md
+++ b/docs/features/smart-home.md
@@ -41,8 +41,10 @@ Silence is never read as an empty room: until a first heartbeat arrives the log 
 nothing at all and the proxy stays in charge, so a Portal that never reports presence doesn't sit
 in Home Assistant claiming the room is permanently empty.
 
-Turn it off with **Use the Portal's own detector** under Settings → Home Assistant (MQTT) to go
-back to the proxy.
+Turn it off with **Use the Portal's own detector** under **Settings → Immortal** to go back to the
+proxy. It lives there rather than under Home Assistant because it isn't MQTT-specific: the
+[fleet agent](fleet.md) and [multi-room audio](multi-room-audio.md) read the same presence signal,
+so they get the better reading too — whether or not Home Assistant is set up.
 
 ## Ambient sensors
 

--- a/docs/guides/home-assistant.md
+++ b/docs/guides/home-assistant.md
@@ -94,9 +94,9 @@ automation:
   host/port/login on the Portal are correct; watch the status line for a connection error.
 - **Screen control does nothing** — the screen-off **device admin** must be granted (the
   [provisioning kit](../provisioning.md) does this; you can also enable it in Immortal settings).
-- **Presence says `proxy`, not `portal`** — the log-reading detector needs the `READ_LOGS`
-  permission. The provisioning kit grants it, so re-run the provisioner on a Portal set up before
-  that grant existed.
+- **Presence says `proxy`, not `portal`** — check **Use the Portal's own detector** is on under
+  Settings → Immortal, then the `READ_LOGS` permission. The provisioning kit grants it, so re-run
+  the provisioner on a Portal set up before that grant existed.
 - **No temperature entity** — not every Portal has an ambient temperature sensor. Entities are only
   advertised for hardware the device actually reports, so a missing one means the sensor isn't
   there.


### PR DESCRIPTION
Follow-up to #208. The log-reading presence detector was owned by `MqttPublisher` — started in `attach()`, stopped in `detach()` — which made the better signal conditional on having a broker connected. That's backwards for the other two things reading `PresenceHub`, neither of which has anything to do with MQTT:

- **The fleet agent's `/info`** (`FleetRoutes.kt`), which reports presence to `fleetctl` and the phone remote.
- **The multi-room companion**, via the `ACTION_PRESENCE` broadcast. Per `docs/design/multi-room-audio.md`, in **Presence** mode the frame and the music follow that shared signal together; otherwise it falls back to Home Assistant occupancy.

## The move

The monitor now lives in `PortalPresenceDetector`, synced from `ImmortalApp`, so every reader gets the real signal whether or not Home Assistant is set up.

Where this matters most is **Always-on mode**: that's exactly when the dream/sleep proxy goes blind — a pinned screen never times out, so the empty-room transition is hidden and `confident` is false — and the log detector still sees straight through.

The setting moves with it, `MqttConfig` → `ImmortalSettings`, since it's no longer HA-specific. It now appears under **Settings → Immortal** and renders from the registry on both the device and the phone remote, which also retires the hand-written row I'd added to the bespoke MQTT screen. **No migration needed** — the pref has never been in a released build (1.67 predates #208).

`sync()` is the whole API and is idempotent; if `READ_LOGS` isn't granted, `start()` returns false and the instance is dropped so a later sync retries — the grant can arrive between runs when someone re-runs the provisioner.

**Ambient sensors deliberately stay with the publisher.** Those really are Home Assistant entities with no other consumer, so an un-configured device should keep paying nothing for them.

## Two smaller things

- **`/info` now reports `source`** alongside `confident`. Without it a fleet operator can't tell a real reading from an inferred one.
- **`docs/design/multi-room-audio.md` § "What's closed"** claimed only a platform-signed app can read presence. Its facts were right and are unchanged — the `PresenceStateContentProvider` and the SmartCamera service are still signature-gated, and nothing here touches either — but the conclusion needed the same correction `limitations.md` got in #208: the gate is on the *interface*, not the information.

## Testing

- `./gradlew :app:testDebugUnitTest` — **333 pass, 0 fail**.
- `./gradlew :app:assembleDebug` — builds.
- The `mqttRegistry_specKeysArePinned` and `immortalRegistry_coversEveryPersistedField` tripwires both had to be satisfied by the move, which is exactly what they're for.
- Still unverified on hardware, same as #208: worth checking `/info` reports `"source":"PORTAL"` on a provisioned Portal, and that presence now reflects the room while the frame is pinned on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013opfPDdDg37KZRo4LMYerM

---
_Generated by [Claude Code](https://claude.ai/code/session_013opfPDdDg37KZRo4LMYerM)_