### PR TITLE
MQTT: stop the audio entities drifting from the device

### DIFF
--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -70,6 +70,7 @@ class MqttPublisher(private val appContext: Context) {
   private val nowPlayingListener = NowPlayingHub.Listener { st -> runCatching { publishMedia(st) } }
   private var batteryReceiver: BroadcastReceiver? = null
   private var screenReceiver: BroadcastReceiver? = null
+  private var micMuteReceiver: BroadcastReceiver? = null
 
   fun start() {
     if (running) return
@@ -126,7 +127,8 @@ class MqttPublisher(private val appContext: Context) {
    *
    * The sensors are restarted rather than left alone so that a changed temperature offset shows
    * up at once — re-registering replays each sensor's current reading — instead of waiting for
-   * the room to move.
+   * the room to move. Current state is republished too, so this is also the deterministic
+   * "something changed underneath you, catch up" nudge for callers outside the publisher.
    */
   fun reconfigure() {
     val c = client ?: return
@@ -136,6 +138,7 @@ class MqttPublisher(private val appContext: Context) {
                 if (MqttConfig.ambientSensors(appContext)) ambient.start()
                 publishDiscovery(c)
                 publishPresence(PresenceHub.current)
+                publishAudioState()
               }
               .onFailure { Log.w(TAG, "reconfigure failed", it) }
         }
@@ -192,6 +195,10 @@ class MqttPublisher(private val appContext: Context) {
                     // sleep) — keeps the screen sensor and presence from going stale.
                     runCatching { publishScreen() }
                     runCatching { publishPresence(PresenceHub.current) }
+                    // Audio for the same reason: the system volume keys and any local control
+                    // move these without telling us, so HA's slider and switches would sit on
+                    // whatever we last published until the next reconnect.
+                    runCatching { publishAudioState() }
                   }
                 }
               }
@@ -263,6 +270,18 @@ class MqttPublisher(private val appContext: Context) {
           addAction(Intent.ACTION_SCREEN_ON)
           addAction(Intent.ACTION_SCREEN_OFF)
         })
+    // Mic mute can be changed by anything on the device — a remapped remote button, another
+    // app, the system — and HA's switch would then sit stale until the next reconnect. The
+    // platform broadcasts every change from API 28 (every Portal), so follow that rather than
+    // asking each caller to remember to republish.
+    val mr =
+        object : BroadcastReceiver() {
+          override fun onReceive(c: Context, i: Intent) = runCatching { publishMicMute() }.let {}
+        }
+    micMuteReceiver = mr
+    // The literal avoids gating on AudioManager.ACTION_MICROPHONE_MUTE_CHANGED (API 28) when
+    // minSdk is 24; on an older device the action simply never fires.
+    appContext.registerReceiver(mr, IntentFilter(ACTION_MIC_MUTE_CHANGED))
     publishScreen()
     publishIp()
     publishAudioState()
@@ -277,6 +296,8 @@ class MqttPublisher(private val appContext: Context) {
     batteryReceiver = null
     screenReceiver?.let { r -> runCatching { appContext.unregisterReceiver(r) } }
     screenReceiver = null
+    micMuteReceiver?.let { r -> runCatching { appContext.unregisterReceiver(r) } }
+    micMuteReceiver = null
   }
 
   // --- commands (broker → device) ---------------------------------------------
@@ -850,6 +871,8 @@ class MqttPublisher(private val appContext: Context) {
 
   private companion object {
     const val TAG = "ImmortalMqtt"
+    /** [android.media.AudioManager.ACTION_MICROPHONE_MUTE_CHANGED], usable below API 28. */
+    const val ACTION_MIC_MUTE_CHANGED = "android.media.action.MICROPHONE_MUTE_CHANGED"
     const val KEEPALIVE_SEC = 45
     const val PING_MS = 20_000L
     const val BACKOFF_MS = 4_000L

--- a/docs/guides/home-assistant.md
+++ b/docs/guides/home-assistant.md
@@ -29,7 +29,7 @@ appear where the hardware exists.
 | Screen | Wake or sleep the display (uses the screen-off device admin). |
 | Play / pause, Next track, Previous track | Transport for whatever is playing. |
 | Media volume, Speaker mute, Volume up / down | Hidden on Portal TV, where volume changes are inaudible. |
-| Microphone mute | |
+| Microphone mute | Follows the device: muting from anywhere on the Portal updates the switch. |
 | Home, Screensaver | Go to the launcher, or show the photo frame. |
 | Open | Send the Portal to a URL, an installed app, or a Home Assistant dashboard path. |
 | Notify | Push a toast with optional image, sound and tap target — see [notifications](../features/smart-home.md#notifications). |


### PR DESCRIPTION
Fixes the mic-mute desync raised in review of #200, on the `main` side, so that PR doesn't have to carry it.

## The problem

`publishMicMute()` is called from `attach()` (on connect) and from the `mic_mute` command handler — nowhere else. So Home Assistant's switch tracked changes that *arrived over MQTT* and nothing else. Anything else muting the microphone left the switch showing the opposite of reality until the next reconnect.

#200 hit this with its remapped remote button and reached for `MqttService.sync(this)` to fix it, which is a no-op against an already-running service (it just re-enters `onStartCommand`).

## The fix

Follow the platform rather than asking every caller to remember. The system broadcasts `MICROPHONE_MUTE_CHANGED` on every change from API 28 — every Portal — so the publisher listens and republishes. That fixes the drift for **all** causes, not just the remote button, and means a local control doesn't need to know the MQTT publisher exists.

Two supporting changes for the same reason:

- **The heartbeat now refreshes audio** alongside screen and presence. The system volume keys move `STREAM_MUSIC` without telling us, and there's no equivalent public broadcast to hang that on, so the existing 20s heartbeat — which already exists precisely because Portal's screen broadcasts are unreliable — picks it up.
- **`reconfigure()` republishes current state**, not just discovery, making `sync(reconfigure = true)` the deterministic "catch up" nudge for callers outside the publisher. That's what #200's code was reaching for.

## Notes

The action is referenced as a string literal rather than `AudioManager.ACTION_MICROPHONE_MUTE_CHANGED`, so it needs no API gate at `minSdk 24`; below 28 it simply never fires and the heartbeat still covers it.

The heartbeat adds up to three retained publishes per 20s per device (volume, speaker mute, mic mute — volume and speaker mute only on models where volume is controllable, so not Portal TV). Trivial for a LAN broker, and it makes every audio entity self-healing rather than correct-only-at-connect.

**What #200 still needs:** with this in, its `MqttService.sync(this)` line can simply be deleted — the broadcast covers it. If the author prefers something explicit, `sync(reconfigure = true)` now works too. Either way it's a one-line change on their side, and I've said so on that PR.

## Testing

- `./gradlew :app:assembleDebug` — builds.
- `./gradlew :app:testDebugUnitTest` — 333 pass, 0 fail.
- **Not verified on hardware**: the assumption is that Portal's AudioService emits `MICROPHONE_MUTE_CHANGED` like stock AOSP. Worth confirming on a device — toggle the mic-mute switch from HA, then mute locally, and check the switch follows. If Portal turns out not to emit it, the heartbeat still corrects within 20s, so this degrades rather than breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013opfPDdDg37KZRo4LMYerM

---
_Generated by [Claude Code](https://claude.ai/code/session_013opfPDdDg37KZRo4LMYerM)_