### PR TITLE
Declare QUERY_ALL_PACKAGES so the app grid works on Android 11+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,15 @@
     <!-- Store: install and remove apps on-device via PackageInstaller. -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
+    <!-- See other installed apps. A no-op on the Portals' Android 9/10, but on
+         Android 11+ package-visibility filtering otherwise blinds us to every
+         third-party app: the launcher grid shows only our own tiles, the store's
+         installed-version checks miss, and MQTT/fleet launch-app commands (which
+         take arbitrary package ids) resolve nothing. QUERY_ALL_PACKAGES rather
+         than a scoped <queries> block because the store catalog and remote
+         launch targets aren't a fixed set we could enumerate. -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
     <!-- Self-healing: reaffirm our screensaver settings if something resets them.
          Not granted at install (privileged); provisioning grants it via
          `pm grant ... WRITE_SECURE_SETTINGS`. Harmless no-op if not granted. -->


### PR DESCRIPTION
## Problem

On Android 11+ devices, Immortal's home grid shows only its own tiles (Calls, App Store, Tools, Settings, Up to date) — every third-party app is missing.

Cause: [package-visibility filtering](https://developer.android.com/training/package-visibility) applies to apps targeting SDK 30+ running on Android 11+, and the manifest declares no `<queries>` block, so `queryIntentActivities`, `getPackageInfo(<other pkg>)`, and `getLaunchIntentForPackage` silently return nothing for other third-party packages. Beyond the empty grid, the store's installed-version checks (`StoreCatalog`) always report not-installed, and MQTT/fleet `launch-app` commands can't resolve their targets.

This never reproduces on the Portals themselves — Android 9/10 predate the filtering — which is presumably why it hasn't come up. It hits anyone running Immortal on a newer device, where it otherwise runs great.

## Fix

Declare `QUERY_ALL_PACKAGES`. A no-op on the Portals, and the standard declaration for a launcher + app store: a scoped `<queries>` intent block would cover the grid, but not `getPackageInfo` on arbitrary store-catalog packages or the arbitrary package ids accepted by the MQTT/fleet launch commands. (The runtime escape hatch — `am compat disable 135549675` — is blocked for non-debuggable apps on user builds, so this can't be fixed from the device side.)

## Testing

Verified on an Android 11 (SDK 30, armeabi-v7a) kiosk tablet (incar DF-21T):

- Stock v1.67: grid shows only Immortal's own tiles.
- v1.67 rebuilt with only this permission added: Home Assistant, Kiosk Satellite, Chromium, Termux, and every other launcher app appear and launch correctly; store installed-detection works.
- Incidentally, this also confirms Immortal runs well beyond the Portal (the v1.67 APK already ships `armeabi-v7a` libs) — launcher, weather, App Store, photo-frame screensaver, and Tools all work on that device once visibility is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)