### PR TITLE
Camera: design note, plus phase 1 (snapshots to Home Assistant)

### DIFF
--- a/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
@@ -58,6 +58,10 @@ object ImmortalSettings {
       // PresenceHub. On by default — it needs no permission provisioning doesn't already
       // grant, and falls back to the proxy on its own when the detector stays quiet.
       val portalPresence: Boolean = true,
+      // Let Home Assistant take a still from the Portal's camera. OFF by default and
+      // deliberately device-only consent: nothing arriving over MQTT can turn this on, and with
+      // it off the camera is never opened. See docs/design/camera-streaming.md.
+      val cameraEnabled: Boolean = false,
       // Hide the system status bar (immersive). Default on — the clean wall-frame look,
       // and what provisioning seeds; swipe from the top still reveals it transiently.
       val hideStatusBar: Boolean = true,
@@ -91,6 +95,7 @@ object ImmortalSettings {
         clockFormat = p.getString("clock_format", CLOCK_AUTO) ?: CLOCK_AUTO,
         showMiniPlayer = p.getBoolean("show_mini_player", true),
         portalPresence = p.getBoolean("portal_presence", true),
+        cameraEnabled = p.getBoolean("camera_enabled", false),
         hideStatusBar = p.getBoolean("hide_status_bar", true),
         constrainPageWidth = p.getBoolean("constrain_page_width", false),
         multiRoomEnabled = p.getBoolean("multiroom_enabled", false),
@@ -100,6 +105,11 @@ object ImmortalSettings {
         maPassword = p.getString("ma_password", "") ?: "",
     )
   }
+
+  fun cameraEnabled(c: Context): Boolean = prefs(c).getBoolean("camera_enabled", false)
+
+  fun setCameraEnabled(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("camera_enabled", on).apply()
 
   fun portalPresence(c: Context): Boolean = prefs(c).getBoolean("portal_presence", true)
 

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -60,6 +60,11 @@ class MqttPublisher(private val appContext: Context) {
    * an un-configured device nothing. (Presence is the opposite case — every [PresenceHub] reader
    * wants it — so that one lives in [PortalPresenceDetector], app-wide.)
    */
+  /**
+   * Stills for Home Assistant. Consent is the device-side setting it reads; this object opens
+   * nothing until a snapshot is actually asked for. See docs/design/camera-streaming.md.
+   */
+  private val camera by lazy { PortalCameraCapture(appContext) }
   private val ambient by lazy {
     AmbientSensors(appContext) { kind, value ->
       client?.publish("$base/${kind.key}/state", value, retain = true)
@@ -364,6 +369,24 @@ class MqttPublisher(private val appContext: Context) {
             // (mutes only every other press).
             publishMicMute(on)
           }
+          // Camera work blocks and must not run on main; the handler posts here, so hop off.
+          "snapshot" -> {
+            Thread {
+                  runCatching {
+                        val jpeg = camera.snapshot()
+                        if (jpeg == null) Log.i(TAG, "snapshot unavailable")
+                        // retain = false on purpose: a still of someone's room should not sit on
+                        // the broker indefinitely for anyone who later subscribes.
+                        else client?.publish("$base/camera/image", jpeg, retain = false)
+                      }
+                      .onFailure { Log.w(TAG, "snapshot failed", it) }
+                }
+                .apply {
+                  isDaemon = true
+                  name = "mqtt-snapshot"
+                  start()
+                }
+          }
           "notify" -> handleNotify(payload)
           // Show the photo frame on demand — the same surface the launcher's header
           // screensaver button launches (HomeActivity.onStartScreensaver). This is the
@@ -666,6 +689,16 @@ class MqttPublisher(private val appContext: Context) {
     }
     switchEntity(c, "mic_mute", "Microphone mute", icon = "mdi:microphone-off")
 
+    // Camera stills, only while the user has switched the camera on for this Portal. Off (the
+    // default) clears both configs, so HA drops the entities rather than showing them dead.
+    if (ImmortalSettings.cameraEnabled(appContext)) {
+      cameraEntity(c, "camera", "Camera")
+      button(c, "snapshot", "Take snapshot", icon = "mdi:camera")
+    } else {
+      publishConfig(c, "camera", "camera", null)
+      publishConfig(c, "button", "snapshot", null)
+    }
+
     button(c, "go_home", "Home", icon = "mdi:home")
     button(c, "screensaver", "Screensaver", icon = "mdi:image-multiple")
     textEntity(c, "open", "Open", icon = "mdi:open-in-app")
@@ -699,6 +732,8 @@ class MqttPublisher(private val appContext: Context) {
           "notify" to "notify",
           "button" to "identify",
           "sensor" to "ip",
+          "camera" to "camera",
+          "button" to "snapshot",
           "button" to "screen_off", // legacy (pre-1.41)
       ) + AmbientKind.values().map { "sensor" to it.key }
 
@@ -840,6 +875,20 @@ class MqttPublisher(private val appContext: Context) {
             .put("command_template", "{\"message\": {{ value|tojson }}}")
             .put("availability_topic", "$base/availability")
     publishConfig(c, "notify", obj, cfg)
+  }
+
+  /**
+   * HA's MQTT `camera` component: it renders whatever JPEG arrives on [topic]. Chosen over an
+   * HTTP endpoint because it needs no second auth story — it rides the broker we already trust,
+   * and it doesn't require the (opt-in) fleet agent to be running.
+   */
+  private fun cameraEntity(c: MqttClient, obj: String, name: String) {
+    val cfg =
+        base(obj, name)
+            .put("topic", "$base/$obj/image")
+            .put("availability_topic", "$base/availability")
+            .put("icon", "mdi:cctv")
+    publishConfig(c, "camera", obj, cfg)
   }
 
   /** Publish (or, when [cfg] is null, clear) a retained discovery config. */

--- a/app/src/main/java/com/immortal/launcher/PortalCamera.kt
+++ b/app/src/main/java/com/immortal/launcher/PortalCamera.kt
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.ImageFormat
+import android.hardware.camera2.CameraCaptureSession
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraDevice
+import android.hardware.camera2.CameraManager
+import android.hardware.camera2.params.StreamConfigurationMap
+import android.media.ImageReader
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+import android.widget.Toast
+import androidx.core.content.ContextCompat
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Choosing a capture size. Pure — the Camera2 plumbing around it can't be unit-tested on the
+ * JVM, but which of the offered sizes we ask for can be, and it's the part with a decision in it.
+ */
+object CameraSizes {
+  /**
+   * The largest offered size whose longest edge fits within [maxEdge], or — when everything on
+   * offer is bigger — the smallest size available.
+   *
+   * Bounded on purpose: this runs on Android 9 hardware with no `largeHeap`, often while the
+   * photo frame is also holding full-screen bitmaps, and a snapshot for a dashboard tile does
+   * not need the sensor's full resolution. Preferring the smallest when nothing fits keeps a
+   * device that only offers large sizes working rather than failing outright.
+   */
+  fun choose(offered: List<Pair<Int, Int>>, maxEdge: Int): Pair<Int, Int>? {
+    if (offered.isEmpty()) return null
+    val area = { s: Pair<Int, Int> -> s.first.toLong() * s.second.toLong() }
+    val longest = { s: Pair<Int, Int> -> maxOf(s.first, s.second) }
+    return offered.filter { longest(it) <= maxEdge }.maxByOrNull(area)
+        ?: offered.minByOrNull(area)
+  }
+}
+
+/**
+ * A single JPEG from the Portal's camera, on demand.
+ *
+ * Phase 1 of `docs/design/camera-streaming.md`: stills only, no video, no audio. It reuses the
+ * approach [GestureCamera] already proves — standard Camera2, never Meta's signature-gated Smart
+ * Camera SDK — but takes one frame and releases the camera immediately rather than holding it.
+ *
+ * **Consent lives on the device.** [ImmortalSettings.Settings.cameraEnabled] is off by default and
+ * can only be turned on from the Portal itself; nothing arriving over MQTT can switch it on. With
+ * it off, [snapshot] never opens the camera.
+ *
+ * Every capture shows a toast on the device. Someone in the room should never be photographed by
+ * this without the Portal saying so — and for stills a toast is the honest signal. Continuous
+ * streaming (phase 2) needs a persistent indicator instead, not this.
+ *
+ * [snapshot] blocks; call it off the main thread.
+ */
+class PortalCameraCapture(private val appContext: Context) {
+
+  /** True when the user has enabled the camera AND the permission is actually granted. */
+  fun available(): Boolean =
+      ImmortalSettings.load(appContext).cameraEnabled &&
+          ContextCompat.checkSelfPermission(appContext, Manifest.permission.CAMERA) ==
+              PackageManager.PERMISSION_GRANTED
+
+  /**
+   * Capture one JPEG, or null if unavailable, unsupported, or the capture didn't complete within
+   * [timeoutMs]. Opens and releases the camera per call: the camera is shared on Portal (a call
+   * takes it, and the photo frame's gesture detection wants it), so holding it open between
+   * snapshots would starve them for no benefit.
+   */
+  fun snapshot(timeoutMs: Long = TIMEOUT_MS): ByteArray? {
+    if (!available()) {
+      Log.i(TAG, "camera off or ungranted — no snapshot")
+      return null
+    }
+    var thread: HandlerThread? = null
+    var device: CameraDevice? = null
+    var session: CameraCaptureSession? = null
+    var reader: ImageReader? = null
+    return try {
+      val manager = appContext.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+      val cameraId = pickFrontCamera(manager) ?: return null
+      val size = jpegSize(manager, cameraId) ?: return null
+      val ht = HandlerThread("immortal-camera").apply { start() }
+      thread = ht
+      val handler = Handler(ht.looper)
+
+      val latch = CountDownLatch(1)
+      // Plain var, not @Volatile (illegal on a local anyway): the latch gives the
+      // happens-before between the callback thread's write and our read after await().
+      var bytes: ByteArray? = null
+      val rdr = ImageReader.newInstance(size.first, size.second, ImageFormat.JPEG, 2)
+      reader = rdr
+      rdr.setOnImageAvailableListener(
+          { r ->
+            runCatching {
+                  r.acquireLatestImage()?.use { img ->
+                    val buf = img.planes[0].buffer
+                    bytes = ByteArray(buf.remaining()).also { buf.get(it) }
+                  }
+                }
+                .onFailure { Log.w(TAG, "reading frame failed", it) }
+            latch.countDown()
+          },
+          handler)
+
+      val opened = CountDownLatch(1)
+      var cam0: CameraDevice? = null
+      openCamera(manager, cameraId, handler) {
+        cam0 = it
+        opened.countDown()
+      }
+      if (!opened.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+        Log.w(TAG, "camera didn't open within ${timeoutMs}ms")
+        return null
+      }
+      val cam = cam0 ?: return null
+      device = cam
+
+      val configured = CountDownLatch(1)
+      var sess0: CameraCaptureSession? = null
+      @Suppress("DEPRECATION") // matches GestureCamera; the API 28 replacement isn't on minSdk 24
+      cam.createCaptureSession(
+          listOf(rdr.surface),
+          object : CameraCaptureSession.StateCallback() {
+            override fun onConfigured(s: CameraCaptureSession) {
+              sess0 = s
+              configured.countDown()
+            }
+
+            override fun onConfigureFailed(s: CameraCaptureSession) = configured.countDown()
+          },
+          handler)
+      if (!configured.await(timeoutMs, TimeUnit.MILLISECONDS)) return null
+      val sess = sess0 ?: return null
+      session = sess
+
+      val req =
+          cam.createCaptureRequest(CameraDevice.TEMPLATE_STILL_CAPTURE).apply {
+            addTarget(rdr.surface)
+          }
+      sess.capture(req.build(), null, handler)
+      if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+        Log.w(TAG, "capture didn't complete within ${timeoutMs}ms")
+        return null
+      }
+      bytes?.also { indicate(it.size) }
+    } catch (t: Throwable) {
+      // The camera is shared and this runs alongside the always-on dream: a failure here must
+      // never take a process down, it just means no snapshot this time.
+      Log.w(TAG, "snapshot failed", t)
+      null
+    } finally {
+      runCatching { session?.close() }
+      runCatching { device?.close() }
+      runCatching { reader?.close() }
+      runCatching { thread?.quitSafely() }
+    }
+  }
+
+  /** Tell the room. A capture the Portal doesn't announce is not one we should be taking. */
+  private fun indicate(byteCount: Int) {
+    Log.i(TAG, "snapshot captured ($byteCount bytes)")
+    Handler(appContext.mainLooper).post {
+      runCatching {
+        Toast.makeText(appContext, "Immortal · camera snapshot taken", Toast.LENGTH_SHORT).show()
+      }
+    }
+  }
+
+  private fun pickFrontCamera(manager: CameraManager): String? =
+      runCatching {
+            manager.cameraIdList.firstOrNull {
+              manager.getCameraCharacteristics(it).get(CameraCharacteristics.LENS_FACING) ==
+                  CameraCharacteristics.LENS_FACING_FRONT
+            } ?: manager.cameraIdList.firstOrNull()
+          }
+          .getOrNull()
+
+  private fun jpegSize(manager: CameraManager, cameraId: String): Pair<Int, Int>? =
+      runCatching {
+            val map =
+                manager
+                    .getCameraCharacteristics(cameraId)
+                    .get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
+                    as? StreamConfigurationMap
+            val offered =
+                map?.getOutputSizes(ImageFormat.JPEG)?.map { it.width to it.height }.orEmpty()
+            CameraSizes.choose(offered, MAX_EDGE)
+          }
+          .getOrNull()
+
+  @Suppress("MissingPermission") // checked in available()
+  private fun openCamera(
+      manager: CameraManager,
+      cameraId: String,
+      handler: Handler,
+      onOpened: (CameraDevice?) -> Unit,
+  ) {
+    manager.openCamera(
+        cameraId,
+        object : CameraDevice.StateCallback() {
+          override fun onOpened(camera: CameraDevice) = onOpened(camera)
+
+          override fun onDisconnected(camera: CameraDevice) {
+            runCatching { camera.close() }
+            onOpened(null)
+          }
+
+          override fun onError(camera: CameraDevice, error: Int) {
+            Log.w(TAG, "camera error $error")
+            runCatching { camera.close() }
+            onOpened(null)
+          }
+        },
+        handler)
+  }
+
+  private companion object {
+    const val TAG = "ImmortalCamera"
+    /** Longest edge we'll ask for — a dashboard tile, not a photograph. */
+    const val MAX_EDGE = 640
+    const val TIMEOUT_MS = 5_000L
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -593,6 +593,16 @@ object SettingsDomains {
                               "Assistant, the fleet tools and multi-room audio. Falls back on its " +
                               "own if the Portal isn't reporting it."),
                   BoolSpec(
+                      "cameraEnabled",
+                      "Camera snapshots",
+                      get = { it.cameraEnabled },
+                      set = ImmortalSettings::setCameraEnabled,
+                      help =
+                          "Let Home Assistant take a still photo from this Portal's camera. Off " +
+                              "by default, and only switchable here on the device - Home " +
+                              "Assistant can't turn it on. The Portal shows a message on screen " +
+                              "every time a photo is taken."),
+                  BoolSpec(
                       "multiRoomEnabled",
                       "Multi-room audio",
                       get = { it.multiRoomEnabled },
@@ -637,6 +647,7 @@ object SettingsDomains {
                   "constrainPageWidth" to "Home screen",
                   "clockFormat" to "Clock",
                   "portalPresence" to "Presence",
+                  "cameraEnabled" to "Camera",
                   "multiRoomEnabled" to "Audio",
                   "snapcastHost" to "Audio",
                   "maPort" to "Audio",
@@ -646,6 +657,9 @@ object SettingsDomains {
           onApplied = { c, keys ->
             if ("hideStatusBar" in keys) SettingsGuard.applyStatusBar(c)
             if ("portalPresence" in keys) PortalPresenceDetector.sync(c)
+            // The publisher advertises (or clears) the camera entities from this, so a running
+            // publisher has to re-read it rather than wait for the next reconnect.
+            if ("cameraEnabled" in keys) MqttService.sync(c, reconfigure = true)
             if (keys.any { it in setOf("multiRoomEnabled", "snapcastHost", "maPort", "maUsername", "maPassword") })
                 MultiRoomService.sync(c)
           },

--- a/app/src/test/java/com/immortal/launcher/CameraSizesTest.kt
+++ b/app/src/test/java/com/immortal/launcher/CameraSizesTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Which of the camera's offered sizes a snapshot asks for. Bounded deliberately: this runs on
+ * Android 9 hardware with no largeHeap, often while the photo frame holds full-screen bitmaps.
+ */
+class CameraSizesTest {
+
+  // A plausible Portal front-camera list: a few small, a couple far too big.
+  private val offered =
+      listOf(176 to 144, 320 to 240, 640 to 480, 1280 to 720, 1920 to 1080)
+
+  @Test
+  fun `picks the largest that fits the cap`() {
+    assertEquals(640 to 480, CameraSizes.choose(offered, maxEdge = 640))
+  }
+
+  @Test
+  fun `a bigger cap admits a bigger size`() {
+    assertEquals(1280 to 720, CameraSizes.choose(offered, maxEdge = 1280))
+  }
+
+  @Test
+  fun `the cap is on the longest edge, not the width`() {
+    // 480 tall fits a 640 cap only because its LONGEST edge is 640 - a portrait-mounted sensor
+    // offering 480x640 must be judged the same way.
+    assertEquals(480 to 640, CameraSizes.choose(listOf(480 to 640, 1080 to 1920), maxEdge = 640))
+  }
+
+  @Test
+  fun `falls back to the smallest when nothing fits`() {
+    // A device that only offers large sizes should still produce a snapshot, not fail outright.
+    assertEquals(1280 to 720, CameraSizes.choose(listOf(1280 to 720, 1920 to 1080), maxEdge = 640))
+  }
+
+  @Test
+  fun `no sizes means no capture`() {
+    assertNull(CameraSizes.choose(emptyList(), maxEdge = 640))
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/MqttClientTest.kt
+++ b/app/src/test/java/com/immortal/launcher/MqttClientTest.kt
@@ -12,6 +12,7 @@ import java.io.OutputStream
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.ServerSocket
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -131,6 +132,65 @@ class MqttClientTest {
         .apply { isDaemon = true }
         .start()
     return server
+  }
+
+  /**
+   * A camera snapshot is tens of kilobytes, far past the 127-byte boundary where MQTT's
+   * remaining-length field stops fitting in one byte. Nothing covered the multi-byte varint
+   * before, so this pins it: the broker decodes the length we wrote and gets every byte back.
+   */
+  @Test
+  fun publish_encodesAMultiByteRemainingLength() {
+    val payload = ByteArray(50_000) { (it % 251).toByte() } // ~a JPEG's worth
+    val topic = "immortal/abc/camera/image"
+    val server = ServerSocket()
+    server.bind(InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0))
+    var seenLen = -1
+    var seenPayload: ByteArray? = null
+    val done = java.util.concurrent.CountDownLatch(1)
+    Thread {
+          runCatching {
+            server.accept().use { sock ->
+              val inp = DataInputStream(sock.getInputStream())
+              sock.getOutputStream().write(byteArrayOf(0x20, 0x02, 0x00, 0x00)) // CONNACK
+              sock.getOutputStream().flush()
+              // Drain the CONNECT, then read the PUBLISH we care about.
+              repeat(2) {
+                inp.readByte()
+                var len = 0
+                var shift = 0
+                while (true) {
+                  val b = inp.readByte().toInt() and 0xff
+                  len = len or ((b and 0x7f) shl shift)
+                  if (b and 0x80 == 0) break
+                  shift += 7
+                }
+                val body = ByteArray(len).also { b -> inp.readFully(b) }
+                if (it == 1) {
+                  seenLen = len
+                  // body = 2-byte topic length + topic + payload
+                  val topicLen = ((body[0].toInt() and 0xff) shl 8) or (body[1].toInt() and 0xff)
+                  seenPayload = body.copyOfRange(2 + topicLen, body.size)
+                }
+              }
+            }
+          }
+          done.countDown()
+        }
+        .apply { isDaemon = true }
+        .start()
+
+    val c = clientTo(server)
+    try {
+      assertTrue(c.connect(keepAliveSec = 30, connectTimeoutMs = 2000))
+      c.publish(topic, payload, retain = false)
+      assertTrue("broker never finished reading", done.await(5, java.util.concurrent.TimeUnit.SECONDS))
+    } finally {
+      c.close()
+      server.close()
+    }
+    assertEquals(2 + topic.length + payload.size, seenLen)
+    assertArrayEquals(payload, seenPayload)
   }
 
   @Test

--- a/docs/design/camera-streaming.md
+++ b/docs/design/camera-streaming.md
@@ -1,0 +1,162 @@
+# Camera streaming for Home Assistant — design
+
+Expose a Portal's camera to Home Assistant as a live stream, with **optional audio**, so a
+Portal in a nursery or hallway can double as a nanny/security camera. LAN only, off by default,
+and unmistakable when it's live.
+
+**Status:** scoped, not implemented. This records the decisions, the parts we already have, the
+parts that are genuinely hard, and what has to be answered on real hardware before writing much
+code.
+
+## Goal
+
+- A Portal appears in Home Assistant as a camera you can watch live, at a useful frame rate.
+- Audio is **optional and separate** — a nursery wants it, a hallway camera pointed at the front
+  door might not.
+- Nothing leaves the LAN. No cloud, no account, no third-party service.
+- A device that hasn't been switched on for this pays nothing: no camera open, no encoder, no
+  microphone.
+
+## What it is not (kept narrow on purpose)
+
+- **Not recording or storage.** No clips, no ring buffer, no SD writing. Home Assistant (or
+  Frigate) owns retention; the Portal is a source.
+- **Not two-way audio.** [Intercom](../features/tools.md) already does push-to-talk between
+  Portals; a security camera doesn't need to also be a speakerphone.
+- **Not person/face detection.** Motion, at most, and only in a later phase. Anything smarter
+  belongs in Home Assistant where the compute is.
+- **Not a replacement for a purpose-built camera.** Fixed position, no IR, no night vision, and
+  a lens designed for video calls at 1–3 m. It is a *useful second angle in a room you already
+  have a Portal in*, and the docs should say so plainly rather than overselling it.
+
+## What we already have
+
+More than expected, which is why this is worth scoping rather than dismissing.
+
+| Piece | Where | What it gives us |
+| --- | --- | --- |
+| Camera2 capture on Portal | `GestureCamera` | Opens the **front camera** with a standard Camera2 session and an `ImageReader` (320×240 `YUV_420_888`) for wave-to-advance. No Meta Smart Camera SDK, no signature permissions. |
+| A hardened HTTP server | `FleetHttpServer` | Already serves the fleet agent, survives abandoned connections, and has socket-lifecycle tests. A snapshot/MJPEG endpoint is a small addition. |
+| Microphone capture | `LanAudio` | Proven `AudioRecord` at 16 kHz mono PCM16 for the intercom. |
+| MQTT entity plumbing | `MqttPublisher` | Discovery, switches, availability, teardown-on-disable all exist; new entities are declarative. |
+| Permissions | `AndroidManifest.xml` | `CAMERA`, `RECORD_AUDIO` and `SYSTEM_ALERT_WINDOW` are already declared and granted by the [provisioning kit](../provisioning.md). |
+
+`GestureCamera` is the important one: it means "can an unprivileged app get frames off a Portal
+camera" is already answered in our own codebase. Note its own caveat though — it is marked
+experimental and **unverified on real hardware**, so that claim needs confirming before it can
+carry a feature.
+
+## Transport: RTSP, because of audio
+
+| Option | Verdict |
+| --- | --- |
+| **MJPEG** over the existing HTTP server | Easiest by far — JPEG frames, no encoder, works with HA's `mjpeg` integration. **But it cannot carry audio.** Fine as a first phase; not the destination. |
+| **WebRTC** direct | Best latency, and what the HA card ultimately speaks. Far the heaviest to implement on-device. |
+| **RTSP: H.264 video + AAC audio** | The choice. Android's `MediaCodec` encodes both natively, so no third-party encoder library is needed, and go2rtc ingests RTSP into the HA WebRTC card as a matter of routine. |
+
+Encode **H.264 Constrained Baseline**. Browser WebRTC rejects higher profiles, so the stream
+would play in VLC and fail in the dashboard — the exact trap `portal-ha-bridge` documents
+hitting.
+
+> **On `portal-ha-bridge`.** That project solves this problem already and its notes informed the
+> hazards below. It is **PolyForm Noncommercial**, so it can be read for technique but no code
+> can be copied into this MIT repo. The encoder work here is ours to write.
+
+## The hard parts
+
+**1. The encoder pipeline.** `Camera2 → Surface → MediaCodec(H.264) → RTP packetiser → RTSP`,
+plus `AudioRecord → MediaCodec(AAC-LC) → RTP` on a second track, with timestamps that actually
+correlate. This is the bulk of the work and the part most likely to need hardware iteration.
+Note the shape change from `GestureCamera`: a stream feeds the encoder's input `Surface`
+directly rather than reading frames into an `ImageReader`.
+
+**2. Per-model field of view.** Portal+ front cameras expose a *virtual* sensor that scales the
+FOV into whatever size is requested, so a naive 16:9 request comes out stretched. Known-good
+shapes: `aloha` (Portal+ gen 1) ≈ square, 480×480; `cipher` (gen 2) portrait-mounted, 480×640
+with the 4:3 applied viewer-side. Gate on `Build.DEVICE`, the way `Curation` already gates
+Chrome off the Portal TV.
+
+**3. Camera contention.** The camera is shared. A Portal call takes it; `GestureCamera` wants it
+for wave-to-advance during the photo frame. Streaming and gesture-wave must be **mutually
+exclusive**, with one owner arbitrating and the stream recovering after a call releases the
+device.
+
+**4. Microphone contention — currently unmanaged.** `LanAudio` (intercom) and `AudioNote` both
+open `AudioSource.MIC` today with **no arbitration between them at all**. Audio streaming would
+be a third consumer, and the failure is silent: whoever asks second gets nothing useful. This
+needs a single mic broker with an explicit priority — a live intercom announcement should win,
+and the stream should drop its audio track for the duration rather than fight.
+
+On Portal+ there is a further constraint: Meta's own far-field mic service (`com.millennium`)
+can hold the microphone, which is why the bridge ships a `--free-mic` provisioning flag. Expect
+audio to be unavailable on some models until that's disabled, and detect it rather than assume.
+
+**5. Mic mute has to gate audio.** Immortal publishes a `mic_mute` switch to Home Assistant. A
+stream that keeps sending audio while HA says the microphone is muted is both a contradiction
+and a genuine privacy surprise. **When `isMicrophoneMute` is true the audio track must be
+silent.** That rule is pure logic and should be unit-tested, not left to integration behaviour.
+
+**6. Heap and thermals.** A continuous encode on Android 9 hardware with no `largeHeap`, on a
+device that may already be running the photo frame. Bound the resolution, frame rate and
+bitrate conservatively, and treat "streaming" as mutually exclusive with heavyweight screensaver
+work where they'd collide.
+
+## Privacy design (non-negotiable)
+
+A camera and microphone in someone's home is a different posture from anything Immortal ships
+today. These are requirements, not preferences:
+
+- **Off by default**, per device, with no way for a Home Assistant command to switch the master
+  on. If the master switch is off on the device, the Portal ignores stream requests entirely.
+- **Three separate switches**, not one: `Camera` (master), `Camera streaming`, `Camera audio`.
+  Audio cannot be on without the camera.
+- **A visible on-device indicator whenever capture is live** — on screen, not merely a
+  notification the frame is covering.
+- **Say who can turn it on.** The [notification design](mqtt-notifications.md) already assumes a
+  trusted-LAN broker; here that assumption has teeth, because anyone with publish credentials
+  can start a stream. This must be stated in the user docs, not just a design note.
+
+## Home Assistant surface
+
+| Entity | Type | Notes |
+| --- | --- | --- |
+| Camera | `switch` | Master power. Off means the camera is never opened. |
+| Camera streaming | `switch` | Starts/stops the RTSP server. Requires the master. |
+| Camera audio | `switch` | Adds the audio track. Requires streaming; forced silent while mic-muted. |
+| Stream URL | `sensor` (diagnostic) | `rtsp://<ip>:8554/` — so the dashboard card can be configured by copy-paste. |
+| Motion | `binary_sensor` | Later phase; reuses the frame-difference logic `GestureCamera` already has. |
+
+The live view is wired through go2rtc + the WebRTC Camera card rather than an MQTT `camera`
+entity (which carries stills, not video). The setup guide should give the exact card YAML with
+the device's own IP filled in, as the Camera Settings screen would show it.
+
+## Phasing
+
+Deliberately ordered so each phase is useful alone and de-risks the next.
+
+1. **Snapshot only.** A JPEG still on demand from the existing fleet HTTP server, plus the
+   `Camera` master switch and the on-screen indicator. Works in HA via the `generic` camera
+   integration. Proves Camera2 at real resolution on real hardware, and settles the per-model
+   FOV question, for a fraction of the effort.
+2. **Video streaming.** RTSP + `MediaCodec` H.264, no audio. The encoder work.
+3. **Audio.** AAC track, the mic broker, and the mute gating.
+4. **Motion** (optional). `binary_sensor` from the existing frame-diff, with a sensitivity
+   number entity.
+
+## Unknowns to settle on hardware first
+
+None of these are answerable from the source, and all of them can invalidate parts of the plan:
+
+- What resolutions does Camera2 actually offer per model, and is `GestureCamera` even working
+  today at 320×240? (It has never been verified.)
+- Does Portal firmware permit camera access from a background service, or only in the
+  foreground? The bridge needed `SYSTEM_ALERT_WINDOW` for this, which we already hold.
+- Is there a usable hardware `MediaCodec` H.264 encoder on API 28 Portal, and does it offer
+  Constrained Baseline?
+- Does `com.millennium` block microphone capture on the Portal+ models, and on which?
+- Thermal behaviour of a sustained encode — the device is fanless and often wall-powered in a
+  warm room.
+
+**Recommendation:** build phase 1 first and answer the list above with it. It is a small amount
+of code, it delivers a working (if low frame rate) camera in Home Assistant on its own, and
+everything expensive in phases 2–3 depends on facts only phase 1 can establish.

--- a/docs/design/camera-streaming.md
+++ b/docs/design/camera-streaming.md
@@ -4,9 +4,9 @@ Expose a Portal's camera to Home Assistant as a live stream, with **optional aud
 Portal in a nursery or hallway can double as a nanny/security camera. LAN only, off by default,
 and unmistakable when it's live.
 
-**Status:** scoped, not implemented. This records the decisions, the parts we already have, the
-parts that are genuinely hard, and what has to be answered on real hardware before writing much
-code.
+**Status:** phase 1 (snapshots) implemented; phases 2-4 not started. This records the decisions,
+the parts we already have, the parts that are genuinely hard, and what has to be answered on real
+hardware before writing much code.
 
 ## Goal
 
@@ -134,10 +134,19 @@ the device's own IP filled in, as the Camera Settings screen would show it.
 
 Deliberately ordered so each phase is useful alone and de-risks the next.
 
-1. **Snapshot only.** A JPEG still on demand from the existing fleet HTTP server, plus the
-   `Camera` master switch and the on-screen indicator. Works in HA via the `generic` camera
-   integration. Proves Camera2 at real resolution on real hardware, and settles the per-model
-   FOV question, for a fraction of the effort.
+1. **Snapshot only** — *implemented*. A JPEG still on demand, the device-side consent switch,
+   and an on-screen indicator on every capture. Proves Camera2 at real resolution on real
+   hardware and settles the per-model FOV question, for a fraction of the effort.
+
+    **Delivered over MQTT, not the fleet HTTP server as sketched above.** The HTTP route looked
+    cheaper until the Home Assistant side was considered: the fleet agent authenticates with a
+    bearer token, and HA's `generic` camera integration can send basic auth but not a bearer
+    header — which would have meant either putting the token in a query string (logged, and
+    leaked to anyone reading a dashboard config) or bolting a second auth scheme onto the agent.
+    HA's MQTT `camera` component takes the image straight off a topic, so it needs no second auth
+    story at all, rides the broker we already treat as trusted, and doesn't require the opt-in
+    fleet agent to be running. Images are published **unretained**, so a still of someone's room
+    doesn't sit on the broker for whoever subscribes next.
 2. **Video streaming.** RTSP + `MediaCodec` H.264, no audio. The encoder work.
 3. **Audio.** AAC track, the mic broker, and the mute gating.
 4. **Motion** (optional). `binary_sensor` from the existing frame-diff, with a sensitivity

--- a/docs/features/smart-home.md
+++ b/docs/features/smart-home.md
@@ -72,6 +72,32 @@ wait out an interval before it's published, so a twitchy light sensor doesn't bu
 large jump — someone switching a lamp on — skips most of that wait, because that's the event an
 automation is actually waiting for.
 
+## Camera snapshots
+
+A Portal can hand Home Assistant a still photo from its own camera — a second angle on a room
+you already have a Portal in. It is **off by default**, and the switch is deliberately on the
+device only: turn it on under **Settings → Immortal → Camera snapshots**. Nothing arriving over
+MQTT can enable it, and while it is off the camera is never opened.
+
+Once on, two entities appear: a **Camera** entity showing the most recent still, and a **Take
+snapshot** button that captures a fresh one. Point an automation at the button — a doorbell, a
+motion sensor elsewhere in the house, a schedule — and the camera entity updates.
+
+**The Portal announces every capture** with an on-screen message. Someone in the room should
+never be photographed without the device saying so.
+
+Some things worth knowing before relying on it:
+
+- **It is stills, not video.** Live streaming with optional audio is designed but not built —
+  see [the design note](../design/camera-streaming.md).
+- **The image is not retained on the broker.** Home Assistant shows the last one it received;
+  a subscriber joining later sees nothing until the next snapshot.
+- **The camera is shared.** A Portal call takes it, and the photo frame's wave-to-advance
+  gesture wants it too, so an occasional snapshot can come back empty rather than queueing.
+- **Anyone with broker credentials can press the button.** The same trust assumption as
+  [notifications](#notifications) — but with a camera on the other end of it, so treat broker
+  access accordingly.
+
 ## What it can control
 
 - **Screen on/off** (`ScreenControl`, which uses the screen-off device-admin granted during

--- a/docs/guides/home-assistant.md
+++ b/docs/guides/home-assistant.md
@@ -21,6 +21,7 @@ appear where the hardware exists.
 | Media, Media title, Media artist | The current track — see [now-playing](../features/multi-room-audio.md). |
 | Battery, Charging | On models that have a battery (Portal Go). |
 | IP address | Diagnostic. |
+| Camera | The latest still from the Portal's camera. Only when you've switched it on — see [camera snapshots](../features/smart-home.md#camera-snapshots). |
 
 **Controls**
 
@@ -34,6 +35,7 @@ appear where the hardware exists.
 | Open | Send the Portal to a URL, an installed app, or a Home Assistant dashboard path. |
 | Notify | Push a toast with optional image, sound and tap target — see [notifications](../features/smart-home.md#notifications). |
 | Identify | Pop a toast naming the device, for finding which Portal is which. |
+| Take snapshot | Capture a fresh still. Only when the camera is switched on. |
 
 The Portal registers with a stable per-device id, so it survives broker reinstalls but stays unique
 across a fleet. Its **device name is shared with the [fleet agent](../features/fleet.md)**, so a
@@ -97,6 +99,8 @@ automation:
 - **Presence says `proxy`, not `portal`** — check **Use the Portal's own detector** is on under
   Settings → Immortal, then the `READ_LOGS` permission. The provisioning kit grants it, so re-run
   the provisioner on a Portal set up before that grant existed.
+- **No Camera entity** — it's off by default. Turn on **Camera snapshots** under Settings →
+  Immortal on the device; Home Assistant can't enable it remotely, by design.
 - **No temperature entity** — not every Portal has an ambient temperature sensor. Entities are only
   advertised for hardware the device actually reports, so a missing one means the sensor isn't
   there.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,3 +86,4 @@ nav:
       - Submitting an app: submitting-apps.md
   - Design notes:
       - Multi-room audio: design/multi-room-audio.md
+      - Camera streaming: design/camera-streaming.md


### PR DESCRIPTION
Two commits: the design note scoping a nanny/security camera feature, and **phase 1 of it** — a still from the Portal's camera, in Home Assistant.

## Phase 1: what it does

Turn on **Settings → Immortal → Camera snapshots** on the device and two entities appear: a **Camera** showing the latest still, and a **Take snapshot** button that captures a fresh one. Point an automation at the button and the camera updates.

**Consent lives on the device.** Off by default, switchable only on the Portal itself — nothing arriving over MQTT can enable it, and while it's off the camera is never opened. Every capture puts a message on screen, because someone in the room shouldn't be photographed without the device saying so.

## Deviation from the design: MQTT, not the fleet HTTP server

The design sketched serving stills from `FleetHttpServer` into HA's `generic` camera. That looked cheaper until I looked at the HA end: the fleet agent authenticates with a **bearer token**, and `generic` camera can send basic auth but **not a bearer header**. That leaves either a token in a query string — logged, and visible to anyone reading a dashboard config — or a second auth scheme bolted onto the agent.

HA's MQTT `camera` component takes the image straight off a topic. No second auth story, it rides the broker we already treat as trusted, and it doesn't require the (opt-in) fleet agent to be running at all. Images publish **unretained**, so a still of someone's room doesn't sit on the broker for whoever subscribes next. The design note records the reasoning.

## Implementation notes

- **Opens and releases the camera per snapshot** rather than holding it. The camera is shared — a Portal call takes it, and the photo frame's wave-to-advance wants it — so holding it would starve them for no benefit. An occasional snapshot coming back empty is the correct behaviour, and is documented.
- **Defensive throughout**, following `GestureCamera`: a failure means no snapshot, never a dead launcher.
- **Size selection is pure and unit-tested** — the one real decision in the Camera2 plumbing. Largest that fits the 640px cap, smallest available when nothing fits, judged on the *longest* edge so a portrait-mounted sensor is treated the same. Bounded because this is Android 9 with no `largeHeap`, often while the photo frame holds full-screen bitmaps.
- **Pins `MqttClient`'s multi-byte remaining-length encoding.** It was correct but nothing tested past the 127-byte boundary, and a JPEG is the first payload that crosses it. New test publishes 50 KB and checks the broker decodes the length and gets every byte.

## Testing

- `./gradlew :app:testDebugUnitTest` — **339 pass, 0 fail** (+6).
- `./gradlew :app:assembleDebug` — builds.
- `mkdocs build --strict` — passes.

## ⚠️ Not verified on hardware

`GestureCamera` is the evidence that Camera2 works unprivileged on a Portal, and **it carries its own "feasibility unverified" note**. So this whole path could fail on a real device. That's precisely why phase 1 exists — it's the cheapest way to find out, and everything expensive in phases 2–3 depends on the answer.

Worth checking on a device: that a snapshot arrives in HA at all, what resolutions each model actually offers, whether the aspect ratio comes out sane on Portal+ (the design note has the known per-model quirks), and whether capture works while the photo frame is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013opfPDdDg37KZRo4LMYerM