### PR TITLE
Camera: fix snapshots, then live RTSP video with optional audio

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -475,6 +475,13 @@
             android:name=".MqttService"
             android:exported="false" />
 
+        <!-- Live camera streaming (RTSP). Foreground because the camera is held for as long as
+             it runs, and the notification is a second, system-level signal that it's live. -->
+        <service
+            android:name=".CameraStreamService"
+            android:exported="false"
+            android:foregroundServiceType="camera" />
+
         <!-- App switcher, opened from the quick-button overlay (internal). -->
         <activity
             android:name=".AppSwitcherActivity"

--- a/app/src/main/java/com/immortal/launcher/AacRtp.kt
+++ b/app/src/main/java/com/immortal/launcher/AacRtp.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+/**
+ * RTP packetisation for AAC (RFC 3640, `AAC-hbr` mode) and the AudioSpecificConfig an SDP has to
+ * carry — the audio counterpart to [RtpH264].
+ *
+ * Pure, for the same reason: a wrong `config` string or a mis-sized AU header gives a stream that
+ * connects and produces silence or static, with nothing in any log to say why.
+ *
+ * Phase 3 of `docs/design/camera-streaming.md`.
+ */
+object AacRtp {
+  /** Dynamic payload type for the audio track (video uses 96). */
+  const val PAYLOAD_TYPE = 97
+
+  /** AAC-LC. The `2` in an AudioSpecificConfig's five-bit object type. */
+  const val OBJECT_TYPE_AAC_LC = 2
+
+  /** Sample rates in the order MPEG-4 indexes them; the index goes in the config, not the rate. */
+  val SAMPLE_RATE_TABLE =
+      listOf(
+          96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000, 7350)
+
+  /** MPEG-4 sampling frequency index for [rate], or -1 if it isn't one of the standard rates. */
+  fun sampleRateIndex(rate: Int): Int = SAMPLE_RATE_TABLE.indexOf(rate)
+
+  /**
+   * The two-byte AudioSpecificConfig for AAC-LC: 5 bits object type, 4 bits rate index, 4 bits
+   * channel count, then padding. This is what the SDP's `config=` carries, and it's how the
+   * decoder learns the sample rate — get it wrong and audio plays at the wrong speed, or not at
+   * all, while everything else looks healthy.
+   */
+  fun audioSpecificConfig(sampleRate: Int, channels: Int): ByteArray {
+    val rateIndex = sampleRateIndex(sampleRate).coerceAtLeast(0)
+    val bits = (OBJECT_TYPE_AAC_LC shl 11) or (rateIndex shl 7) or (channels shl 3)
+    return byteArrayOf((bits ushr 8).toByte(), bits.toByte())
+  }
+
+  /** The config as the lower-case hex the SDP expects. */
+  fun configHex(sampleRate: Int, channels: Int): String =
+      audioSpecificConfig(sampleRate, channels).joinToString("") { "%02x".format(it) }
+
+  /**
+   * Wrap one AAC access unit as an RTP payload.
+   *
+   * `AAC-hbr` prefixes the audio with a 2-byte AU-headers-length **in bits**, then one 16-bit AU
+   * header per unit: 13 bits of size and 3 bits of index. One unit per packet keeps latency low
+   * and the arithmetic honest.
+   *
+   * @param frame a raw AAC frame with **no** ADTS header — MediaCodec emits raw frames, and an
+   *   ADTS header left on would be decoded as audio data.
+   */
+  fun packetize(frame: ByteArray): ByteArray {
+    val payload = ByteArray(4 + frame.size)
+    payload[0] = 0x00 // AU-headers-length: 16 bits...
+    payload[1] = 0x10 // ...i.e. one 16-bit header
+    val header = (frame.size shl 3) // 13-bit size, 3-bit index (0)
+    payload[2] = (header ushr 8).toByte()
+    payload[3] = header.toByte()
+    System.arraycopy(frame, 0, payload, 4, frame.size)
+    return payload
+  }
+
+  /** RTP timestamps for audio run at the sample rate, not 90 kHz. */
+  fun timestamp(presentationTimeUs: Long, sampleRate: Int): Long =
+      presentationTimeUs * sampleRate / 1_000_000L
+
+  /**
+   * The `m=audio` half of the SDP. `sizelength`/`indexlength`/`indexdeltalength` must agree with
+   * the 13+3 split [packetize] writes, or the receiver mis-parses every packet.
+   */
+  fun audioSdp(sampleRate: Int, channels: Int, trackId: Int, payloadType: Int = PAYLOAD_TYPE): String =
+      buildString {
+        append("m=audio 0 RTP/AVP $payloadType\r\n")
+        append("a=rtpmap:$payloadType mpeg4-generic/$sampleRate/$channels\r\n")
+        append(
+            "a=fmtp:$payloadType streamtype=5;profile-level-id=1;mode=AAC-hbr;" +
+                "sizelength=13;indexlength=3;indexdeltalength=3;" +
+                "config=${configHex(sampleRate, channels)}\r\n")
+        append("a=control:trackID=$trackId\r\n")
+      }
+}
+
+/**
+ * Who may hold the microphone.
+ *
+ * The Portal has one, and before this nothing arbitrated for it: [LanAudio] (the intercom) and
+ * [AudioNote] both opened `AudioSource.MIC` directly, so whoever asked second simply got nothing
+ * useful — silently. Adding a third consumer (the camera's audio track) made that untenable.
+ *
+ * Priority, not fairness: a person talking beats a background stream. A higher-priority claim
+ * takes the microphone from a lower-priority holder, which then finds out via [holder] and stops.
+ * Equal priority does not preempt — the incumbent keeps it.
+ */
+object MicOwner {
+  /** A live intercom announcement — someone is speaking right now. */
+  const val PRIORITY_INTERCOM = 100
+
+  /** A voice note being recorded deliberately by the user. */
+  const val PRIORITY_NOTE = 90
+
+  /** The camera's audio track: continuous, and the first thing that should yield. */
+  const val PRIORITY_STREAM = 10
+
+  private val lock = Any()
+  private var current: String? = null
+  private var currentPriority = 0
+
+  /** Who holds the microphone, or null if nobody does. */
+  val holder: String?
+    get() = synchronized(lock) { current }
+
+  /**
+   * Claim the microphone for [owner]. Returns true when granted — either it was free, or [owner]
+   * already had it, or [priority] beat the incumbent.
+   */
+  fun acquire(owner: String, priority: Int): Boolean =
+      synchronized(lock) {
+        val held = current
+        if (held == null || held == owner || priority > currentPriority) {
+          current = owner
+          currentPriority = priority
+          true
+        } else {
+          false
+        }
+      }
+
+  /** Release, but only if [owner] still holds it — a preempted owner must not clear the winner. */
+  fun release(owner: String) =
+      synchronized(lock) {
+        if (current == owner) {
+          current = null
+          currentPriority = 0
+        }
+      }
+
+  /** True while [owner] still holds the microphone; a preempted holder should stop capturing. */
+  fun holds(owner: String): Boolean = synchronized(lock) { current == owner }
+
+  /** Test seam — the object is a process-wide singleton. */
+  fun resetForTest() =
+      synchronized(lock) {
+        current = null
+        currentPriority = 0
+      }
+}

--- a/app/src/main/java/com/immortal/launcher/AudioNote.kt
+++ b/app/src/main/java/com/immortal/launcher/AudioNote.kt
@@ -22,6 +22,7 @@ import android.util.Log
  */
 class AudioNote(private val context: Context) {
   private val TAG = "ImmortalNote"
+  private val MIC_OWNER = "audio-note"
   private var recorder: MediaRecorder? = null
   private var player: MediaPlayer? = null
 
@@ -31,6 +32,13 @@ class AudioNote(private val context: Context) {
   /** Begin recording to the note file (overwrites any previous memo). */
   fun startRecording(): Boolean = runCatching {
     stopPlaying()
+    // Deliberate user action, so it outranks the camera stream's audio track and takes the
+    // microphone from it. See [MicOwner] — nothing arbitrated this before, and a note recorded
+    // while something else held the mic came out silent.
+    if (!MicOwner.acquire(MIC_OWNER, MicOwner.PRIORITY_NOTE)) {
+      Log.w(TAG, "microphone held by ${MicOwner.holder} — not recording")
+      return@runCatching false
+    }
     val file = NotesConfig.audioFile(context)
     @Suppress("DEPRECATION")
     val rec = if (Build.VERSION.SDK_INT >= 31) MediaRecorder(context) else MediaRecorder()
@@ -49,7 +57,11 @@ class AudioNote(private val context: Context) {
     recordStartMs = System.currentTimeMillis()
     recorder = rec
     true
-  }.getOrElse { Log.w(TAG, "startRecording failed", it); false }
+  }.getOrElse {
+    Log.w(TAG, "startRecording failed", it)
+    MicOwner.release(MIC_OWNER)
+    false
+  }
 
   private var recordStartMs = 0L
 
@@ -61,6 +73,7 @@ class AudioNote(private val context: Context) {
   fun stopRecording(): Boolean {
     val r = recorder ?: return NotesConfig.hasAudioNote(context)
     recorder = null
+    MicOwner.release(MIC_OWNER)
     // MediaRecorder.stop() throws if stopped almost immediately (no encoded frames),
     // leaving a corrupt file. Guard against a too-short tap.
     val tooShort = System.currentTimeMillis() - recordStartMs < 500

--- a/app/src/main/java/com/immortal/launcher/AudioStream.kt
+++ b/app/src/main/java/com/immortal/launcher/AudioStream.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioRecord
+import android.media.MediaCodec
+import android.media.MediaCodecInfo
+import android.media.MediaFormat
+import android.media.MediaRecorder
+import android.util.Log
+import androidx.core.content.ContextCompat
+
+/**
+ * The camera stream's audio track: microphone → AAC-LC, emitted frame by frame for [AacRtp] to
+ * packetise. Phase 3 of `docs/design/camera-streaming.md`.
+ *
+ * Two rules matter more than the encoding:
+ *
+ *  - **Mic mute means silence on the wire.** Immortal publishes a `mic_mute` switch to Home
+ *    Assistant. A stream that keeps sending audio while Home Assistant says the microphone is
+ *    muted is both a contradiction and a genuine privacy surprise, so muting stops audio leaving
+ *    the device entirely — see [shouldEmit].
+ *  - **A person talking outranks a background stream.** The microphone is arbitrated through
+ *    [MicOwner]; if the intercom takes it mid-stream, the audio track stops and the video carries
+ *    on rather than both fighting over a device only one can have.
+ */
+class AudioStream(
+    private val appContext: Context,
+    private val onFrame: (frame: ByteArray, presentationTimeUs: Long) -> Unit,
+) {
+  @Volatile private var running = false
+  private var record: AudioRecord? = null
+  private var codec: MediaCodec? = null
+  private var worker: Thread? = null
+
+  private val audio by lazy {
+    appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+  }
+
+  fun isRunning(): Boolean = running
+
+  /** Start capturing. False when the permission is missing, or something louder holds the mic. */
+  fun start(): Boolean {
+    if (running) return true
+    if (ContextCompat.checkSelfPermission(appContext, Manifest.permission.RECORD_AUDIO) !=
+        PackageManager.PERMISSION_GRANTED) {
+      Log.i(TAG, "no record-audio permission — streaming without sound")
+      return false
+    }
+    if (!MicOwner.acquire(OWNER, MicOwner.PRIORITY_STREAM)) {
+      Log.i(TAG, "microphone held by ${MicOwner.holder} — streaming without sound")
+      return false
+    }
+    return runCatching {
+          val minBuf =
+              AudioRecord.getMinBufferSize(
+                  SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT)
+          val rec =
+              AudioRecord(
+                  MediaRecorder.AudioSource.MIC,
+                  SAMPLE_RATE,
+                  AudioFormat.CHANNEL_IN_MONO,
+                  AudioFormat.ENCODING_PCM_16BIT,
+                  maxOf(minBuf, BUFFER_BYTES))
+          record = rec
+
+          val enc = MediaCodec.createEncoderByType(MIME)
+          codec = enc
+          val format =
+              MediaFormat.createAudioFormat(MIME, SAMPLE_RATE, CHANNELS).apply {
+                setInteger(
+                    MediaFormat.KEY_AAC_PROFILE, MediaCodecInfo.CodecProfileLevel.AACObjectLC)
+                setInteger(MediaFormat.KEY_BIT_RATE, BIT_RATE)
+                setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, BUFFER_BYTES)
+              }
+          enc.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+          enc.start()
+          rec.startRecording()
+
+          running = true
+          worker = Thread(::pump, "immortal-audio").apply { isDaemon = true; start() }
+          Log.i(TAG, "audio started at ${SAMPLE_RATE}Hz")
+          true
+        }
+        .onFailure {
+          Log.w(TAG, "audio start failed", it)
+          stop()
+        }
+        .getOrDefault(false)
+  }
+
+  fun stop() {
+    running = false
+    worker?.interrupt()
+    runCatching { record?.stop() }
+    runCatching { record?.release() }
+    runCatching { codec?.stop() }
+    runCatching { codec?.release() }
+    record = null
+    codec = null
+    worker = null
+    MicOwner.release(OWNER)
+    Log.i(TAG, "audio stopped")
+  }
+
+  /**
+   * Read PCM, encode, emit. Muting doesn't tear the pipeline down — it just stops frames leaving,
+   * so unmuting resumes immediately with the timeline intact rather than renegotiating the track.
+   */
+  private fun pump() {
+    val buf = ByteArray(BUFFER_BYTES)
+    val info = MediaCodec.BufferInfo()
+    while (running) {
+      if (!MicOwner.holds(OWNER)) {
+        Log.i(TAG, "microphone taken by ${MicOwner.holder} — stopping audio")
+        break
+      }
+      val rec = record ?: break
+      val enc = codec ?: break
+      val read = runCatching { rec.read(buf, 0, buf.size) }.getOrDefault(-1)
+      if (read <= 0) continue
+      runCatching {
+            val inIndex = enc.dequeueInputBuffer(TIMEOUT_US)
+            if (inIndex >= 0) {
+              enc.getInputBuffer(inIndex)?.apply {
+                clear()
+                put(buf, 0, read)
+              }
+              enc.queueInputBuffer(inIndex, 0, read, System.nanoTime() / 1000, 0)
+            }
+            var outIndex = enc.dequeueOutputBuffer(info, TIMEOUT_US)
+            while (outIndex >= 0) {
+              if (info.size > 0 && info.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG == 0) {
+                val out = enc.getOutputBuffer(outIndex)
+                if (out != null) {
+                  out.position(info.offset)
+                  out.limit(info.offset + info.size)
+                  val frame = ByteArray(info.size).also { out.get(it) }
+                  if (shouldEmit(micMuted = audio.isMicrophoneMute, holdsMic = true)) {
+                    onFrame(frame, info.presentationTimeUs)
+                  }
+                }
+              }
+              enc.releaseOutputBuffer(outIndex, false)
+              outIndex = enc.dequeueOutputBuffer(info, 0)
+            }
+          }
+          .onFailure {
+            if (running) Log.w(TAG, "audio encode failed", it)
+          }
+    }
+    if (running) stop()
+  }
+
+  companion object {
+    private const val TAG = "ImmortalAudio"
+    private const val MIME = "audio/mp4a-latm"
+    private const val OWNER = "camera-stream"
+
+    /** 16 kHz mono, matching [LanAudio]: speech-grade, and cheap on a fanless device. */
+    const val SAMPLE_RATE = 16000
+    const val CHANNELS = 1
+    private const val BIT_RATE = 32_000
+    private const val BUFFER_BYTES = 4096
+    private const val TIMEOUT_US = 10_000L
+
+    /**
+     * Whether an encoded frame may go on the wire. Muting the microphone must mean **no audio
+     * leaves the device** — anything else contradicts the switch Home Assistant is showing.
+     */
+    fun shouldEmit(micMuted: Boolean, holdsMic: Boolean): Boolean = !micMuted && holdsMic
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/CameraStream.kt
+++ b/app/src/main/java/com/immortal/launcher/CameraStream.kt
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.hardware.camera2.CameraCaptureSession
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraDevice
+import android.hardware.camera2.CameraManager
+import android.hardware.camera2.CaptureRequest
+import android.hardware.camera2.params.StreamConfigurationMap
+import android.media.MediaCodec
+import android.media.MediaCodecInfo
+import android.media.MediaFormat
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+import android.view.Surface
+import androidx.core.content.ContextCompat
+
+/** Encoder sizing decisions, kept pure so the numbers are reviewable without a device. */
+object StreamProfile {
+  const val MIME = "video/avc"
+
+  /**
+   * `MediaCodecInfo.CodecProfileLevel.AVCProfileConstrainedBaseline`, written as a literal
+   * because the constant only exists from API 27 and minSdk here is 24. Constrained Baseline is
+   * not a preference: browser WebRTC refuses anything higher, so a stream encoded as High plays
+   * in VLC and fails in the Home Assistant card — the exact trap the design note records.
+   */
+  const val PROFILE_CONSTRAINED_BASELINE = 0x10000
+
+  /** Seconds between keyframes. A client can only start decoding at one, so short beats tidy. */
+  const val KEYFRAME_INTERVAL_S = 1
+
+  /**
+   * Bits per second for a given frame size and rate, at roughly 0.1 bits per pixel per frame —
+   * a sane quality/size trade for a fixed indoor scene, and gentle on a fanless Portal that may
+   * be encoding for hours. Clamped so a tiny frame still gets a usable floor and a large one
+   * can't run away with the radio.
+   */
+  fun bitrateFor(width: Int, height: Int, fps: Int): Int {
+    val raw = (width.toLong() * height.toLong() * fps.toLong() / 10L).toInt()
+    return raw.coerceIn(200_000, 4_000_000)
+  }
+}
+
+/**
+ * Camera2 → H.264, the encoder half of live streaming (phase 2 of
+ * `docs/design/camera-streaming.md`). Frames go straight from the camera into the encoder's input
+ * [Surface] — no `ImageReader`, no copy through the heap, which is what makes a sustained stream
+ * viable on this hardware at all.
+ *
+ * Emits NAL units through [onNals] as they come out of the codec; [RtpH264] turns those into RTP,
+ * and the RTSP server puts them on the wire. Kept separate from that so the encoder can be
+ * verified on a device before any of the network side exists.
+ *
+ * The camera is shared: a Portal call takes it, and [GestureCamera] and [PortalCameraCapture]
+ * both want it too. Only one of those can hold it at a time, so streaming is mutually exclusive
+ * with them by construction — whoever asks second fails, and fails softly.
+ */
+class CameraStream(
+    private val appContext: Context,
+    private val onNals: (nals: List<ByteArray>, presentationTimeUs: Long, keyframe: Boolean) -> Unit,
+) {
+  @Volatile private var running = false
+  private var thread: HandlerThread? = null
+  private var device: CameraDevice? = null
+  private var session: CameraCaptureSession? = null
+  private var codec: MediaCodec? = null
+  private var inputSurface: Surface? = null
+  private var drain: Thread? = null
+
+  /** SPS and PPS from the codec's config buffer, needed for the SDP. Null until encoding starts. */
+  @Volatile var sps: ByteArray? = null
+    private set
+
+  @Volatile var pps: ByteArray? = null
+    private set
+
+  /** Frame size actually in use, once started — the SDP and any UI want to report it. */
+  @Volatile var width = 0
+    private set
+
+  @Volatile var height = 0
+    private set
+
+  fun isRunning(): Boolean = running
+
+  /**
+   * Open the camera and start encoding. Returns false when it can't — no permission, no camera,
+   * no encoder, or the camera is already held by something else. Never throws.
+   */
+  fun start(fps: Int = FPS): Boolean {
+    if (running) return true
+    if (ContextCompat.checkSelfPermission(appContext, Manifest.permission.CAMERA) !=
+        PackageManager.PERMISSION_GRANTED) {
+      Log.i(TAG, "no camera permission — not streaming")
+      return false
+    }
+    return runCatching {
+          val manager = appContext.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+          val cameraId = pickCamera(manager) ?: return false
+          val size = streamSize(manager, cameraId) ?: return false
+          width = size.first
+          height = size.second
+
+          val ht = HandlerThread("immortal-stream").apply { start() }
+          thread = ht
+          val handler = Handler(ht.looper)
+
+          val enc = MediaCodec.createEncoderByType(StreamProfile.MIME)
+          codec = enc
+          val format =
+              MediaFormat.createVideoFormat(StreamProfile.MIME, width, height).apply {
+                setInteger(
+                    MediaFormat.KEY_COLOR_FORMAT,
+                    MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface)
+                setInteger(
+                    MediaFormat.KEY_BIT_RATE, StreamProfile.bitrateFor(width, height, fps))
+                setInteger(MediaFormat.KEY_FRAME_RATE, fps)
+                setInteger(
+                    MediaFormat.KEY_I_FRAME_INTERVAL, StreamProfile.KEYFRAME_INTERVAL_S)
+                // Ask for Constrained Baseline. Not every encoder honours the request; the SDP
+                // reports what the SPS actually says, so a device that ignores this is visible
+                // rather than mysterious.
+                setInteger(MediaFormat.KEY_PROFILE, StreamProfile.PROFILE_CONSTRAINED_BASELINE)
+              }
+          enc.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+          val surface = enc.createInputSurface()
+          inputSurface = surface
+          enc.start()
+
+          running = true
+          drain = Thread(::drainLoop, "immortal-stream-drain").apply { isDaemon = true; start() }
+          openCamera(manager, cameraId, surface, handler)
+          Log.i(TAG, "streaming ${width}x$height @${fps}fps")
+          true
+        }
+        .onFailure {
+          Log.w(TAG, "stream start failed", it)
+          stop()
+        }
+        .getOrDefault(false)
+  }
+
+  /** Stop and release everything. Idempotent, and safe to call from any thread. */
+  fun stop() {
+    running = false
+    runCatching { session?.close() }
+    runCatching { device?.close() }
+    runCatching { codec?.stop() }
+    runCatching { codec?.release() }
+    runCatching { inputSurface?.release() }
+    runCatching { thread?.quitSafely() }
+    drain?.interrupt()
+    session = null
+    device = null
+    codec = null
+    inputSurface = null
+    thread = null
+    drain = null
+    Log.i(TAG, "streaming stopped")
+  }
+
+  /**
+   * Pull encoded buffers out of the codec and hand on their NALs. The first buffer is flagged
+   * codec-config and carries SPS+PPS glued together — kept for the SDP rather than sent, since
+   * RTP announces parameter sets out of band.
+   */
+  private fun drainLoop() {
+    val info = MediaCodec.BufferInfo()
+    while (running) {
+      val enc = codec ?: break
+      val index = runCatching { enc.dequeueOutputBuffer(info, DRAIN_TIMEOUT_US) }.getOrElse { break }
+      if (index < 0) continue
+      runCatching {
+            val buf = enc.getOutputBuffer(index)
+            if (buf != null && info.size > 0) {
+              buf.position(info.offset)
+              buf.limit(info.offset + info.size)
+              val bytes = ByteArray(info.size).also { buf.get(it) }
+              val nals = RtpH264.splitAnnexB(bytes)
+              if (info.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG != 0) {
+                nals.forEach {
+                  when (RtpH264.nalType(it)) {
+                    NAL_SPS -> sps = it
+                    NAL_PPS -> pps = it
+                  }
+                }
+                Log.i(TAG, "codec config: sps=${sps?.size} pps=${pps?.size}")
+              } else if (nals.isNotEmpty()) {
+                val keyframe = info.flags and MediaCodec.BUFFER_FLAG_KEY_FRAME != 0
+                onNals(nals, info.presentationTimeUs, keyframe)
+              }
+            }
+          }
+          .onFailure { Log.w(TAG, "drain failed", it) }
+      runCatching { enc.releaseOutputBuffer(index, false) }
+    }
+  }
+
+  private fun pickCamera(manager: CameraManager): String? =
+      runCatching {
+            manager.cameraIdList.firstOrNull {
+              manager.getCameraCharacteristics(it).get(CameraCharacteristics.LENS_FACING) ==
+                  CameraCharacteristics.LENS_FACING_FRONT
+            } ?: manager.cameraIdList.firstOrNull()
+          }
+          .getOrNull()
+
+  /**
+   * Sizes the camera can feed an encoder surface. Uses the same bounded choice as stills — the
+   * per-model field-of-view quirks in the design note apply here too, and a bigger frame costs
+   * bitrate and heat for a scene that doesn't need it.
+   */
+  private fun streamSize(manager: CameraManager, cameraId: String): Pair<Int, Int>? =
+      runCatching {
+            val map =
+                manager
+                    .getCameraCharacteristics(cameraId)
+                    .get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
+                    as? StreamConfigurationMap
+            val offered =
+                map?.getOutputSizes(MediaCodec::class.java)?.map { it.width to it.height }.orEmpty()
+            CameraSizes.choose(offered, MAX_EDGE)
+          }
+          .getOrNull()
+
+  @Suppress("MissingPermission") // checked in start()
+  private fun openCamera(
+      manager: CameraManager,
+      cameraId: String,
+      surface: Surface,
+      handler: Handler,
+  ) {
+    manager.openCamera(
+        cameraId,
+        object : CameraDevice.StateCallback() {
+          override fun onOpened(camera: CameraDevice) {
+            device = camera
+            runCatching { startSession(camera, surface, handler) }
+                .onFailure {
+                  Log.w(TAG, "session failed", it)
+                  stop()
+                }
+          }
+
+          override fun onDisconnected(camera: CameraDevice) = stop()
+
+          override fun onError(camera: CameraDevice, error: Int) {
+            Log.w(TAG, "camera error $error")
+            stop()
+          }
+        },
+        handler)
+  }
+
+  @Suppress("DEPRECATION") // matches GestureCamera; the API 28 replacement isn't on minSdk 24
+  private fun startSession(camera: CameraDevice, surface: Surface, handler: Handler) {
+    camera.createCaptureSession(
+        listOf(surface),
+        object : CameraCaptureSession.StateCallback() {
+          override fun onConfigured(s: CameraCaptureSession) {
+            session = s
+            runCatching {
+                  val req =
+                      camera.createCaptureRequest(CameraDevice.TEMPLATE_RECORD).apply {
+                        addTarget(surface)
+                      }
+                  s.setRepeatingRequest(req.build(), null, handler)
+                }
+                .onFailure {
+                  Log.w(TAG, "repeating request failed", it)
+                  stop()
+                }
+          }
+
+          override fun onConfigureFailed(s: CameraCaptureSession) {
+            Log.w(TAG, "capture session config failed")
+            stop()
+          }
+        },
+        handler)
+  }
+
+  private companion object {
+    const val TAG = "ImmortalStream"
+    const val FPS = 15
+    /** Same bound as stills: a room view, not a photograph, and kind to a fanless device. */
+    const val MAX_EDGE = 640
+    const val DRAIN_TIMEOUT_US = 10_000L
+    const val NAL_SPS = 7
+    const val NAL_PPS = 8
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/CameraStreamService.kt
+++ b/app/src/main/java/com/immortal/launcher/CameraStreamService.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+
+/**
+ * Live video for Home Assistant: owns the encoder ([CameraStream]) and the [RtspServer] that puts
+ * its frames on the wire. Phase 2 of `docs/design/camera-streaming.md`.
+ *
+ * A foreground service because the camera is held for as long as it runs — this is exactly the
+ * case Android's foreground requirement exists for, and the notification is a second, system-level
+ * signal that the camera is live, alongside the on-screen indicator.
+ *
+ * **Streaming does not survive a reboot.** [ImmortalSettings.cameraEnabled] is the consent and
+ * persists; whether the stream is actually running does not, so a Portal that loses power comes
+ * back with the camera idle rather than quietly broadcasting a room again.
+ */
+class CameraStreamService : Service() {
+
+  private var stream: CameraStream? = null
+  private var server: RtspServer? = null
+
+  override fun onCreate() {
+    super.onCreate()
+    createChannel()
+    startForeground(NOTIF_ID, notification())
+    val s = CameraStream(applicationContext) { nals, ptsUs, keyframe ->
+      server?.broadcast(nals, ptsUs, keyframe)
+    }
+    stream = s
+    val srv =
+        RtspServer(
+            sdp = {
+              val sps = s.sps
+              val pps = s.pps
+              if (sps == null || pps == null) null
+              else RtspSdp.videoSdp(s.width, s.height, sps, pps)
+            },
+            onActiveChanged = { active -> Log.i(TAG, "viewers: $active") },
+        )
+    server = srv
+    val ok = runCatching { srv.start() }.isSuccess && s.start()
+    if (!ok) {
+      Log.w(TAG, "couldn't start streaming — stopping")
+      running = false
+      stopSelf()
+    } else {
+      running = true
+      Log.i(TAG, "streaming service up on :${RtspServer.DEFAULT_PORT}")
+    }
+  }
+
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_NOT_STICKY
+
+  override fun onBind(intent: Intent?): IBinder? = null
+
+  override fun onDestroy() {
+    running = false
+    runCatching { stream?.stop() }
+    runCatching { server?.stop() }
+    stream = null
+    server = null
+    super.onDestroy()
+  }
+
+  private fun createChannel() {
+    if (Build.VERSION.SDK_INT >= 26) {
+      val ch =
+          NotificationChannel(CHANNEL, "Camera streaming", NotificationManager.IMPORTANCE_LOW)
+              .apply { description = "Shown whenever this Portal's camera is streaming" }
+      getSystemService(NotificationManager::class.java)?.createNotificationChannel(ch)
+    }
+  }
+
+  private fun notification(): Notification {
+    val b =
+        if (Build.VERSION.SDK_INT >= 26) Notification.Builder(this, CHANNEL)
+        else @Suppress("DEPRECATION") Notification.Builder(this)
+    return b.setSmallIcon(R.mipmap.ic_launcher)
+        .setContentTitle("Immortal · camera streaming")
+        .setContentText("This Portal's camera is live")
+        .setOngoing(true)
+        .build()
+  }
+
+  companion object {
+    private const val TAG = "ImmortalStream"
+    private const val CHANNEL = "camera_stream"
+    private const val NOTIF_ID = 4713
+
+    /** True while the service is up — what the Home Assistant switch reports. */
+    @Volatile
+    var running = false
+      private set
+
+    /**
+     * Start or stop streaming. Starting requires the device-side camera consent: a Home Assistant
+     * command can turn the stream on only within permission already granted on the Portal, never
+     * grant it.
+     */
+    fun sync(context: Context, on: Boolean) {
+      val intent = Intent(context, CameraStreamService::class.java)
+      if (on && ImmortalSettings.cameraEnabled(context)) {
+        if (Build.VERSION.SDK_INT >= 26) context.startForegroundService(intent)
+        else context.startService(intent)
+      } else {
+        context.stopService(intent)
+        running = false
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/CameraStreamService.kt
+++ b/app/src/main/java/com/immortal/launcher/CameraStreamService.kt
@@ -32,6 +32,7 @@ import android.util.Log
 class CameraStreamService : Service() {
 
   private var stream: CameraStream? = null
+  private var audio: AudioStream? = null
   private var server: RtspServer? = null
 
   override fun onCreate() {
@@ -48,11 +49,30 @@ class CameraStreamService : Service() {
               val sps = s.sps
               val pps = s.pps
               if (sps == null || pps == null) null
-              else RtspSdp.videoSdp(s.width, s.height, sps, pps)
+              else
+                  RtspSdp.sessionSdp(
+                      s.width,
+                      s.height,
+                      sps,
+                      pps,
+                      // Only describe an audio track if sound is actually running: promising one
+                      // we can't deliver leaves a client waiting for packets that never come.
+                      audioSampleRate = if (audio?.isRunning() == true) AudioStream.SAMPLE_RATE else null,
+                  )
             },
             onActiveChanged = { active -> Log.i(TAG, "viewers: $active") },
         )
     server = srv
+    // Audio starts before the SDP can be asked for, so the description is right from the first
+    // DESCRIBE. It's allowed to fail — no permission, or something louder holding the microphone
+    // — and the stream simply carries on without sound.
+    if (ImmortalSettings.cameraAudio(applicationContext)) {
+      val a = AudioStream(applicationContext) { frame, ptsUs ->
+        srv.broadcastAudio(frame, ptsUs, AudioStream.SAMPLE_RATE)
+      }
+      audio = if (a.start()) a else null
+      if (audio == null) Log.i(TAG, "continuing without audio")
+    }
     val ok = runCatching { srv.start() }.isSuccess && s.start()
     if (!ok) {
       Log.w(TAG, "couldn't start streaming — stopping")
@@ -71,8 +91,10 @@ class CameraStreamService : Service() {
   override fun onDestroy() {
     running = false
     runCatching { stream?.stop() }
+    runCatching { audio?.stop() }
     runCatching { server?.stop() }
     stream = null
+    audio = null
     server = null
     super.onDestroy()
   }

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
@@ -112,6 +112,16 @@ object ImmortalSettings {
    */
   fun cameraEnabled(c: Context): Boolean = prefs(c).getBoolean("camera_enabled", false)
 
+  /**
+   * Include sound in the camera stream. Persisted (a nursery wants it on every time), but it only
+   * ever takes effect while streaming, which deliberately doesn't persist. Muting the microphone
+   * still silences it — see [AudioStream.shouldEmit].
+   */
+  fun cameraAudio(c: Context): Boolean = prefs(c).getBoolean("camera_audio", false)
+
+  fun setCameraAudio(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("camera_audio", on).apply()
+
   fun setCameraEnabled(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("camera_enabled", on).apply()
 

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettings.kt
@@ -58,10 +58,6 @@ object ImmortalSettings {
       // PresenceHub. On by default — it needs no permission provisioning doesn't already
       // grant, and falls back to the proxy on its own when the detector stays quiet.
       val portalPresence: Boolean = true,
-      // Let Home Assistant take a still from the Portal's camera. OFF by default and
-      // deliberately device-only consent: nothing arriving over MQTT can turn this on, and with
-      // it off the camera is never opened. See docs/design/camera-streaming.md.
-      val cameraEnabled: Boolean = false,
       // Hide the system status bar (immersive). Default on — the clean wall-frame look,
       // and what provisioning seeds; swipe from the top still reveals it transiently.
       val hideStatusBar: Boolean = true,
@@ -95,7 +91,6 @@ object ImmortalSettings {
         clockFormat = p.getString("clock_format", CLOCK_AUTO) ?: CLOCK_AUTO,
         showMiniPlayer = p.getBoolean("show_mini_player", true),
         portalPresence = p.getBoolean("portal_presence", true),
-        cameraEnabled = p.getBoolean("camera_enabled", false),
         hideStatusBar = p.getBoolean("hide_status_bar", true),
         constrainPageWidth = p.getBoolean("constrain_page_width", false),
         multiRoomEnabled = p.getBoolean("multiroom_enabled", false),
@@ -106,6 +101,15 @@ object ImmortalSettings {
     )
   }
 
+  /**
+   * Let Home Assistant take a still from the Portal's camera. Off by default, and deliberately
+   * device-only consent: nothing arriving over MQTT can turn it on, and with it off the camera
+   * is never opened. See docs/design/camera-streaming.md.
+   *
+   * Stored here rather than in [MqttConfig] — where its setting is now surfaced — so that anyone
+   * who already switched it on keeps it, with no migration to get wrong. It's an app-level
+   * capability; Home Assistant is simply what consumes it.
+   */
   fun cameraEnabled(c: Context): Boolean = prefs(c).getBoolean("camera_enabled", false)
 
   fun setCameraEnabled(c: Context, on: Boolean) =

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -7,6 +7,12 @@
 
 package com.immortal.launcher
 
+import androidx.core.content.ContextCompat
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.compose.rememberLauncherForActivityResult
+import android.widget.Toast
+import android.content.pm.PackageManager
+import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -713,6 +719,19 @@ internal fun MqttScreen(onBack: () -> Unit) {
   var validateCert by remember { mutableStateOf(MqttConfig.validateCert(context)) }
   var ambientSensors by remember { mutableStateOf(MqttConfig.ambientSensors(context)) }
   var tempOffset by remember { mutableStateOf(MqttConfig.tempOffset(context)) }
+  var cameraEnabled by remember { mutableStateOf(ImmortalSettings.cameraEnabled(context)) }
+  // CAMERA is a runtime permission that provisioning doesn't grant, and nothing else in the app
+  // asks for it — so without this the toggle switched on and every snapshot silently did nothing.
+  val cameraPermission =
+      rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        if (!granted) {
+          cameraEnabled = false
+          ImmortalSettings.setCameraEnabled(context, false)
+          Toast.makeText(context, "Camera permission is needed for snapshots", Toast.LENGTH_LONG)
+              .show()
+        }
+        MqttService.sync(context, reconfigure = true)
+      }
   // MqttStatus is a plain holder updated off the main thread, so poll it for live
   // "Connecting… → Connected" feedback (Compose won't recompose on its writes).
   var status by remember { mutableStateOf(MqttStatus.text) }
@@ -748,6 +767,19 @@ internal fun MqttScreen(onBack: () -> Unit) {
     MqttConfig.setAmbientSensors(context, ambientSensors)
     MqttConfig.setTempOffset(context, tempOffset)
     MqttService.sync(context, reconfigure = true)
+  }
+
+  /**
+   * Enabling the camera asks for the permission there and then. Turning it on without it looks
+   * like it worked and then does nothing, which is exactly how this shipped the first time.
+   */
+  fun applyCamera(on: Boolean) {
+    ImmortalSettings.setCameraEnabled(context, on)
+    val granted =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
+            PackageManager.PERMISSION_GRANTED
+    if (on && !granted) cameraPermission.launch(Manifest.permission.CAMERA)
+    else MqttService.sync(context, reconfigure = true)
   }
 
   Column(
@@ -1020,6 +1052,34 @@ internal fun MqttScreen(onBack: () -> Unit) {
                 color = Color(0xFF7C7C7C),
                 fontSize = 13.sp,
                 modifier = Modifier.padding(start = 18.dp, end = 18.dp, bottom = 14.dp),
+            )
+          }
+        }
+        Spacer(Modifier.size(26.dp))
+        SectionLabel("Camera")
+        Card {
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Column(modifier = Modifier.weight(1f)) {
+              Text("Camera snapshots", color = Color.White, fontSize = 15.sp)
+              Text(
+                  "Let Home Assistant take a still photo from this Portal's camera. Only " +
+                      "switchable here - Home Assistant can't turn it on - and the screen says " +
+                      "so every time a photo is taken.",
+                  color = Color(0xFF9A9A9A),
+                  fontSize = 13.sp,
+                  modifier = Modifier.padding(top = 2.dp),
+              )
+            }
+            Segmented(
+                options = listOf("Off" to "off", "On" to "on"),
+                selected = if (cameraEnabled) "on" else "off",
+                onSelect = {
+                  cameraEnabled = it == "on"
+                  applyCamera(cameraEnabled)
+                },
             )
           }
         }

--- a/app/src/main/java/com/immortal/launcher/LanAudio.kt
+++ b/app/src/main/java/com/immortal/launcher/LanAudio.kt
@@ -36,6 +36,7 @@ class LanAudio {
   // here would make ServerSocket(PORT) in startBroadcast() fail to bind.
   val PORT = 8724
   private val SAMPLE_RATE = 16000
+  private val MIC_OWNER = "intercom"
 
   @Volatile private var running = false
   private var serverThread: Thread? = null
@@ -75,6 +76,13 @@ class LanAudio {
   }
 
   private fun pumpMicTo(out: OutputStream) {
+    // Someone speaking outranks anything else that wants the microphone (the camera stream's
+    // audio track, in practice), and takes it. Before [MicOwner] existed nothing arbitrated at
+    // all: whoever opened the mic second just got silence, with nothing to say why.
+    if (!MicOwner.acquire(MIC_OWNER, MicOwner.PRIORITY_INTERCOM)) {
+      Log.w(TAG, "microphone held by ${MicOwner.holder} — not announcing")
+      return
+    }
     val minBuf = AudioRecord.getMinBufferSize(
         SAMPLE_RATE, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT)
     val rec = AudioRecord(
@@ -83,12 +91,13 @@ class LanAudio {
     runCatching {
       rec.startRecording()
       val buf = ByteArray(2048)
-      while (running) {
+      while (running && MicOwner.holds(MIC_OWNER)) {
         val n = rec.read(buf, 0, buf.size)
         if (n > 0) out.write(buf, 0, n) else break
       }
     }.onFailure { Log.w(TAG, "mic pump ended", it) }
     runCatching { rec.stop() }; runCatching { rec.release() }
+    MicOwner.release(MIC_OWNER)
   }
 
   /** Connect to [host] and play whatever audio it streams. [onState] reports connect

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -407,6 +407,17 @@ class MqttPublisher(private val appContext: Context) {
             CameraStreamService.sync(appContext, payload.trim().equals("ON", ignoreCase = true))
             publishStreamState()
           }
+          "camera_audio" -> {
+            val on = payload.trim().equals("ON", ignoreCase = true)
+            ImmortalSettings.setCameraAudio(appContext, on)
+            // Audio is set up when the stream starts, so a change mid-stream needs a restart to
+            // take effect — the SDP has to describe the track for a client to ask for it.
+            if (CameraStreamService.running) {
+              CameraStreamService.sync(appContext, false)
+              CameraStreamService.sync(appContext, true)
+            }
+            publishStreamState()
+          }
           "notify" -> handleNotify(payload)
           // Show the photo frame on demand — the same surface the launcher's header
           // screensaver button launches (HomeActivity.onStartScreensaver). This is the
@@ -590,6 +601,10 @@ class MqttPublisher(private val appContext: Context) {
     val c = client ?: return
     if (!ImmortalSettings.cameraEnabled(appContext)) return
     c.publish("$base/camera_stream/state", if (CameraStreamService.running) "ON" else "OFF", retain = true)
+    c.publish(
+        "$base/camera_audio/state",
+        if (ImmortalSettings.cameraAudio(appContext)) "ON" else "OFF",
+        retain = true)
     val ip = currentIp()
     c.publish(
         "$base/stream_url/state",
@@ -732,11 +747,13 @@ class MqttPublisher(private val appContext: Context) {
       cameraEntity(c, "camera", "Camera")
       button(c, "snapshot", "Take snapshot", icon = "mdi:camera")
       switchEntity(c, "camera_stream", "Camera streaming", icon = "mdi:video")
+      switchEntity(c, "camera_audio", "Camera audio", icon = "mdi:volume-high")
       sensor(c, "stream_url", "Stream URL", icon = "mdi:link-variant", diagnostic = true)
     } else {
       publishConfig(c, "camera", "camera", null)
       publishConfig(c, "button", "snapshot", null)
       publishConfig(c, "switch", "camera_stream", null)
+      publishConfig(c, "switch", "camera_audio", null)
       publishConfig(c, "sensor", "stream_url", null)
     }
 
@@ -776,6 +793,7 @@ class MqttPublisher(private val appContext: Context) {
           "camera" to "camera",
           "button" to "snapshot",
           "switch" to "camera_stream",
+          "switch" to "camera_audio",
           "sensor" to "stream_url",
           "button" to "screen_off", // legacy (pre-1.41)
       ) + AmbientKind.values().map { "sensor" to it.key }

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -144,6 +144,7 @@ class MqttPublisher(private val appContext: Context) {
                 publishDiscovery(c)
                 publishPresence(PresenceHub.current)
                 publishAudioState()
+                publishStreamState()
               }
               .onFailure { Log.w(TAG, "reconfigure failed", it) }
         }
@@ -204,6 +205,7 @@ class MqttPublisher(private val appContext: Context) {
                     // move these without telling us, so HA's slider and switches would sit on
                     // whatever we last published until the next reconnect.
                     runCatching { publishAudioState() }
+                    runCatching { publishStreamState() }
                   }
                 }
               }
@@ -290,6 +292,7 @@ class MqttPublisher(private val appContext: Context) {
     publishScreen()
     publishIp()
     publishAudioState()
+    publishStreamState()
     if (MqttConfig.ambientSensors(appContext)) ambient.start()
   }
 
@@ -396,6 +399,13 @@ class MqttPublisher(private val appContext: Context) {
                   name = "mqtt-snapshot"
                   start()
                 }
+          }
+          // Streaming can only be switched on within consent already given on the device;
+          // CameraStreamService.sync enforces that, and we report back what actually happened
+          // rather than what was asked for.
+          "camera_stream" -> {
+            CameraStreamService.sync(appContext, payload.trim().equals("ON", ignoreCase = true))
+            publishStreamState()
           }
           "notify" -> handleNotify(payload)
           // Show the photo frame on demand — the same surface the launcher's header
@@ -571,6 +581,23 @@ class MqttPublisher(private val appContext: Context) {
     c.publish("$base/charging/state", if (charging) "ON" else "OFF", retain = true)
   }
 
+  /**
+   * Whether the stream is live, and where to point a player at it. Reported from the service's
+   * own state, so a stream that refused to start (no permission, camera busy) shows as off
+   * rather than leaving the switch stuck on.
+   */
+  private fun publishStreamState() {
+    val c = client ?: return
+    if (!ImmortalSettings.cameraEnabled(appContext)) return
+    c.publish("$base/camera_stream/state", if (CameraStreamService.running) "ON" else "OFF", retain = true)
+    val ip = currentIp()
+    c.publish(
+        "$base/stream_url/state",
+        if (ip.isBlank()) "unknown" else "rtsp://$ip:${RtspServer.DEFAULT_PORT}/",
+        retain = true,
+    )
+  }
+
   private fun publishIp() {
     client?.publish("$base/ip/state", currentIp().ifBlank { "unknown" }, retain = true)
   }
@@ -704,9 +731,13 @@ class MqttPublisher(private val appContext: Context) {
     if (ImmortalSettings.cameraEnabled(appContext)) {
       cameraEntity(c, "camera", "Camera")
       button(c, "snapshot", "Take snapshot", icon = "mdi:camera")
+      switchEntity(c, "camera_stream", "Camera streaming", icon = "mdi:video")
+      sensor(c, "stream_url", "Stream URL", icon = "mdi:link-variant", diagnostic = true)
     } else {
       publishConfig(c, "camera", "camera", null)
       publishConfig(c, "button", "snapshot", null)
+      publishConfig(c, "switch", "camera_stream", null)
+      publishConfig(c, "sensor", "stream_url", null)
     }
 
     button(c, "go_home", "Home", icon = "mdi:home")
@@ -744,6 +775,8 @@ class MqttPublisher(private val appContext: Context) {
           "sensor" to "ip",
           "camera" to "camera",
           "button" to "snapshot",
+          "switch" to "camera_stream",
+          "sensor" to "stream_url",
           "button" to "screen_off", // legacy (pre-1.41)
       ) + AmbientKind.values().map { "sensor" to it.key }
 

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -374,10 +374,20 @@ class MqttPublisher(private val appContext: Context) {
             Thread {
                   runCatching {
                         val jpeg = camera.snapshot()
-                        if (jpeg == null) Log.i(TAG, "snapshot unavailable")
-                        // retain = false on purpose: a still of someone's room should not sit on
-                        // the broker indefinitely for anyone who later subscribes.
-                        else client?.publish("$base/camera/image", jpeg, retain = false)
+                        when {
+                          jpeg == null -> Log.i(TAG, "snapshot unavailable")
+                          // A broker with a message size limit doesn't reject an oversize
+                          // PUBLISH, it drops the CONNECTION — taking presence, sensors and
+                          // everything else down with it, once per press. Never hand it one:
+                          // say so on the device instead, where the user can act on it.
+                          jpeg.size > MAX_IMAGE_BYTES -> {
+                            Log.w(TAG, "snapshot ${jpeg.size} bytes exceeds $MAX_IMAGE_BYTES; not publishing")
+                            camera.toast("Immortal · snapshot too large for the broker")
+                          }
+                          // retain = false on purpose: a still of someone's room should not sit on
+                          // the broker indefinitely for anyone who later subscribes.
+                          else -> client?.publish("$base/camera/image", jpeg, retain = false)
+                        }
                       }
                       .onFailure { Log.w(TAG, "snapshot failed", it) }
                 }
@@ -925,5 +935,11 @@ class MqttPublisher(private val appContext: Context) {
     const val KEEPALIVE_SEC = 45
     const val PING_MS = 20_000L
     const val BACKOFF_MS = 4_000L
+    /**
+     * Biggest image we'll put on the wire. Mosquitto's `message_size_limit` and its equivalents
+     * are commonly set well below a full-quality still, and exceeding one costs the whole
+     * connection rather than just the message.
+     */
+    const val MAX_IMAGE_BYTES = 200_000
   }
 }

--- a/app/src/main/java/com/immortal/launcher/PortalCamera.kt
+++ b/app/src/main/java/com/immortal/launcher/PortalCamera.kt
@@ -15,6 +15,7 @@ import android.hardware.camera2.CameraCaptureSession
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraDevice
 import android.hardware.camera2.CameraManager
+import android.hardware.camera2.CaptureRequest
 import android.hardware.camera2.params.StreamConfigurationMap
 import android.media.ImageReader
 import android.os.Handler
@@ -69,7 +70,7 @@ class PortalCameraCapture(private val appContext: Context) {
 
   /** True when the user has enabled the camera AND the permission is actually granted. */
   fun available(): Boolean =
-      ImmortalSettings.load(appContext).cameraEnabled &&
+      ImmortalSettings.cameraEnabled(appContext) &&
           ContextCompat.checkSelfPermission(appContext, Manifest.permission.CAMERA) ==
               PackageManager.PERMISSION_GRANTED
 
@@ -82,6 +83,9 @@ class PortalCameraCapture(private val appContext: Context) {
   fun snapshot(timeoutMs: Long = TIMEOUT_MS): ByteArray? {
     if (!available()) {
       Log.i(TAG, "camera off or ungranted — no snapshot")
+      toast(
+          if (ImmortalSettings.cameraEnabled(appContext)) "Immortal · no camera permission"
+          else "Immortal · camera snapshots are off")
       return null
     }
     var thread: HandlerThread? = null
@@ -149,13 +153,18 @@ class PortalCameraCapture(private val appContext: Context) {
       val req =
           cam.createCaptureRequest(CameraDevice.TEMPLATE_STILL_CAPTURE).apply {
             addTarget(rdr.surface)
+            // Without this the device picks its own default, typically 95+, and a 640px still
+            // lands in the hundreds of KB — big enough that a broker with a message size limit
+            // drops the whole connection rather than just the image. A dashboard tile does not
+            // need that fidelity.
+            set(CaptureRequest.JPEG_QUALITY, JPEG_QUALITY)
           }
       sess.capture(req.build(), null, handler)
       if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
         Log.w(TAG, "capture didn't complete within ${timeoutMs}ms")
         return null
       }
-      bytes?.also { indicate(it.size) }
+      bytes?.also { indicate(it.size) } ?: null.also { toast("Immortal · camera snapshot failed") }
     } catch (t: Throwable) {
       // The camera is shared and this runs alongside the always-on dream: a failure here must
       // never take a process down, it just means no snapshot this time.
@@ -172,10 +181,13 @@ class PortalCameraCapture(private val appContext: Context) {
   /** Tell the room. A capture the Portal doesn't announce is not one we should be taking. */
   private fun indicate(byteCount: Int) {
     Log.i(TAG, "snapshot captured ($byteCount bytes)")
+    toast("Immortal · camera snapshot taken")
+  }
+
+  /** On-screen feedback, including for failures — a silent no-op is impossible to diagnose. */
+  internal fun toast(text: String) {
     Handler(appContext.mainLooper).post {
-      runCatching {
-        Toast.makeText(appContext, "Immortal · camera snapshot taken", Toast.LENGTH_SHORT).show()
-      }
+      runCatching { Toast.makeText(appContext, text, Toast.LENGTH_SHORT).show() }
     }
   }
 
@@ -231,6 +243,8 @@ class PortalCameraCapture(private val appContext: Context) {
     const val TAG = "ImmortalCamera"
     /** Longest edge we'll ask for — a dashboard tile, not a photograph. */
     const val MAX_EDGE = 640
+    /** Modest on purpose; see the capture request. */
+    const val JPEG_QUALITY: Byte = 75
     const val TIMEOUT_MS = 5_000L
   }
 }

--- a/app/src/main/java/com/immortal/launcher/RtpH264.kt
+++ b/app/src/main/java/com/immortal/launcher/RtpH264.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+/**
+ * RTP packetisation for H.264, per RFC 6184 — the wire format an RTSP client expects.
+ *
+ * Pure and self-contained on purpose. This is the part of a streaming stack where mistakes are
+ * both easy and invisible (an off-by-one in a fragmentation header produces a stream that
+ * *almost* plays, or plays in VLC and not in a browser), and it's the only part that can be
+ * tested properly without a Portal in front of you.
+ *
+ * Phase 2 of `docs/design/camera-streaming.md`.
+ */
+object RtpH264 {
+  /** Dynamic payload type for H.264. Announced in the SDP; any value in 96..127 would do. */
+  const val PAYLOAD_TYPE = 96
+
+  /** H.264 RTP runs on a 90 kHz clock, fixed by RFC 6184. */
+  const val CLOCK_HZ = 90_000L
+
+  /** FU-A fragmentation unit, the NAL type used for a fragmented NAL. */
+  const val NAL_FU_A = 28
+
+  /**
+   * Conservative payload budget per packet: a 1500-byte Ethernet MTU less IP, UDP and RTP
+   * headers, with room to spare for tunnelling. Fragmentation is cheap; a dropped oversize
+   * datagram is not.
+   */
+  const val MAX_PAYLOAD = 1400
+
+  /**
+   * Split one NAL unit into RTP payloads.
+   *
+   * A NAL that fits goes out whole (a "single NAL unit packet" — the payload *is* the NAL,
+   * header byte included). Anything larger is fragmented FU-A: the original NAL header is
+   * replaced by a two-byte prefix carrying its type and start/end markers, so the receiver can
+   * rebuild it.
+   *
+   * @param nal one NAL unit **without** its start code.
+   */
+  fun packetize(nal: ByteArray, maxPayload: Int = MAX_PAYLOAD): List<ByteArray> {
+    if (nal.isEmpty()) return emptyList()
+    if (nal.size <= maxPayload) return listOf(nal)
+
+    val header = nal[0].toInt() and 0xff
+    val indicator = ((header and 0xE0) or NAL_FU_A).toByte() // F and NRI kept, type = FU-A
+    val nalType = (header and 0x1F).toByte()
+    // The original header byte isn't sent; its type moves into the FU header.
+    val body = nal.copyOfRange(1, nal.size)
+    val perPacket = maxPayload - 2 // FU indicator + FU header
+    val out = ArrayList<ByteArray>((body.size + perPacket - 1) / perPacket)
+    var offset = 0
+    while (offset < body.size) {
+      val take = minOf(perPacket, body.size - offset)
+      val start = offset == 0
+      val end = offset + take >= body.size
+      var fuHeader = nalType.toInt()
+      if (start) fuHeader = fuHeader or 0x80
+      if (end) fuHeader = fuHeader or 0x40
+      out.add(
+          ByteArray(take + 2).also {
+            it[0] = indicator
+            it[1] = fuHeader.toByte()
+            System.arraycopy(body, offset, it, 2, take)
+          })
+      offset += take
+    }
+    return out
+  }
+
+  /**
+   * The 12-byte RTP header. [marker] goes on the final packet of an access unit — that's how the
+   * receiver knows a frame is complete and can be handed to the decoder, so a stream that never
+   * sets it stalls or plays late.
+   */
+  fun header(
+      sequence: Int,
+      timestamp: Long,
+      ssrc: Int,
+      marker: Boolean,
+      payloadType: Int = PAYLOAD_TYPE,
+  ): ByteArray {
+    val b = ByteArray(12)
+    b[0] = 0x80.toByte() // version 2, no padding, no extension, 0 CSRCs
+    b[1] = (payloadType or if (marker) 0x80 else 0).toByte()
+    b[2] = (sequence ushr 8).toByte()
+    b[3] = sequence.toByte()
+    b[4] = (timestamp ushr 24).toByte()
+    b[5] = (timestamp ushr 16).toByte()
+    b[6] = (timestamp ushr 8).toByte()
+    b[7] = timestamp.toByte()
+    b[8] = (ssrc ushr 24).toByte()
+    b[9] = (ssrc ushr 16).toByte()
+    b[10] = (ssrc ushr 8).toByte()
+    b[11] = ssrc.toByte()
+    return b
+  }
+
+  /** Microseconds (what MediaCodec reports) to the 90 kHz RTP clock. */
+  fun timestamp(presentationTimeUs: Long): Long = presentationTimeUs * CLOCK_HZ / 1_000_000L
+
+  /**
+   * Split an Annex B buffer — what MediaCodec emits, NALs separated by 3- or 4-byte start codes
+   * — into the individual NAL units. The codec hands us the SPS and PPS glued together in one
+   * config buffer, so this is how they get taken apart for the SDP.
+   */
+  fun splitAnnexB(buffer: ByteArray): List<ByteArray> {
+    val starts = ArrayList<Int>()
+    var i = 0
+    while (i + 3 <= buffer.size) {
+      val threeByte = buffer[i] == 0.toByte() && buffer[i + 1] == 0.toByte() && buffer[i + 2] == 1.toByte()
+      val fourByte =
+          i + 4 <= buffer.size &&
+              buffer[i] == 0.toByte() &&
+              buffer[i + 1] == 0.toByte() &&
+              buffer[i + 2] == 0.toByte() &&
+              buffer[i + 3] == 1.toByte()
+      when {
+        fourByte -> {
+          starts.add(i + 4)
+          i += 4
+        }
+        threeByte -> {
+          starts.add(i + 3)
+          i += 3
+        }
+        else -> i++
+      }
+    }
+    if (starts.isEmpty()) return emptyList()
+    return starts.mapIndexed { idx, from ->
+      // A NAL runs to the start code of the next one, minus that code's leading zero bytes.
+      val to = if (idx + 1 < starts.size) trimStartCode(buffer, starts[idx + 1]) else buffer.size
+      buffer.copyOfRange(from, maxOf(from, to))
+    }
+        .filter { it.isNotEmpty() }
+  }
+
+  /** Walk back off the start code preceding [nextNalStart] to find where the previous NAL ends. */
+  private fun trimStartCode(buffer: ByteArray, nextNalStart: Int): Int {
+    var end = nextNalStart - 3 // the 00 00 01 always present
+    if (end > 0 && buffer[end - 1] == 0.toByte()) end-- // 4-byte form
+    return end
+  }
+
+  /** The NAL type of [nal] (7 = SPS, 8 = PPS, 5 = IDR), or -1 when empty. */
+  fun nalType(nal: ByteArray): Int = if (nal.isEmpty()) -1 else nal[0].toInt() and 0x1F
+}

--- a/app/src/main/java/com/immortal/launcher/RtspSdp.kt
+++ b/app/src/main/java/com/immortal/launcher/RtspSdp.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+/**
+ * The session description an RTSP client fetches with DESCRIBE, and the encodings it needs.
+ *
+ * Pure, so the exact bytes can be checked without a Portal. It matters: a client decides whether
+ * it can play the stream from this text alone, and a wrong `profile-level-id` or a mangled
+ * parameter set produces a black picture with no error anywhere.
+ */
+object RtspSdp {
+  private const val B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+  /**
+   * Standard base64. Hand-rolled because `java.util.Base64` needs API 26 and `android.util.Base64`
+   * is stubbed out in JVM unit tests — this way the SDP is testable and works on every Portal.
+   */
+  fun base64(bytes: ByteArray): String {
+    if (bytes.isEmpty()) return ""
+    val out = StringBuilder((bytes.size + 2) / 3 * 4)
+    var i = 0
+    while (i < bytes.size) {
+      val b0 = bytes[i].toInt() and 0xff
+      val b1 = if (i + 1 < bytes.size) bytes[i + 1].toInt() and 0xff else 0
+      val b2 = if (i + 2 < bytes.size) bytes[i + 2].toInt() and 0xff else 0
+      out.append(B64[b0 ushr 2])
+      out.append(B64[((b0 and 0x03) shl 4) or (b1 ushr 4)])
+      out.append(if (i + 1 < bytes.size) B64[((b1 and 0x0F) shl 2) or (b2 ushr 6)] else '=')
+      out.append(if (i + 2 < bytes.size) B64[b2 and 0x3F] else '=')
+      i += 3
+    }
+    return out.toString()
+  }
+
+  /**
+   * The `profile-level-id`: profile_idc, the constraint flags, and level_idc as six hex digits,
+   * read straight out of the SPS. Taken from the SPS rather than from what we *asked* the encoder
+   * for, so a device that quietly ignored the profile request describes itself honestly.
+   */
+  fun profileLevelId(sps: ByteArray): String {
+    // sps[0] is the NAL header; the three bytes after it are what this field encodes.
+    if (sps.size < 4) return "42001f" // constrained baseline 3.1, a safe-to-advertise default
+    return "%02x%02x%02x".format(sps[1].toInt() and 0xff, sps[2].toInt() and 0xff, sps[3].toInt() and 0xff)
+  }
+
+  /**
+   * A minimal single-video-track SDP. `packetization-mode=1` says the stream may use FU-A
+   * fragmentation, which it will for any real keyframe; the parameter sets travel here rather
+   * than in the stream, which is why the encoder's config buffer is kept rather than sent.
+   */
+  fun videoSdp(
+      width: Int,
+      height: Int,
+      sps: ByteArray,
+      pps: ByteArray,
+      payloadType: Int = RtpH264.PAYLOAD_TYPE,
+  ): String {
+    val params = "${base64(sps)},${base64(pps)}"
+    return buildString {
+      append("v=0\r\n")
+      append("o=- 0 0 IN IP4 0.0.0.0\r\n")
+      append("s=Immortal\r\n")
+      append("c=IN IP4 0.0.0.0\r\n")
+      append("t=0 0\r\n")
+      append("a=tool:immortal\r\n")
+      append("m=video 0 RTP/AVP $payloadType\r\n")
+      append("a=rtpmap:$payloadType H264/${RtpH264.CLOCK_HZ}\r\n")
+      append(
+          "a=fmtp:$payloadType packetization-mode=1;profile-level-id=${profileLevelId(sps)};" +
+              "sprop-parameter-sets=$params\r\n")
+      append("a=framesize:$payloadType $width-$height\r\n")
+      append("a=control:trackID=0\r\n")
+    }
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/RtspSdp.kt
+++ b/app/src/main/java/com/immortal/launcher/RtspSdp.kt
@@ -75,7 +75,23 @@ object RtspSdp {
           "a=fmtp:$payloadType packetization-mode=1;profile-level-id=${profileLevelId(sps)};" +
               "sprop-parameter-sets=$params\r\n")
       append("a=framesize:$payloadType $width-$height\r\n")
-      append("a=control:trackID=0\r\n")
+      append("a=control:trackID=${RtspServer.VIDEO_TRACK}\r\n")
     }
   }
+
+  /**
+   * The full session: video, plus the audio track when sound is running. Audio is a separate
+   * media section with its own clock and its own control URL, so a client can set up one track
+   * and not the other — which is exactly what a viewer that only wants a picture will do.
+   */
+  fun sessionSdp(
+      width: Int,
+      height: Int,
+      sps: ByteArray,
+      pps: ByteArray,
+      audioSampleRate: Int? = null,
+      audioChannels: Int = 1,
+  ): String =
+      videoSdp(width, height, sps, pps) +
+          (audioSampleRate?.let { AacRtp.audioSdp(it, audioChannels, RtspServer.AUDIO_TRACK) } ?: "")
 }

--- a/app/src/main/java/com/immortal/launcher/RtspServer.kt
+++ b/app/src/main/java/com/immortal/launcher/RtspServer.kt
@@ -41,11 +41,16 @@ class RtspServer(
   @Volatile private var running = false
   private val clients = CopyOnWriteArrayList<Client>()
   @Volatile private var sequence = 0
+  @Volatile private var audioSequence = 0
   private val ssrc = (System.nanoTime() and 0x7FFFFFFF).toInt()
+  // A distinct SSRC: two streams sharing one would be treated as a single confused source.
+  private val audioSsrc = ssrc xor 0x5A5A5A5A
 
   /** One connected client. [playing] gates RTP: a client gets frames only after it says PLAY. */
   private class Client(val socket: Socket, val out: OutputStream) {
     @Volatile var playing = false
+    /** True once the client has SETUP the audio track; it only gets sound if it asked for it. */
+    @Volatile var wantsAudio = false
     val writeLock = Any()
   }
 
@@ -150,12 +155,17 @@ class RtspServer(
               body = body)
         }
       }
-      "SETUP" ->
-          respond(
-              client,
-              cseq,
-              extra =
-                  "Transport: RTP/AVP/TCP;unicast;interleaved=0-1\r\nSession: $SESSION_ID\r\n")
+      "SETUP" -> {
+        // Each track gets its own interleaved channel pair on the one connection: video on 0/1,
+        // audio on 2/3. A client that never SETUPs track 1 simply never receives sound.
+        val audioTrack = req.uri.contains("trackID=$AUDIO_TRACK")
+        if (audioTrack) client.wantsAudio = true
+        val channels = if (audioTrack) "$AUDIO_CHANNEL-${AUDIO_CHANNEL + 1}" else "$RTP_CHANNEL-${RTP_CHANNEL + 1}"
+        respond(
+            client,
+            cseq,
+            extra = "Transport: RTP/AVP/TCP;unicast;interleaved=$channels\r\nSession: $SESSION_ID\r\n")
+      }
       "PLAY" -> {
         respond(client, cseq, extra = "Session: $SESSION_ID\r\nRange: npt=0.000-\r\n")
         client.playing = true
@@ -213,14 +223,37 @@ class RtspServer(
     if (keyframe) Log.v(TAG, "keyframe sent to ${playing.size} client(s)")
   }
 
+  /**
+   * Send one AAC frame to every client that asked for the audio track.
+   *
+   * Audio keeps its own sequence numbers and its own clock — RTP timestamps are per-stream, and
+   * running audio on the video's 90 kHz clock is a classic way to get sound that drifts.
+   */
+  fun broadcastAudio(frame: ByteArray, presentationTimeUs: Long, sampleRate: Int) {
+    if (!running) return
+    val listeners = clients.filter { it.playing && it.wantsAudio }
+    if (listeners.isEmpty()) return
+    audioSequence = (audioSequence + 1) and 0xFFFF
+    val packet =
+        RtpH264.header(
+            audioSequence,
+            AacRtp.timestamp(presentationTimeUs, sampleRate),
+            audioSsrc,
+            // Every AAC frame is a complete access unit, so the marker is always set.
+            marker = true,
+            payloadType = AacRtp.PAYLOAD_TYPE,
+        ) + AacRtp.packetize(frame)
+    listeners.forEach { send(it, packet, AUDIO_CHANNEL) }
+  }
+
   /** Interleaved framing: '$', channel, 2-byte length, then the RTP packet (RFC 2326 §10.12). */
-  private fun send(client: Client, packet: ByteArray) {
+  private fun send(client: Client, packet: ByteArray, channel: Byte = RTP_CHANNEL) {
     runCatching {
           synchronized(client.writeLock) {
             client.out.write(
                 byteArrayOf(
                     INTERLEAVE_MAGIC,
-                    RTP_CHANNEL,
+                    channel,
                     (packet.size ushr 8).toByte(),
                     packet.size.toByte()))
             client.out.write(packet)
@@ -245,6 +278,9 @@ class RtspServer(
     private const val SESSION_ID = "immortal"
     private const val INTERLEAVE_MAGIC: Byte = 0x24 // '$'
     private const val RTP_CHANNEL: Byte = 0
+    private const val AUDIO_CHANNEL: Byte = 2
+    const val VIDEO_TRACK = 0
+    const val AUDIO_TRACK = 1
     private const val NAL_SPS = 7
     private const val NAL_PPS = 8
   }

--- a/app/src/main/java/com/immortal/launcher/RtspServer.kt
+++ b/app/src/main/java/com/immortal/launcher/RtspServer.kt
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.util.Log
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * A small RTSP server: enough of RFC 2326 for go2rtc, VLC and ffmpeg to fetch the description and
+ * play the stream, and no more.
+ *
+ * **RTP is interleaved over the same TCP connection** (RFC 2326 §10.12) rather than sent on
+ * separate UDP ports. That's a deliberate simplification: one socket to manage, no port
+ * negotiation, no NAT or firewall questions on a home LAN, and no packet loss to conceal — at the
+ * cost of TCP's head-of-line blocking, which for a fixed indoor scene at 15fps is a fair trade.
+ *
+ * Frames arrive through [broadcast] and are fanned out to every playing client. A client that has
+ * fallen behind or gone away is dropped rather than allowed to block the encoder.
+ *
+ * Phase 2 of `docs/design/camera-streaming.md`.
+ */
+class RtspServer(
+    private val port: Int = DEFAULT_PORT,
+    /** The SDP to answer DESCRIBE with, or null while the encoder hasn't produced one yet. */
+    private val sdp: () -> String?,
+    /** Called when the first client starts playing, and when the last one stops. */
+    private val onActiveChanged: (active: Boolean) -> Unit = {},
+) {
+  private var server: ServerSocket? = null
+  private var acceptThread: Thread? = null
+  @Volatile private var running = false
+  private val clients = CopyOnWriteArrayList<Client>()
+  @Volatile private var sequence = 0
+  private val ssrc = (System.nanoTime() and 0x7FFFFFFF).toInt()
+
+  /** One connected client. [playing] gates RTP: a client gets frames only after it says PLAY. */
+  private class Client(val socket: Socket, val out: OutputStream) {
+    @Volatile var playing = false
+    val writeLock = Any()
+  }
+
+  fun isRunning(): Boolean = running
+
+  fun clientCount(): Int = clients.count { it.playing }
+
+  /** Bind and start accepting. Throws on bind failure so the caller can report it. */
+  fun start() {
+    if (running) return
+    val s = ServerSocket(port)
+    s.reuseAddress = true
+    server = s
+    running = true
+    acceptThread =
+        Thread({ acceptLoop(s) }, "immortal-rtsp").apply {
+          isDaemon = true
+          start()
+        }
+    Log.i(TAG, "RTSP listening on :$port")
+  }
+
+  fun stop() {
+    running = false
+    clients.forEach { runCatching { it.socket.close() } }
+    clients.clear()
+    runCatching { server?.close() }
+    server = null
+    acceptThread?.interrupt()
+    acceptThread = null
+    Log.i(TAG, "RTSP stopped")
+  }
+
+  private fun acceptLoop(s: ServerSocket) {
+    while (running) {
+      val socket = runCatching { s.accept() }.getOrElse { return }
+      Thread({ serve(socket) }, "immortal-rtsp-client").apply {
+        isDaemon = true
+        start()
+      }
+    }
+  }
+
+  /**
+   * Speak RTSP to one client until it goes away. Every failure closes just this connection — a
+   * browser opening a speculative socket, or a client vanishing mid-stream, must never disturb
+   * the encoder or the other viewers.
+   */
+  private fun serve(socket: Socket) {
+    val client = Client(socket, socket.getOutputStream())
+    clients.add(client)
+    runCatching {
+          socket.tcpNoDelay = true
+          val reader = BufferedReader(InputStreamReader(socket.getInputStream(), Charsets.US_ASCII))
+          while (running && !socket.isClosed) {
+            val request = readRequest(reader) ?: break
+            handle(client, request)
+          }
+        }
+        .onFailure { if (running) Log.i(TAG, "client ended: ${it.message}") }
+    clients.remove(client)
+    runCatching { socket.close() }
+    if (client.playing) notifyActive()
+  }
+
+  /** Read one request: the request line, then headers, to the blank line. Null at end of stream. */
+  private fun readRequest(reader: BufferedReader): Request? {
+    val line = reader.readLine() ?: return null
+    if (line.isBlank()) return readRequest(reader)
+    val parts = line.split(' ')
+    if (parts.size < 2) return null
+    val headers = HashMap<String, String>()
+    while (true) {
+      val h = reader.readLine() ?: break
+      if (h.isBlank()) break
+      val idx = h.indexOf(':')
+      if (idx > 0) headers[h.substring(0, idx).trim().lowercase()] = h.substring(idx + 1).trim()
+    }
+    return Request(parts[0].uppercase(), parts[1], headers)
+  }
+
+  private class Request(val method: String, val uri: String, val headers: Map<String, String>)
+
+  private fun handle(client: Client, req: Request) {
+    val cseq = req.headers["cseq"] ?: "0"
+    when (req.method) {
+      "OPTIONS" ->
+          respond(client, cseq, extra = "Public: OPTIONS, DESCRIBE, SETUP, PLAY, TEARDOWN\r\n")
+      "DESCRIBE" -> {
+        val body = sdp()
+        if (body == null) {
+          // The encoder hasn't produced its parameter sets yet; a client that retries will get
+          // them. Better than describing a stream we can't yet describe correctly.
+          respond(client, cseq, status = "454 Session Not Found")
+        } else {
+          respond(
+              client,
+              cseq,
+              extra =
+                  "Content-Base: ${req.uri}\r\nContent-Type: application/sdp\r\n" +
+                      "Content-Length: ${body.toByteArray(Charsets.US_ASCII).size}\r\n",
+              body = body)
+        }
+      }
+      "SETUP" ->
+          respond(
+              client,
+              cseq,
+              extra =
+                  "Transport: RTP/AVP/TCP;unicast;interleaved=0-1\r\nSession: $SESSION_ID\r\n")
+      "PLAY" -> {
+        respond(client, cseq, extra = "Session: $SESSION_ID\r\nRange: npt=0.000-\r\n")
+        client.playing = true
+        notifyActive()
+        Log.i(TAG, "client playing (${clientCount()} total)")
+      }
+      "TEARDOWN" -> {
+        respond(client, cseq, extra = "Session: $SESSION_ID\r\n")
+        client.playing = false
+        runCatching { client.socket.close() }
+        notifyActive()
+      }
+      else -> respond(client, cseq, status = "501 Not Implemented")
+    }
+  }
+
+  private fun respond(
+      client: Client,
+      cseq: String,
+      status: String = "200 OK",
+      extra: String = "",
+      body: String = "",
+  ) {
+    val text = "RTSP/1.0 $status\r\nCSeq: $cseq\r\n$extra\r\n$body"
+    synchronized(client.writeLock) {
+      client.out.write(text.toByteArray(Charsets.US_ASCII))
+      client.out.flush()
+    }
+  }
+
+  /**
+   * Packetise one access unit and send it to every playing client.
+   *
+   * The marker bit goes on the final packet of the frame — that's what tells a decoder the frame
+   * is complete, and a stream that never sets it stalls or plays late.
+   */
+  fun broadcast(nals: List<ByteArray>, presentationTimeUs: Long, keyframe: Boolean) {
+    if (!running) return
+    val playing = clients.filter { it.playing }
+    if (playing.isEmpty()) return
+    val timestamp = RtpH264.timestamp(presentationTimeUs)
+    // Parameter sets are announced in the SDP, so they're not repeated in the stream; everything
+    // else in this access unit goes out in order.
+    val payloadNals = nals.filter { RtpH264.nalType(it) !in setOf(NAL_SPS, NAL_PPS) }
+    if (payloadNals.isEmpty()) return
+    payloadNals.forEachIndexed { nalIndex, nal ->
+      val packets = RtpH264.packetize(nal)
+      packets.forEachIndexed { pktIndex, payload ->
+        val lastOfFrame = nalIndex == payloadNals.lastIndex && pktIndex == packets.lastIndex
+        sequence = (sequence + 1) and 0xFFFF
+        val packet = RtpH264.header(sequence, timestamp, ssrc, marker = lastOfFrame) + payload
+        playing.forEach { send(it, packet) }
+      }
+    }
+    if (keyframe) Log.v(TAG, "keyframe sent to ${playing.size} client(s)")
+  }
+
+  /** Interleaved framing: '$', channel, 2-byte length, then the RTP packet (RFC 2326 §10.12). */
+  private fun send(client: Client, packet: ByteArray) {
+    runCatching {
+          synchronized(client.writeLock) {
+            client.out.write(
+                byteArrayOf(
+                    INTERLEAVE_MAGIC,
+                    RTP_CHANNEL,
+                    (packet.size ushr 8).toByte(),
+                    packet.size.toByte()))
+            client.out.write(packet)
+            client.out.flush()
+          }
+        }
+        .onFailure {
+          // A client that has gone away or fallen behind is dropped; it must not stall the encoder.
+          Log.i(TAG, "dropping client: ${it.message}")
+          client.playing = false
+          runCatching { client.socket.close() }
+          clients.remove(client)
+          notifyActive()
+        }
+  }
+
+  private fun notifyActive() = runCatching { onActiveChanged(clientCount() > 0) }
+
+  companion object {
+    private const val TAG = "ImmortalRtsp"
+    const val DEFAULT_PORT = 8554
+    private const val SESSION_ID = "immortal"
+    private const val INTERLEAVE_MAGIC: Byte = 0x24 // '$'
+    private const val RTP_CHANNEL: Byte = 0
+    private const val NAL_SPS = 7
+    private const val NAL_PPS = 8
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -735,6 +735,15 @@ object SettingsDomains {
                               "Assistant can't turn it on. The Portal shows a message on screen " +
                               "every time a photo is taken.",
                       visible = { c, _ -> MqttConfig.isEnabled(c) }),
+                  BoolSpec(
+                      "cameraAudio",
+                      "Camera sound",
+                      get = { ImmortalSettings.cameraAudio(it) },
+                      set = ImmortalSettings::setCameraAudio,
+                      help =
+                          "Include sound in the camera stream. Muting the microphone silences it, " +
+                              "and a live intercom announcement takes the microphone back.",
+                      visible = { c, _ -> MqttConfig.isEnabled(c) && ImmortalSettings.cameraEnabled(c) }),
                   IntSpec(
                       "tempOffset",
                       "Temperature offset",
@@ -758,7 +767,8 @@ object SettingsDomains {
                   "validateCert" to "Security",
                   "ambientSensors" to "Sensors",
                   "tempOffset" to "Sensors",
-                  "cameraEnabled" to "Camera"),
+                  "cameraEnabled" to "Camera",
+                  "cameraAudio" to "Camera"),
           onApplied = { c, keys ->
             // TLS<->port convenience hop, lifted out of the bespoke on-device screen so the phone
             // remote gets it too (it didn't before — a real drift): flipping TLS moves the port to

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -593,16 +593,6 @@ object SettingsDomains {
                               "Assistant, the fleet tools and multi-room audio. Falls back on its " +
                               "own if the Portal isn't reporting it."),
                   BoolSpec(
-                      "cameraEnabled",
-                      "Camera snapshots",
-                      get = { it.cameraEnabled },
-                      set = ImmortalSettings::setCameraEnabled,
-                      help =
-                          "Let Home Assistant take a still photo from this Portal's camera. Off " +
-                              "by default, and only switchable here on the device - Home " +
-                              "Assistant can't turn it on. The Portal shows a message on screen " +
-                              "every time a photo is taken."),
-                  BoolSpec(
                       "multiRoomEnabled",
                       "Multi-room audio",
                       get = { it.multiRoomEnabled },
@@ -647,7 +637,6 @@ object SettingsDomains {
                   "constrainPageWidth" to "Home screen",
                   "clockFormat" to "Clock",
                   "portalPresence" to "Presence",
-                  "cameraEnabled" to "Camera",
                   "multiRoomEnabled" to "Audio",
                   "snapcastHost" to "Audio",
                   "maPort" to "Audio",
@@ -659,7 +648,6 @@ object SettingsDomains {
             if ("portalPresence" in keys) PortalPresenceDetector.sync(c)
             // The publisher advertises (or clears) the camera entities from this, so a running
             // publisher has to re-read it rather than wait for the next reconnect.
-            if ("cameraEnabled" in keys) MqttService.sync(c, reconfigure = true)
             if (keys.any { it in setOf("multiRoomEnabled", "snapcastHost", "maPort", "maUsername", "maPassword") })
                 MultiRoomService.sync(c)
           },
@@ -736,6 +724,17 @@ object SettingsDomains {
                           "Publish this Portal's ambient sensors (temperature, light) to Home " +
                               "Assistant. Only sensors this model actually has will appear.",
                       visible = { c, _ -> MqttConfig.isEnabled(c) }),
+                  BoolSpec(
+                      "cameraEnabled",
+                      "Camera snapshots",
+                      get = { ImmortalSettings.cameraEnabled(it) },
+                      set = ImmortalSettings::setCameraEnabled,
+                      help =
+                          "Let Home Assistant take a still photo from this Portal's camera. Off " +
+                              "by default, and only switchable here on the device - Home " +
+                              "Assistant can't turn it on. The Portal shows a message on screen " +
+                              "every time a photo is taken.",
+                      visible = { c, _ -> MqttConfig.isEnabled(c) }),
                   IntSpec(
                       "tempOffset",
                       "Temperature offset",
@@ -758,7 +757,8 @@ object SettingsDomains {
                   "useTls" to "Security",
                   "validateCert" to "Security",
                   "ambientSensors" to "Sensors",
-                  "tempOffset" to "Sensors"),
+                  "tempOffset" to "Sensors",
+                  "cameraEnabled" to "Camera"),
           onApplied = { c, keys ->
             // TLS<->port convenience hop, lifted out of the bespoke on-device screen so the phone
             // remote gets it too (it didn't before — a real drift): flipping TLS moves the port to
@@ -771,7 +771,7 @@ object SettingsDomains {
             }
             // These are read by the running publisher, not just at connect time, so tell it to
             // re-read them — a plain sync() would no-op against an already-running service.
-            val live = keys.any { it in setOf("ambientSensors", "tempOffset") }
+            val live = keys.any { it in setOf("ambientSensors", "tempOffset", "cameraEnabled") }
             MqttService.sync(c, reconfigure = live)
           },
       )

--- a/app/src/test/java/com/immortal/launcher/AacRtpTest.kt
+++ b/app/src/test/java/com/immortal/launcher/AacRtpTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * AAC over RTP. Failures here are quiet ones — a stream that connects and plays silence, or plays
+ * at the wrong speed — so the wire format is pinned rather than eyeballed.
+ */
+class AacRtpTest {
+
+  @Test
+  fun `the config encodes AAC-LC, the rate index and the channel count`() {
+    // 16 kHz mono: object type 2, rate index 8, 1 channel.
+    // 00010 1000 0001 000 -> 0x14 0x08
+    assertArrayEquals(byteArrayOf(0x14, 0x08), AacRtp.audioSpecificConfig(16000, 1))
+    assertEquals("1408", AacRtp.configHex(16000, 1))
+  }
+
+  @Test
+  fun `44_1kHz stereo encodes differently, as it must`() {
+    // rate index 4, 2 channels -> 00010 0100 0010 000 = 0x12 0x10
+    assertEquals("1210", AacRtp.configHex(44100, 2))
+  }
+
+  @Test
+  fun `the rate index is an index, not the rate`() {
+    assertEquals(3, AacRtp.sampleRateIndex(48000))
+    assertEquals(8, AacRtp.sampleRateIndex(16000))
+    assertEquals(-1, AacRtp.sampleRateIndex(12345))
+  }
+
+  @Test
+  fun `a packet carries the AU header then the frame, unaltered`() {
+    val frame = ByteArray(200) { (it % 251).toByte() }
+    val packet = AacRtp.packetize(frame)
+    assertEquals(204, packet.size)
+    assertEquals(0x00, packet[0].toInt())
+    assertEquals(0x10, packet[1].toInt()) // one 16-bit AU header
+    // 13-bit size, 3-bit index: 200 << 3 = 1600 = 0x0640
+    assertEquals(0x06, packet[2].toInt() and 0xff)
+    assertEquals(0x40, packet[3].toInt() and 0xff)
+    assertArrayEquals(frame, packet.copyOfRange(4, packet.size))
+  }
+
+  @Test
+  fun `audio timestamps run at the sample rate, not 90kHz`() {
+    // One second of 16 kHz audio is 16000 ticks - using the video clock here would desync sound.
+    assertEquals(16_000L, AacRtp.timestamp(1_000_000L, 16000))
+    assertEquals(1_024L, AacRtp.timestamp(64_000L, 16000)) // one AAC frame
+  }
+
+  @Test
+  fun `the fmtp line agrees with the header size the packetiser writes`() {
+    val sdp = AacRtp.audioSdp(16000, 1, trackId = 1)
+    assertTrue(sdp.contains("m=audio 0 RTP/AVP 97\r\n"))
+    assertTrue(sdp.contains("a=rtpmap:97 mpeg4-generic/16000/1\r\n"))
+    assertTrue("13+3 split must match packetize()", sdp.contains("sizelength=13;indexlength=3"))
+    assertTrue(sdp.contains("mode=AAC-hbr"))
+    assertTrue(sdp.contains("config=1408"))
+    assertTrue(sdp.contains("a=control:trackID=1"))
+  }
+}
+
+/**
+ * The rule that decides whether captured audio may leave the device. Small, but it's the one that
+ * has to be right: Home Assistant shows a mic-mute switch, and a stream that keeps sending sound
+ * while that switch says muted is both a lie and a privacy surprise.
+ */
+class AudioMuteGateTest {
+
+  @Test
+  fun `muting the microphone stops audio leaving the device`() {
+    assertFalse(AudioStream.shouldEmit(micMuted = true, holdsMic = true))
+  }
+
+  @Test
+  fun `audio flows only while unmuted and holding the mic`() {
+    assertTrue(AudioStream.shouldEmit(micMuted = false, holdsMic = true))
+    assertFalse(AudioStream.shouldEmit(micMuted = false, holdsMic = false))
+    assertFalse(AudioStream.shouldEmit(micMuted = true, holdsMic = false))
+  }
+}
+
+/**
+ * Microphone arbitration. Before this nothing arbitrated at all — the intercom and voice notes
+ * both opened the mic directly, and whoever asked second silently got nothing.
+ */
+class MicOwnerTest {
+
+  @Before fun reset() = MicOwner.resetForTest()
+
+  @Test
+  fun `a free microphone is granted`() {
+    assertTrue(MicOwner.acquire("stream", MicOwner.PRIORITY_STREAM))
+    assertEquals("stream", MicOwner.holder)
+  }
+
+  @Test
+  fun `someone speaking takes it from a background stream`() {
+    MicOwner.acquire("stream", MicOwner.PRIORITY_STREAM)
+    assertTrue(MicOwner.acquire("intercom", MicOwner.PRIORITY_INTERCOM))
+    assertEquals("intercom", MicOwner.holder)
+    // The preempted owner can tell, which is how it knows to stop capturing.
+    assertFalse(MicOwner.holds("stream"))
+  }
+
+  @Test
+  fun `a background stream cannot take it from someone speaking`() {
+    MicOwner.acquire("intercom", MicOwner.PRIORITY_INTERCOM)
+    assertFalse(MicOwner.acquire("stream", MicOwner.PRIORITY_STREAM))
+    assertEquals("intercom", MicOwner.holder)
+  }
+
+  @Test
+  fun `equal priority does not preempt the incumbent`() {
+    MicOwner.acquire("note", MicOwner.PRIORITY_NOTE)
+    assertFalse(MicOwner.acquire("other", MicOwner.PRIORITY_NOTE))
+    assertEquals("note", MicOwner.holder)
+  }
+
+  @Test
+  fun `re-acquiring what you already hold is fine`() {
+    MicOwner.acquire("stream", MicOwner.PRIORITY_STREAM)
+    assertTrue(MicOwner.acquire("stream", MicOwner.PRIORITY_STREAM))
+  }
+
+  @Test
+  fun `a preempted owner releasing does not free the new holder`() {
+    // The bug this prevents: the stream's cleanup running after the intercom took over, and
+    // handing the microphone away from the person actually talking.
+    MicOwner.acquire("stream", MicOwner.PRIORITY_STREAM)
+    MicOwner.acquire("intercom", MicOwner.PRIORITY_INTERCOM)
+    MicOwner.release("stream")
+    assertEquals("intercom", MicOwner.holder)
+  }
+
+  @Test
+  fun `releasing frees it for the next claim`() {
+    MicOwner.acquire("intercom", MicOwner.PRIORITY_INTERCOM)
+    MicOwner.release("intercom")
+    assertEquals(null, MicOwner.holder)
+    assertTrue(MicOwner.acquire("stream", MicOwner.PRIORITY_STREAM))
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/RtpH264Test.kt
+++ b/app/src/test/java/com/immortal/launcher/RtpH264Test.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * RFC 6184 packetisation. Worth testing hard: a mistake here yields a stream that almost works —
+ * plays in one client, stalls in another — and no amount of staring at a Portal tells you why.
+ */
+class RtpH264Test {
+
+  /** header byte for a NAL: F=0, NRI=3 (important), type = [type]. */
+  private fun nalHeader(type: Int): Byte = ((3 shl 5) or type).toByte()
+
+  private fun nal(type: Int, bodySize: Int): ByteArray =
+      ByteArray(bodySize + 1).also {
+        it[0] = nalHeader(type)
+        for (i in 1..bodySize) it[i] = (i % 251).toByte()
+      }
+
+  // --- single NAL ------------------------------------------------------------
+
+  @Test
+  fun `a NAL that fits is sent whole, header byte included`() {
+    val n = nal(type = 1, bodySize = 100)
+    val packets = RtpH264.packetize(n, maxPayload = 1400)
+    assertEquals(1, packets.size)
+    assertArrayEquals(n, packets[0])
+  }
+
+  @Test
+  fun `exactly the payload limit still fits in one packet`() {
+    val n = nal(type = 1, bodySize = 1399) // 1400 bytes with the header
+    assertEquals(1, RtpH264.packetize(n, maxPayload = 1400).size)
+  }
+
+  @Test
+  fun `an empty NAL produces nothing`() {
+    assertTrue(RtpH264.packetize(ByteArray(0)).isEmpty())
+  }
+
+  // --- FU-A fragmentation ----------------------------------------------------
+
+  @Test
+  fun `a large NAL fragments, and reassembles to the original`() {
+    val n = nal(type = 5, bodySize = 5000) // an IDR, comfortably over the limit
+    val packets = RtpH264.packetize(n, maxPayload = 1400)
+    assertTrue("expected fragmentation", packets.size > 1)
+
+    // Every fragment carries the FU-A indicator with the original NRI preserved.
+    packets.forEach {
+      assertEquals("FU-A type", RtpH264.NAL_FU_A, it[0].toInt() and 0x1F)
+      assertEquals("NRI preserved", 3, (it[0].toInt() and 0x60) shr 5)
+      assertTrue("within MTU", it.size <= 1400)
+    }
+
+    // Start on the first only, end on the last only.
+    assertEquals(0x80, packets.first()[1].toInt() and 0x80)
+    assertEquals(0, packets.first()[1].toInt() and 0x40)
+    assertEquals(0x40, packets.last()[1].toInt() and 0x40)
+    assertEquals(0, packets.last()[1].toInt() and 0x80)
+    packets.drop(1).dropLast(1).forEach { assertEquals(0, it[1].toInt() and 0xC0) }
+
+    // The FU header carries the original NAL type on every fragment.
+    packets.forEach { assertEquals(5, it[1].toInt() and 0x1F) }
+
+    // Reassembling the fragments rebuilds the original NAL body.
+    val rebuilt = packets.flatMap { it.drop(2) }.toByteArray()
+    assertArrayEquals(n.copyOfRange(1, n.size), rebuilt)
+  }
+
+  @Test
+  fun `one byte over the limit still fragments correctly`() {
+    val n = nal(type = 1, bodySize = 1400) // 1401 bytes
+    val packets = RtpH264.packetize(n, maxPayload = 1400)
+    assertEquals(2, packets.size)
+    val rebuilt = packets.flatMap { it.drop(2) }.toByteArray()
+    assertArrayEquals(n.copyOfRange(1, n.size), rebuilt)
+  }
+
+  // --- RTP header ------------------------------------------------------------
+
+  @Test
+  fun `the header carries version, sequence, timestamp and ssrc`() {
+    val h = RtpH264.header(sequence = 0x1234, timestamp = 0x89ABCDEF, ssrc = 0x11223344, marker = false)
+    assertEquals(12, h.size)
+    assertEquals(0x80, h[0].toInt() and 0xff) // version 2
+    assertEquals(RtpH264.PAYLOAD_TYPE, h[1].toInt() and 0x7f)
+    assertEquals(0x12, h[2].toInt() and 0xff)
+    assertEquals(0x34, h[3].toInt() and 0xff)
+    assertEquals(0x89, h[4].toInt() and 0xff)
+    assertEquals(0xEF, h[7].toInt() and 0xff)
+    assertEquals(0x11, h[8].toInt() and 0xff)
+    assertEquals(0x44, h[11].toInt() and 0xff)
+  }
+
+  @Test
+  fun `the marker bit is what tells the decoder a frame is complete`() {
+    assertEquals(0, RtpH264.header(1, 0, 0, marker = false)[1].toInt() and 0x80)
+    assertEquals(0x80, RtpH264.header(1, 0, 0, marker = true)[1].toInt() and 0x80)
+  }
+
+  @Test
+  fun `microseconds convert to the 90kHz clock`() {
+    assertEquals(90_000L, RtpH264.timestamp(1_000_000L)) // one second
+    // A 30fps frame is 33333us, which is 2999.97 ticks - it truncates. That's fine and expected:
+    // every timestamp derives from the same source clock, so the sub-tick remainder doesn't
+    // accumulate into drift the way a per-frame increment would.
+    assertEquals(2_999L, RtpH264.timestamp(33_333L))
+    assertEquals(3_000L, RtpH264.timestamp(33_334L))
+  }
+
+  // --- Annex B splitting -----------------------------------------------------
+
+  @Test
+  fun `splits a config buffer into SPS and PPS`() {
+    // What MediaCodec hands over as its codec-config buffer: both NALs, start codes between.
+    val sps = nal(type = 7, bodySize = 8)
+    val pps = nal(type = 8, bodySize = 3)
+    val buf = byteArrayOf(0, 0, 0, 1) + sps + byteArrayOf(0, 0, 0, 1) + pps
+    val nals = RtpH264.splitAnnexB(buf)
+    assertEquals(2, nals.size)
+    assertArrayEquals(sps, nals[0])
+    assertArrayEquals(pps, nals[1])
+    assertEquals(7, RtpH264.nalType(nals[0]))
+    assertEquals(8, RtpH264.nalType(nals[1]))
+  }
+
+  @Test
+  fun `handles the three-byte start code too`() {
+    val a = nal(type = 7, bodySize = 4)
+    val b = nal(type = 8, bodySize = 2)
+    val buf = byteArrayOf(0, 0, 1) + a + byteArrayOf(0, 0, 1) + b
+    val nals = RtpH264.splitAnnexB(buf)
+    assertEquals(2, nals.size)
+    assertArrayEquals(a, nals[0])
+    assertArrayEquals(b, nals[1])
+  }
+
+  @Test
+  fun `a buffer with no start code yields nothing`() {
+    assertTrue(RtpH264.splitAnnexB(byteArrayOf(9, 9, 9, 9)).isEmpty())
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/RtspSdpTest.kt
+++ b/app/src/test/java/com/immortal/launcher/RtspSdpTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The SDP is how a client decides whether it can play the stream at all, and a mistake here shows
+ * up as a black picture with no error — so it's checked byte for byte rather than by eye.
+ */
+class RtspSdpTest {
+
+  // A plausible constrained-baseline SPS: NAL header, then profile_idc / constraints / level_idc.
+  private val sps = byteArrayOf(0x67, 0x42.toByte(), 0xC0.toByte(), 0x1F, 0x11, 0x22)
+  private val pps = byteArrayOf(0x68, 0xCE.toByte(), 0x3C, 0x80.toByte())
+
+  @Test
+  fun `base64 matches the standard, including padding`() {
+    assertEquals("", RtspSdp.base64(ByteArray(0)))
+    assertEquals("TQ==", RtspSdp.base64("M".toByteArray()))
+    assertEquals("TWE=", RtspSdp.base64("Ma".toByteArray()))
+    assertEquals("TWFu", RtspSdp.base64("Man".toByteArray()))
+    assertEquals("cGxlYXN1cmUu", RtspSdp.base64("pleasure.".toByteArray()))
+  }
+
+  @Test
+  fun `base64 handles bytes above 127`() {
+    // Signed-byte sloppiness here would corrupt the parameter sets and break decoding.
+    assertEquals("/w==", RtspSdp.base64(byteArrayOf(0xFF.toByte())))
+    assertEquals("gID/", RtspSdp.base64(byteArrayOf(0x80.toByte(), 0x80.toByte(), 0xFF.toByte())))
+  }
+
+  @Test
+  fun `profile-level-id comes from the SPS, not from what we asked for`() {
+    // 0x42 = baseline, 0xC0 = constrained, 0x1F = level 3.1.
+    assertEquals("42c01f", RtspSdp.profileLevelId(sps))
+  }
+
+  @Test
+  fun `a too-short SPS falls back rather than producing nonsense`() {
+    assertEquals("42001f", RtspSdp.profileLevelId(byteArrayOf(0x67)))
+  }
+
+  @Test
+  fun `the SDP carries everything a client needs`() {
+    val sdp = RtspSdp.videoSdp(640, 480, sps, pps)
+    assertTrue(sdp.startsWith("v=0\r\n"))
+    assertTrue("rtpmap", sdp.contains("a=rtpmap:96 H264/90000\r\n"))
+    assertTrue("fragmentation announced", sdp.contains("packetization-mode=1"))
+    assertTrue("profile from SPS", sdp.contains("profile-level-id=42c01f"))
+    assertTrue("parameter sets", sdp.contains("sprop-parameter-sets=${RtspSdp.base64(sps)},${RtspSdp.base64(pps)}"))
+    assertTrue("frame size", sdp.contains("a=framesize:96 640-480"))
+    assertTrue("control track", sdp.contains("a=control:trackID=0"))
+    // CRLF throughout: some clients reject bare LF.
+    assertTrue("no bare LF", sdp.split("\n").dropLast(1).all { it.endsWith("\r") })
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/RtspSdpTest.kt
+++ b/app/src/test/java/com/immortal/launcher/RtspSdpTest.kt
@@ -49,6 +49,21 @@ class RtspSdpTest {
   }
 
   @Test
+  fun `the session describes video alone, or video and audio`() {
+    val videoOnly = RtspSdp.sessionSdp(640, 480, sps, pps)
+    assertTrue(videoOnly.contains("m=video"))
+    assertTrue("no audio track when there's no sound", !videoOnly.contains("m=audio"))
+
+    val withAudio = RtspSdp.sessionSdp(640, 480, sps, pps, audioSampleRate = 16000)
+    assertTrue(withAudio.contains("m=video"))
+    assertTrue(withAudio.contains("m=audio"))
+    // Separate control URLs are what let a client set up one track and not the other.
+    assertTrue(withAudio.contains("a=control:trackID=0"))
+    assertTrue(withAudio.contains("a=control:trackID=1"))
+    assertTrue("video must come first", withAudio.indexOf("m=video") < withAudio.indexOf("m=audio"))
+  }
+
+  @Test
   fun `the SDP carries everything a client needs`() {
     val sdp = RtspSdp.videoSdp(640, 480, sps, pps)
     assertTrue(sdp.startsWith("v=0\r\n"))

--- a/app/src/test/java/com/immortal/launcher/StreamProfileTest.kt
+++ b/app/src/test/java/com/immortal/launcher/StreamProfileTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Encoder sizing. The Camera2/MediaCodec plumbing needs a device; these numbers don't. */
+class StreamProfileTest {
+
+  @Test
+  fun `bitrate scales with pixels and frame rate`() {
+    val small = StreamProfile.bitrateFor(320, 240, 15)
+    val large = StreamProfile.bitrateFor(640, 480, 15)
+    val faster = StreamProfile.bitrateFor(640, 480, 30)
+    assertTrue("more pixels costs more", large > small)
+    assertTrue("more frames costs more", faster > large)
+  }
+
+  @Test
+  fun `a typical Portal stream lands in a sane range`() {
+    // 640x480 at 15fps over a LAN: hundreds of kbps, not megabits.
+    val bps = StreamProfile.bitrateFor(640, 480, 15)
+    assertTrue("got $bps", bps in 400_000..600_000)
+  }
+
+  @Test
+  fun `a tiny frame still gets a usable floor`() {
+    assertEquals(200_000, StreamProfile.bitrateFor(160, 120, 5))
+  }
+
+  @Test
+  fun `a large frame is capped rather than running away`() {
+    assertEquals(4_000_000, StreamProfile.bitrateFor(1920, 1080, 30))
+  }
+
+  @Test
+  fun `constrained baseline is what we ask for`() {
+    // Browser WebRTC rejects anything higher, so a stream encoded as High plays in VLC and
+    // fails in the Home Assistant card. Pinned because it's a literal (the constant is API 27+).
+    assertEquals(0x10000, StreamProfile.PROFILE_CONSTRAINED_BASELINE)
+  }
+}

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -366,7 +366,8 @@ class SettingsDomainTest {
             "validateCert",
             "ambientSensors",
             "tempOffset",
-            "cameraEnabled"),
+            "cameraEnabled",
+            "cameraAudio"),
         SettingsDomains.mqtt.specs.map { it.key }.toSet())
   }
 

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -365,7 +365,8 @@ class SettingsDomainTest {
             "useTls",
             "validateCert",
             "ambientSensors",
-            "tempOffset"),
+            "tempOffset",
+            "cameraEnabled"),
         SettingsDomains.mqtt.specs.map { it.key }.toSet())
   }
 

--- a/docs/design/camera-streaming.md
+++ b/docs/design/camera-streaming.md
@@ -4,8 +4,7 @@ Expose a Portal's camera to Home Assistant as a live stream, with **optional aud
 Portal in a nursery or hallway can double as a nanny/security camera. LAN only, off by default,
 and unmistakable when it's live.
 
-**Status:** phase 1 (snapshots) and phase 2 (live video) implemented; phase 3 (audio) and
-phase 4 (motion) not started. This records the decisions,
+**Status:** phases 1-3 implemented (snapshots, live video, audio); phase 4 (motion) not started. This records the decisions,
 the parts we already have, the parts that are genuinely hard, and what has to be answered on real
 hardware before writing much code.
 
@@ -82,7 +81,7 @@ for wave-to-advance during the photo frame. Streaming and gesture-wave must be *
 exclusive**, with one owner arbitrating and the stream recovering after a call releases the
 device.
 
-**4. Microphone contention — currently unmanaged.** `LanAudio` (intercom) and `AudioNote` both
+**4. Microphone contention — was unmanaged; now brokered through `MicOwner`.** `LanAudio` (intercom) and `AudioNote` both
 open `AudioSource.MIC` today with **no arbitration between them at all**. Audio streaming would
 be a third consumer, and the failure is silent: whoever asks second gets nothing useful. This
 needs a single mic broker with an explicit priority — a live intercom announcement should win,
@@ -92,7 +91,7 @@ On Portal+ there is a further constraint: Meta's own far-field mic service (`com
 can hold the microphone, which is why the bridge ships a `--free-mic` provisioning flag. Expect
 audio to be unavailable on some models until that's disabled, and detect it rather than assume.
 
-**5. Mic mute has to gate audio.** Immortal publishes a `mic_mute` switch to Home Assistant. A
+**5. Mic mute has to gate audio — done, and unit-tested.** Immortal publishes a `mic_mute` switch to Home Assistant. A
 stream that keeps sending audio while HA says the microphone is muted is both a contradiction
 and a genuine privacy surprise. **When `isMicrophoneMute` is true the audio track must be
 silent.** That rule is pure logic and should be unit-tested, not left to integration behaviour.
@@ -156,7 +155,14 @@ Deliberately ordered so each phase is useful alone and de-risks the next.
     15fps. The parts where a mistake is invisible rather than loud — RTP packetisation, FU-A
     fragmentation, the SDP — are pure and unit-tested (`RtpH264`, `RtspSdp`); the Camera2 and
     `MediaCodec` plumbing around them is not, and needs a device.
-3. **Audio.** AAC track, the mic broker, and the mute gating.
+3. **Audio** — *implemented*. An AAC-LC track alongside the video, its own RTP clock and
+   control URL, so a viewer that only wants a picture sets up one track and not the other.
+
+    Both hazards named above are addressed. [`MicOwner`] arbitrates the microphone by priority,
+    and the intercom and voice notes now go through it too — closing the pre-existing gap where
+    nothing arbitrated at all and whoever asked second silently got nothing. Muting the
+    microphone stops audio leaving the device rather than merely lowering it, which is the only
+    reading of the `mic_mute` switch that isn't a lie.
 4. **Motion** (optional). `binary_sensor` from the existing frame-diff, with a sensitivity
    number entity.
 

--- a/docs/design/camera-streaming.md
+++ b/docs/design/camera-streaming.md
@@ -4,7 +4,8 @@ Expose a Portal's camera to Home Assistant as a live stream, with **optional aud
 Portal in a nursery or hallway can double as a nanny/security camera. LAN only, off by default,
 and unmistakable when it's live.
 
-**Status:** phase 1 (snapshots) implemented; phases 2-4 not started. This records the decisions,
+**Status:** phase 1 (snapshots) and phase 2 (live video) implemented; phase 3 (audio) and
+phase 4 (motion) not started. This records the decisions,
 the parts we already have, the parts that are genuinely hard, and what has to be answered on real
 hardware before writing much code.
 
@@ -147,7 +148,14 @@ Deliberately ordered so each phase is useful alone and de-risks the next.
     story at all, rides the broker we already treat as trusted, and doesn't require the opt-in
     fleet agent to be running. Images are published **unretained**, so a still of someone's room
     doesn't sit on the broker for whoever subscribes next.
-2. **Video streaming.** RTSP + `MediaCodec` H.264, no audio. The encoder work.
+2. **Video streaming** — *implemented*. RTSP + `MediaCodec` H.264, no audio yet.
+
+    RTP is **interleaved over the RTSP TCP connection** rather than sent on separate UDP ports.
+    One socket, no port negotiation, nothing to explain to a firewall on a home LAN, and no loss
+    to conceal — at the cost of head-of-line blocking, a fair trade for a fixed indoor scene at
+    15fps. The parts where a mistake is invisible rather than loud — RTP packetisation, FU-A
+    fragmentation, the SDP — are pure and unit-tested (`RtpH264`, `RtspSdp`); the Camera2 and
+    `MediaCodec` plumbing around them is not, and needs a device.
 3. **Audio.** AAC track, the mic broker, and the mute gating.
 4. **Motion** (optional). `binary_sensor` from the existing frame-diff, with a sensitivity
    number entity.
@@ -156,12 +164,16 @@ Deliberately ordered so each phase is useful alone and de-risks the next.
 
 None of these are answerable from the source, and all of them can invalidate parts of the plan:
 
-- What resolutions does Camera2 actually offer per model, and is `GestureCamera` even working
-  today at 320×240? (It has never been verified.)
+- ~~Does Camera2 work unprivileged on a Portal at all?~~ **Yes** — confirmed on hardware in
+  phase 1: real capture, real JPEG, camera indicator lit. This was the question the whole design
+  hung on.
+- What resolutions does Camera2 actually offer per model, for stills and for an encoder surface?
 - Does Portal firmware permit camera access from a background service, or only in the
   foreground? The bridge needed `SYSTEM_ALERT_WINDOW` for this, which we already hold.
 - Is there a usable hardware `MediaCodec` H.264 encoder on API 28 Portal, and does it offer
-  Constrained Baseline?
+  Constrained Baseline? (The encoder asks for it; the SDP reports what the SPS actually says, so
+  a device that ignores the request describes itself honestly rather than silently failing in a
+  browser.)
 - Does `com.millennium` block microphone capture on the Portal+ models, and on which?
 - Thermal behaviour of a sustained encode — the device is fanless and often wall-powered in a
   warm room.

--- a/docs/features/smart-home.md
+++ b/docs/features/smart-home.md
@@ -88,8 +88,8 @@ never be photographed without the device saying so.
 
 Some things worth knowing before relying on it:
 
-- **It is stills, not video.** Live streaming with optional audio is designed but not built —
-  see [the design note](../design/camera-streaming.md).
+- **Stills and live video, but no sound yet.** Audio is designed but not built — see
+  [the design note](../design/camera-streaming.md).
 - **The image is not retained on the broker.** Home Assistant shows the last one it received;
   a subscriber joining later sees nothing until the next snapshot.
 - **The camera is shared.** A Portal call takes it, and the photo frame's wave-to-advance
@@ -102,6 +102,32 @@ Some things worth knowing before relying on it:
 - **Anyone with broker credentials can press the button.** The same trust assumption as
   [notifications](#notifications) — but with a camera on the other end of it, so treat broker
   access accordingly.
+
+## Live camera streaming
+
+With the camera switched on, Home Assistant also gains a **Camera streaming** switch. Turn it on
+and the Portal serves live H.264 video over RTSP; a **Stream URL** diagnostic sensor tells you
+where, typically `rtsp://<portal-ip>:8554/`.
+
+It plays directly in VLC. For a Home Assistant dashboard, feed it through go2rtc — the
+**WebRTC Camera** card is the usual route:
+
+```yaml
+type: custom:webrtc-camera
+url: 'rtsp://<portal-ip>:8554/'
+```
+
+Points worth knowing:
+
+- **No audio yet.** Video only; sound is the next phase.
+- **Streaming does not survive a reboot.** The camera *permission* persists, the live stream
+  doesn't — a Portal that loses power comes back idle rather than quietly broadcasting a room.
+- **Home Assistant can start the stream, but never enable the camera.** The switch only works
+  within the consent given on the device.
+- **While it runs, the camera is held.** Snapshots, the photo frame's wave-to-advance gesture and
+  a Portal call all want the same camera, so they can't overlap with streaming.
+- **The notification is deliberate.** A permanent one shows while the camera is live — a
+  system-level signal alongside the on-screen one.
 
 ## What it can control
 

--- a/docs/features/smart-home.md
+++ b/docs/features/smart-home.md
@@ -88,8 +88,7 @@ never be photographed without the device saying so.
 
 Some things worth knowing before relying on it:
 
-- **Stills and live video, but no sound yet.** Audio is designed but not built — see
-  [the design note](../design/camera-streaming.md).
+- **Stills, live video, and optional sound** — see [live streaming](#live-camera-streaming).
 - **The image is not retained on the broker.** Home Assistant shows the last one it received;
   a subscriber joining later sees nothing until the next snapshot.
 - **The camera is shared.** A Portal call takes it, and the photo frame's wave-to-advance
@@ -119,7 +118,14 @@ url: 'rtsp://<portal-ip>:8554/'
 
 Points worth knowing:
 
-- **No audio yet.** Video only; sound is the next phase.
+- **Sound is optional and separate.** Turn on **Camera sound** (the Home Assistant switch, or
+  Settings → Home Assistant (MQTT)) and the stream carries audio as well. It's off by default,
+  and a viewer that only wants a picture can take the video track alone.
+- **Muting the microphone silences the stream.** Not quietened — no audio leaves the device at
+  all while the `Microphone mute` switch is on. That switch is the truth.
+- **Someone talking takes the microphone back.** A live [intercom](tools.md) announcement, or
+  recording a voice note, outranks a background stream: the sound drops out for the duration and
+  the video carries on.
 - **Streaming does not survive a reboot.** The camera *permission* persists, the live stream
   doesn't — a Portal that loses power comes back idle rather than quietly broadcasting a room.
 - **Home Assistant can start the stream, but never enable the camera.** The switch only works

--- a/docs/features/smart-home.md
+++ b/docs/features/smart-home.md
@@ -76,7 +76,7 @@ automation is actually waiting for.
 
 A Portal can hand Home Assistant a still photo from its own camera — a second angle on a room
 you already have a Portal in. It is **off by default**, and the switch is deliberately on the
-device only: turn it on under **Settings → Immortal → Camera snapshots**. Nothing arriving over
+device only: turn it on under **Settings → Home Assistant (MQTT) → Camera snapshots**. Nothing arriving over
 MQTT can enable it, and while it is off the camera is never opened.
 
 Once on, two entities appear: a **Camera** entity showing the most recent still, and a **Take
@@ -94,6 +94,11 @@ Some things worth knowing before relying on it:
   a subscriber joining later sees nothing until the next snapshot.
 - **The camera is shared.** A Portal call takes it, and the photo frame's wave-to-advance
   gesture wants it too, so an occasional snapshot can come back empty rather than queueing.
+- **The image has to fit your broker's message size limit.** Snapshots are captured small on
+  purpose (640px, moderate JPEG quality), which keeps them well inside a typical limit. If your
+  broker still refuses one, the Portal says *snapshot too large for the broker* on screen rather
+  than sending it — an oversize publish costs the whole MQTT connection, not just the image.
+  Mosquitto's limit is `message_size_limit`.
 - **Anyone with broker credentials can press the button.** The same trust assumption as
   [notifications](#notifications) — but with a camera on the other end of it, so treat broker
   access accordingly.

--- a/docs/guides/home-assistant.md
+++ b/docs/guides/home-assistant.md
@@ -100,7 +100,12 @@ automation:
   Settings → Immortal, then the `READ_LOGS` permission. The provisioning kit grants it, so re-run
   the provisioner on a Portal set up before that grant existed.
 - **No Camera entity** — it's off by default. Turn on **Camera snapshots** under Settings →
-  Immortal on the device; Home Assistant can't enable it remotely, by design.
+  Home Assistant (MQTT) on the device; Home Assistant can't enable it remotely, by design.
+- **The snapshot button does nothing** — watch the Portal's screen, which now says why. *No
+  camera permission* means the grant is missing: re-run the [provisioning kit](../provisioning.md),
+  or `adb shell pm grant com.immortal.launcher android.permission.CAMERA`. *Snapshot too large
+  for the broker* means your broker's message size limit is below the image; raise Mosquitto's
+  `message_size_limit`. If your broker log shows `disconnected: oversize packet`, that's this.
 - **No temperature entity** — not every Portal has an ambient temperature sensor. Entities are only
   advertised for hardware the device actually reports, so a missing one means the sensor isn't
   there.

--- a/docs/guides/home-assistant.md
+++ b/docs/guides/home-assistant.md
@@ -38,6 +38,7 @@ appear where the hardware exists.
 | Identify | Pop a toast naming the device, for finding which Portal is which. |
 | Take snapshot | Capture a fresh still. Only when the camera is switched on. |
 | Camera streaming | Start/stop live RTSP video — see [live streaming](../features/smart-home.md#live-camera-streaming). |
+| Camera audio | Include sound in the stream. Silenced entirely while the microphone is muted. |
 
 The Portal registers with a stable per-device id, so it survives broker reinstalls but stays unique
 across a fleet. Its **device name is shared with the [fleet agent](../features/fleet.md)**, so a

--- a/docs/guides/home-assistant.md
+++ b/docs/guides/home-assistant.md
@@ -22,6 +22,7 @@ appear where the hardware exists.
 | Battery, Charging | On models that have a battery (Portal Go). |
 | IP address | Diagnostic. |
 | Camera | The latest still from the Portal's camera. Only when you've switched it on — see [camera snapshots](../features/smart-home.md#camera-snapshots). |
+| Stream URL | Where the live video is served, for a dashboard card. Diagnostic. |
 
 **Controls**
 
@@ -36,6 +37,7 @@ appear where the hardware exists.
 | Notify | Push a toast with optional image, sound and tap target — see [notifications](../features/smart-home.md#notifications). |
 | Identify | Pop a toast naming the device, for finding which Portal is which. |
 | Take snapshot | Capture a fresh still. Only when the camera is switched on. |
+| Camera streaming | Start/stop live RTSP video — see [live streaming](../features/smart-home.md#live-camera-streaming). |
 
 The Portal registers with a stable per-device id, so it survives broker reinstalls but stays unique
 across a fleet. Its **device name is shared with the [fleet agent](../features/fleet.md)**, so a

--- a/provisioning/provision.ps1
+++ b/provisioning/provision.ps1
@@ -247,6 +247,9 @@ function Grant-Perms {
   A shell pm grant $cfg["PKG"] android.permission.WRITE_EXTERNAL_STORAGE | Out-Null
   # Lets the fleet agent's /logcat endpoint read system-wide logs (development perm).
   A shell pm grant $cfg["PKG"] android.permission.READ_LOGS | Out-Null
+  # Camera snapshots for Home Assistant. The feature stays OFF until the user turns it on in
+  # Settings; granting here only means it works when they do, instead of silently doing nothing.
+  A shell pm grant $cfg["PKG"] android.permission.CAMERA | Out-Null
   # Lets Immortal bring the photo frame back instantly when the system force-wakes
   # the screensaver (~2 min in, a quirk of Meta's power manager) even if another
   # app is in the foreground.

--- a/provisioning/provision.sh
+++ b/provisioning/provision.sh
@@ -311,6 +311,9 @@ grant_perms() {
   # Lets the fleet agent's /logcat endpoint read system-wide logs (READ_LOGS is a
   # development permission, so pm grant works). Harmless if it can't be granted.
   a shell pm grant "$PKG" android.permission.READ_LOGS >/dev/null 2>&1
+  # Camera snapshots for Home Assistant. The feature stays OFF until the user turns it on in
+  # Settings; granting here only means it works when they do, instead of silently doing nothing.
+  a shell pm grant "$PKG" android.permission.CAMERA >/dev/null 2>&1
   # Lets Immortal bring the photo frame back instantly when the system force-wakes
   # the screensaver (~2 min in, a quirk of Meta's power manager) even if another
   # app is in the foreground. SYSTEM_ALERT_WINDOW holders may start activities


### PR DESCRIPTION
Three commits taking the camera from "shipped but broken" to the feature the design set out: **live video with optional sound**.

---

# Part 1: fix what 1.69 shipped

**The CAMERA permission was never obtainable** — runtime permission, not in provisioning's list, never requested. The toggle switched on and every snapshot silently did nothing. Now requested on enable, granted by provisioning, and the setting turns itself back off if refused.

**Every failure was silent.** The toast only fired on success. All failure paths now say what went wrong on screen.

**The image was too big for the broker.** No `JPEG_QUALITY` set, so a 640px still ran to hundreds of KB, and Mosquitto answers an oversize publish by *closing the connection* — `disconnected: oversize packet` — taking presence and the sensors down on every press. Now quality 75 plus a refusal to publish over 200 KB.

Also moved the toggle to **Settings → Home Assistant (MQTT)**.

# Part 2: live video

Turn on **Camera streaming** and the Portal serves H.264 over RTSP; a **Stream URL** sensor gives the address.

- **Camera → MediaCodec input Surface directly** — no copy through the heap, which is what makes a sustained stream viable here.
- **Constrained Baseline requested**, because browser WebRTC refuses anything higher. The SDP reports what the **SPS actually says**, so an encoder that ignores the request describes itself honestly rather than failing mysteriously in a browser.
- **RTP interleaved over the RTSP TCP connection** — one socket, no port negotiation, nothing to explain to a home firewall.

# Part 3: optional audio

Sound was the reason RTSP beat MJPEG, so this finishes the thought: an **AAC-LC track alongside the video**, with its own RTP clock and control URL, so a viewer wanting only a picture sets up one track and not the other. The SDP advertises audio **only when audio is actually running** — promising a track we can't deliver leaves a client waiting for packets that never come.

The two hazards the design note called out are the real substance:

**The microphone had no owner.** `LanAudio` and `AudioNote` both opened `AudioSource.MIC` directly with nothing arbitrating, so whoever asked second silently got nothing — a pre-existing bug a third consumer would only have worsened. `MicOwner` now brokers by priority: a person speaking outranks a background stream and takes the mic; equal priority doesn't preempt; and a preempted owner releasing can't hand the microphone away from whoever won. **The intercom and voice notes go through it too**, so the gap is closed rather than stepped around.

**Mic mute now means silence on the wire.** A stream sending audio while HA's `mic_mute` switch says muted is a contradiction and a privacy surprise. Muting stops audio leaving the device entirely; the pipeline stays up so unmuting resumes with the timeline intact.

---

## What's tested vs what needs a device

The failure modes here are quiet ones — a stream that connects and plays silence, or at the wrong speed — so the wire formats are pinned: FU-A fragments reassemble byte-for-byte, the video marker bit lands on the last packet of an access unit, the AudioSpecificConfig and the 13+3 AU-header split agree with the `fmtp` line that describes them, audio timestamps run at the sample rate rather than the video clock, and the mute gate and mic priorities are unit-tested.

**376 tests pass** (+37 across this PR). `assembleDebug`, `mkdocs build --strict` and `bash -n provision.sh` all pass. The Camera2, MediaCodec and AudioRecord plumbing can only be proven on hardware.

## Suggested device check, in order

1. **VLC on `rtsp://<ip>:8554/`** — one test exercising encoder, packetiser, SDP and server together.
2. Turn on **Camera sound**, re-open in VLC. If video plays and audio doesn't, the SDP's `config=` is the first suspect.
3. Mute the microphone from HA mid-stream — audio should stop dead, video continue.
4. Trigger an intercom announcement while streaming — sound should drop out and come back.
5. Then the HA card via go2rtc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013opfPDdDg37KZRo4LMYerM