### PR TITLE
Camera streaming: make it start on real hardware

### DIFF
--- a/app/src/main/java/com/immortal/launcher/CameraStream.kt
+++ b/app/src/main/java/com/immortal/launcher/CameraStream.kt
@@ -116,24 +116,8 @@ class CameraStream(
           thread = ht
           val handler = Handler(ht.looper)
 
-          val enc = MediaCodec.createEncoderByType(StreamProfile.MIME)
+          val enc = configureEncoder(width, height, fps) ?: return false
           codec = enc
-          val format =
-              MediaFormat.createVideoFormat(StreamProfile.MIME, width, height).apply {
-                setInteger(
-                    MediaFormat.KEY_COLOR_FORMAT,
-                    MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface)
-                setInteger(
-                    MediaFormat.KEY_BIT_RATE, StreamProfile.bitrateFor(width, height, fps))
-                setInteger(MediaFormat.KEY_FRAME_RATE, fps)
-                setInteger(
-                    MediaFormat.KEY_I_FRAME_INTERVAL, StreamProfile.KEYFRAME_INTERVAL_S)
-                // Ask for Constrained Baseline. Not every encoder honours the request; the SDP
-                // reports what the SPS actually says, so a device that ignores this is visible
-                // rather than mysterious.
-                setInteger(MediaFormat.KEY_PROFILE, StreamProfile.PROFILE_CONSTRAINED_BASELINE)
-              }
-          enc.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
           val surface = enc.createInputSurface()
           inputSurface = surface
           enc.start()
@@ -168,6 +152,50 @@ class CameraStream(
     thread = null
     drain = null
     Log.i(TAG, "streaming stopped")
+  }
+
+  /**
+   * Build and configure the encoder, asking for Constrained Baseline but not insisting.
+   *
+   * Portal's encoder rejects the profile hint outright — `CodecException 0x80001001` straight out
+   * of `configure()`, verified on a Portal Go — so a single attempt meant no stream at all. A
+   * level is set alongside the profile because a profile without one is the classic way to make
+   * `configure()` throw; if that still fails we drop both and take whatever the encoder picks.
+   *
+   * Falling back is safe precisely because the SDP reports what the **SPS** says rather than what
+   * we asked for: a client is told the truth either way, and a stream that plays in VLC but not a
+   * browser is a visible, explicable outcome rather than a silent failure.
+   */
+  private fun configureEncoder(w: Int, h: Int, fps: Int): MediaCodec? {
+    for (withProfile in listOf(true, false)) {
+      val enc =
+          runCatching { MediaCodec.createEncoderByType(StreamProfile.MIME) }.getOrNull() ?: return null
+      val format =
+          MediaFormat.createVideoFormat(StreamProfile.MIME, w, h).apply {
+            setInteger(
+                MediaFormat.KEY_COLOR_FORMAT,
+                MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface)
+            setInteger(MediaFormat.KEY_BIT_RATE, StreamProfile.bitrateFor(w, h, fps))
+            setInteger(MediaFormat.KEY_FRAME_RATE, fps)
+            setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, StreamProfile.KEYFRAME_INTERVAL_S)
+            if (withProfile) {
+              setInteger(MediaFormat.KEY_PROFILE, StreamProfile.PROFILE_CONSTRAINED_BASELINE)
+              setInteger(MediaFormat.KEY_LEVEL, MediaCodecInfo.CodecProfileLevel.AVCLevel31)
+            }
+          }
+      val configured =
+          runCatching { enc.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE) }
+      if (configured.isSuccess) {
+        if (!withProfile) {
+          Log.w(TAG, "encoder rejected the Constrained Baseline hint; using its own profile")
+        }
+        return enc
+      }
+      Log.i(TAG, "configure (profile=$withProfile) failed: ${configured.exceptionOrNull()?.message}")
+      runCatching { enc.release() }
+    }
+    Log.w(TAG, "no usable H.264 encoder configuration")
+    return null
   }
 
   /**

--- a/app/src/main/java/com/immortal/launcher/CameraStreamService.kt
+++ b/app/src/main/java/com/immortal/launcher/CameraStreamService.kt
@@ -82,6 +82,7 @@ class CameraStreamService : Service() {
       running = true
       Log.i(TAG, "streaming service up on :${RtspServer.DEFAULT_PORT}")
     }
+    notifyState()
   }
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_NOT_STICKY
@@ -90,6 +91,7 @@ class CameraStreamService : Service() {
 
   override fun onDestroy() {
     running = false
+    notifyState()
     runCatching { stream?.stop() }
     runCatching { audio?.stop() }
     runCatching { server?.stop() }
@@ -130,6 +132,17 @@ class CameraStreamService : Service() {
       private set
 
     /**
+     * Notified whenever [running] actually changes.
+     *
+     * Starting a service is asynchronous, so a caller that publishes state straight after
+     * [sync] reports the state from *before* the start — which read as the switch refusing to
+     * stay on. The service is the only thing that knows when it truly came up, so it says so.
+     */
+    @Volatile var onStateChanged: (() -> Unit)? = null
+
+    private fun notifyState() = runCatching { onStateChanged?.invoke() }.let {}
+
+    /**
      * Start or stop streaming. Starting requires the device-side camera consent: a Home Assistant
      * command can turn the stream on only within permission already granted on the Portal, never
      * grant it.
@@ -141,7 +154,9 @@ class CameraStreamService : Service() {
         else context.startService(intent)
       } else {
         context.stopService(intent)
-        running = false
+        // stopService is asynchronous too, but onDestroy will notify; setting it here keeps an
+        // immediate read honest for the case where the service wasn't running at all.
+        if (running) running = false else notifyState()
       }
     }
   }

--- a/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmortalSettingsActivity.kt
@@ -720,6 +720,20 @@ internal fun MqttScreen(onBack: () -> Unit) {
   var ambientSensors by remember { mutableStateOf(MqttConfig.ambientSensors(context)) }
   var tempOffset by remember { mutableStateOf(MqttConfig.tempOffset(context)) }
   var cameraEnabled by remember { mutableStateOf(ImmortalSettings.cameraEnabled(context)) }
+  var cameraAudio by remember { mutableStateOf(ImmortalSettings.cameraAudio(context)) }
+  var streaming by remember { mutableStateOf(CameraStreamService.running) }
+  // RECORD_AUDIO has the same shape as CAMERA: declared, not granted by provisioning, and
+  // nothing on this path asked for it — so sound silently never worked.
+  val micPermission =
+      rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        if (!granted) {
+          cameraAudio = false
+          ImmortalSettings.setCameraAudio(context, false)
+          Toast.makeText(context, "Microphone permission is needed for stream sound", Toast.LENGTH_LONG)
+              .show()
+        }
+        MqttService.sync(context, reconfigure = true)
+      }
   // CAMERA is a runtime permission that provisioning doesn't grant, and nothing else in the app
   // asks for it — so without this the toggle switched on and every snapshot silently did nothing.
   val cameraPermission =
@@ -1081,6 +1095,62 @@ internal fun MqttScreen(onBack: () -> Unit) {
                   applyCamera(cameraEnabled)
                 },
             )
+          }
+          if (cameraEnabled) {
+            Divider()
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(18.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+              Column(modifier = Modifier.weight(1f)) {
+                Text("Camera sound", color = Color.White, fontSize = 15.sp)
+                Text(
+                    "Include sound in the video stream. Muting the microphone silences it, and " +
+                        "an intercom announcement takes the microphone back.",
+                    color = Color(0xFF9A9A9A),
+                    fontSize = 13.sp,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+              }
+              Segmented(
+                  options = listOf("Off" to "off", "On" to "on"),
+                  selected = if (cameraAudio) "on" else "off",
+                  onSelect = {
+                    cameraAudio = it == "on"
+                    ImmortalSettings.setCameraAudio(context, cameraAudio)
+                    val granted =
+                        ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+                            PackageManager.PERMISSION_GRANTED
+                    if (cameraAudio && !granted) micPermission.launch(Manifest.permission.RECORD_AUDIO)
+                    else MqttService.sync(context, reconfigure = true)
+                  },
+              )
+            }
+            Divider()
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(18.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+              Column(modifier = Modifier.weight(1f)) {
+                Text("Stream video now", color = Color.White, fontSize = 15.sp)
+                Text(
+                    "Start the live RTSP stream from here as well as from Home Assistant. " +
+                        "Play it at rtsp://127.0.0.1:8554/ on this Portal, or at the Portal's " +
+                        "own address from elsewhere. Stops on reboot.",
+                    color = Color(0xFF9A9A9A),
+                    fontSize = 13.sp,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+              }
+              Segmented(
+                  options = listOf("Off" to "off", "On" to "on"),
+                  selected = if (streaming) "on" else "off",
+                  onSelect = {
+                    streaming = it == "on"
+                    CameraStreamService.sync(context, streaming)
+                  },
+              )
+            }
           }
         }
       }

--- a/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
+++ b/app/src/main/java/com/immortal/launcher/MqttPublisher.kt
@@ -294,10 +294,14 @@ class MqttPublisher(private val appContext: Context) {
     publishAudioState()
     publishStreamState()
     if (MqttConfig.ambientSensors(appContext)) ambient.start()
+    // The service knows when it actually came up; publishing straight after sync() reported the
+    // state from BEFORE the start, which read as the switch refusing to stay on.
+    CameraStreamService.onStateChanged = { runCatching { publishStreamState() }.let {} }
   }
 
   private fun detach() {
     runCatching { ambient.stop() }
+    CameraStreamService.onStateChanged = null
     runCatching { PresenceHub.removeListener(presenceListener) }
     runCatching { NowPlayingHub.removeListener(nowPlayingListener) }
     batteryReceiver?.let { r -> runCatching { appContext.unregisterReceiver(r) } }
@@ -403,10 +407,10 @@ class MqttPublisher(private val appContext: Context) {
           // Streaming can only be switched on within consent already given on the device;
           // CameraStreamService.sync enforces that, and we report back what actually happened
           // rather than what was asked for.
-          "camera_stream" -> {
-            CameraStreamService.sync(appContext, payload.trim().equals("ON", ignoreCase = true))
-            publishStreamState()
-          }
+          // No publish here: the service reports its own state once it has actually started or
+          // stopped, through onStateChanged.
+          "camera_stream" ->
+              CameraStreamService.sync(appContext, payload.trim().equals("ON", ignoreCase = true))
           "camera_audio" -> {
             val on = payload.trim().equals("ON", ignoreCase = true)
             ImmortalSettings.setCameraAudio(appContext, on)

--- a/docs/guides/home-assistant.md
+++ b/docs/guides/home-assistant.md
@@ -104,6 +104,14 @@ automation:
   the provisioner on a Portal set up before that grant existed.
 - **No Camera entity** — it's off by default. Turn on **Camera snapshots** under Settings →
   Home Assistant (MQTT) on the device; Home Assistant can't enable it remotely, by design.
+- **Camera streaming won't stay on** — check `adb logcat -s ImmortalStream:V`. A
+  `MediaCodec ... configure` failure means the encoder refused our settings; Immortal retries
+  without the profile hint, so this should now start anyway. `no record-audio permission` means
+  sound is ungranted: re-run the [provisioning kit](../provisioning.md), or turn **Camera sound**
+  on from the device, which asks for it.
+- **Testing the stream on the Portal itself** — install VLC on it and open
+  `rtsp://127.0.0.1:8554/`. From another machine, use the Portal's address: Home Assistant's
+  **Stream URL** or **IP address** sensor has it, or `adb shell ip addr show wlan0`.
 - **The snapshot button does nothing** — watch the Portal's screen, which now says why. *No
   camera permission* means the grant is missing: re-run the [provisioning kit](../provisioning.md),
   or `adb shell pm grant com.immortal.launcher android.permission.CAMERA`. *Snapshot too large

--- a/provisioning/provision.ps1
+++ b/provisioning/provision.ps1
@@ -250,6 +250,8 @@ function Grant-Perms {
   # Camera snapshots for Home Assistant. The feature stays OFF until the user turns it on in
   # Settings; granting here only means it works when they do, instead of silently doing nothing.
   A shell pm grant $cfg["PKG"] android.permission.CAMERA | Out-Null
+  # Sound for the camera stream, and the intercom. Both stay OFF until the user turns them on.
+  A shell pm grant $cfg["PKG"] android.permission.RECORD_AUDIO | Out-Null
   # Lets Immortal bring the photo frame back instantly when the system force-wakes
   # the screensaver (~2 min in, a quirk of Meta's power manager) even if another
   # app is in the foreground.

--- a/provisioning/provision.sh
+++ b/provisioning/provision.sh
@@ -314,6 +314,8 @@ grant_perms() {
   # Camera snapshots for Home Assistant. The feature stays OFF until the user turns it on in
   # Settings; granting here only means it works when they do, instead of silently doing nothing.
   a shell pm grant "$PKG" android.permission.CAMERA >/dev/null 2>&1
+  # Sound for the camera stream, and the intercom. Both stay OFF until the user turns them on.
+  a shell pm grant "$PKG" android.permission.RECORD_AUDIO >/dev/null 2>&1
   # Lets Immortal bring the photo frame back instantly when the system force-wakes
   # the screensaver (~2 min in, a quirk of Meta's power manager) even if another
   # app is in the foreground. SYSTEM_ALERT_WINDOW holders may start activities


### PR DESCRIPTION
Three faults, all found by putting 1.70 on a Portal Go. The logcat told the whole story.

## 1. The encoder rejected our profile hint

```
W ImmortalStream: android.media.MediaCodec$CodecException: Error 0x80001001
	at android.media.MediaCodec.configure(MediaCodec.java:2024)
	at com.immortal.launcher.CameraStream.start(CameraStream.kt:136)
```

Asking for Constrained Baseline threw straight out of `configure()`, so the stream never started at all.

It now asks for the profile **with a level alongside it** — a profile without one is the classic way to make `configure()` throw — and if that still fails, drops both and takes whatever the encoder picks.

Falling back is safe precisely because of a decision made earlier: **the SDP reports what the SPS says, not what we asked for**. A client is told the truth either way, and "plays in VLC, not in the browser" is at least a visible, explicable outcome rather than a silent one.

## 2. The switch snapped back to off, every time

`startForegroundService` is asynchronous, and the publisher read the service's state *immediately* after calling it — so it published the state from **before** the start, always, and Home Assistant dutifully showed the switch going off again.

The service now reports its own state once it has actually started or stopped. This one was a guaranteed bug, not hardware-dependent; I should have caught it.

## 3. Sound could never work

```
I ImmortalAudio: no record-audio permission — streaming without sound
```

`RECORD_AUDIO` had **exactly the same hole `CAMERA` did**: declared in the manifest, not granted by provisioning, and nothing on this path ever requested it. Provisioning grants it now, and turning **Camera sound** on asks for it.

## Also: the two missing rows

Neither *Camera sound* nor a way to start streaming appeared on the device. My earlier approach registered a spec in the `mqtt` domain, which reaches the phone remote but **not** the bespoke on-device MQTT screen — a limitation documented in `SettingsDomains` that I walked into anyway.

Both now have real rows on the Home Assistant settings page, including a **Stream video now** toggle so the stream can be started and tested without Home Assistant in the loop.

## Testing

- 376 tests pass; `assembleDebug`, `mkdocs build --strict`, `bash -n provision.sh` all pass.
- Docs gained troubleshooting for both symptoms, plus the answer to "how do I test it on the Portal itself" — `rtsp://127.0.0.1:8554/` in VLC on the device.

## What to try after installing

1. Re-run the provisioner (or turn **Camera sound** on, which asks) so `RECORD_AUDIO` is granted.
2. **Settings → Home Assistant (MQTT) → Stream video now**, then VLC on the Portal at `rtsp://127.0.0.1:8554/`.
3. `adb logcat -s ImmortalStream:V` will now say whether the profile hint was accepted or fell back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013opfPDdDg37KZRo4LMYerM

---
_Generated by [Claude Code](https://claude.ai/code/session_013opfPDdDg37KZRo4LMYerM)_