### PR TITLE
Screensaver: Immich Photo Details

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -183,6 +183,12 @@
             android:exported="false"
             android:theme="@style/Theme.SampleApp" />
 
+        <!-- Photo-caption layout subpage (line order, per-line size/weight, icons). -->
+        <activity
+            android:name=".CaptionStyleActivity"
+            android:exported="false"
+            android:theme="@style/Theme.SampleApp" />
+
         <!-- "Control from your phone": pairing screen for the phone web remote. -->
         <activity
             android:name=".RemotePairActivity"

--- a/app/src/main/java/com/immortal/launcher/CaptionStyleActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/CaptionStyleActivity.kt
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2026 Starbright Lab.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.immortal.launcher
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.immortal.launcher.ui.theme.SampleAppTheme
+
+/**
+ * The photo-caption layout editor, on its own subpage (reached from the "Caption layout" row in
+ * screensaver settings). Owns everything about *how* the caption is drawn — the top-to-bottom
+ * order of the lines, each line's size and weight, and whether icons show — while the plain
+ * on/off switches for each line stay in the settings registry, where they also reach the phone
+ * remote.
+ *
+ * This is a sub-screen rather than a pile of generic rows because reordering isn't a scalar: a
+ * "move up / move down" affordance is the only way to express a permutation on a D-pad. Same
+ * reasoning (and the same shape) as the clock-face picker.
+ */
+class CaptionStyleActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent { SampleAppTheme(darkTheme = true) { CaptionStyleScreen() } }
+  }
+}
+
+@Composable
+private fun CaptionStyleScreen() {
+  val context = LocalContext.current
+  val activity = context as? Activity
+  val loaded = remember { ScreensaverConfig.load(context) }
+  var order by remember { mutableStateOf(PhotoCaption.parseOrder(loaded.captionOrder)) }
+  var styles by remember { mutableStateOf(PhotoCaption.parseStyles(loaded.captionStyles)) }
+  var icons by remember { mutableStateOf(loaded.captionIcons) }
+  // The per-line on/off switches live in the registry (so they also reach the phone remote); they
+  // are mirrored here because an editor you can't switch a line off from would be a strange one.
+  var enabled by remember { mutableStateOf(enabledLines(loaded)) }
+
+  fun persistOrder(next: List<PhotoCaption.Line>) {
+    order = next
+    ScreensaverConfig.setCaptionOrder(context, next)
+  }
+
+  fun persistStyle(line: PhotoCaption.Line, style: PhotoCaption.LineStyle) {
+    val next = styles + (line to style)
+    styles = next
+    ScreensaverConfig.setCaptionStyles(context, next)
+  }
+
+  Column(
+      modifier =
+          Modifier.fillMaxSize()
+              .onPreviewKeyEvent { e ->
+                if (e.key == Key.Back) {
+                  if (e.type == KeyEventType.KeyUp) activity?.finish()
+                  true
+                } else false
+              }
+              .background(Color(0xFF101012))
+              .verticalScroll(rememberScrollState())
+              .padding(horizontal = 28.dp, vertical = 32.dp),
+  ) {
+    Column(modifier = Modifier.widthIn(max = 1100.dp)) {
+      Text("Caption layout", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
+      Text(
+          "Choose which details show under your photos, what order they read in, and how big and " +
+              "bold each one is. Text follows your clock face's font and colour.",
+          color = Color(0xFF9A9A9A),
+          fontSize = 16.sp,
+          modifier = Modifier.padding(top = 6.dp),
+      )
+      Spacer(Modifier.size(26.dp))
+
+      Card {
+        ToggleRow("Show icons", icons) { v ->
+          ScreensaverConfig.setCaptionIcons(context, v)
+          icons = v
+        }
+      }
+      Spacer(Modifier.size(22.dp))
+
+      order.forEachIndexed { index, line ->
+        val style = styles[line] ?: line.defaultStyle
+        SectionLabel(line.label)
+        Card {
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(start = 18.dp, end = 6.dp, top = 12.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Image(
+                painter = painterResource(line.iconRes),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(Color(0xFFDDDDDD)),
+                modifier = Modifier.size(22.dp),
+            )
+            Spacer(Modifier.size(12.dp))
+            Text(
+                "Line ${index + 1} of ${order.size}",
+                color = Color(0xFF9A9A9A),
+                fontSize = 14.sp,
+                modifier = Modifier.weight(1f),
+            )
+            MoveButton("▲", enabled = index > 0) { persistOrder(order.moved(index, -1)) }
+            MoveButton("▼", enabled = index < order.lastIndex) { persistOrder(order.moved(index, +1)) }
+          }
+          ToggleRow("Show this line", enabled[line] == true) { v ->
+            setLineEnabled(context, line, v)
+            enabled = enabled + (line to v)
+          }
+          Divider()
+          Stepper(
+              label = "Size",
+              valueText = "${style.size}%",
+              widthMin = 78.dp,
+              onMinus = {
+                persistStyle(line, style.copy(size = PhotoCaption.clampSize(style.size - PhotoCaption.LineStyle.SIZE_STEP)))
+              },
+              onPlus = {
+                persistStyle(line, style.copy(size = PhotoCaption.clampSize(style.size + PhotoCaption.LineStyle.SIZE_STEP)))
+              },
+          )
+          Divider()
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(18.dp),
+              verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text("Weight", color = Color.White, fontSize = 17.sp, modifier = Modifier.weight(1f))
+            Segmented(
+                PhotoCaption.Weight.entries.map { it.label to it.key },
+                style.weight.key,
+            ) { key ->
+              PhotoCaption.Weight.fromKey(key)?.let { persistStyle(line, style.copy(weight = it)) }
+            }
+          }
+        }
+        Spacer(Modifier.size(18.dp))
+      }
+
+      Spacer(Modifier.size(4.dp))
+      Card {
+        ActionRow("Reset layout to defaults") {
+          ScreensaverConfig.resetCaptionLayout(context)
+          order = PhotoCaption.DEFAULT_ORDER
+          styles = PhotoCaption.parseStyles(null)
+        }
+      }
+      Spacer(Modifier.size(22.dp))
+      PreviewButton {
+        runCatching { context.startActivity(Intent(context, PhotoFramePreviewActivity::class.java)) }
+      }
+      Text(
+          "A line only appears when the photo actually has that detail — and the whole caption is " +
+              "hidden on the full-screen flip clock, which owns the frame on its own.",
+          color = Color(0xFF7C7C7C),
+          fontSize = 13.sp,
+          modifier = Modifier.padding(top = 14.dp, start = 4.dp, end = 4.dp),
+      )
+    }
+  }
+}
+
+/** This line moved [delta] places, with the list closing up behind it. */
+private fun List<PhotoCaption.Line>.moved(index: Int, delta: Int): List<PhotoCaption.Line> {
+  val target = (index + delta).coerceIn(0, lastIndex)
+  if (target == index) return this
+  val out = toMutableList()
+  out.add(target, out.removeAt(index))
+  return out
+}
+
+private fun enabledLines(s: ScreensaverConfig.Settings): Map<PhotoCaption.Line, Boolean> =
+    mapOf(
+        PhotoCaption.Line.LOCATION to s.captionLocation,
+        PhotoCaption.Line.DATE to s.captionDate,
+        PhotoCaption.Line.DESCRIPTION to s.captionDescription,
+        PhotoCaption.Line.PEOPLE to s.captionPeople,
+        PhotoCaption.Line.TAGS to s.captionTags,
+    )
+
+/** Write through to the same setters the registry specs bind to, so the two can't drift. */
+private fun setLineEnabled(context: android.content.Context, line: PhotoCaption.Line, on: Boolean) {
+  when (line) {
+    PhotoCaption.Line.LOCATION -> ScreensaverConfig.setCaptionLocation(context, on)
+    PhotoCaption.Line.DATE -> ScreensaverConfig.setCaptionDate(context, on)
+    PhotoCaption.Line.DESCRIPTION -> ScreensaverConfig.setCaptionDescription(context, on)
+    PhotoCaption.Line.PEOPLE -> ScreensaverConfig.setCaptionPeople(context, on)
+    PhotoCaption.Line.TAGS -> ScreensaverConfig.setCaptionTags(context, on)
+  }
+}
+
+/** A ▲/▼ reorder button, dimmed and inert at the ends of the list. */
+@Composable
+private fun MoveButton(glyph: String, enabled: Boolean, onClick: () -> Unit) {
+  Surface(
+      color = if (enabled) Color(0xFF2A2A2C) else Color.Transparent,
+      shape = RoundedCornerShape(10.dp),
+      modifier = Modifier.padding(start = 8.dp),
+  ) {
+    Text(
+        glyph,
+        color = if (enabled) Color.White else Color(0xFF4A4A4A),
+        fontSize = 17.sp,
+        textAlign = TextAlign.Center,
+        modifier =
+            Modifier.size(44.dp)
+                .tvFocusable(RoundedCornerShape(10.dp), enabled = enabled) { onClick() }
+                .padding(top = 10.dp),
+    )
+  }
+}
+
+@Composable
+private fun ActionRow(title: String, onClick: () -> Unit) {
+  Text(
+      title,
+      color = Color.White,
+      fontSize = 17.sp,
+      modifier = Modifier.fillMaxWidth().tvFocusableRow { onClick() }.padding(18.dp),
+  )
+}
+
+@Composable
+private fun PreviewButton(onClick: () -> Unit) {
+  Surface(color = Color(0xFF2E6BE6), shape = RoundedCornerShape(14.dp), modifier = Modifier.fillMaxWidth()) {
+    Text(
+        "Preview screensaver",
+        color = Color.White,
+        fontSize = 17.sp,
+        fontWeight = FontWeight.SemiBold,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.fillMaxWidth().tvFocusableRow { onClick() }.padding(vertical = 16.dp),
+    )
+  }
+}

--- a/app/src/main/java/com/immortal/launcher/CaptionStyleActivity.kt
+++ b/app/src/main/java/com/immortal/launcher/CaptionStyleActivity.kt
@@ -51,14 +51,21 @@ import com.immortal.launcher.ui.theme.SampleAppTheme
 
 /**
  * The photo-caption layout editor, on its own subpage (reached from the "Caption layout" row in
- * screensaver settings). Owns everything about *how* the caption is drawn — the top-to-bottom
- * order of the lines, each line's size and weight, and whether icons show — while the plain
- * on/off switches for each line stay in the settings registry, where they also reach the phone
- * remote.
+ * screensaver settings).
  *
- * This is a sub-screen rather than a pile of generic rows because reordering isn't a scalar: a
- * "move up / move down" affordance is the only way to express a permutation on a D-pad. Same
- * reasoning (and the same shape) as the clock-face picker.
+ * It holds **only what the settings registry can't express**: the top-to-bottom order of the
+ * lines, and each line's size and weight. Everything that *is* a plain scalar — which lines show
+ * at all, and whether icons draw — stays a `SettingSpec` on the screensaver settings screen, so
+ * it renders there once and reaches the phone remote for free. Duplicating those switches here
+ * would give the same setting two homes and no single source of truth.
+ *
+ * Which is why this lists only the lines that are currently switched on: arranging a line that
+ * isn't drawn is meaningless, and a disabled row here would just be the switch again in disguise.
+ * A line's place in the order survives being switched off and back on.
+ *
+ * A sub-screen rather than a pile of generic rows because reordering isn't a scalar: "move up /
+ * move down" is the only way to express a permutation on a D-pad. Same reasoning (and the same
+ * shape) as the clock-face picker.
  */
 class CaptionStyleActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -74,10 +81,9 @@ private fun CaptionStyleScreen() {
   val loaded = remember { ScreensaverConfig.load(context) }
   var order by remember { mutableStateOf(PhotoCaption.parseOrder(loaded.captionOrder)) }
   var styles by remember { mutableStateOf(PhotoCaption.parseStyles(loaded.captionStyles)) }
-  var icons by remember { mutableStateOf(loaded.captionIcons) }
-  // The per-line on/off switches live in the registry (so they also reach the phone remote); they
-  // are mirrored here because an editor you can't switch a line off from would be a strange one.
-  var enabled by remember { mutableStateOf(enabledLines(loaded)) }
+  // Read-only here: the switches live on the previous screen. Re-read on every entry, because
+  // that's where the user just came from.
+  val enabled = remember { enabledLines(loaded) }
 
   fun persistOrder(next: List<PhotoCaption.Line>) {
     order = next
@@ -106,23 +112,29 @@ private fun CaptionStyleScreen() {
     Column(modifier = Modifier.widthIn(max = 1100.dp)) {
       Text("Caption layout", color = Color.White, fontSize = 34.sp, fontWeight = FontWeight.SemiBold)
       Text(
-          "Choose which details show under your photos, what order they read in, and how big and " +
-              "bold each one is. Text follows your clock face's font and colour.",
+          "Arrange the details showing under your photos, and set how big and bold each one is. " +
+              "Text follows your clock face's font and colour.",
           color = Color(0xFF9A9A9A),
           fontSize = 16.sp,
           modifier = Modifier.padding(top = 6.dp),
       )
       Spacer(Modifier.size(26.dp))
 
-      Card {
-        ToggleRow("Show icons", icons) { v ->
-          ScreensaverConfig.setCaptionIcons(context, v)
-          icons = v
+      val shown = order.filter { enabled[it] == true }
+      if (shown.isEmpty()) {
+        Card {
+          Text(
+              "No caption lines are switched on. Turn some on under Photo details in screensaver " +
+                  "settings, then come back to arrange them.",
+              color = Color(0xFF9A9A9A),
+              fontSize = 15.sp,
+              modifier = Modifier.padding(18.dp),
+          )
         }
+        Spacer(Modifier.size(22.dp))
       }
-      Spacer(Modifier.size(22.dp))
 
-      order.forEachIndexed { index, line ->
+      shown.forEachIndexed { index, line ->
         val style = styles[line] ?: line.defaultStyle
         SectionLabel(line.label)
         Card {
@@ -138,17 +150,19 @@ private fun CaptionStyleScreen() {
             )
             Spacer(Modifier.size(12.dp))
             Text(
-                "Line ${index + 1} of ${order.size}",
+                "Line ${index + 1} of ${shown.size}",
                 color = Color(0xFF9A9A9A),
                 fontSize = 14.sp,
                 modifier = Modifier.weight(1f),
             )
-            MoveButton("▲", enabled = index > 0) { persistOrder(order.moved(index, -1)) }
-            MoveButton("▼", enabled = index < order.lastIndex) { persistOrder(order.moved(index, +1)) }
-          }
-          ToggleRow("Show this line", enabled[line] == true) { v ->
-            setLineEnabled(context, line, v)
-            enabled = enabled + (line to v)
+            // Swapping with the neighbouring *shown* line leaves any switched-off line where it
+            // sits, so its position is still there when it comes back.
+            MoveButton("▲", enabled = index > 0) {
+              persistOrder(order.swapped(line, shown[index - 1]))
+            }
+            MoveButton("▼", enabled = index < shown.lastIndex) {
+              persistOrder(order.swapped(line, shown[index + 1]))
+            }
           }
           Divider()
           Stepper(
@@ -192,8 +206,9 @@ private fun CaptionStyleScreen() {
         runCatching { context.startActivity(Intent(context, PhotoFramePreviewActivity::class.java)) }
       }
       Text(
-          "A line only appears when the photo actually has that detail — and the whole caption is " +
-              "hidden on the full-screen flip clock, which owns the frame on its own.",
+          "Only the lines you've switched on under Photo details are listed here. A line still " +
+              "shows just when the photo has that detail, and the whole caption is hidden on the " +
+              "full-screen flip clock, which owns the frame on its own.",
           color = Color(0xFF7C7C7C),
           fontSize = 13.sp,
           modifier = Modifier.padding(top = 14.dp, start = 4.dp, end = 4.dp),
@@ -202,12 +217,17 @@ private fun CaptionStyleScreen() {
   }
 }
 
-/** This line moved [delta] places, with the list closing up behind it. */
-private fun List<PhotoCaption.Line>.moved(index: Int, delta: Int): List<PhotoCaption.Line> {
-  val target = (index + delta).coerceIn(0, lastIndex)
-  if (target == index) return this
+/** The order with [a] and [b] trading places; everything else keeps its slot. */
+private fun List<PhotoCaption.Line>.swapped(
+    a: PhotoCaption.Line,
+    b: PhotoCaption.Line,
+): List<PhotoCaption.Line> {
+  val i = indexOf(a)
+  val j = indexOf(b)
+  if (i < 0 || j < 0 || i == j) return this
   val out = toMutableList()
-  out.add(target, out.removeAt(index))
+  out[i] = b
+  out[j] = a
   return out
 }
 
@@ -219,17 +239,6 @@ private fun enabledLines(s: ScreensaverConfig.Settings): Map<PhotoCaption.Line, 
         PhotoCaption.Line.PEOPLE to s.captionPeople,
         PhotoCaption.Line.TAGS to s.captionTags,
     )
-
-/** Write through to the same setters the registry specs bind to, so the two can't drift. */
-private fun setLineEnabled(context: android.content.Context, line: PhotoCaption.Line, on: Boolean) {
-  when (line) {
-    PhotoCaption.Line.LOCATION -> ScreensaverConfig.setCaptionLocation(context, on)
-    PhotoCaption.Line.DATE -> ScreensaverConfig.setCaptionDate(context, on)
-    PhotoCaption.Line.DESCRIPTION -> ScreensaverConfig.setCaptionDescription(context, on)
-    PhotoCaption.Line.PEOPLE -> ScreensaverConfig.setCaptionPeople(context, on)
-    PhotoCaption.Line.TAGS -> ScreensaverConfig.setCaptionTags(context, on)
-  }
-}
 
 /** A ▲/▼ reorder button, dimmed and inert at the ends of the list. */
 @Composable

--- a/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
+++ b/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
@@ -8,6 +8,7 @@
 package com.immortal.launcher
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.content.Intent
 import android.content.IntentFilter
 import android.graphics.Bitmap
@@ -114,14 +115,11 @@ class FaceRenderer(
   private var lastArtBitmap: Bitmap? = null
   private var npListener: NowPlayingHub.Listener? = null
 
-  // Photo caption (place / date / description / people / tags). A grid element like the rest, fed
-  // per-photo via [setCaption]; each line hides itself when that photo has nothing for it.
+  // Photo caption. A grid element like the rest, fed per-photo via [setCaption]; each line hides
+  // itself when that photo has nothing for it. Insertion order IS the user's chosen draw order
+  // (see [buildCaption]), so this is a LinkedHashMap and never a plain map.
   private var captionPanel: LinearLayout? = null
-  private var captionPlace: TextView? = null
-  private var captionDate: TextView? = null
-  private var captionDescription: TextView? = null
-  private var captionPeople: TextView? = null
-  private var captionTags: TextView? = null
+  private val captionLines = LinkedHashMap<PhotoCaption.Line, TextView>()
 
   fun start(face: Face) {
     this.face = face
@@ -152,11 +150,7 @@ class FaceRenderer(
     // Caption views are rebuilt below (or not, on a full-bleed face) — drop stale refs so a
     // late setCaption() can't poke a detached view from the previous face.
     captionPanel = null
-    captionPlace = null
-    captionDate = null
-    captionDescription = null
-    captionPeople = null
-    captionTags = null
+    captionLines.clear()
 
     buildClockCluster(face.clock)
     val fullBleed = clockFace?.fullBleed == true
@@ -478,48 +472,97 @@ class FaceRenderer(
    * The photo caption as a grid element, so it stacks with whatever else lands in the same cell
    * (notably the now-playing card — both default to bottom-right) instead of overlapping it.
    *
-   * Up to five stacked lines: the place in bold over a lighter date (the original pair, from EXIF
-   * or from Immich), then the Immich-only detail — the description the user typed, who's in the
-   * shot, and its tags. Each is a step smaller and dimmer than the line above, so the block reads
-   * as one caption rather than five competing rows, and each hides itself when that photo has
-   * nothing for it. Hidden entirely until [setCaption] gets real metadata.
+   * One [TextView] per [PhotoCaption.Line], added in the user's chosen order, each with its own
+   * size and weight and an optional leading glyph. Every line is drawn from the **face's** clock
+   * spec — same font family, colour, opacity and shadow as the clock, date and weather — so the
+   * caption reads as part of one overlay rather than a panel bolted onto it. Hidden entirely
+   * until [setCaption] gets real metadata; individual lines hide when that photo has nothing for
+   * them.
    */
   private fun buildCaption(spec: CaptionSpec) {
+    val cfg = ScreensaverConfig.load(context)
     val align = horizontalGravity(spec.position)
+    val styles = PhotoCaption.parseStyles(cfg.captionStyles)
     val col = LinearLayout(context)
     col.orientation = LinearLayout.VERTICAL
     col.gravity = align
     col.visibility = View.GONE
+    // The glyphs overhang the text box; let them draw rather than be clipped to the column.
+    col.clipChildren = false
+    col.clipToPadding = false
 
-    // A caption line: hidden until it has text, capped in width so a long description (or a photo
-    // full of named faces) wraps/ellipsizes instead of stretching the column across the frame.
-    fun line(sizeSp: Float, color: Int, lightFont: Boolean, maxLines: Int = 1): TextView {
-      val t = text(sizeSp, color, lightFont)
-      t.maxLines = maxLines
-      t.ellipsize = TextUtils.TruncateAt.END
-      t.gravity = align
-      t.maxWidth = dp(560)
-      t.visibility = View.GONE
+    PhotoCaption.parseOrder(cfg.captionOrder).forEach { line ->
+      val style = styles[line] ?: line.defaultStyle
+      val t = captionLine(line, style, align, cfg.captionIcons)
       col.addView(t, LinearLayout.LayoutParams(WRAP, WRAP))
-      return t
+      captionLines[line] = t
     }
-
-    val place = line(19f, Color.WHITE, false).apply { typeface = Typeface.DEFAULT_BOLD }
-    val date = line(14f, 0xCCFFFFFF.toInt(), true)
-    val description = line(15f, 0xE6FFFFFF.toInt(), true, maxLines = 2)
-    val people = line(14f, 0xCCFFFFFF.toInt(), true)
-    val tags = line(13f, 0x99FFFFFF.toInt(), true)
 
     // Top margin gives breathing room from whatever sits above in the same cell (the now-playing
     // card). A GONE sibling contributes no space, so a lone caption isn't pushed off the bottom.
     bucket(spec.position)
         .addView(col, LinearLayout.LayoutParams(WRAP, WRAP).apply { topMargin = dp(18) })
     captionPanel = col
-    captionPlace = place
-    captionDate = date
-    captionDescription = description
-    captionPeople = people
-    captionTags = tags
+  }
+
+  /**
+   * One caption line, styled from the face so it matches the clock/date/weather: the face's font
+   * (its light variant for [PhotoCaption.Weight.LIGHT], bolded for [PhotoCaption.Weight.BOLD]),
+   * its colour, and its shadow. Size is the caption base scaled by the line's own percentage and
+   * again by the face's `sizeScale`, so bumping the clock size carries the caption with it.
+   *
+   * The alpha ramp by weight is what keeps a five-line block legible: a bold line reads at the
+   * face's full opacity, lighter ones sit back, which is the hierarchy the original hardcoded
+   * caption got from fixed colours — now derived, so it follows a recoloured face.
+   */
+  private fun captionLine(
+      line: PhotoCaption.Line,
+      style: PhotoCaption.LineStyle,
+      align: Int,
+      icons: Boolean,
+  ): TextView {
+    val clock = face.clock
+    val fade =
+        when (style.weight) {
+          PhotoCaption.Weight.BOLD -> 1f
+          PhotoCaption.Weight.REGULAR -> 0.9f
+          PhotoCaption.Weight.LIGHT -> 0.8f
+        }
+    val color = FaceStyle.colorWithOpacity(clock.color, clock.opacity * fade)
+    val t = TextView(context)
+    t.textSize = CAPTION_BASE_SP * style.size / 100f * clock.sizeScale / 100f
+    t.setTextColor(color)
+    t.typeface = captionTypeface(style.weight)
+    FaceStyle.applyShadow(t, clock.shadow, clock.color)
+    // A description can run long and a crowd of names longer; cap the width so the column can't
+    // stretch across the frame, and let the description use a second row before it ellipsizes.
+    t.maxLines = if (line == PhotoCaption.Line.DESCRIPTION) 2 else 1
+    t.ellipsize = TextUtils.TruncateAt.END
+    t.gravity = align
+    t.maxWidth = dp(560)
+    t.visibility = View.GONE
+    if (icons) applyCaptionIcon(t, line, color)
+    return t
+  }
+
+  /** The face's own typeface, taken light or bolded to hit the line's weight. */
+  private fun captionTypeface(weight: PhotoCaption.Weight): Typeface {
+    val base = FaceStyle.typeface(assets, face.clock, light = weight == PhotoCaption.Weight.LIGHT)
+    return if (weight == PhotoCaption.Weight.BOLD) Typeface.create(base, Typeface.BOLD) else base
+  }
+
+  /**
+   * Put the line's glyph ahead of its text, sized to the text and tinted to match it — so an icon
+   * tracks a size or colour change instead of drifting out of proportion. Best-effort: a drawable
+   * that won't load simply leaves the line text-only.
+   */
+  private fun applyCaptionIcon(t: TextView, line: PhotoCaption.Line, color: Int) {
+    val icon = runCatching { context.getDrawable(line.iconRes) }.getOrNull()?.mutate() ?: return
+    val px = (t.textSize * 1.05f).toInt().coerceAtLeast(1)
+    icon.setBounds(0, 0, px, px)
+    t.setCompoundDrawablesRelative(icon, null, null, null)
+    t.compoundDrawableTintList = ColorStateList.valueOf(color)
+    t.compoundDrawablePadding = dp(8)
   }
 
   /**
@@ -533,16 +576,11 @@ class FaceRenderer(
       col.visibility = View.GONE
       return
     }
-    fun line(v: TextView?, s: String?) {
-      val t = s?.trim()?.ifBlank { null }
-      v?.visibility = if (t == null) View.GONE else View.VISIBLE
-      v?.text = t ?: ""
+    captionLines.forEach { (line, view) ->
+      val text = caption[line]
+      view.visibility = if (text == null) View.GONE else View.VISIBLE
+      view.text = text ?: ""
     }
-    line(captionPlace, caption.place)
-    line(captionDate, caption.date)
-    line(captionDescription, caption.description)
-    line(captionPeople, caption.people)
-    line(captionTags, caption.tags)
     col.visibility = View.VISIBLE
   }
 
@@ -704,4 +742,13 @@ class FaceRenderer(
   private val MATCH = FrameLayout.LayoutParams.MATCH_PARENT
   private val WRAP = FrameLayout.LayoutParams.WRAP_CONTENT
   private fun dp(v: Int): Int = (v * context.resources.displayMetrics.density).toInt()
+
+  private companion object {
+    /**
+     * The caption's 100% size, in sp. Every line is a percentage of this (see
+     * [PhotoCaption.LineStyle.size]), so the shipped defaults land on the sizes the original
+     * hardcoded caption used: 95% = 19sp for the place, 70% = 14sp for the date.
+     */
+    const val CAPTION_BASE_SP = 20f
+  }
 }

--- a/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
+++ b/app/src/main/java/com/immortal/launcher/FaceRenderer.kt
@@ -114,10 +114,14 @@ class FaceRenderer(
   private var lastArtBitmap: Bitmap? = null
   private var npListener: NowPlayingHub.Listener? = null
 
-  // Photo caption (place / date). A grid element like the rest, fed per-photo via [setCaption].
+  // Photo caption (place / date / description / people / tags). A grid element like the rest, fed
+  // per-photo via [setCaption]; each line hides itself when that photo has nothing for it.
   private var captionPanel: LinearLayout? = null
   private var captionPlace: TextView? = null
   private var captionDate: TextView? = null
+  private var captionDescription: TextView? = null
+  private var captionPeople: TextView? = null
+  private var captionTags: TextView? = null
 
   fun start(face: Face) {
     this.face = face
@@ -150,6 +154,9 @@ class FaceRenderer(
     captionPanel = null
     captionPlace = null
     captionDate = null
+    captionDescription = null
+    captionPeople = null
+    captionTags = null
 
     buildClockCluster(face.clock)
     val fullBleed = clockFace?.fullBleed == true
@@ -468,9 +475,14 @@ class FaceRenderer(
   }
 
   /**
-   * The photo caption ("place" bold over a lighter "date") as a grid element, so it stacks with
-   * whatever else lands in the same cell (notably the now-playing card — both default to
-   * bottom-right) instead of overlapping it. Hidden until [setCaption] gets real metadata.
+   * The photo caption as a grid element, so it stacks with whatever else lands in the same cell
+   * (notably the now-playing card — both default to bottom-right) instead of overlapping it.
+   *
+   * Up to five stacked lines: the place in bold over a lighter date (the original pair, from EXIF
+   * or from Immich), then the Immich-only detail — the description the user typed, who's in the
+   * shot, and its tags. Each is a step smaller and dimmer than the line above, so the block reads
+   * as one caption rather than five competing rows, and each hides itself when that photo has
+   * nothing for it. Hidden entirely until [setCaption] gets real metadata.
    */
   private fun buildCaption(spec: CaptionSpec) {
     val align = horizontalGravity(spec.position)
@@ -478,16 +490,26 @@ class FaceRenderer(
     col.orientation = LinearLayout.VERTICAL
     col.gravity = align
     col.visibility = View.GONE
-    val place = text(19f, Color.WHITE, false)
-    place.typeface = Typeface.DEFAULT_BOLD
-    place.maxLines = 1
-    place.ellipsize = TextUtils.TruncateAt.END
-    place.gravity = align
-    val date = text(14f, 0xCCFFFFFF.toInt(), true)
-    date.maxLines = 1
-    date.gravity = align
-    col.addView(place, LinearLayout.LayoutParams(WRAP, WRAP))
-    col.addView(date, LinearLayout.LayoutParams(WRAP, WRAP))
+
+    // A caption line: hidden until it has text, capped in width so a long description (or a photo
+    // full of named faces) wraps/ellipsizes instead of stretching the column across the frame.
+    fun line(sizeSp: Float, color: Int, lightFont: Boolean, maxLines: Int = 1): TextView {
+      val t = text(sizeSp, color, lightFont)
+      t.maxLines = maxLines
+      t.ellipsize = TextUtils.TruncateAt.END
+      t.gravity = align
+      t.maxWidth = dp(560)
+      t.visibility = View.GONE
+      col.addView(t, LinearLayout.LayoutParams(WRAP, WRAP))
+      return t
+    }
+
+    val place = line(19f, Color.WHITE, false).apply { typeface = Typeface.DEFAULT_BOLD }
+    val date = line(14f, 0xCCFFFFFF.toInt(), true)
+    val description = line(15f, 0xE6FFFFFF.toInt(), true, maxLines = 2)
+    val people = line(14f, 0xCCFFFFFF.toInt(), true)
+    val tags = line(13f, 0x99FFFFFF.toInt(), true)
+
     // Top margin gives breathing room from whatever sits above in the same cell (the now-playing
     // card). A GONE sibling contributes no space, so a lone caption isn't pushed off the bottom.
     bucket(spec.position)
@@ -495,29 +517,32 @@ class FaceRenderer(
     captionPanel = col
     captionPlace = place
     captionDate = date
+    captionDescription = description
+    captionPeople = people
+    captionTags = tags
   }
 
   /**
-   * Push the latest photo caption (main thread). A blank/absent place AND date hides it; otherwise
+   * Push the latest photo caption (main thread). A null/empty caption hides the block; otherwise
    * each line shows only when it has content. No-op when the caption isn't built (disabled, or a
    * full-bleed face).
    */
-  fun setCaption(place: String?, date: String?) {
+  fun setCaption(caption: PhotoCaption.Caption?) {
     val col = captionPanel ?: return
-    val p = place?.takeIf { it.isNotBlank() }
-    val d = date?.takeIf { it.isNotBlank() }
-    if (p == null && d == null) {
+    if (caption == null || caption.isEmpty) {
       col.visibility = View.GONE
       return
     }
-    captionPlace?.apply {
-      visibility = if (p == null) View.GONE else View.VISIBLE
-      text = p ?: ""
+    fun line(v: TextView?, s: String?) {
+      val t = s?.trim()?.ifBlank { null }
+      v?.visibility = if (t == null) View.GONE else View.VISIBLE
+      v?.text = t ?: ""
     }
-    captionDate?.apply {
-      visibility = if (d == null) View.GONE else View.VISIBLE
-      text = d ?: ""
-    }
+    line(captionPlace, caption.place)
+    line(captionDate, caption.date)
+    line(captionDescription, caption.description)
+    line(captionPeople, caption.people)
+    line(captionTags, caption.tags)
     col.visibility = View.VISIBLE
   }
 

--- a/app/src/main/java/com/immortal/launcher/ImmichSource.kt
+++ b/app/src/main/java/com/immortal/launcher/ImmichSource.kt
@@ -10,6 +10,9 @@ package com.immortal.launcher
 import android.util.Log
 import java.net.HttpURLConnection
 import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -29,6 +32,8 @@ import org.json.JSONObject
  *    through search — see #135.)
  *  - image bytes:   `GET  /api/assets/{id}/thumbnail?size=preview` → JPEG sized to the screen
  *  - video stream:  `GET  /api/assets/{id}/video/playback` → the (server-transcoded) clip
+ *  - one asset:     `GET  /api/assets/{id}` → `{localDateTime, exifInfo, people, tags}`, the
+ *    caption detail a re-encoded preview can't carry (see [details])
  *
  * Everything is best-effort: any failure returns null and the caller falls back to the default
  * feed, so the frame is never blank — but every failure is logged under [TAG], because a silent
@@ -40,8 +45,30 @@ object ImmichSource {
   /** A library album, for the connection picker. */
   data class Album(val id: String, val name: String, val count: Int)
 
-  /** One playable asset: a preview-image URL, or a video-playback URL when [isVideo]. */
-  data class Media(val url: String, val isVideo: Boolean)
+  /** One playable asset: its Immich id, plus a preview-image or video-playback URL. */
+  data class Media(val id: String, val url: String, val isVideo: Boolean)
+
+  /**
+   * What Immich knows about one photo that its re-encoded preview JPEG can't carry: when and
+   * where it was taken, the description the user typed on it, who Immich recognised in it, and
+   * the tags it's filed under. Every field is optional — an unnamed face or an untagged photo
+   * simply contributes nothing to the caption.
+   */
+  data class Details(
+      val dateMillis: Long? = null,
+      val description: String? = null,
+      val place: String? = null,
+      val people: List<String> = emptyList(),
+      val tags: List<String> = emptyList(),
+  ) {
+    val isEmpty: Boolean
+      get() =
+          dateMillis == null &&
+              description == null &&
+              place == null &&
+              people.isEmpty() &&
+              tags.isEmpty()
+  }
 
   /** Header(s) every Immich request (including image downloads) must carry. */
   fun authHeaders(apiKey: String): Map<String, String> = mapOf("x-api-key" to apiKey.trim())
@@ -101,11 +128,104 @@ object ImmichSource {
               Log.w(TAG, "search returned no assets (album=${albumId ?: "library"})")
             }
             assets.map { (id, isVideo) ->
-              Media(if (isVideo) playbackUrl(b, id) else previewUrl(b, id), isVideo)
+              Media(id, if (isVideo) playbackUrl(b, id) else previewUrl(b, id), isVideo)
             }
           }
           .onFailure { Log.w(TAG, "media list failed (album=${albumId ?: "library"})", it) }
           .getOrNull()
+
+  /**
+   * Everything the caption can show for one asset, from `GET /api/assets/{id}` — the single
+   * endpoint that carries `exifInfo`, `people` and `tags` together. (The search listing used by
+   * [listMedia] can be asked for some of these via `withExif`/`withPeople`, but which relations it
+   * actually returns has moved between Immich versions, and tags aren't among them; one small GET
+   * per displayed photo is both complete and version-proof.)
+   *
+   * Best-effort like the rest: null on any failure, so the photo simply shows uncaptioned.
+   */
+  fun details(base: String, apiKey: String, assetId: String): Details? =
+      runCatching {
+            val body =
+                httpGet("${normalizeBase(base)}/api/assets/$assetId", authHeaders(apiKey))
+                    ?: return null
+            parseDetails(body)
+          }
+          .onFailure { Log.w(TAG, "asset details failed ($assetId)", it) }
+          .getOrNull()
+
+  /** Pull the caption fields out of an Immich asset body. Pure, so it's unit-testable. */
+  internal fun parseDetails(body: String): Details {
+    val o = JSONObject(body)
+    val exif = o.optJSONObject("exifInfo")
+    return Details(
+        // `localDateTime` is the wall clock where the shot was taken, which is the day a photo
+        // frame should name; `dateTimeOriginal` carries the same digits with a separate offset.
+        // `fileCreatedAt` is a true UTC instant and is only a last resort (an import can set it
+        // long after the shutter fired).
+        dateMillis =
+            parseIso(stringOf(o, "localDateTime"))
+                ?: parseIso(stringOf(exif, "dateTimeOriginal"))
+                ?: parseIso(stringOf(o, "fileCreatedAt"), UTC),
+        description = stringOf(exif, "description"),
+        place = placeOf(exif),
+        people = namesOf(o.optJSONArray("people")),
+        tags = tagsOf(o.optJSONArray("tags")),
+    )
+  }
+
+  /** "City, Country" from an `exifInfo` block — the shape [PhotoCaption] already renders for EXIF. */
+  private fun placeOf(exif: JSONObject?): String? {
+    val primary = stringOf(exif, "city") ?: stringOf(exif, "state")
+    val country = stringOf(exif, "country")
+    return when {
+      primary != null && country != null -> "$primary, $country"
+      else -> primary ?: country
+    }
+  }
+
+  /** Named people only — a face Immich hasn't been given a name for has nothing to show. */
+  private fun namesOf(arr: JSONArray?): List<String> = fieldsOf(arr) { stringOf(it, "name") }
+
+  /**
+   * Tag labels. Immich nests tags, so `value` is the full path ("Holiday/Beach") and `name` the
+   * leaf; prefer the leaf, and derive it from the path on a server that only sends `value`.
+   */
+  private fun tagsOf(arr: JSONArray?): List<String> =
+      fieldsOf(arr) { t ->
+        stringOf(t, "name") ?: stringOf(t, "value")?.substringAfterLast('/')?.ifBlank { null }
+      }
+
+  private fun fieldsOf(arr: JSONArray?, pick: (JSONObject) -> String?): List<String> {
+    if (arr == null) return emptyList()
+    return (0 until arr.length()).mapNotNull { i -> arr.optJSONObject(i)?.let(pick) }.distinct()
+  }
+
+  /**
+   * A trimmed string field, or null when it's absent, blank, or an explicit JSON null — Immich
+   * sends nulls for the fields it has nothing for (no GPS → `city`/`country` null), and Android's
+   * `JSONObject.optString` hands those back as the literal text "null".
+   */
+  private fun stringOf(o: JSONObject?, key: String): String? =
+      o?.takeIf { !it.isNull(key) }?.optString(key)?.trim()?.ifBlank { null }
+
+  // Immich timestamps are ISO-8601 ("2026-06-22T18:11:12.000Z" / "...+02:00"). Only the calendar
+  // day ever reaches the caption, so we read the leading "yyyy-MM-dd'T'HH:mm:ss" and drop the
+  // fractional seconds and offset — in the device's own zone by default, which is what makes
+  // `localDateTime`'s digits land on the day the shutter fired. SimpleDateFormat isn't
+  // thread-safe (and this is shared by the caption threads), so every use is synchronized.
+  private val ISO = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
+  private val UTC: TimeZone = TimeZone.getTimeZone("UTC")
+
+  private fun parseIso(raw: String?, zone: TimeZone = TimeZone.getDefault()): Long? {
+    if (raw == null || raw.length < 19) return null
+    return runCatching {
+          synchronized(ISO) {
+            ISO.timeZone = zone
+            ISO.parse(raw.substring(0, 19))
+          }?.time
+        }
+        .getOrNull()
+  }
 
   /**
    * Asset (id, isVideo) pairs via the paged `POST /api/search/metadata` endpoint. When [albumId]

--- a/app/src/main/java/com/immortal/launcher/PhotoCaption.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoCaption.kt
@@ -17,16 +17,44 @@ import java.util.concurrent.ConcurrentHashMap
 import org.json.JSONObject
 
 /**
- * Photo metadata for the screensaver caption — the "taken at <place> · <date>" line,
- * tvOS-style. Read from EXIF, so it only exists for the user's *own* photos: the local
- * folder and SMB (NAS) sources, which decode real image files. The web/CDN sources
- * (Picsum/Unsplash, iCloud/Google shared albums, Immich) serve re-encoded images with
- * EXIF stripped, so there's nothing to show there and the caption is simply hidden.
+ * Photo metadata for the screensaver caption — the "taken at <place> · <date>" block,
+ * tvOS-style — plus the formatting of every line the frame draws ([Caption]).
+ *
+ * Two things can fill it in:
+ *  - **EXIF**, for the user's *own* photo files: the local folder and SMB (NAS) sources, which
+ *    decode real images. That yields the capture date and (reverse-geocoded) place.
+ *  - **Immich**, which is asked for each photo's stored detail directly
+ *    ([ImmichSource.details]) — date, description, place, people and tags. Its previews are
+ *    re-encoded with EXIF stripped, so the server is the only thing that knows them.
+ *
+ * The remaining web/CDN sources (Picsum/Unsplash, iCloud/Google shared albums, WebDAV) serve
+ * stripped images with no companion API, so there's nothing to show and the caption stays hidden.
  *
  * Everything is best-effort: a missing date, absent GPS, or a failed lookup just means
  * less (or no) caption — never a crash and never a blocked slideshow.
  */
 object PhotoCaption {
+
+  /**
+   * One photo's caption, as the frame will draw it: up to five short lines, any of which may be
+   * absent (the renderer hides an empty one). [place] and [date] can come from either source;
+   * [description], [people] and [tags] only ever come from Immich.
+   */
+  data class Caption(
+      val place: String? = null,
+      val date: String? = null,
+      val description: String? = null,
+      val people: String? = null,
+      val tags: String? = null,
+  ) {
+    val isEmpty: Boolean
+      get() =
+          place.isNullOrBlank() &&
+              date.isNullOrBlank() &&
+              description.isNullOrBlank() &&
+              people.isNullOrBlank() &&
+              tags.isNullOrBlank()
+  }
 
   /** Capture date (epoch millis) and GPS coordinates pulled from a photo's EXIF block. */
   data class Meta(val dateMillis: Long?, val lat: Double?, val lng: Double?) {
@@ -58,6 +86,39 @@ object PhotoCaption {
   /** Friendly capture date, e.g. "June 22, 2026" in the device locale. Null when absent. */
   fun formatDate(millis: Long?): String? =
       millis?.let { SimpleDateFormat("MMMM d, yyyy", Locale.getDefault()).format(Date(it)) }
+
+  // A caption line has to stay one row on a 1280px-wide Portal, and a well-tagged photo of a
+  // family gathering can carry a dozen of each — so both lists are capped and the remainder is
+  // summarised rather than truncated mid-name.
+  private const val MAX_PEOPLE = 4
+  private const val MAX_TAGS = 5
+
+  /**
+   * The people line: "Alice, Bob & Carol", or "Alice, Bob, Carol, Dave +3" past [MAX_PEOPLE].
+   * Null when nobody is named.
+   */
+  fun formatPeople(names: List<String>): String? {
+    val list = cleaned(names)
+    return when {
+      list.isEmpty() -> null
+      list.size > MAX_PEOPLE -> list.take(MAX_PEOPLE).joinToString(", ") + " +${list.size - MAX_PEOPLE}"
+      list.size == 1 -> list[0]
+      else -> list.dropLast(1).joinToString(", ") + " & " + list.last()
+    }
+  }
+
+  /** The tags line: "Beach · Sunset · Italy", with a "+n" tail past [MAX_TAGS]. Null when none. */
+  fun formatTags(names: List<String>): String? {
+    val list = cleaned(names)
+    if (list.isEmpty()) return null
+    val more = list.size - MAX_TAGS
+    val shown = list.take(MAX_TAGS) + (if (more > 0) listOf("+$more") else emptyList())
+    return shown.joinToString("  ·  ")
+  }
+
+  /** Trimmed, de-duplicated, blanks dropped — what both lines start from. */
+  private fun cleaned(names: List<String>): List<String> =
+      names.mapNotNull { it.trim().ifBlank { null } }.distinct()
 
   // --- reverse geocoding (keyless) -------------------------------------------
   // BigDataCloud's reverse-geocode-client endpoint needs no key — the same keyless-web-service

--- a/app/src/main/java/com/immortal/launcher/PhotoCaption.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoCaption.kt
@@ -36,25 +36,127 @@ import org.json.JSONObject
 object PhotoCaption {
 
   /**
-   * One photo's caption, as the frame will draw it: up to five short lines, any of which may be
-   * absent (the renderer hides an empty one). [place] and [date] can come from either source;
-   * [description], [people] and [tags] only ever come from Immich.
+   * The five things a caption can say about a photo. This is the identity the whole feature is
+   * keyed on: the user's chosen [order], the per-line [LineStyle], the settings toggles, and the
+   * icon each line draws all hang off it, so adding a sixth line is one entry here plus a
+   * drawable.
+   *
+   * The defaults reproduce the original two-line caption exactly — a bold place over a lighter
+   * date — with the Immich-only lines tucked underneath, each a step smaller.
    */
-  data class Caption(
-      val place: String? = null,
-      val date: String? = null,
-      val description: String? = null,
-      val people: String? = null,
-      val tags: String? = null,
+  enum class Line(
+      /** Stable key used in prefs and on the wire. Never rename — it's persisted. */
+      val key: String,
+      /** Label for the settings screen. */
+      val label: String,
+      /** The glyph drawn ahead of the text when icons are on. */
+      val iconRes: Int,
+      val defaultSize: Int,
+      val defaultWeight: Weight,
   ) {
-    val isEmpty: Boolean
-      get() =
-          place.isNullOrBlank() &&
-              date.isNullOrBlank() &&
-              description.isNullOrBlank() &&
-              people.isNullOrBlank() &&
-              tags.isNullOrBlank()
+    LOCATION("location", "Location", R.drawable.ic_caption_location, 95, Weight.BOLD),
+    DATE("date", "Photo date", R.drawable.ic_caption_date, 70, Weight.LIGHT),
+    DESCRIPTION("description", "Description", R.drawable.ic_caption_description, 75, Weight.LIGHT),
+    PEOPLE("people", "People", R.drawable.ic_caption_people, 70, Weight.LIGHT),
+    TAGS("tags", "Tags", R.drawable.ic_caption_tags, 65, Weight.LIGHT);
+
+    val defaultStyle: LineStyle
+      get() = LineStyle(defaultSize, defaultWeight)
+
+    companion object {
+      fun fromKey(key: String?): Line? = entries.firstOrNull { it.key == key?.trim() }
+    }
   }
+
+  /**
+   * How heavy a line's type is. Rendered from the *face's own font* (see
+   * [FaceStyle.typeface]) rather than a face of its own, so the caption reads as part of the same
+   * overlay as the clock, date and weather: [LIGHT] takes the face's light variant, [BOLD] bolds
+   * the face's regular one.
+   */
+  enum class Weight(val key: String, val label: String) {
+    LIGHT("light", "Light"),
+    REGULAR("regular", "Regular"),
+    BOLD("bold", "Bold");
+
+    companion object {
+      fun fromKey(key: String?): Weight? = entries.firstOrNull { it.key == key?.trim() }
+    }
+  }
+
+  /** How one line is drawn: [size] as a percentage of the caption base size, plus its [weight]. */
+  data class LineStyle(val size: Int, val weight: Weight) {
+    companion object {
+      const val MIN_SIZE = 50
+      const val MAX_SIZE = 200
+      const val SIZE_STEP = 5
+    }
+  }
+
+  /** Keep a line size inside the range the settings stepper offers. */
+  fun clampSize(size: Int): Int = size.coerceIn(LineStyle.MIN_SIZE, LineStyle.MAX_SIZE)
+
+  /**
+   * One photo's caption: the text for each line that has something to say, in no particular
+   * order — the *drawing* order is the user's ([parseOrder]), not this map's.
+   */
+  data class Caption(val lines: Map<Line, String>) {
+    val isEmpty: Boolean
+      get() = lines.isEmpty()
+
+    operator fun get(line: Line): String? = lines[line]
+
+    companion object {
+      val EMPTY = Caption(emptyMap())
+
+      /**
+       * Build a caption from whatever the source could supply. Blank and null values are dropped
+       * here, once, so neither the controller nor the renderer has to keep re-checking them.
+       */
+      fun of(vararg values: Pair<Line, String?>): Caption =
+          Caption(
+              values
+                  .mapNotNull { (line, v) -> v?.trim()?.ifBlank { null }?.let { line to it } }
+                  .toMap())
+    }
+  }
+
+  // --- order and per-line style (persisted as compact strings) -----------------
+  // Both are stored as one string each rather than ten scalar prefs: they're a single editable
+  // unit owned by one screen (CaptionStyleActivity), the way the photo-source credentials are.
+  // Parsing is total — an unknown key, a missing line or outright garbage degrades to the
+  // defaults rather than losing the caption, because a bad string must never blank the frame.
+
+  /** The default top-to-bottom order, as declared in [Line]. */
+  val DEFAULT_ORDER: List<Line> = Line.entries.toList()
+
+  /** `"location,date,…"` → lines, de-duplicated, with anything missing appended in default order. */
+  fun parseOrder(raw: String?): List<Line> {
+    val named = raw.orEmpty().split(',').mapNotNull { Line.fromKey(it) }.distinct()
+    return named + DEFAULT_ORDER.filterNot { it in named }
+  }
+
+  fun serializeOrder(order: List<Line>): String = order.joinToString(",") { it.key }
+
+  /** `"location:95:bold,date:70:light,…"` → per-line style, falling back to each line's default. */
+  fun parseStyles(raw: String?): Map<Line, LineStyle> {
+    val out = LinkedHashMap<Line, LineStyle>()
+    Line.entries.forEach { out[it] = it.defaultStyle }
+    raw.orEmpty().split(',').forEach { part ->
+      val bits = part.split(':')
+      val line = Line.fromKey(bits.getOrNull(0)) ?: return@forEach
+      val size = bits.getOrNull(1)?.trim()?.toIntOrNull()?.let(::clampSize) ?: line.defaultSize
+      val weight = Weight.fromKey(bits.getOrNull(2)) ?: line.defaultWeight
+      out[line] = LineStyle(size, weight)
+    }
+    return out
+  }
+
+  fun serializeStyles(styles: Map<Line, LineStyle>): String =
+      Line.entries.joinToString(",") { line ->
+        val st = styles[line] ?: line.defaultStyle
+        "${line.key}:${st.size}:${st.weight.key}"
+      }
 
   /** Capture date (epoch millis) and GPS coordinates pulled from a photo's EXIF block. */
   data class Meta(val dateMillis: Long?, val lat: Double?, val lng: Double?) {

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -619,7 +619,11 @@ class PhotoFrameController(
         if (meta.hasLocation && settings.captionLocation) PhotoCaption.placeName(meta.lat!!, meta.lng!!)
         else null
     val date = if (settings.captionDate) PhotoCaption.formatDate(meta.dateMillis) else null
-    val caption = PhotoCaption.Caption(place = place, date = date)
+    val caption =
+        PhotoCaption.Caption.of(
+            PhotoCaption.Line.LOCATION to place,
+            PhotoCaption.Line.DATE to date,
+        )
     ui.post { if (g == gen) faceRenderer.setCaption(caption) }
   }
 
@@ -646,14 +650,21 @@ class PhotoFrameController(
     }
   }
 
-  /** An Immich asset's detail, narrowed to the lines the user has left switched on. */
+  /**
+   * An Immich asset's detail, narrowed to the lines the user has left switched on. Which order
+   * they're drawn in, and at what size and weight, is the renderer's business (and the user's) —
+   * this only decides what there is to say.
+   */
   private fun captionFor(d: ImmichSource.Details): PhotoCaption.Caption =
-      PhotoCaption.Caption(
-          place = d.place.takeIf { settings.captionLocation },
-          date = if (settings.captionDate) PhotoCaption.formatDate(d.dateMillis) else null,
-          description = d.description.takeIf { settings.captionDescription },
-          people = if (settings.captionPeople) PhotoCaption.formatPeople(d.people) else null,
-          tags = if (settings.captionTags) PhotoCaption.formatTags(d.tags) else null,
+      PhotoCaption.Caption.of(
+          PhotoCaption.Line.LOCATION to d.place.takeIf { settings.captionLocation },
+          PhotoCaption.Line.DATE to
+              (if (settings.captionDate) PhotoCaption.formatDate(d.dateMillis) else null),
+          PhotoCaption.Line.DESCRIPTION to d.description.takeIf { settings.captionDescription },
+          PhotoCaption.Line.PEOPLE to
+              (if (settings.captionPeople) PhotoCaption.formatPeople(d.people) else null),
+          PhotoCaption.Line.TAGS to
+              (if (settings.captionTags) PhotoCaption.formatTags(d.tags) else null),
       )
 
   /** A clean upcoming-events panel top-right, over the photo. Its own translucent

--- a/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
+++ b/app/src/main/java/com/immortal/launcher/PhotoFrameController.kt
@@ -39,6 +39,7 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import kotlin.math.abs
 import org.json.JSONArray
@@ -110,9 +111,11 @@ class PhotoFrameController(
   private var kenBurns: AnimatorSet? = null
   private var kenBurnsStyle = 0
 
-  // The "place · date" caption is now a FaceRenderer grid element (so it stacks with the
-  // now-playing card instead of overlapping it). This controller still reads the EXIF here
-  // (own photos only — local folder / SMB) and pushes it via [FaceRenderer.setCaption].
+  // The photo caption is a FaceRenderer grid element (so it stacks with the now-playing card
+  // instead of overlapping it). This controller still gathers the metadata: EXIF for the user's
+  // own files (local folder / SMB), and a per-asset server lookup for Immich, which knows the
+  // description, people and tags on top of the date and place. Pushed via
+  // [FaceRenderer.setCaption]; see [publishCaption] / [loadCaptionForImmich].
 
   // The overlay (clock / date / weather / battery / now-playing) is built and driven by the
   // FaceRenderer from a Face descriptor; this controller owns only the photo/video layer.
@@ -183,6 +186,13 @@ class PhotoFrameController(
   // public shares, the x-api-key for Immich. Applied in [advanceRemote]/[downloadBitmap]/
   // [showRemoteVideo].
   private var remoteHeaders: Map<String, String> = emptyMap()
+  // Immich captions: the asset id behind each remote URL, so a displayed photo can be traced back
+  // to the server and asked for its stored detail (date / description / place / people / tags).
+  // Non-empty exactly while Immich is the live source. The fetched detail is cached for the
+  // session — a frame loops the same album for days and a photo's detail doesn't change under it,
+  // so each asset is asked for once. Bounded by the listing cap (1000 assets of short strings).
+  private var immichAssetIds: Map<String, String> = emptyMap()
+  private val immichDetails = ConcurrentHashMap<String, ImmichSource.Details>()
   // The subset of [remoteUrls] that are videos (Immich with "Play videos" on); these stream
   // through the VideoView instead of the bitmap download. See [showRemoteVideo].
   private var remoteVideos: Set<String> = emptySet()
@@ -387,6 +397,7 @@ class PhotoFrameController(
               val ordered = if (source.shuffle) media.shuffled() else media
               remoteUrls = ordered.map { it.url }
               remoteVideos = media.filter { it.isVideo }.mapTo(HashSet()) { it.url }
+              immichAssetIds = ordered.associate { it.url to it.id }
               remoteHeaders = ImmichSource.authHeaders(source.key)
               remoteMode = true
               remoteIndex = -1
@@ -599,14 +610,51 @@ class PhotoFrameController(
 
   private fun publishCaption(meta: PhotoCaption.Meta?, g: Int) {
     if (meta == null || meta.isEmpty) {
-      ui.post { if (g == gen) faceRenderer.setCaption(null, null) }
+      ui.post { if (g == gen) faceRenderer.setCaption(null) }
       return
     }
-    // Resolve the place name on this background thread (network) before touching the UI.
-    val place = if (meta.hasLocation) PhotoCaption.placeName(meta.lat!!, meta.lng!!) else null
-    val date = PhotoCaption.formatDate(meta.dateMillis)
-    ui.post { if (g == gen) faceRenderer.setCaption(place, date) }
+    // Resolve the place name on this background thread (network) before touching the UI. Both
+    // lines honour the user's switches; with both off there's nothing left and the block hides.
+    val place =
+        if (meta.hasLocation && settings.captionLocation) PhotoCaption.placeName(meta.lat!!, meta.lng!!)
+        else null
+    val date = if (settings.captionDate) PhotoCaption.formatDate(meta.dateMillis) else null
+    val caption = PhotoCaption.Caption(place = place, date = date)
+    ui.post { if (g == gen) faceRenderer.setCaption(caption) }
   }
+
+  /**
+   * Ask Immich for the displayed photo's stored detail off [metaIo] and publish it as the caption
+   * — date, description, place, people and tags, none of which survive into the preview JPEG the
+   * frame actually draws. Guarded by [gen] like the EXIF paths, so a slow fetch for a superseded
+   * photo is dropped, and served from [immichDetails] on every loop after the first.
+   */
+  private fun loadCaptionForImmich(url: String, g: Int) {
+    val assetId = immichAssetIds[url]
+    val base = settings.immichUrl
+    val key = settings.immichKey
+    if (assetId == null || base.isNullOrBlank() || key.isNullOrBlank()) {
+      faceRenderer.setCaption(null)
+      return
+    }
+    metaIo.execute {
+      val details =
+          immichDetails[assetId]
+              ?: ImmichSource.details(base, key, assetId)?.also { immichDetails[assetId] = it }
+      val caption = details?.takeIf { !it.isEmpty }?.let { captionFor(it) }
+      ui.post { if (g == gen) faceRenderer.setCaption(caption) }
+    }
+  }
+
+  /** An Immich asset's detail, narrowed to the lines the user has left switched on. */
+  private fun captionFor(d: ImmichSource.Details): PhotoCaption.Caption =
+      PhotoCaption.Caption(
+          place = d.place.takeIf { settings.captionLocation },
+          date = if (settings.captionDate) PhotoCaption.formatDate(d.dateMillis) else null,
+          description = d.description.takeIf { settings.captionDescription },
+          people = if (settings.captionPeople) PhotoCaption.formatPeople(d.people) else null,
+          tags = if (settings.captionTags) PhotoCaption.formatTags(d.tags) else null,
+      )
 
   /** A clean upcoming-events panel top-right, over the photo. Its own translucent
    *  rounded backing keeps it legible without a full-screen scrim. Hidden until a
@@ -1241,7 +1289,7 @@ class PhotoFrameController(
 
   private fun showVideo(path: String, g: Int) {
     cancelKenBurns()
-    faceRenderer.setCaption(null, null)
+    faceRenderer.setCaption(null)
     photo.setImageDrawable(null)
     photo.visibility = View.GONE
     blurPhoto.setImageDrawable(null)
@@ -1361,9 +1409,14 @@ class PhotoFrameController(
         remoteReresolveStreak = 0
         photo.visibility = View.VISIBLE
         show(bmp)
-        // EXIF caption only for SMB here — it reads the user's own files. The HTTP remote sources
-        // (iCloud/Google/Immich/DAV) serve EXIF-stripped images, so they carry no caption.
-        if (smbSource != null) loadCaptionForSmb(url, g) else faceRenderer.setCaption(null, null)
+        // Captions on the remote path: SMB reads EXIF straight off the user's own files, and
+        // Immich is asked for the detail it stores server-side. The rest (iCloud/Google/DAV)
+        // serve EXIF-stripped images with no metadata API, so they carry no caption.
+        when {
+          smbSource != null -> loadCaptionForSmb(url, g)
+          immichAssetIds.isNotEmpty() -> loadCaptionForImmich(url, g)
+          else -> faceRenderer.setCaption(null)
+        }
         ui.postDelayed(remoteTick, intervalMs())
       }
     }
@@ -1394,7 +1447,7 @@ class PhotoFrameController(
       }
     }
     cancelKenBurns()
-    faceRenderer.setCaption(null, null)
+    faceRenderer.setCaption(null)
     photo.setImageDrawable(null)
     photo.visibility = View.GONE
     blurPhoto.setImageDrawable(null)
@@ -1484,6 +1537,7 @@ class PhotoFrameController(
     remoteMode = false
     remoteHeaders = emptyMap()
     remoteVideos = emptySet()
+    immichAssetIds = emptyMap()
     remoteFetch = null
     smbSource?.let { s -> io.execute { runCatching { s.close() } } }
     smbSource = null
@@ -1583,7 +1637,7 @@ class PhotoFrameController(
   }
 
   private fun show(bmp: Bitmap) {
-    faceRenderer.setCaption(null, null)
+    faceRenderer.setCaption(null)
 
     val targetLayer = incomingLayer
     val outgoingLayer = currentLayer

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -168,6 +168,13 @@ object ScreensaverConfig {
       val captionDescription: Boolean = true,
       val captionTags: Boolean = true,
       val captionPeople: Boolean = true,
+      // Draw a small glyph ahead of each caption line (pin / calendar / note / people / tag).
+      val captionIcons: Boolean = true,
+      // The caption's layout, owned by CaptionStyleActivity and stored as two compact strings
+      // (see PhotoCaption.parseOrder / parseStyles): the top-to-bottom line order, and each
+      // line's size-percentage + weight. Blank = every line at its default.
+      val captionOrder: String = "",
+      val captionStyles: String = "",
       // Whether to draw a clock face at all. Off = photos only (the now-playing card still follows
       // its own [showNowPlaying] switch). On by default.
       val facesEnabled: Boolean = true,
@@ -310,6 +317,9 @@ object ScreensaverConfig {
         captionDescription = p.getBoolean("caption_description", true),
         captionTags = p.getBoolean("caption_tags", true),
         captionPeople = p.getBoolean("caption_people", true),
+        captionIcons = p.getBoolean("caption_icons", true),
+        captionOrder = p.getString("caption_order", "") ?: "",
+        captionStyles = p.getString("caption_styles", "") ?: "",
         facesEnabled = p.getBoolean("faces_enabled", true),
         faceId = p.getString("face_id", "immortal-classic") ?: "immortal-classic",
         faceSizeIndex = p.getInt("face_size_index", 1),
@@ -351,6 +361,21 @@ object ScreensaverConfig {
 
   fun setCaptionPeople(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("caption_people", on).apply()
+
+  fun setCaptionIcons(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("caption_icons", on).apply()
+
+  /** Persist the caption's top-to-bottom line order (see [PhotoCaption.serializeOrder]). */
+  fun setCaptionOrder(c: Context, order: List<PhotoCaption.Line>) =
+      prefs(c).edit().putString("caption_order", PhotoCaption.serializeOrder(order)).apply()
+
+  /** Persist every line's size + weight (see [PhotoCaption.serializeStyles]). */
+  fun setCaptionStyles(c: Context, styles: Map<PhotoCaption.Line, PhotoCaption.LineStyle>) =
+      prefs(c).edit().putString("caption_styles", PhotoCaption.serializeStyles(styles)).apply()
+
+  /** Drop every caption layout tweak — order, sizes and weights all back to the defaults. */
+  fun resetCaptionLayout(c: Context) =
+      prefs(c).edit().remove("caption_order").remove("caption_styles").apply()
 
   fun setCropVertical(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("crop_vertical", on).apply()

--- a/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
+++ b/app/src/main/java/com/immortal/launcher/ScreensaverConfig.kt
@@ -159,6 +159,15 @@ object ScreensaverConfig {
       // The legibility gradient under the bottom widget cluster. On by default (the original
       // frame look); off shows the photo clean edge-to-edge (issue #144).
       val showGradient: Boolean = true,
+      // Which lines the photo caption may show (see [PhotoCaption]). Date and location come from
+      // EXIF for your own files (folder / SMB) and from the server for Immich; description, tags
+      // and people are Immich-only, because it's the only source that knows them. All on by
+      // default — a photo with nothing to say still shows no caption.
+      val captionDate: Boolean = true,
+      val captionLocation: Boolean = true,
+      val captionDescription: Boolean = true,
+      val captionTags: Boolean = true,
+      val captionPeople: Boolean = true,
       // Whether to draw a clock face at all. Off = photos only (the now-playing card still follows
       // its own [showNowPlaying] switch). On by default.
       val facesEnabled: Boolean = true,
@@ -296,6 +305,11 @@ object ScreensaverConfig {
         showNowPlaying = p.getBoolean("show_now_playing", true),
         antiBurnIn = p.getBoolean("anti_burn_in", true),
         showGradient = p.getBoolean("show_gradient", true),
+        captionDate = p.getBoolean("caption_date", true),
+        captionLocation = p.getBoolean("caption_location", true),
+        captionDescription = p.getBoolean("caption_description", true),
+        captionTags = p.getBoolean("caption_tags", true),
+        captionPeople = p.getBoolean("caption_people", true),
         facesEnabled = p.getBoolean("faces_enabled", true),
         faceId = p.getString("face_id", "immortal-classic") ?: "immortal-classic",
         faceSizeIndex = p.getInt("face_size_index", 1),
@@ -322,6 +336,21 @@ object ScreensaverConfig {
         blurBackground = p.getBoolean("blur_background", true),
     )
   }
+
+  fun setCaptionDate(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("caption_date", on).apply()
+
+  fun setCaptionLocation(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("caption_location", on).apply()
+
+  fun setCaptionDescription(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("caption_description", on).apply()
+
+  fun setCaptionTags(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("caption_tags", on).apply()
+
+  fun setCaptionPeople(c: Context, on: Boolean) =
+      prefs(c).edit().putBoolean("caption_people", on).apply()
 
   fun setCropVertical(c: Context, on: Boolean) =
       prefs(c).edit().putBoolean("crop_vertical", on).apply()

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -10,6 +10,7 @@ package com.immortal.launcher.settings
 import android.content.Context
 import com.immortal.launcher.CalendarFeed
 import com.immortal.launcher.CalendarUrlEntryActivity
+import com.immortal.launcher.CaptionStyleActivity
 import com.immortal.launcher.SunriseConfig
 import com.immortal.launcher.SunriseScheduler
 import com.immortal.launcher.ChimeConfig
@@ -23,6 +24,7 @@ import com.immortal.launcher.FleetCalendar
 import com.immortal.launcher.FleetConfig
 import com.immortal.launcher.FleetScreensaver
 import com.immortal.launcher.FrameMode
+import com.immortal.launcher.PhotoCaption
 import com.immortal.launcher.PhotoFramePreviewActivity
 import com.immortal.launcher.PortalPresenceDetector
 import com.immortal.launcher.ScreensaverDismiss
@@ -163,6 +165,28 @@ object SettingsDomains {
         s.usesFolder -> "Local folder"
         else -> "Immortal photos"
       }
+
+  /**
+   * The caption-layout row's summary: the lines currently switched on, in the order they'll be
+   * drawn, so the row says what the caption will look like without opening the editor.
+   */
+  private fun captionLayoutLabel(s: ScreensaverConfig.Settings): String {
+    val on =
+        PhotoCaption.parseOrder(s.captionOrder).filter { line ->
+          when (line) {
+            PhotoCaption.Line.LOCATION -> s.captionLocation
+            PhotoCaption.Line.DATE -> s.captionDate
+            PhotoCaption.Line.DESCRIPTION -> s.captionDescription
+            PhotoCaption.Line.PEOPLE -> s.captionPeople
+            PhotoCaption.Line.TAGS -> s.captionTags
+          }
+        }
+    return when {
+      on.isEmpty() -> "No caption"
+      on.size <= 2 -> on.joinToString(", ") { it.label }
+      else -> on.take(2).joinToString(", ") { it.label } + " +${on.size - 2}"
+    }
+  }
 
   /**
    * The photo-frame display settings — the slice the legacy `FleetScreensaver.toJson` reports.
@@ -308,6 +332,26 @@ object SettingsDomains {
                       set = ScreensaverConfig::setCaptionTags,
                       help = "Show the tags the photo is filed under in Immich.",
                       visible = { _, s -> s.usesImmich }),
+                  BoolSpec(
+                      "captionIcons",
+                      "Show icons",
+                      get = { it.captionIcons },
+                      set = ScreensaverConfig::setCaptionIcons,
+                      help = "Put a small glyph in front of each line - a pin, a calendar, a tag.",
+                      visible = { _, s -> s.usesImmich || s.usesFolder || s.usesSmb }),
+                  // Order and per-line size/weight are a permutation plus ten coupled values -
+                  // not scalars a generic row can express - so they get their own editor, the way
+                  // the clock face does. The switches above stay specs so the phone remote keeps
+                  // the coarse control.
+                  NavSpec(
+                      "captionLayout",
+                      "Caption layout",
+                      value = { _, s -> captionLayoutLabel(s) },
+                      activity = CaptionStyleActivity::class.java,
+                      help =
+                          "Reorder the caption's lines and set how big and bold each one is. Text " +
+                              "follows your clock face's font and colour.",
+                      visible = { _, s -> s.usesImmich || s.usesFolder || s.usesSmb }),
                   // On-device cache: only meaningful for a network source that re-fetches the same
                   // assets every loop (Immich / WebDAV). Hidden for a local folder or the built-in
                   // feed, where there's nothing to save a round-trip on.
@@ -513,6 +557,8 @@ object SettingsDomains {
                   "captionDescription" to "Photo details",
                   "captionPeople" to "Photo details",
                   "captionTags" to "Photo details",
+                  "captionIcons" to "Photo details",
+                  "captionLayout" to "Photo details",
                   "batterySaver" to "Power & sleep",
                   "presenceMode" to "Power & sleep",
                   "idleSleepMin" to "Power & sleep",

--- a/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
+++ b/app/src/main/java/com/immortal/launcher/settings/SettingsDomains.kt
@@ -270,6 +270,44 @@ object SettingsDomains {
                       get = { it.blurBackground },
                       set = ScreensaverConfig::setBlurBackground,
                       help = "Fills letterbox sidebars in fit mode with a blurred copy of the photo instead of solid black."),
+                  // Photo caption lines. Date + location are available wherever the photo carries
+                  // them — your own files (EXIF) and Immich (the server knows); description, tags
+                  // and people only exist on Immich, so those three gate on it.
+                  BoolSpec(
+                      "captionDate",
+                      "Photo date",
+                      get = { it.captionDate },
+                      set = ScreensaverConfig::setCaptionDate,
+                      help = "Show when the photo was taken, under the place name.",
+                      visible = { _, s -> s.usesImmich || s.usesFolder || s.usesSmb }),
+                  BoolSpec(
+                      "captionLocation",
+                      "Location",
+                      get = { it.captionLocation },
+                      set = ScreensaverConfig::setCaptionLocation,
+                      help = "Show where the photo was taken, e.g. \"Arezzo, Italy\".",
+                      visible = { _, s -> s.usesImmich || s.usesFolder || s.usesSmb }),
+                  BoolSpec(
+                      "captionDescription",
+                      "Description",
+                      get = { it.captionDescription },
+                      set = ScreensaverConfig::setCaptionDescription,
+                      help = "Show the description you typed on the photo in Immich.",
+                      visible = { _, s -> s.usesImmich }),
+                  BoolSpec(
+                      "captionPeople",
+                      "People",
+                      get = { it.captionPeople },
+                      set = ScreensaverConfig::setCaptionPeople,
+                      help = "Show the names of the people Immich recognised in the photo.",
+                      visible = { _, s -> s.usesImmich }),
+                  BoolSpec(
+                      "captionTags",
+                      "Tags",
+                      get = { it.captionTags },
+                      set = ScreensaverConfig::setCaptionTags,
+                      help = "Show the tags the photo is filed under in Immich.",
+                      visible = { _, s -> s.usesImmich }),
                   // On-device cache: only meaningful for a network source that re-fetches the same
                   // assets every loop (Immich / WebDAV). Hidden for a local folder or the built-in
                   // feed, where there's nothing to save a round-trip on.
@@ -470,6 +508,11 @@ object SettingsDomains {
                   "ambientDashboard" to "Display",
                   "gestureWave" to "Display",
                   "welcomeEnabled" to "Display",
+                  "captionDate" to "Photo details",
+                  "captionLocation" to "Photo details",
+                  "captionDescription" to "Photo details",
+                  "captionPeople" to "Photo details",
+                  "captionTags" to "Photo details",
                   "batterySaver" to "Power & sleep",
                   "presenceMode" to "Power & sleep",
                   "idleSleepMin" to "Power & sleep",

--- a/app/src/main/res/drawable/ic_caption_date.xml
+++ b/app/src/main/res/drawable/ic_caption_date.xml
@@ -1,0 +1,16 @@
+<!-- Copyright (c) 2026 Starbright Lab.
+     This source code is licensed under the MIT license found in the
+     LICENSE file in the root directory of this source tree. -->
+<!-- Photo-caption glyph: a wall calendar (body, header rule, two hangers). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeColor="#FFFFFFFF"
+      android:strokeWidth="2"
+      android:strokeLineJoin="round"
+      android:strokeLineCap="round"
+      android:pathData="M4.5,6.5 L19.5,6.5 L19.5,20 L4.5,20 Z M4.5,10.5 L19.5,10.5 M8.5,3.5 L8.5,7.5 M15.5,3.5 L15.5,7.5" />
+</vector>

--- a/app/src/main/res/drawable/ic_caption_description.xml
+++ b/app/src/main/res/drawable/ic_caption_description.xml
@@ -1,0 +1,15 @@
+<!-- Copyright (c) 2026 Starbright Lab.
+     This source code is licensed under the MIT license found in the
+     LICENSE file in the root directory of this source tree. -->
+<!-- Photo-caption glyph: lines of text, the last one short (a written note). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeColor="#FFFFFFFF"
+      android:strokeWidth="2"
+      android:strokeLineCap="round"
+      android:pathData="M4,7.5 L20,7.5 M4,12 L20,12 M4,16.5 L13,16.5" />
+</vector>

--- a/app/src/main/res/drawable/ic_caption_location.xml
+++ b/app/src/main/res/drawable/ic_caption_location.xml
@@ -1,0 +1,18 @@
+<!-- Copyright (c) 2026 Starbright Lab.
+     This source code is licensed under the MIT license found in the
+     LICENSE file in the root directory of this source tree. -->
+<!-- Photo-caption glyph: a map pin (teardrop outline with a solid centre). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeColor="#FFFFFFFF"
+      android:strokeWidth="2"
+      android:strokeLineJoin="round"
+      android:pathData="M12,21.5 C12,21.5 19,14.5 19,9.5 C19,5.63 15.87,2.5 12,2.5 C8.13,2.5 5,5.63 5,9.5 C5,14.5 12,21.5 12,21.5 Z" />
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M12,7 C13.38,7 14.5,8.12 14.5,9.5 C14.5,10.88 13.38,12 12,12 C10.62,12 9.5,10.88 9.5,9.5 C9.5,8.12 10.62,7 12,7 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_caption_people.xml
+++ b/app/src/main/res/drawable/ic_caption_people.xml
@@ -1,0 +1,21 @@
+<!-- Copyright (c) 2026 Starbright Lab.
+     This source code is licensed under the MIT license found in the
+     LICENSE file in the root directory of this source tree. -->
+<!-- Photo-caption glyph: two people (head + shoulders, one behind). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeColor="#FFFFFFFF"
+      android:strokeWidth="2"
+      android:strokeLineJoin="round"
+      android:strokeLineCap="round"
+      android:pathData="M9,4.5 C10.93,4.5 12.5,6.07 12.5,8 C12.5,9.93 10.93,11.5 9,11.5 C7.07,11.5 5.5,9.93 5.5,8 C5.5,6.07 7.07,4.5 9,4.5 Z M2.5,20 C2.5,16.41 5.41,13.5 9,13.5 C12.59,13.5 15.5,16.41 15.5,20" />
+  <path
+      android:strokeColor="#FFFFFFFF"
+      android:strokeWidth="2"
+      android:strokeLineCap="round"
+      android:pathData="M16,5.4 C17.49,6.02 18.5,7.49 18.5,9.15 C18.5,10.4 17.93,11.55 17,12.3 M17.5,14.4 C19.86,15.13 21.5,17.34 21.5,20" />
+</vector>

--- a/app/src/main/res/drawable/ic_caption_tags.xml
+++ b/app/src/main/res/drawable/ic_caption_tags.xml
@@ -1,0 +1,18 @@
+<!-- Copyright (c) 2026 Starbright Lab.
+     This source code is licensed under the MIT license found in the
+     LICENSE file in the root directory of this source tree. -->
+<!-- Photo-caption glyph: a luggage-style tag with its eyelet. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeColor="#FFFFFFFF"
+      android:strokeWidth="2"
+      android:strokeLineJoin="round"
+      android:pathData="M3.5,3.5 L11,3.5 L20.5,13 L13,20.5 L3.5,11 Z" />
+  <path
+      android:fillColor="#FFFFFFFF"
+      android:pathData="M7,5.6 C7.77,5.6 8.4,6.23 8.4,7 C8.4,7.77 7.77,8.4 7,8.4 C6.23,8.4 5.6,7.77 5.6,7 C5.6,6.23 6.23,5.6 7,5.6 Z" />
+</vector>

--- a/app/src/test/java/com/immortal/launcher/ImmichSourceTest.kt
+++ b/app/src/test/java/com/immortal/launcher/ImmichSourceTest.kt
@@ -7,7 +7,13 @@
 
 package com.immortal.launcher
 
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ImmichSourceTest {
@@ -37,4 +43,97 @@ class ImmichSourceTest {
   fun authHeaders_carryTrimmedApiKey() {
     assertEquals(mapOf("x-api-key" to "secret"), ImmichSource.authHeaders(" secret "))
   }
+
+  // --- asset detail (the screensaver caption) ---------------------------------
+
+  @Test
+  fun parseDetails_readsDateDescriptionPlacePeopleAndTags() {
+    val d =
+        ImmichSource.parseDetails(
+            """
+            {
+              "id": "abc",
+              "type": "IMAGE",
+              "localDateTime": "2026-06-22T18:11:12.000Z",
+              "fileCreatedAt": "2026-06-22T16:11:12.000Z",
+              "exifInfo": {
+                "dateTimeOriginal": "2026-06-22T18:11:12.000+02:00",
+                "description": "  Summer trip to Tuscany  ",
+                "city": "Arezzo",
+                "state": "Tuscany",
+                "country": "Italy"
+              },
+              "people": [{"name": "Alice"}, {"name": ""}, {"name": "Bob"}, {"name": "Alice"}],
+              "tags": [
+                {"name": "Beach", "value": "Holiday/Beach"},
+                {"value": "Holiday/Sunset"}
+              ]
+            }
+            """)
+    assertEquals("Summer trip to Tuscany", d.description)
+    assertEquals("Arezzo, Italy", d.place)
+    // Unnamed faces are dropped and duplicates collapse; tags fall back to the path's leaf.
+    assertEquals(listOf("Alice", "Bob"), d.people)
+    assertEquals(listOf("Beach", "Sunset"), d.tags)
+    // `localDateTime` wins, and its digits are the wall clock — never shifted by the device zone.
+    assertEquals(localMillis("2026-06-22 18:11:12"), d.dateMillis)
+    assertFalse(d.isEmpty)
+  }
+
+  @Test
+  fun parseDetails_fallsBackFromLocalDateTimeToExifThenTheUtcFileTimestamp() {
+    assertEquals(
+        localMillis("2026-06-22 18:11:12"),
+        ImmichSource.parseDetails("""{"exifInfo":{"dateTimeOriginal":"2026-06-22T18:11:12.000+02:00"}}""")
+            .dateMillis)
+    // fileCreatedAt is a true UTC instant, so it is read as one.
+    assertEquals(
+        utcMillis("2026-01-02 03:04:05"),
+        ImmichSource.parseDetails("""{"fileCreatedAt":"2026-01-02T03:04:05.000Z"}""").dateMillis)
+  }
+
+  @Test
+  fun parseDetails_placeFallsBackToStateThenCountry() {
+    assertEquals(
+        "Tuscany, Italy",
+        ImmichSource.parseDetails("""{"exifInfo":{"state":"Tuscany","country":"Italy"}}""").place)
+    assertEquals("France", ImmichSource.parseDetails("""{"exifInfo":{"country":"France"}}""").place)
+    assertNull(ImmichSource.parseDetails("""{"exifInfo":{}}""").place)
+  }
+
+  @Test
+  fun parseDetails_treatsJsonNullsAndBlanksAsNothingToShow() {
+    // What Immich actually sends for a photo with no GPS, no description and nobody tagged.
+    val d =
+        ImmichSource.parseDetails(
+            """
+            {
+              "localDateTime": null,
+              "exifInfo": {"description": "", "city": null, "state": null, "country": null},
+              "people": [],
+              "tags": []
+            }
+            """)
+    assertNull(d.description)
+    assertNull(d.place)
+    assertNull(d.dateMillis)
+    assertTrue(d.people.isEmpty())
+    assertTrue(d.tags.isEmpty())
+    assertTrue(d.isEmpty)
+  }
+
+  @Test
+  fun parseDetails_survivesAnAssetWithNothingButAnId() {
+    assertTrue(ImmichSource.parseDetails("""{"id":"abc"}""").isEmpty)
+  }
+
+  /** The same wall-clock instant the parser should produce, whatever zone the test host is in. */
+  private fun localMillis(s: String): Long =
+      SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).parse(s)!!.time
+
+  private fun utcMillis(s: String): Long =
+      SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+          .apply { timeZone = TimeZone.getTimeZone("UTC") }
+          .parse(s)!!
+          .time
 }

--- a/app/src/test/java/com/immortal/launcher/PhotoCaptionTest.kt
+++ b/app/src/test/java/com/immortal/launcher/PhotoCaptionTest.kt
@@ -1,7 +1,9 @@
 package com.immortal.launcher
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PhotoCaptionTest {
@@ -36,5 +38,45 @@ class PhotoCaptionTest {
   fun parsePlace_nullWhenEmpty() {
     assertNull(PhotoCaption.parsePlace("""{}"""))
     assertNull(PhotoCaption.parsePlace("""{"city":"","countryName":""}"""))
+  }
+
+  // --- caption lines ----------------------------------------------------------
+
+  @Test
+  fun formatPeople_readsAsASentence() {
+    assertEquals("Alice", PhotoCaption.formatPeople(listOf("Alice")))
+    assertEquals("Alice & Bob", PhotoCaption.formatPeople(listOf("Alice", " Bob ")))
+    assertEquals("Alice, Bob & Carol", PhotoCaption.formatPeople(listOf("Alice", "Bob", "Carol")))
+    assertEquals("Alice", PhotoCaption.formatPeople(listOf("Alice", "Alice")))
+  }
+
+  @Test
+  fun formatPeople_summarisesACrowdInsteadOfOverflowingTheLine() {
+    assertEquals(
+        "Alice, Bob, Carol, Dave +2",
+        PhotoCaption.formatPeople(listOf("Alice", "Bob", "Carol", "Dave", "Erin", "Frank")))
+  }
+
+  @Test
+  fun formatPeople_nullWhenNobodyIsNamed() {
+    assertNull(PhotoCaption.formatPeople(emptyList()))
+    assertNull(PhotoCaption.formatPeople(listOf("", "   ")))
+  }
+
+  @Test
+  fun formatTags_joinsAndCaps() {
+    assertNull(PhotoCaption.formatTags(emptyList()))
+    assertEquals("Beach  \u00b7  Sunset", PhotoCaption.formatTags(listOf("Beach", " Sunset ")))
+    assertEquals(
+        "a  \u00b7  b  \u00b7  c  \u00b7  d  \u00b7  e  \u00b7  +2",
+        PhotoCaption.formatTags(listOf("a", "b", "c", "d", "e", "f", "g")))
+  }
+
+  @Test
+  fun caption_isEmptyUntilSomeLineHasContent() {
+    assertTrue(PhotoCaption.Caption().isEmpty)
+    assertTrue(PhotoCaption.Caption(place = "   ", date = "").isEmpty)
+    assertFalse(PhotoCaption.Caption(tags = "Beach").isEmpty)
+    assertFalse(PhotoCaption.Caption(place = "Arezzo, Italy").isEmpty)
   }
 }

--- a/app/src/test/java/com/immortal/launcher/PhotoCaptionTest.kt
+++ b/app/src/test/java/com/immortal/launcher/PhotoCaptionTest.kt
@@ -73,10 +73,84 @@ class PhotoCaptionTest {
   }
 
   @Test
-  fun caption_isEmptyUntilSomeLineHasContent() {
-    assertTrue(PhotoCaption.Caption().isEmpty)
-    assertTrue(PhotoCaption.Caption(place = "   ", date = "").isEmpty)
-    assertFalse(PhotoCaption.Caption(tags = "Beach").isEmpty)
-    assertFalse(PhotoCaption.Caption(place = "Arezzo, Italy").isEmpty)
+  fun caption_dropsBlanksAndIsEmptyUntilSomeLineHasContent() {
+    assertTrue(PhotoCaption.Caption.EMPTY.isEmpty)
+    assertTrue(
+        PhotoCaption.Caption.of(
+                PhotoCaption.Line.LOCATION to "   ",
+                PhotoCaption.Line.DATE to "",
+                PhotoCaption.Line.TAGS to null,
+            )
+            .isEmpty)
+    val c =
+        PhotoCaption.Caption.of(
+            PhotoCaption.Line.LOCATION to "  Arezzo, Italy  ",
+            PhotoCaption.Line.DATE to null,
+        )
+    assertFalse(c.isEmpty)
+    assertEquals("Arezzo, Italy", c[PhotoCaption.Line.LOCATION]) // trimmed
+    assertNull(c[PhotoCaption.Line.DATE]) // absent, not blank
+  }
+
+  // --- caption layout (order + per-line style) --------------------------------
+
+  @Test
+  fun parseOrder_defaultsAndRoundTrips() {
+    assertEquals(PhotoCaption.DEFAULT_ORDER, PhotoCaption.parseOrder(null))
+    assertEquals(PhotoCaption.DEFAULT_ORDER, PhotoCaption.parseOrder(""))
+    val custom = listOf(PhotoCaption.Line.TAGS, PhotoCaption.Line.PEOPLE, PhotoCaption.Line.DATE,
+        PhotoCaption.Line.LOCATION, PhotoCaption.Line.DESCRIPTION)
+    assertEquals(custom, PhotoCaption.parseOrder(PhotoCaption.serializeOrder(custom)))
+  }
+
+  @Test
+  fun parseOrder_repairsAPartialOrGarbageString() {
+    // A line the string forgot is appended in default order rather than vanishing from the frame.
+    assertEquals(
+        listOf(PhotoCaption.Line.TAGS, PhotoCaption.Line.LOCATION, PhotoCaption.Line.DATE,
+            PhotoCaption.Line.DESCRIPTION, PhotoCaption.Line.PEOPLE),
+        PhotoCaption.parseOrder("tags,location"))
+    // Unknown keys and duplicates are dropped, not honoured twice.
+    assertEquals(
+        listOf(PhotoCaption.Line.DATE, PhotoCaption.Line.LOCATION, PhotoCaption.Line.DESCRIPTION,
+            PhotoCaption.Line.PEOPLE, PhotoCaption.Line.TAGS),
+        PhotoCaption.parseOrder("date,nonsense,date"))
+    assertEquals(PhotoCaption.DEFAULT_ORDER, PhotoCaption.parseOrder("!!!"))
+  }
+
+  @Test
+  fun parseStyles_defaultsMatchTheOriginalCaption() {
+    val d = PhotoCaption.parseStyles(null)
+    // 95% and 70% of the 20sp base are the 19sp/14sp the hardcoded caption used.
+    assertEquals(95, d.getValue(PhotoCaption.Line.LOCATION).size)
+    assertEquals(PhotoCaption.Weight.BOLD, d.getValue(PhotoCaption.Line.LOCATION).weight)
+    assertEquals(70, d.getValue(PhotoCaption.Line.DATE).size)
+    assertEquals(PhotoCaption.Weight.LIGHT, d.getValue(PhotoCaption.Line.DATE).weight)
+    assertEquals(PhotoCaption.Line.entries.size, d.size)
+  }
+
+  @Test
+  fun parseStyles_roundTripsAndFallsBackPerField() {
+    val custom =
+        PhotoCaption.parseStyles(null) +
+            (PhotoCaption.Line.TAGS to PhotoCaption.LineStyle(120, PhotoCaption.Weight.REGULAR))
+    assertEquals(custom, PhotoCaption.parseStyles(PhotoCaption.serializeStyles(custom)))
+    // A malformed entry falls back to that line's default without taking the others with it.
+    val patched = PhotoCaption.parseStyles("tags:oops:nope,people:130:bold")
+    assertEquals(PhotoCaption.Line.TAGS.defaultStyle, patched.getValue(PhotoCaption.Line.TAGS))
+    assertEquals(
+        PhotoCaption.LineStyle(130, PhotoCaption.Weight.BOLD),
+        patched.getValue(PhotoCaption.Line.PEOPLE))
+  }
+
+  @Test
+  fun clampSize_keepsALineInsideTheStepperRange() {
+    assertEquals(PhotoCaption.LineStyle.MIN_SIZE, PhotoCaption.clampSize(0))
+    assertEquals(PhotoCaption.LineStyle.MAX_SIZE, PhotoCaption.clampSize(9999))
+    assertEquals(100, PhotoCaption.clampSize(100))
+    // Out-of-range values in a persisted string are clamped, never taken literally.
+    assertEquals(
+        PhotoCaption.LineStyle.MAX_SIZE,
+        PhotoCaption.parseStyles("tags:9999:bold").getValue(PhotoCaption.Line.TAGS).size)
   }
 }

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -207,6 +207,9 @@ class SettingsDomainTest {
             "smbHost", "smbShare", "smbPath", "smbUser", "smbPass",
             "davUrl", "davUser", "davPass", "webUrl",
             "facesEnabled", "faceId", "faceSizeIndex",
+            // Caption order + per-line size/weight: a permutation and ten coupled values, edited
+            // as one unit in CaptionStyleActivity (reached via the "captionLayout" NavSpec).
+            "captionOrder", "captionStyles",
             "dismissAppComponent", "dismissHaDashboard",
             "calendarUrl", "calendarEnabled", "calendarRange", "calendarSize", "calendarSide",
         )
@@ -223,7 +226,7 @@ class SettingsDomainTest {
     // via the server), and description/people/tags only on Immich, which alone stores them.
     val byKey = SettingsDomains.screensaver.specs.associateBy { it.key }
     val fromImmichOnly = listOf("captionDescription", "captionPeople", "captionTags")
-    val fromAnyOwnPhotos = listOf("captionDate", "captionLocation")
+    val fromAnyOwnPhotos = listOf("captionDate", "captionLocation", "captionIcons", "captionLayout")
 
     fun visible(keys: List<String>, s: com.immortal.launcher.ScreensaverConfig.Settings) =
         keys.filter { byKey.getValue(it).visibleWhen(ctx, s) }
@@ -245,6 +248,36 @@ class SettingsDomainTest {
     // The built-in feed carries no metadata at all, so the whole group stays hidden.
     val builtIn = com.immortal.launcher.ScreensaverConfig.Settings()
     assertEquals(emptyList<String>(), visible(fromImmichOnly + fromAnyOwnPhotos, builtIn))
+  }
+
+  @Test
+  fun captionLayoutRow_summarisesTheLinesInTheOrderTheyWillBeDrawn() {
+    // The nav row has to say what the caption looks like without opening the editor, so it reads
+    // the SNAPSHOT (no prefs I/O) - which is also why a mock Context is enough here.
+    val nav =
+        SettingsDomains.screensaver.specs.first { it.key == "captionLayout" }
+            as NavSpec<com.immortal.launcher.ScreensaverConfig.Settings>
+
+    val allOn = com.immortal.launcher.ScreensaverConfig.Settings()
+    assertEquals("Location, Photo date +3", nav.value(ctx, allOn))
+
+    // Reordered, and down to two lines: both are reflected, in the user's order.
+    val reordered =
+        allOn.copy(
+            captionOrder = "tags,location,date,description,people",
+            captionDate = false,
+            captionDescription = false,
+            captionPeople = false)
+    assertEquals("Tags, Location", nav.value(ctx, reordered))
+
+    val nothing =
+        allOn.copy(
+            captionLocation = false,
+            captionDate = false,
+            captionDescription = false,
+            captionPeople = false,
+            captionTags = false)
+    assertEquals("No caption", nav.value(ctx, nothing))
   }
 
   @Test

--- a/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
+++ b/app/src/test/java/com/immortal/launcher/settings/SettingsDomainTest.kt
@@ -217,6 +217,37 @@ class SettingsDomainTest {
   }
 
   @Test
+  fun screensaverCaptionLines_onlyOfferWhatTheActiveSourceCanSupply() {
+    // The caption lines are declaratively gated so a control never promises something the source
+    // can't deliver: date + location wherever the photo carries them (own files via EXIF, Immich
+    // via the server), and description/people/tags only on Immich, which alone stores them.
+    val byKey = SettingsDomains.screensaver.specs.associateBy { it.key }
+    val fromImmichOnly = listOf("captionDescription", "captionPeople", "captionTags")
+    val fromAnyOwnPhotos = listOf("captionDate", "captionLocation")
+
+    fun visible(keys: List<String>, s: com.immortal.launcher.ScreensaverConfig.Settings) =
+        keys.filter { byKey.getValue(it).visibleWhen(ctx, s) }
+
+    val immich =
+        com.immortal.launcher.ScreensaverConfig.Settings(
+            source = com.immortal.launcher.ScreensaverConfig.SOURCE_IMMICH,
+            immichUrl = "http://immich:2283",
+            immichKey = "secret")
+    assertEquals(fromImmichOnly, visible(fromImmichOnly, immich))
+    assertEquals(fromAnyOwnPhotos, visible(fromAnyOwnPhotos, immich))
+
+    val folder =
+        com.immortal.launcher.ScreensaverConfig.Settings(
+            source = com.immortal.launcher.ScreensaverConfig.SOURCE_FOLDER, folderPath = "/sdcard/Pics")
+    assertEquals(emptyList<String>(), visible(fromImmichOnly, folder))
+    assertEquals(fromAnyOwnPhotos, visible(fromAnyOwnPhotos, folder))
+
+    // The built-in feed carries no metadata at all, so the whole group stays hidden.
+    val builtIn = com.immortal.launcher.ScreensaverConfig.Settings()
+    assertEquals(emptyList<String>(), visible(fromImmichOnly + fromAnyOwnPhotos, builtIn))
+  }
+
+  @Test
   fun immortalRegistry_coversEveryPersistedField_orExplicitlyAccountsForIt() {
     // The on-device Immortal screen now renders its top-level controls from this domain, so a new
     // ImmortalSettings.Settings field that nobody adds a spec for would silently never appear. Every

--- a/docs/features/screensaver.md
+++ b/docs/features/screensaver.md
@@ -40,11 +40,39 @@ you don't type URLs and credentials on the Portal:
 | iCloud shared album | Paste a shared-album link (supports Apple's newer CloudKit link format). |
 | Google Photos | Paste a public shared-album link. |
 | Synology Photos | Paste a public album share link. For a local HTTPS address, the NAS certificate must be trusted by the Portal. |
-| [Immich](https://immich.app/) | A self-hosted photo library. Photos **and** videos (with "Play videos" on), from an album or the whole library. |
+| [Immich](https://immich.app/) | A self-hosted photo library. Photos **and** videos (with "Play videos" on), from an album or the whole library. Photos can carry a [caption](#photo-captions) with their date, description, location, people and tags. |
 | Network share (SMB) | A file server on your LAN. |
 | WebDAV | Any WebDAV server. |
 | Web page | Pull images from any web page. |
 | Built-in feed | Keyless. Pick between Lorem Picsum (stock photography), the Met Museum and Art Institute of Chicago collections, Wikimedia featured landscapes, or NASA's Astronomy Picture of the Day. Unsplash-ready with a key. |
+
+## Photo captions
+
+The frame can label the photo it's showing, tvOS-style, in the corner of the overlay — under the
+now-playing card when both are up. Up to five lines, each of which appears only when that photo
+has something for it:
+
+| Line | What it shows |
+| --- | --- |
+| **Location** | Where the photo was taken — "Arezzo, Italy" |
+| **Photo date** | When it was taken — "June 22, 2026" |
+| **Description** | The description you typed on the photo in Immich |
+| **People** | The people Immich recognised — "Alice, Bob & Carol" |
+| **Tags** | The tags the photo is filed under in Immich |
+
+Which sources can fill these in depends on what survives to the Portal:
+
+- **Immich** supplies all five. The frame asks the server for each photo as it comes up
+  (`GET /api/assets/{id}`) and caches the answer, so a looping album asks once per photo.
+- **Your own folder** and a **network share (SMB)** supply the date and location, read from the
+  photo's own EXIF block; the location is reverse-geocoded to a place name.
+- The remaining sources (built-in feed, iCloud/Google shared albums, WebDAV) serve re-encoded
+  images with EXIF stripped and have no metadata API, so they show no caption.
+
+Each line has its own switch under **Photo details** in the screensaver settings (on the Portal or
+from the [phone remote](remote.md)); a switch only appears when the active source can actually
+supply that line. All five are on by default. Captions are hidden on a full-bleed clock face
+(which owns the whole frame) and while a video is playing.
 
 ## Presence-aware behaviour
 

--- a/docs/features/screensaver.md
+++ b/docs/features/screensaver.md
@@ -60,6 +60,9 @@ has something for it:
 | **People** | The people Immich recognised — "Alice, Bob & Carol" |
 | **Tags** | The tags the photo is filed under in Immich |
 
+Each line can carry a small glyph — a pin, a calendar, a note, people, a tag — sized and tinted to
+match its text. Turn them off with **Show icons**.
+
 Which sources can fill these in depends on what survives to the Portal:
 
 - **Immich** supplies all five. The frame asks the server for each photo as it comes up
@@ -73,6 +76,24 @@ Each line has its own switch under **Photo details** in the screensaver settings
 from the [phone remote](remote.md)); a switch only appears when the active source can actually
 supply that line. All five are on by default. Captions are hidden on a full-bleed clock face
 (which owns the whole frame) and while a video is playing.
+
+### Layout and type
+
+The caption is drawn in your **clock face's own font, colour, opacity and shadow** — the same type
+as the clock, date and weather — so it reads as part of one overlay rather than a panel bolted onto
+it. Sizes are a percentage of a shared base, scaled again by the face's own size, so making the
+clock bigger carries the caption with it. A bold line sits at the face's full opacity and lighter
+ones step back, which is what keeps a five-line block legible.
+
+**Photo details → Caption layout** opens an editor (`CaptionStyleActivity`) for the rest:
+
+- **Order** — move any line up or down; the caption is drawn top to bottom in that order.
+- **Size** — 50–200% per line, in 5% steps.
+- **Weight** — Light, Regular or Bold per line, taken from the face's own font.
+- **Reset layout to defaults** — back to the shipped order and sizes.
+
+The defaults reproduce the original caption exactly: a bold place over a lighter date, with the
+Immich-only lines beneath, each a step smaller.
 
 ## Presence-aware behaviour
 

--- a/docs/features/screensaver.md
+++ b/docs/features/screensaver.md
@@ -85,12 +85,18 @@ it. Sizes are a percentage of a shared base, scaled again by the face's own size
 clock bigger carries the caption with it. A bold line sits at the face's full opacity and lighter
 ones step back, which is what keeps a five-line block legible.
 
-**Photo details → Caption layout** opens an editor (`CaptionStyleActivity`) for the rest:
+**Photo details → Caption layout** opens an editor (`CaptionStyleActivity`) for what a settings
+row can't express:
 
 - **Order** — move any line up or down; the caption is drawn top to bottom in that order.
 - **Size** — 50–200% per line, in 5% steps.
 - **Weight** — Light, Regular or Bold per line, taken from the face's own font.
 - **Reset layout to defaults** — back to the shipped order and sizes.
+
+It lists only the lines you've switched on, since arranging a line that isn't drawn is meaningless
+— a line keeps its place in the order while it's switched off. Everything that *is* a plain switch
+(which lines show, and **Show icons**) stays on the screensaver settings screen, so it has one home
+and also reaches the [phone remote](remote.md).
 
 The defaults reproduce the original caption exactly: a bold place over a lighter date, with the
 Immich-only lines beneath, each a step smaller.


### PR DESCRIPTION
Adds the Immich photo details the screensaver has been missing — date, description, tags, location, people — and makes the caption block that shows them configurable and visually part of the overlay rather than bolted onto it. Also allows for configuration of size, font styling, and order of the details displayed.

## Why

To allow images from Immich to show details and other metadata from photos in the screensaver overlay. Have guests over that are going to ask where and when that photo was taken? Let's just show them. 

## What changed

**1. Read the detail from Immich**

- `ImmichSource.details()` / `parseDetails()` over `GET /api/assets/{id}` — the one endpoint carrying `exifInfo`, `people` and `tags` together. The search listing's `withExif`/`withPeople` relations have moved between versions and don't carry tags, so one small GET per displayed photo is both complete and version-proof.
- Parsing handles the real-world edges: explicit JSON nulls (Android's `optString` hands those back as the literal `"null"`), nested tag paths (`Holiday/Beach` → `Beach`), unnamed faces, and date precedence — capture wall clock before the UTC import timestamp, so the named day never shifts.
- `Media` carries the asset id so a displayed URL traces back to the server. `PhotoFrameController` fetches on the existing `metaIo` thread, gen-guarded exactly like the EXIF paths, and caches per asset for the session, so a looping album asks once per photo.
- Five settings under a new **Photo details** section, declared once in the screensaver domain so they render on-device *and* on the phone remote. Gated declaratively: date/location for Immich, folder or SMB; description/people/tags for Immich only.

**2. Icons, ordering, per-line styling, and the face's own type**

- Type comes from the face's `ClockSpec` — the same source the clock, date, weather and battery draw from: font family, colour, opacity and shadow. Size is a percentage of a shared base scaled again by the face's `sizeScale`, so resizing the clock carries the caption with it.
- `PhotoCaption.Line` is the identity the feature is keyed on — label, icon, default size and weight — and `Caption` is a map keyed by it, so the draw order is the user's rather than the order fields happen to be declared in. Adding a sixth line is one enum entry plus a drawable.
- Five new vector glyphs (pin, calendar, note, people, tag), drawn ahead of each line, sized to the text and tinted to match it so they track a size or colour change. Global **Show icons** switch.
- `CaptionStyleActivity`: reorder lines, set each one's size (50–200%) and weight (Light/Regular/Bold), reset. Its own screen because a permutation isn't a scalar a generic settings row can express — the same call the clock-face picker makes. Order and styles persist as two compact strings, parsed totally: an unknown key, a missing line or outright garbage degrades to defaults rather than blanking a frame.

## Notes for a reviewer

- **`captionOrder` / `captionStyles` are in the `SettingsDomainTest` `managedElsewhere` set**, alongside `faceId` / `faceSizeIndex` — they're Activity-managed, matching the clock-face-picker precedent. Every other new field has a spec.
- **Videos still show no caption.** Every source clears the caption while a clip plays; left alone rather than changed as a side effect. Easy to extend at the `advanceRemote` video branch if wanted.
- No install or provisioning behaviour was touched.
- **Verified working, on real hardware** -- tested on a Facebook Portal Gen1 and Portal+ Gen1, talking to a live Immich server.

## Testing

- `./gradlew :app:testDebugUnitTest` — **393 tests, 0 failures** (up from 387). New coverage: parser date precedence, place fallback, JSON nulls, tag paths, caption formatters, order round-trip and repair, style parse fallback, size clamping, settings gating, and the nav-row summary.
- `./gradlew :app:assembleDebug` — clean; all five drawables confirmed packaged.
- `mkdocs build --strict` — clean.
- **Verified working, on real hardware** -- tested on a Facebook Portal Gen1 and Portal+ Gen1, talking to a live Immich server.
